### PR TITLE
Account for the HDF5 library not having the MPI-POSIX VFD configured in.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -9,6 +9,8 @@ This file contains a high-level description of this package's evolution. Release
 
 ### 4.3.3-rc1 Released TBD
 
+* When the NC_MPIPOSIX flag is given for parallel I/O access and the HDF5 library does not have the MPI-POSIX VFD configured in, the NC_MPIPOSIX flag is transparently aliased to the NC_MPIIO flag within the netCDF-4 library.
+
 ## 4.3.2 Released 2014-04-23
 
 * As part of an ongoing project, the Doxygen-generated netcdf documentation has been reorganized.  The goal is to make the documentation easier to parse, and to eliminate redundant material.  This project is ongoing.

--- a/nc_test4/tst_nc4perf.c
+++ b/nc_test4/tst_nc4perf.c
@@ -244,6 +244,11 @@ int test_pio_4d(size_t cache_size, int facc_type, int access_flag, MPI_Comm comm
    return 0;
 }
 
+/* Note: When the MPI-POSIX VFD is not compiled in to HDF5, the NC_MPIPOSIX
+ *      flag will be aliased to the NC_MPIIO flag within the library, and
+ *      therefore this test will exercise the aliasing, with the MPI-IO VFD,
+ *      under that configuration. -QAK
+ */
 #define NUM_MODES 2
 #define NUM_FACC 2
 #define NUM_CHUNK_COMBOS_2D 3

--- a/nc_test4/tst_parallel3.c
+++ b/nc_test4/tst_parallel3.c
@@ -129,6 +129,11 @@ int main(int argc, char **argv)
    if (mpi_rank == 0)
       SUMMARIZE_ERR;
 
+/* Note: When the MPI-POSIX VFD is not compiled in to HDF5, the NC_MPIPOSIX
+ *      flag will be aliased to the NC_MPIIO flag within the library, and
+ *      therefore this test will exercise the aliasing, with the MPI-IO VFD,
+ *      under that configuration. -QAK
+ */
    if (mpi_rank == 0)
       printf("*** Testing parallel IO for raw-data with MPIPOSIX-IO (driver)...");
    facc_type = NC_NETCDF4|NC_MPIPOSIX;


### PR DESCRIPTION
Patch to account for HDF5 library not having the MPI-POSIX VFD.
