### PR TITLE
ncgen: Fix java generation for nan values, use Float.NaN and Double.NaN

### DIFF
--- a/ncgen/jdata.c
+++ b/ncgen/jdata.c
@@ -50,10 +50,18 @@ j_constant(Generator* generator, NCConstant* con, Bytebuffer* buf,...)
 	bbprintf(codetmp,"%d",con->value.int32v);
 	break;
     case NC_FLOAT:
-	bbprintf(codetmp,"%f",con->value.floatv);
+	/* Special case for nan */
+	if(isnan(con->value.floatv))
+	    bbprintf(codetmp,"Float.NaN");
+	else
+	    bbprintf(codetmp,"%f",con->value.floatv);
 	break;
     case NC_DOUBLE:
-	bbprintf(codetmp,"%lf",con->value.doublev);
+	/* Special case for nan */
+	if(isnan(con->value.doublev))
+	    bbprintf(codetmp,"Double.NaN");
+	else
+	    bbprintf(codetmp,"%lf",con->value.doublev);
 	break;
     case NC_UBYTE:
         bbprintf(codetmp,"%hhu",con->value.uint8v);


### PR DESCRIPTION
Java needs Float.NaN to include a nan value, simple fix like example in cdata.c
