### PR TITLE
Refactored read_scale(), memio_new(), var_create_dataset() and makespeci...

### DIFF
--- a/include/nc4internal.h
+++ b/include/nc4internal.h
@@ -97,16 +97,22 @@ typedef enum {VAR, DIM, ATT} NC_OBJ_T;
  * as the netCDF dimid. */
 #define NC_DIMID_ATT_NAME "_Netcdf4Dimid"
 
+/* Generic doubly-linked list node */
+typedef struct NC_LIST_NODE
+{
+   void *next;
+   void *prev;
+} NC_LIST_NODE_T;
+
 /* This is a struct to handle the dim metadata. */
 typedef struct NC_DIM_INFO
 {
+   NC_LIST_NODE_T l;            /* Use generic doubly-linked list (must be first) */
    char *name;
    size_t len;
    int dimid;
    int unlimited;
    int extended;
-   struct NC_DIM_INFO *next;
-   struct NC_DIM_INFO *prev;
    hid_t hdf_dimscaleid;
    HDF5_OBJID_T hdf5_objid;
    struct NC_VAR_INFO *coord_var; /* The coord var, if it exists. */
@@ -115,10 +121,9 @@ typedef struct NC_DIM_INFO
 
 typedef struct NC_ATT_INFO
 {
+   NC_LIST_NODE_T l;            /* Use generic doubly-linked list (must be first) */
    int len;
    char *name;
-   struct NC_ATT_INFO *next;
-   struct NC_ATT_INFO *prev;
    int dirty;
    int created;
    nc_type xtype;
@@ -133,6 +138,7 @@ typedef struct NC_ATT_INFO
 /* This is a struct to handle the var metadata. */
 typedef struct NC_VAR_INFO
 {
+   NC_LIST_NODE_T l;            /* Use generic doubly-linked list (must be first) */
    char *name;
    char *hdf5_name; /* used if different from name */
    int ndims;
@@ -140,8 +146,6 @@ typedef struct NC_VAR_INFO
    NC_DIM_INFO_T **dim;
    int varid;
    int natts;
-   struct NC_VAR_INFO *next;
-   struct NC_VAR_INFO *prev;
    int dirty;
    int created;         /* Variable has already been created (_not_ that it was just created) */
    int written_to;
@@ -174,8 +178,7 @@ typedef struct NC_VAR_INFO
 
 typedef struct NC_FIELD_INFO
 {
-   struct NC_FIELD_INFO *next;
-   struct NC_FIELD_INFO *prev;
+   NC_LIST_NODE_T l;            /* Use generic doubly-linked list (must be first) */
    nc_type nctype;
    hid_t hdf_typeid;
    hid_t native_typeid;
@@ -188,16 +191,14 @@ typedef struct NC_FIELD_INFO
 
 typedef struct NC_ENUM_MEMBER_INFO
 {
-   struct NC_ENUM_MEMBER_INFO *next;
-   struct NC_ENUM_MEMBER_INFO *prev;
+   NC_LIST_NODE_T l;            /* Use generic doubly-linked list (must be first) */
    char *name;
    void *value;
 } NC_ENUM_MEMBER_INFO_T;
 
 typedef struct NC_TYPE_INFO
 {
-   struct NC_TYPE_INFO *next;
-   struct NC_TYPE_INFO *prev;
+   NC_LIST_NODE_T l;            /* Use generic doubly-linked list (must be first) */
    nc_type nc_typeid;
    hid_t hdf_typeid;
    hid_t native_typeid;
@@ -219,11 +220,10 @@ typedef struct NC_TYPE_INFO
  * parthenogenesis. */
 typedef struct NC_GRP_INFO
 {
+   NC_LIST_NODE_T l;            /* Use generic doubly-linked list (must be first) */
    int nc_grpid;
    struct NC_GRP_INFO *parent;
    struct NC_GRP_INFO *children;
-   struct NC_GRP_INFO *next; /* points to siblings */
-   struct NC_GRP_INFO *prev; /* points to siblings */
    NC_VAR_INFO_T *var;
    NC_DIM_INFO_T *dim;
    NC_ATT_INFO_T *att;
@@ -291,16 +291,10 @@ int nc4_convert_type(const void *src, void *dest,
 /* These functions do HDF5 things. */
 int rec_detach_scales(NC_GRP_INFO_T *grp, int dimid, hid_t dimscaleid);
 int nc4_open_var_grp2(NC_GRP_INFO_T *grp, int varid, hid_t *dataset);
-int pg_var(NC_PG_T pg, NC *nc, int ncid, int varid, nc_type xtype, int is_long, void *ip);
-int nc4_pg_var1(NC_PG_T pg, NC *nc, int ncid, int varid, const size_t *indexp, 
-		nc_type xtype, int is_long, void *ip);
 int nc4_put_vara(NC *nc, int ncid, int varid, const size_t *startp, 
 		 const size_t *countp, nc_type xtype, int is_long, void *op);
 int nc4_get_vara(NC *nc, int ncid, int varid, const size_t *startp, 
 		 const size_t *countp, nc_type xtype, int is_long, void *op);
-int nc4_pg_varm(NC_PG_T pg, NC *nc, int ncid, int varid, const size_t *startp, 
-		const size_t *countp, const ptrdiff_t *stridep,
-		const ptrdiff_t *imapp, nc_type xtype, int is_long, void *op);
 int nc4_rec_match_dimscales(NC_GRP_INFO_T *grp);
 int nc4_rec_detect_need_to_preserve_dimids(NC_GRP_INFO_T *grp, int *bad_coord_orderp);
 int nc4_rec_write_metadata(NC_GRP_INFO_T *grp, int bad_coord_order);
@@ -341,9 +335,9 @@ int nc4_get_hdf_typeid(NC_HDF5_FILE_INFO_T *h5, nc_type xtype,
 int nc4_nc4f_list_add(NC *nc, const char *path, int mode);
 int nc4_var_list_add(NC_VAR_INFO_T **list, NC_VAR_INFO_T **var);
 int nc4_var_list_del(NC_VAR_INFO_T **list, NC_VAR_INFO_T *var);
-int nc4_dim_list_add(NC_DIM_INFO_T **list);
+int nc4_dim_list_add(NC_DIM_INFO_T **list, NC_DIM_INFO_T **dim);
 int nc4_dim_list_del(NC_DIM_INFO_T **list, NC_DIM_INFO_T *dim);
-int nc4_att_list_add(NC_ATT_INFO_T **list);
+int nc4_att_list_add(NC_ATT_INFO_T **list, NC_ATT_INFO_T **att);
 int nc4_type_list_add(NC_TYPE_INFO_T **list, NC_TYPE_INFO_T **new_type);
 int nc4_field_list_add(NC_FIELD_INFO_T **list, int fieldid, const char *name,
 		       size_t offset, hid_t field_hdf_typeid, hid_t native_typeid, 

--- a/libsrc/memio.c
+++ b/libsrc/memio.c
@@ -103,7 +103,6 @@ memio_new(const char* path, int ioflags, off_t initialsize, ncio** nciopp, NCMEM
     int status = NC_NOERR;
     ncio* nciop = NULL;
     NCMEMIO* memio = NULL;
-    int openfd = -1;
 
     if(pagesize == 0) {
 
@@ -156,15 +155,20 @@ memio_new(const char* path, int ioflags, off_t initialsize, ncio** nciopp, NCMEM
     memio->persist = fIsSet(ioflags,NC_WRITE);
 
     if(nciopp) *nciopp = nciop;
+    else {
+        free((char*)nciop->path);
+        free(nciop);
+    }
     if(memiop) *memiop = memio;
+    else free(memio);
 
 done:
-    if(openfd >= 0) close(openfd);
     return status;
 
 fail:
     if(nciop != NULL) {
         if(nciop->path != NULL) free((char*)nciop->path);
+        free(nciop);
     }
     goto done;
 }

--- a/libsrc4/nc3stub.c
+++ b/libsrc4/nc3stub.c
@@ -294,11 +294,6 @@ nc3_inq_unlimdim(int ncid, int *unlimdimidp) {abort();}
 int
 nc3_show_metadata(int ncid) {abort();}
 
-#ifdef IGNORE
-int
-nc3_delete_mp(const char * path, int basepe) {abort();}
-#endif
-
 int
 nc3_put_att_text(int ncid, int varid, const char *name,
 		size_t len, const char *op) {abort();}

--- a/libsrc4/nc4grp.c
+++ b/libsrc4/nc4grp.c
@@ -18,7 +18,7 @@ $Id: nc4grp.c,v 1.44 2010/05/25 17:54:23 dmh Exp $
 int
 NC4_def_grp(int parent_ncid, const char *name, int *new_ncid)
 {
-   NC_GRP_INFO_T *grp, *g;
+   NC_GRP_INFO_T *grp;
    NC_HDF5_FILE_INFO_T *h5;
    char norm_name[NC_MAX_NAME + 1];
    int retval;
@@ -52,7 +52,7 @@ NC4_def_grp(int parent_ncid, const char *name, int *new_ncid)
     * group creation will be done when metadata is written by a
     * sync. */
    if ((retval = nc4_grp_list_add(&(grp->children), h5->next_nc_grpid, 
-				  grp, grp->nc4_info->controller, norm_name, &g)))
+				  grp, grp->nc4_info->controller, norm_name, NULL)))
       return retval;
    if (new_ncid)
       *new_ncid = grp->nc4_info->controller->ext_ncid | h5->next_nc_grpid;
@@ -154,7 +154,7 @@ NC4_inq_ncid(int ncid, const char *name, int *grp_ncid)
       return retval;
 
    /* Look through groups for one of this name. */
-   for (g = grp->children; g; g = g->next)
+   for (g = grp->children; g; g = g->l.next)
       if (!strcmp(norm_name, g->name)) /* found it! */
       {
 	 if (grp_ncid)
@@ -191,7 +191,7 @@ NC4_inq_grps(int ncid, int *numgrps, int *ncids)
    }
 
    /* Count the number of groups in this group. */
-   for (g = grp->children; g; g = g->next)
+   for (g = grp->children; g; g = g->l.next)
    {
       if (ncids)
       {
@@ -415,7 +415,7 @@ NC4_inq_varids(int ncid, int *nvars, int *varids)
        * 'em. The list is in correct (i.e. creation) order. */
       if (grp->var)
       {
-	 for (var = grp->var; var; var = var->next)
+	 for (var = grp->var; var; var = var->l.next)
 	 {
 	    if (varids)
 	       varids[num_vars] = var->varid;
@@ -473,11 +473,11 @@ NC4_inq_dimids(int ncid, int *ndims, int *dimids, int include_parents)
    else
    {
       /* First count them. */
-      for (dim = grp->dim; dim; dim = dim->next)
+      for (dim = grp->dim; dim; dim = dim->l.next)
 	 num++;
       if (include_parents)
 	 for (g = grp->parent; g; g = g->parent)
-	    for (dim = g->dim; dim; dim = dim->next)
+	    for (dim = g->dim; dim; dim = dim->l.next)
 	       num++;
       
       /* If the user wants the dimension ids, get them. */
@@ -486,13 +486,13 @@ NC4_inq_dimids(int ncid, int *ndims, int *dimids, int include_parents)
 	 int n = 0;
 
 	 /* Get dimension ids from this group. */
-	 for (dim = grp->dim; dim; dim = dim->next)
+	 for (dim = grp->dim; dim; dim = dim->l.next)
 	    dimids[n++] = dim->dimid;
 
 	 /* Get dimension ids from parent groups. */
 	 if (include_parents)
 	    for (g = grp->parent; g; g = g->parent)
-	       for (dim = g->dim; dim; dim = dim->next)
+	       for (dim = g->dim; dim; dim = dim->l.next)
 		  dimids[n++] = dim->dimid;
 	 
 	 qsort(dimids, num, sizeof(int), int_cmp);

--- a/libsrc4/nc4var.c
+++ b/libsrc4/nc4var.c
@@ -98,7 +98,7 @@ NC4_set_var_chunk_cache(int ncid, int varid, size_t size, size_t nelems,
    assert(nc && grp && h5);
 
    /* Find the var. */
-   for (var = grp->var; var; var = var->next)
+   for (var = grp->var; var; var = var->l.next)
       if (var->varid == varid)
          break;
    if (!var)
@@ -161,7 +161,7 @@ NC4_get_var_chunk_cache(int ncid, int varid, size_t *sizep,
    assert(nc && grp && h5);
 
    /* Find the var. */
-   for (var = grp->var; var; var = var->next)
+   for (var = grp->var; var; var = var->l.next)
       if (var->varid == varid)
          break;
    if (!var)
@@ -524,7 +524,7 @@ nc_def_var_nc4(int ncid, const char *name, nc_type xtype,
     * is not a coordinate variable. I need to change its HDF5 name,
     * because the dimension will cause a HDF5 dataset to be created,
     * and this var has the same name. */
-   for (dim = grp->dim; dim; dim = dim->next)
+   for (dim = grp->dim; dim; dim = dim->l.next)
       if (!strcmp(dim->name, norm_name) && 
 	  (!var->ndims || dimidsp[0] != dim->dimid))
       {
@@ -636,7 +636,7 @@ NC4_inq_var_all(int ncid, int varid, char *name, nc_type *xtypep,
    {
       if (nattsp)
       {
-         for (att = grp->att; att; att = att->next)
+         for (att = grp->att; att; att = att->l.next)
             natts++;
          *nattsp = natts;
       }
@@ -644,7 +644,7 @@ NC4_inq_var_all(int ncid, int varid, char *name, nc_type *xtypep,
    }
 
    /* Find the var. */
-   for (var = grp->var; var; var = var->next)
+   for (var = grp->var; var; var = var->l.next)
       if (var->varid == varid)
          break;
    
@@ -664,7 +664,7 @@ NC4_inq_var_all(int ncid, int varid, char *name, nc_type *xtypep,
          dimidsp[d] = var->dimids[d];
    if (nattsp)
    {
-      for (att = var->att; att; att = att->next)
+      for (att = var->att; att; att = att->l.next)
          natts++;
       *nattsp = natts;
    }
@@ -757,7 +757,7 @@ nc_def_var_extra(int ncid, int varid, int *shuffle, int *deflate,
    assert(nc && grp && h5);
 
    /* Find the var. */
-   for (var = grp->var; var; var = var->next)
+   for (var = grp->var; var; var = var->l.next)
       if (var->varid == varid)
          break;
    
@@ -811,7 +811,7 @@ nc_def_var_extra(int ncid, int varid, int *shuffle, int *deflate,
    {
 #ifndef USE_SZIP
       return NC_EINVAL;
-#endif
+#else /* USE_SZIP */
       if (var->deflate)
 	 return NC_EINVAL;
       if ((*options_mask != NC_SZIP_EC_OPTION_MASK) &&
@@ -823,6 +823,7 @@ nc_def_var_extra(int ncid, int varid, int *shuffle, int *deflate,
       var->options_mask = *options_mask;
       var->pixels_per_block = *pixels_per_block;
       var->contiguous = 0;
+#endif /* USE_SZIP */
    }
 
    /* Shuffle filter? */
@@ -1108,7 +1109,7 @@ NC4_inq_varid(int ncid, const char *name, int *varidp)
       return retval;
 
    /* Find var of this name. */
-   for (var = grp->var; var; var = var->next)
+   for (var = grp->var; var; var = var->l.next)
       if (!(strcmp(var->name, norm_name)))
       {
          *varidp = var->varid;
@@ -1160,12 +1161,12 @@ NC4_rename_var(int ncid, int varid, const char *name)
       return retval;
 
    /* Is name in use? */
-   for (var = grp->var; var; var = var->next)
+   for (var = grp->var; var; var = var->l.next)
       if (!strncmp(var->name, name, NC_MAX_NAME))
          return NC_ENAMEINUSE;   
 
    /* Find the var. */
-   for (var = grp->var; var; var = var->next)
+   for (var = grp->var; var; var = var->l.next)
       if (var->varid == varid)
          break;
    if (!var)
@@ -1270,7 +1271,7 @@ NC4_var_par_access(int ncid, int varid, int par_access)
       return NC_ENOPAR;
 
    /* Find the var, and set its preference. */
-   for (var = grp->var; var; var = var->next)
+   for (var = grp->var; var; var = var->l.next)
       if (var->varid == varid)
          break;
    if (!var)

--- a/libsrc4/ncfunc.c
+++ b/libsrc4/ncfunc.c
@@ -14,29 +14,6 @@ conditions.
 #include "nc4internal.h"
 #include "nc3dispatch.h"
 
-#ifdef IGNORE
-/* Keep a linked list of file info objects. */
-extern NC_FILE_INFO_T *nc_file;
-#endif
-
-#ifdef IGNORE
-/* This function deletes a member of parliment. Be careful! Last time
- * this function was used, Labor got in! This function only does
- * anything for netcdf-3 files. */
-
-int
-nc_delete(const char *path)
-{
-   return NC3_delete_mp(path, 0);
-}
-
-int
-nc_delete_mp(const char *path, int basepe)
-{
-   return NC3_delete_mp(path, basepe);
-}
-#endif
-
 /* This will return the length of a netcdf data type in bytes. Since
    we haven't added any new types, I just call the v3 function.
    Ed Hartnett 10/43/03
@@ -46,32 +23,14 @@ nc_delete_mp(const char *path, int basepe)
 int
 NC4_set_base_pe(int ncid, int pe)
 {
-#if 0
-   NC *nc;
-   if (!(nc = nc4_find_nc_file(ncid)))
-      return NC_EBADID;
-   if (nc->nc4_info)
       return NC_ENOTNC3;
-   return NC3_set_base_pe(nc->int_ncid,  pe);
-#else
-      return NC_ENOTNC3;
-#endif
 }
 
 /* This function only does anything for netcdf-3 files. */
 int
 NC4_inq_base_pe(int ncid, int *pe)
 {
-#if 0
-   NC *nc;
-   if (!(nc = nc4_find_nc_file(ncid)))
-      return NC_EBADID;
-   if (nc->nc4_info)
-      return NC_ENOTNC3;
-   return NC3_inq_base_pe(nc->int_ncid, pe);
-#else
    return NC_ENOTNC3;
-#endif
 }
 
 /* Get the format (i.e. classic, 64-bit-offset, or netcdf-4) of an
@@ -80,7 +39,7 @@ int
 NC4_inq_format(int ncid, int *formatp)
 {
    NC *nc;
-   NC_HDF5_FILE_INFO_T* h5;
+   NC_HDF5_FILE_INFO_T* nc4_info;
 
    LOG((2, "nc_inq_format: ncid 0x%x", ncid));
 
@@ -88,30 +47,22 @@ NC4_inq_format(int ncid, int *formatp)
       return NC_NOERR;
 
    /* Find the file metadata. */
-   if (!(nc = nc4_find_nc_file(ncid,&h5)))
+   if (!(nc = nc4_find_nc_file(ncid,&nc4_info)))
       return NC_EBADID;
 
 #if 0 /*def USE_PNETCDF*/
    /* Take care of files created/opened with parallel-netcdf library. */
-   if (h5->pnetcdf_file)
+   if (nc4_info->pnetcdf_file)
      return ncmpi_inq_format(nc->int_ncid, formatp);
 #endif /* USE_PNETCDF */
 
-#if 0
-   /* If this isn't a netcdf-4 file, pass this call on to the netcdf-3
-    * library. */
-   if (!nc->nc4_info)
-      return NC3_inq_format(nc->int_ncid, formatp);
-#endif
-   
    /* Otherwise, this is a netcdf-4 file. Check if classic NC3 rules
     * are in effect for this file. */
-   if (h5->cmode & NC_CLASSIC_MODEL)
+   if (nc4_info->cmode & NC_CLASSIC_MODEL)
       *formatp = NC_FORMAT_NETCDF4_CLASSIC;
    else
       *formatp = NC_FORMAT_NETCDF4;
 
    return NC_NOERR;
 }
-
 

--- a/nc_test/test_write.c
+++ b/nc_test/test_write.c
@@ -193,69 +193,47 @@ test_nc_redef(void)
 	error("nc_close: %s", nc_strerror(err));
 
     /* check scratch file written as expected */
-
-    /* These checks don't work for the HDF5 alpha releases so far, but
-     * Quincey tells me this will eventually work. Until then, block
-     * out the tests with the HDF5_ALPHA_RELEASE macro. */
-#ifndef HDF5_ALPHA_RELEASE
     check_file(scratch);  /* checks all except "abc" stuff added above */
-#endif
-    err = nc_open(scratch, NC_NOWRITE, &ncid);
-    IF (err)
+
+    IF ((err = nc_open(scratch, NC_NOWRITE, &ncid)))
         error("nc_open: %s", nc_strerror(err));
-    err = nc_inq_dim(ncid, dimid, name, &length);
-    IF (err) 
+    IF ((err = nc_inq_dim(ncid, dimid, name, &length))) 
 	error("nc_inq_dim: %s", nc_strerror(err));
     IF (strcmp(name, "abc") != 0) 
 	error("Unexpected dim name");
     IF (length != sizehint) 
 	error("Unexpected dim length");
-    err = nc_get_var1_double(ncid, varid, NULL, &var);
-    IF (err)
+    IF ((err = nc_get_var1_double(ncid, varid, NULL, &var)))
         error("nc_get_var1_double: %s", nc_strerror(err));
     IF (var != 1.0)
         error("nc_get_var1_double: unexpected value");
-    err = nc_close(ncid);
-    IF (err)
+    IF ((err = nc_close(ncid)))
         error("nc_close: %s", nc_strerror(err));
 
     /* open scratch file for writing, add another dim, var, att, then check */
-    err = nc_open(scratch, NC_WRITE, &ncid);
-    IF (err)
+    IF ((err = nc_open(scratch, NC_WRITE, &ncid)))
         error("nc_open: %s", nc_strerror(err));
-    err = nc_redef(ncid);
-    IF (err)
+    IF ((err = nc_redef(ncid)))
         error("nc_redef: %s", nc_strerror(err));
-    err = nc_def_dim(ncid, "def", sizehint, &dimid);
-    IF (err)
+    IF ((err = nc_def_dim(ncid, "def", sizehint, &dimid)))
         error("nc_def_dim: %s", nc_strerror(err));
-    err = nc_def_var(ncid, "defScalar", NC_INT, 0, NULL, &varid);
-    IF (err)
+    IF ((err = nc_def_var(ncid, "defScalar", NC_INT, 0, NULL, &varid)))
         error("nc_def_var: %s", nc_strerror(err));
-    err = nc_def_var(ncid, "def", NC_INT, 1, &dimid, &varid1);
-    IF (err)
+    IF ((err = nc_def_var(ncid, "def", NC_INT, 1, &dimid, &varid1)))
         error("nc_def_var: %s", nc_strerror(err));
-    err = nc_put_att_text(ncid, NC_GLOBAL, "Credits", 1+strlen("Thanks!"), 
-			  "Thanks!");
-    IF (err)
+    IF ((err = nc_put_att_text(ncid, NC_GLOBAL, "Credits", 1+strlen("Thanks!"), "Thanks!")))
         error("nc_put_att_text: %s", nc_strerror(err));
-    err = nc_enddef(ncid);
-    IF (err)
+    IF ((err = nc_enddef(ncid)))
         error("nc_enddef: %s", nc_strerror(err));
     var = 2.0;
-    err = nc_put_var1_double(ncid, varid, NULL, &var);
-    IF (err)
+    IF ((err = nc_put_var1_double(ncid, varid, NULL, &var)))
         error("nc_put_var1_double: %s", nc_strerror(err));
-    err = nc_close(ncid);
-    IF (err) 
+    IF ((err = nc_close(ncid))) 
 	error("nc_close: %s", nc_strerror(err));
 
-    /* These checks don't work for the HDF5 alpha releases so far, but
-     * Quincey tells me this will eventually work. Until then, block
-     * out the tests with the HDF5_ALPHA_RELEASE macro. */
-#ifndef HDF5_ALPHA_RELEASE
+    /* check scratch file written as expected */
     check_file(scratch);
-#endif
+
     err = nc_open(scratch, NC_NOWRITE, &ncid);
     IF (err)
         error("nc_open: %s", nc_strerror(err));

--- a/nc_test/util.c
+++ b/nc_test/util.c
@@ -756,9 +756,9 @@ check_dims(int  ncid)
 	IF (err)
 	    error("nc_inq_dim: %s", nc_strerror(err));
 	IF (strcmp(name, dim_name[i]) != 0)
-	    error("Unexpected name of dimension %d", i);
+	    error("Unexpected name of dimension %d: '%s', expected: '%s'", i, name, dim_name[i]);
 	IF (length != dim_len[i])
-	    error("Unexpected length %d of dimension %d", length, i);
+	    error("Unexpected length %d of dimension %d, expected %zu", length, i, dim_len[i]);
     }
 }
 

--- a/ncgen/generate.c
+++ b/ncgen/generate.c
@@ -453,7 +453,7 @@ normalizeopaquelength(NCConstant* prim, unsigned long nbytes)
     } else {/* prim->value.opaquev.len < nnibs => expand*/
         char* s;
 	s = (char*)emalloc(nnibs+1);
-	memset(s,'0',nnibs);
+	memset(s,'0',nnibs);    /* Fill with '0' characters */
 	memcpy(s,prim->value.opaquev.stringv,prim->value.opaquev.len);
 	s[nnibs] = '\0';
 	efree(prim->value.opaquev.stringv);

--- a/ncgen/getfill.c
+++ b/ncgen/getfill.c
@@ -51,10 +51,9 @@ static void
 fill(Symbol* tsym, Datalist* filler)
 {
     int i;
-    NCConstant con;
+    NCConstant con = nullconstant;
     Datalist* sublist;
 
-    con.filled = 0;
     ASSERT(tsym->objectclass == NC_TYPE);
     switch (tsym->subclass) {
     case NC_ENUM: case NC_OPAQUE: case NC_PRIM:
@@ -87,8 +86,7 @@ filllist(Symbol* tsym, Datalist* dl)
 {
     int i;
     Datalist* sublist;
-    NCConstant con;
-    con.filled = 0;
+    NCConstant con = nullconstant;
 
     ASSERT(tsym->objectclass == NC_TYPE);
     switch (tsym->subclass) {

--- a/ncgen/ncgen.y
+++ b/ncgen/ncgen.y
@@ -1172,13 +1172,22 @@ makespecial(int tag, Symbol* vsym, Symbol* tsym, void* data, int isconst)
     Symbol* attr = NULL;
     Datalist* list;
     NCConstant* con;
-    Specialdata* special = (Specialdata*)malloc(sizeof(Specialdata));
     NCConstant iconst;
     int tf = 0;
     char* sdata = NULL;
     int idata =  -1;
 
-    special->flags = 0;
+    if(tag == _FORMAT) {
+        if(vsym != NULL) {
+            derror("_Format: must be global attribute");
+            vsym = NULL;
+        }
+    } else {
+        if(vsym == NULL) {
+	    derror("%s: must have non-NULL vsym", specialname(tag));
+	    return NULL;
+        }
+    }
 
     specials_flag += (tag == _FILLVALUE_FLAG ? 0 : 1);
 
@@ -1189,11 +1198,6 @@ makespecial(int tag, Symbol* vsym, Symbol* tsym, void* data, int isconst)
     } else {
         list = (Datalist*)data;
         con = (NCConstant*)list->data;
-    }
-
-    if(tag == _FORMAT && vsym != NULL) {
-	derror("_Format: must be global attribute");
-	vsym = NULL;
     }
 
     switch (tag) {
@@ -1229,14 +1233,13 @@ makespecial(int tag, Symbol* vsym, Symbol* tsym, void* data, int isconst)
     default: PANIC1("unexpected special tag: %d",tag);
     }
     
-    if(vsym != NULL) special = &vsym->var.special;
     if(tag == _FORMAT_FLAG) {
 	struct Kvalues* kvalue;
-	int found;
-	found = 0;
+	int found = 0;
+
 	/* Use the table in main.c */
-        for(kvalue=legalkinds;kvalue->name;kvalue++) {
-	    if(strcmp(sdata,kvalue->name) == 0) {
+        for(kvalue = legalkinds; kvalue->name; kvalue++) {
+	    if(strcmp(sdata, kvalue->name) == 0) {
 		format_flag = kvalue->k_flag;
 		found = 1;
 	        break;
@@ -1244,79 +1247,86 @@ makespecial(int tag, Symbol* vsym, Symbol* tsym, void* data, int isconst)
 	}
 	if(!found)
 	    derror("_Format: illegal value: %s",sdata);
-    } else if(tag == _FILLVALUE_FLAG) {
-	special->_Fillvalue = list;
-	/* fillvalue must be a single value*/
-	if(list->length != 1)
-	    derror("_FillValue: must be a single (possibly compound) value",
-			vsym->name);
-        /* check that the attribute value contains no fill values*/
-        if(containsfills(list)) {
-	    derror("Attribute data may not contain fill values (i.e. _ )");
-        }
-	/* _FillValue is also a real attribute*/
-	if(vsym->objectclass != NC_VAR) {
-	    derror("_FillValue attribute not associated with variable: %s",vsym->name);
-	}
-	if(tsym  == NULL) tsym = vsym->typ.basetype;
-	else if(vsym->typ.basetype != tsym) {
-	    derror("_FillValue attribute type does not match variable type: %s",vsym->name);
-	}
-	attr=makeattribute(install("_FillValue"),vsym,tsym,list,ATTRVAR);
-    } else switch (tag) {
-        case _STORAGE_FLAG:
-            if(strcmp(sdata,"contiguous") == 0)
-                special->_Storage = NC_CONTIGUOUS;
-            else if(strcmp(sdata,"chunked") == 0)
-                special->_Storage = NC_CHUNKED;
-            else
-                derror("_Storage: illegal value: %s",sdata);
-            special->flags |= _STORAGE_FLAG;
-            break;
-        case _FLETCHER32_FLAG:
-            special->_Fletcher32 = tf;
-            special->flags |= _FLETCHER32_FLAG;
-            break;
-        case _DEFLATE_FLAG:
-            special->_DeflateLevel = idata;
-            special->flags |= _DEFLATE_FLAG;
-            break;
-        case _SHUFFLE_FLAG:
-	    special->_Shuffle = tf;
-            special->flags |= _SHUFFLE_FLAG;
-            break;
-        case _ENDIAN_FLAG:
-            if(strcmp(sdata,"little") == 0)
-                special->_Endianness = 1;
-            else if(strcmp(sdata,"big") == 0)
-                special->_Endianness = 2;
-            else
-                derror("_Endianness: illegal value: %s",sdata);
-            special->flags |= _ENDIAN_FLAG;
-            break;
-        case _NOFILL_FLAG:
-            special->_Fill = (1 - tf); /* negate */
-            special->flags |= _NOFILL_FLAG;
-            break;
-        case _CHUNKSIZES_FLAG: {
-	    int i;
-            special->nchunks = list->length;
-            special->_ChunkSizes = (size_t*)emalloc(sizeof(size_t)*special->nchunks);
-            for(i=0;i<special->nchunks;i++) {
-		iconst.nctype = NC_INT;
-		convert1(&list->data[i],&iconst);
-	        if(iconst.nctype == NC_INT) {
-		    special->_ChunkSizes[i] = (size_t)iconst.value.int32v;
-	        } else
-		    derror("%s: illegal value",specialname(tag));
+    } else {
+        Specialdata* special;
+
+        /* Set up special info */
+        special = &vsym->var.special;
+        special->flags = 0;
+
+        if(tag == _FILLVALUE_FLAG) {
+            special->_Fillvalue = list;
+            /* fillvalue must be a single value*/
+            if(list->length != 1)
+                derror("_FillValue: must be a single (possibly compound) value",
+                            vsym->name);
+            /* check that the attribute value contains no fill values*/
+            if(containsfills(list)) {
+                derror("Attribute data may not contain fill values (i.e. _ )");
             }
-            special->flags |= _CHUNKSIZES_FLAG;
-	    /* Chunksizes => storage == chunked */
-            special->flags |= _STORAGE_FLAG;
-            special->_Storage = NC_CHUNKED;
-            } break;
-        default: PANIC1("makespecial: illegal token: %d",tag);
-     }
+            /* _FillValue is also a real attribute*/
+            if(vsym->objectclass != NC_VAR) {
+                derror("_FillValue attribute not associated with variable: %s",vsym->name);
+            }
+            if(tsym  == NULL) tsym = vsym->typ.basetype;
+            else if(vsym->typ.basetype != tsym) {
+                derror("_FillValue attribute type does not match variable type: %s",vsym->name);
+            }
+            attr=makeattribute(install("_FillValue"),vsym,tsym,list,ATTRVAR);
+        } else switch (tag) {
+            case _STORAGE_FLAG:
+                if(strcmp(sdata,"contiguous") == 0)
+                    special->_Storage = NC_CONTIGUOUS;
+                else if(strcmp(sdata,"chunked") == 0)
+                    special->_Storage = NC_CHUNKED;
+                else
+                    derror("_Storage: illegal value: %s",sdata);
+                special->flags |= _STORAGE_FLAG;
+                break;
+            case _FLETCHER32_FLAG:
+                special->_Fletcher32 = tf;
+                special->flags |= _FLETCHER32_FLAG;
+                break;
+            case _DEFLATE_FLAG:
+                special->_DeflateLevel = idata;
+                special->flags |= _DEFLATE_FLAG;
+                break;
+            case _SHUFFLE_FLAG:
+                special->_Shuffle = tf;
+                special->flags |= _SHUFFLE_FLAG;
+                break;
+            case _ENDIAN_FLAG:
+                if(strcmp(sdata,"little") == 0)
+                    special->_Endianness = 1;
+                else if(strcmp(sdata,"big") == 0)
+                    special->_Endianness = 2;
+                else
+                    derror("_Endianness: illegal value: %s",sdata);
+                special->flags |= _ENDIAN_FLAG;
+                break;
+            case _NOFILL_FLAG:
+                special->_Fill = (1 - tf); /* negate */
+                special->flags |= _NOFILL_FLAG;
+                break;
+            case _CHUNKSIZES_FLAG: {
+                int i;
+                special->nchunks = list->length;
+                special->_ChunkSizes = (size_t*)emalloc(sizeof(size_t)*special->nchunks);
+                for(i=0;i<special->nchunks;i++) {
+                    iconst.nctype = NC_INT;
+                    convert1(&list->data[i],&iconst);
+                    if(iconst.nctype == NC_INT) {
+                        special->_ChunkSizes[i] = (size_t)iconst.value.int32v;
+                    } else
+                        derror("%s: illegal value",specialname(tag));
+                }
+                special->flags |= _CHUNKSIZES_FLAG;
+                /* Chunksizes => storage == chunked */
+                special->flags |= _STORAGE_FLAG;
+                special->_Storage = NC_CHUNKED;
+                } break;
+            default: PANIC1("makespecial: illegal token: %d",tag);
+         }
 
     return attr;
 }
@@ -1403,11 +1413,10 @@ be returned.
 static NCConstant
 evaluate(Symbol* fcn, Datalist* arglist)
 {
-    NCConstant result;
+    NCConstant result = nullconstant;
 
     /* prepare the result */
     result.lineno = fcn->lineno;
-    result.filled = 0;
 
     if(strcasecmp(fcn->name,"time") == 0) {
         char* timekind = NULL;


### PR DESCRIPTION
Refactored read_scale(), memio_new(), var_create_dataset() and makespecial()  to clean up resources properly on failure.

Refactored doubly-linked list code for objects in the libsrc4 directory, cleaning up the add/del routines, breaking out the common next/prev pointers into a struct and extracting the add/del operations on them, changed the list of dims to add new dims in the same order as the other types, made all add routines able to optionally return a pointer to the newly created object.

Removed some dead code (pg_var(), nc4_pg_var1(), nc4_pg_varm(), misc. small routines, etc)

Fixed fill value handling for string types in nc4_get_vara().

Changed many malloc()+strcpy() pairs into calls to strdup().

Cleaned up misc. other minor Coverity issues.
