### PR TITLE
Improve cmake exported configuration files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1180,7 +1180,7 @@ configure_file(
 
 install(FILES ${netCDF_BINARY_DIR}/netcdf-config.cmake
   ${netCDF_BINARY_DIR}/netcdf-config-version.cmake
-  DESTINATION share/cmake)
+  DESTINATION share/cmake/netcdf)
 
 
 ###

--- a/netcdf-config-version.cmake.in
+++ b/netcdf-config-version.cmake.in
@@ -1,10 +1,10 @@
 # Cmake Package & Configuration file support.
 # Based on code from 'Mastering Cmake'
 
-set (PACKAGE_VERSION "@version@")
-if (NOT "${PACKAGE_FIND_VERSION}" VERSION_GREATER "@version@")
+set (PACKAGE_VERSION "@VERSION@")
+if (NOT "${PACKAGE_FIND_VERSION}" VERSION_GREATER "@VERSION@")
 	set (PACKAGE_VERSION_COMPATIBLE 1) # Compatible with older.
-	if ("${PACKAGE_FIND_VERSION}" VERSION_EQUAL "@version@")
+	if ("${PACKAGE_FIND_VERSION}" VERSION_EQUAL "@VERSION@")
 		set(PACKAGE_VERSION_EXACT 1) # exact match for this version.
 	endif()
 endif()

--- a/netcdf-config.cmake.in
+++ b/netcdf-config.cmake.in
@@ -11,5 +11,5 @@ include ("${_prefix}/share/cmake/netcdf-targets.cmake")
 # Report other information
 set (netcdf_INCLUDE_DIRS "${_prefix}/include/")
 
-
+set (netcdf_LIBRARIES "netcdf")
 


### PR DESCRIPTION
1. Version was not propagated to netcdf-config-version.cmake
2. The cmake configuration files were installed in a directory that is not one of the standard directories relative to the installation directory that cmake will search in find_package(netcdf NO_MODULE)
3. Set netcdf_LIBRARIES
