### PR TITLE
CMake export files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1438,20 +1438,26 @@ JNA Support:        ${HAS_JNA}
 ")
 
 # Generate file from template.
+include(CMakePackageConfigHelpers)
 set(ConfigPackageLocation ${CMAKE_INSTALL_LIBDIR}/cmake/netCDF)
-CONFIGURE_FILE(
+CONFIGURE_PACKAGE_CONFIG_FILE(
   "${CMAKE_CURRENT_SOURCE_DIR}/netCDFConfig.cmake.in"
   "${CMAKE_CURRENT_BINARY_DIR}/netCDFConfig.cmake"
+  INSTALL_DESTINATION "${ConfigPackageLocation}"
+  NO_CHECK_REQUIRED_COMPONENTS_MACRO
+  PATH_VARS
+  CMAKE_INSTALL_PREFIX
+  CMAKE_INSTALL_INCLUDEDIR
+  CMAKE_INSTALL_LIBDIR
   )
 
 INSTALL(
-  FILES "${netCDF_BINARY_DIR}/netCDFConfig.cmake"
+  FILES "${CMAKE_CURRENT_BINARY_DIR}/netCDFConfig.cmake"
   DESTINATION "${ConfigPackageLocation}"
   COMPONENT Devel
   )
 
 # Create export configuration
-include(CMakePackageConfigHelpers)
 write_basic_package_version_file(
   "${CMAKE_CURRENT_BINARY_DIR}/netCDF/netCDFConfigVersion.cmake"
   VERSION ${netCDF_VERSION}

--- a/netCDFConfig.cmake.in
+++ b/netCDFConfig.cmake.in
@@ -2,11 +2,12 @@
 #
 # General
 #
+@PACKAGE_INIT@
+
 set(NetCDFVersion "@PACKAGE_VERSION@")
-set(CONFIG_DATE "@CONFIG_DATE@")
-set(HOST_SYSTEM "@host_cpu@-@host_vendor@-@host_os@")
-set(BUILD_DIR "@abs_top_builddir@")
-set(netCDF_INSTALL_PREFIX "@CMAKE_INSTALL_PREFIX@")
+set_and_check(netCDF_INSTALL_PREFIX "@PACKAGE_CMAKE_INSTALL_PREFIX@")
+set_and_check(netCDF_INCLUDE_DIR "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@")
+set_and_check(netCDF_LIB_DIR "@PACKAGE_CMAKE_INSTALL_LIBDIR@")
 
 # Compiling Options
 #


### PR DESCRIPTION
This pull request implements proper CMake export functionality as mentioned in bug https://github.com/Unidata/netcdf-fortran/issues/20 and https://github.com/Unidata/netcdf-fortran/issues/17. If any dependent library is built with CMake, it can make use of the HDF5 info.
