### PR TITLE
Drop extra setting of CMAKE_INSTALL_RPATH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -435,8 +435,6 @@ IF(NOT MSVC)
     set(CMAKE_MACOSX_RPATH ON)
   endif(APPLE)
 
-  SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
-
   # add the automatically determined parts of the RPATH
   # which point to directories outside the build tree to the install RPATH
   SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)


### PR DESCRIPTION
This fixes rpath being set to /usr/lib64 on Fedora system builds.  Perhaps a stray merge line.
