### PR TITLE
hyphens used as minus signs

### DIFF
--- a/docs/netcdf.m4
+++ b/docs/netcdf.m4
@@ -426,12 +426,12 @@ INCLUDE(netcdf)
 ifelse(API,C,,
 .SS Most Systems:)
 ifelse(NETCDF4,TRUE,
-COMPILER() ...  -lnetcdf -lhdf5_hl -lhdf5 -lz -lm,
-COMPILER() ... -lnetcdf)
+COMPILER() ...  \-lnetcdf \-lhdf5_hl \-lhdf5 \-lz \-lm,
+COMPILER() ... \-lnetcdf)
 ifelse(API,C,,
 .sp
 .SS CRAY PVP Systems:
-f90 -dp -i64 ... -lnetcdf
+f90 \-dp \-i64 ... \-lnetcdf
 )
 .ad
 .hy
@@ -704,7 +704,7 @@ NVARS() will contain the number of variables,
 NATTS() will contain the number of attributes, and
 UNLIMDIMID() will contain the
 dimension ID of the unlimited dimension if one exists, or
-ifelse(API,C, <<-1>>, <<0>>) otherwise.
+ifelse(API,C, <<\-1>>, <<0>>) otherwise.
 FORMATN() will contain the version number of the dataset <format>, one of
 MACRO(FORMAT_CLASSIC), MACRO(FORMAT_64BIT), MACRO(FORMAT_NETCDF4), or
 MACRO(FORMAT_NETCDF4_CLASSIC).

--- a/ncdump/nccopy.1
+++ b/ncdump/nccopy.1
@@ -7,19 +7,19 @@ nccopy \- Copy a netCDF file, optionally changing format, compression, or chunki
 .HP
 nccopy
 .nh
-\%[-k \fI kind_name \fP]
-\%[-\fIkind_code\fP]
-\%[-d \fI n \fP]
-\%[-s]
-\%[-c \fI chunkspec \fP]
-\%[-u]
-\%[-w]
-\%[-[v|V] var1,...]
-\%[-[g|G] grp1,...]
-\%[-m \fI bufsize \fP]
-\%[-h \fI chunk_cache \fP]
-\%[-e \fI cache_elems \fP]
-\%[-r]
+\%[\-k \fI kind_name \fP]
+\%[\-\fIkind_code\fP]
+\%[\-d \fI n \fP]
+\%[\-s]
+\%[\-c \fI chunkspec \fP]
+\%[\-u]
+\%[\-w]
+\%[\-[v|V] var1,...]
+\%[\-[g|G] grp1,...]
+\%[\-m \fI bufsize \fP]
+\%[\-h \fI chunk_cache \fP]
+\%[\-e \fI cache_elems \fP]
+\%[\-r]
 \%\fI infile \fP
 \%\fI outfile \fP
 .hy
@@ -58,7 +58,7 @@ If DAP support was enabled when \fBnccopy\fP was built, the file name may
 specify a DAP URL. This may be used to convert data on DAP servers to
 local netCDF files.
 .SH OPTIONS
-.IP "\fB -k \fP \fI kind_name \fP"
+.IP "\fB \-k \fP \fI kind_name \fP"
 Use format name to specify the kind of file to be created
 and, by inference, the data model (i.e. netcdf-3 (classic) or
 netcdf-4 (enhanced)).  The possible arguments are:
@@ -91,7 +91,7 @@ The numeric code "7" is used because "7=3+4", specifying the format
 that uses the netCDF-3 data model for compatibility with the netCDF-4
 storage format for performance. Credit is due to NCO for use of these
 numeric codes instead of the old and confusing format numbers.
-.IP "\fB -d \fP \fI n \fP"
+.IP "\fB \-d \fP \fI n \fP"
 For netCDF-4 output, including netCDF-4 classic model, specify
 deflation level (level of compression) for variable data output.  0
 corresponds to no compression and 9 to maximum compression, with
@@ -108,30 +108,30 @@ the input by default.
 Note that \fBnccopy\fP requires all variables to be compressed using the
 same compression level, but the API has no such restriction.  With
 a program you can customize compression for each variable independently.
-.IP "\fB -s \fP"
+.IP "\fB \-s \fP"
 For netCDF-4 output, including netCDF-4 classic model, specify
 shuffling of variable data bytes before compression or after
 decompression.  Shuffling refers to interlacing of bytes in a chunk so
 that the first bytes of all values are contiguous in storage, followed
 by all the second bytes, and so on, which often improves compression.
 This option is ignored unless a non-zero deflation level is specified.
-Using -d0 to specify no deflation on input data that has been
+Using \-d0 to specify no deflation on input data that has been
 compressed and shuffled turns off both compression and shuffling in
 the output.
-.IP "\fB -u \fP"
+.IP "\fB \-u \fP"
 Convert any unlimited size dimensions in the input to fixed size
 dimensions in the output.  This can speed up variable-at-a-time
 access, but slow down record-at-a-time access to multiple variables
 along an unlimited dimension.
-.IP "\fB -w \fP"
+.IP "\fB \-w \fP"
 Keep output in memory (as a diskless netCDF file) until output is
 closed, at which time output file is written to disk.  This can
 greatly speedup operations such as converting unlimited dimension to
-fixed size (-u option), chunking, rechunking, or compressing the
+fixed size (\-u option), chunking, rechunking, or compressing the
 input.  It requires that available memory is large enough to hold the
 output file.  This option may provide a larger speedup than careful
-tuning of the -m, -h, or -e options, and it's certainly a lot simpler.
-.IP "\fB -c \fP \fIchunkspec\fP"
+tuning of the \-m, \-h, or \-e options, and it's certainly a lot simpler.
+.IP "\fB \-c \fP \fIchunkspec\fP"
 For netCDF-4 output, including netCDF-4 classic model, specify
 chunking (multidimensional tiling) for variable data in the output.
 This is useful to specify the units of disk access, compression, or
@@ -153,13 +153,13 @@ unnamed dimensions will also use the actual dimension length for the
 chunk length.  An example of a chunkspec for variables that use 'm'
 and 'n' dimensions might be 'm/100,n/200' to specify 100 by 200
 chunks. To see the chunking resulting from copying with a chunkspec,
-use the '-s' option of ncdump on the output file.
+use the '\-s' option of ncdump on the output file.
 .IP
 The chunkspec '/' that omits all dimension names and
 corresponding chunk lengths specifies that no chunking is to occur in
 the output, so can be used to unchunk all the chunked variables.
 To see the chunking resulting from copying with a chunkspec,
-use the '-s' option of ncdump on the output file.
+use the '\-s' option of ncdump on the output file.
 .IP
 As an I/O optimization, \fBnccopy\fP has a threshold for the minimum size of
 non-record variables that get chunked, currently 8192 bytes.  In the future,
@@ -170,7 +170,7 @@ share the chunk size associated with that dimension, but the
 programming interface has no such restriction.  If you need to
 customize chunking for variables independently, you will need to use
 the library API in a custom utility program.
-.IP "\fB -v \fP \fI var1,... \fP"
+.IP "\fB \-v \fP \fI var1,... \fP"
 The output will include data values for the specified variables, in
 addition to the declarations of all dimensions, variables, and
 attributes. One or more variables must be specified by name in the
@@ -183,7 +183,7 @@ file may be specified with an absolute path name, such as
 "grp/var" specifies all matching variable names in the file.  The
 default, without this option, is to include data values for \fI all \fP variables
 in the output.
-.IP "\fB -V \fP \fI var1,... \fP"
+.IP "\fB \-V \fP \fI var1,... \fP"
 The output will include the specified variables only but all dimensions and
 global or group attributes. One or more variables must be specified by name in the
 comma-delimited list following this option. The list must be a single argument
@@ -194,21 +194,21 @@ an absolute path name, such as '/GroupA/GroupA2/var'.  Use of a relative path
 name such as 'var' or 'grp/var' specifies all matching variable names in the
 file.  The default, without this option, is to include \fI all \fP variables in the
 output.
-.IP "\fB -g \fP \fI grp1,... \fP"
+.IP "\fB \-g \fP \fI grp1,... \fP"
 The output will include data values only for the specified groups.
 One or more groups must be specified by name in the comma-delimited
 list following this option. The list must be a single argument to the
 command. The named groups must be valid netCDF groups in the
 input-file. The default, without this option, is to include data values for all
 groups in the output.
-.IP "\fB -G \fP \fI grp1,... \fP"
+.IP "\fB \-G \fP \fI grp1,... \fP"
 The output will include only the specified groups.
 One or more groups must be specified by name in the comma-delimited
 list following this option. The list must be a single argument to the
 command. The named groups must be valid netCDF groups in the
 input-file. The default, without this option, is to include all groups in the
 output.
-.IP "\fB -m \fP \fI bufsize \fP"
+.IP "\fB \-m \fP \fI bufsize \fP"
 An integer or floating-point number that specifies the size, in bytes,
 of the copy buffer used to copy large variables.  A suffix of K, M, G,
 or T multiplies the copy buffer size by one thousand, million,
@@ -216,9 +216,9 @@ billion, or trillion, respectively.  The default is 5 Mbytes,
 but will be increased if necessary to hold at least one chunk of
 netCDF-4 chunked variables in the input file.  You may want to specify
 a value larger than the default for copying large files over high
-latency networks.  Using the '-w' option may provide better
+latency networks.  Using the '\-w' option may provide better
 performance, if the output fits in memory.
-.IP "\fB -h \fP \fI chunk_cache \fP"
+.IP "\fB \-h \fP \fI chunk_cache \fP"
 For netCDF-4 output, including netCDF-4 classic model, an integer or
 floating-point number that specifies the size in bytes of chunk cache
 allocated for each chunked variable.  This is not a property of the file, but merely
@@ -231,9 +231,9 @@ configure-time constant CHUNK_CACHE_SIZE when the netCDF library was
 built).  Ideally, the \fBnccopy\fP utility should accept only one memory
 buffer size and divide it optimally between a copy buffer and chunk
 cache, but no general algorithm for computing the optimum chunk cache
-size has been implemented yet. Using the '-w' option may provide
+size has been implemented yet. Using the '\-w' option may provide
 better performance, if the output fits in memory.
-.IP "\fB -e \fP \fI cache_elems \fP"
+.IP "\fB \-e \fP \fI cache_elems \fP"
 For netCDF-4 output, including netCDF-4 classic model, specifies
 number of chunks that the chunk cache can hold. A suffix of K, M, G,
 or T multiplies the number of chunks that can be held in the cache
@@ -246,7 +246,7 @@ CHUNK_CACHE_NELEMS when the netCDF library was built).  Ideally, the
 \fBnccopy\fP utility should determine an optimum value for this parameter,
 but no general algorithm for computing the optimum number of chunk
 cache elements has been implemented yet.
-.IP "\fB -r \fP"
+.IP "\fB \-r \fP"
 Read netCDF classic or 64-bit offset input file into a diskless netCDF
 file in memory before copying.  Requires that input file be small
 enough to fit into memory.  For \fBnccopy\fP, this doesn't seem to provide
@@ -272,7 +272,7 @@ Convert a netCDF-4 classic model file, compressed.nc, that uses compression,
 to a netCDF-3 file classic.nc:
 .RS
 .HP
-nccopy -k classic compressed.nc classic.nc
+nccopy \-k classic compressed.nc classic.nc
 .RE
 .LP
 Note that 'nc3' could be used instead of 'classic'.
@@ -292,7 +292,7 @@ Compress all the variables in the input file foo.nc, a netCDF file of any
 type, to the output file bar.nc:
 .RS
 .HP
-nccopy -d1 foo.nc bar.nc
+nccopy \-d1 foo.nc bar.nc
 .RE
 .LP
 If foo.nc was a classic or 64-bit offset netCDF file, bar.nc will be a
@@ -316,7 +316,7 @@ such access.  To chunk the data in the input file slow.nc, a netCDF
 file of any type, to the output file fast.nc, you could use;
 .RS
 .HP
-nccopy -c time/1000,lat/40,lon/40 slow.nc fast.nc
+nccopy \-c time/1000,lat/40,lon/40 slow.nc fast.nc
 .RE
 .LP
 to specify data chunks of 1000 times, 40 latitudes, and 40 longitudes.
@@ -325,7 +325,7 @@ up the rechunking operation significantly by creating the output in
 memory before writing it to disk on close:
 .RS
 .HP
-nccopy -w -c time/1000,lat/40,lon/40 slow.nc fast.nc
+nccopy \-w \-c time/1000,lat/40,lon/40 slow.nc fast.nc
 .RE
 .SH "SEE ALSO"
 .LP

--- a/ncdump/ncdump.1
+++ b/ncdump/ncdump.1
@@ -7,14 +7,14 @@ ncdump \- Convert netCDF file to text form (CDL)
 .HP
 ncdump
 .nh
-\%[-chistxw]
-\%[-v \fIvar1,...\fP]
-\%[-b \fIlang\fP]
-\%[-f \fIlang\fP]
-\%[-l \fIlen\fP]
-\%[-n \fIname\fP]
-\%[-p \fIf_digits[,d_digits]\fP]
-\%[-g \fIgrp1,...\fP]
+\%[\-chistxw]
+\%[\-v \fIvar1,...\fP]
+\%[\-b \fIlang\fP]
+\%[\-f \fIlang\fP]
+\%[\-l \fIlen\fP]
+\%[\-n \fIname\fP]
+\%[\-p \fIf_digits[,d_digits]\fP]
+\%[\-g \fIgrp1,...\fP]
 \%\fIfile\fP
 .br
 .ft B
@@ -39,7 +39,7 @@ data representation between binary and text representations.  See
 representations.
 .LP
 \fBncdump\fP may also be used to determine what kind of netCDF file is used
-(which variant of the netCDF file format) with the -k option.
+(which variant of the netCDF file format) with the \-k option.
 .LP
 If DAP support was enabled when \fBncdump\fP was built, the file name
 may specify a DAP URL. This allows \fBncdump\fP to access data sources
@@ -121,19 +121,19 @@ be used.  If \fIlang\fP begins with `F' or `f', then Fortran language
 conventions will be used.  In either case, the data will be presented
 in the same order; only the annotations will differ.  This option may
 be useful for piping data into other filters, since each data value
-appears on a separate line, fully identified. (At most one of '-b' or '-f' options may be present.)
+appears on a separate line, fully identified. (At most one of '\-b' or '\-f' options may be present.)
 .IP "\fB-l\fP \fIlength\fP"
 Changes the default maximum line length (80) used in formatting lists of
 non-character data values.
 .IP "\fB-n\fP \fIname\fP"
-CDL requires a name for a netCDF file, for use by \fBncgen -b\fP in
+CDL requires a name for a netCDF file, for use by \fBncgen \-b\fP in
 generating a default netCDF file name.  By default, \fIncdump\fP constructs
 this name from the last component of the file name of the input netCDF file
 by stripping off any extension it has.  Use the \fB-n\fP option to specify a
-different name.  Although the output file name used by \fBncgen -b\fP can be
+different name.  Although the output file name used by \fBncgen \-b\fP can be
 specified, it may be wise to have \fIncdump\fP change the default name to
 avoid inadvertently overwriting a valuable netCDF file when using
-\fBncdump\fP, editing the resulting CDL file, and using \fBncgen -b\fP to
+\fBncdump\fP, editing the resulting CDL file, and using \fBncgen \-b\fP to
 generate a new netCDF file from the edited CDL file.
 .IP "\fB-p\fP \fIfloat_digits[,double_digits]\fP"
 Specifies default precision (number of significant digits) to use in
@@ -163,8 +163,8 @@ format variant 2).  NetCDF-4, uses a third variant of the format,
 to features supported by the netCDF-3 data model but represented using
 the HDF5 format, so that an unmodified netCDF-3 program can read or
 write the file just by relinking with the netCDF-4 library.  
-The string output by using the `-k' option may be provided as the
-value of the `-k' option to ncgen(1) to
+The string output by using the `\-k' option may be provided as the
+value of the `\-k' option to ncgen(1) to
 specify exactly what kind of netCDF file to generate, when you want to
 override the default inferred from the CDL.
 .IP "\fB-s\fP"
@@ -212,7 +212,7 @@ values interpreted with this option include the CF Conventions values
 `gregorian' or `standard', `proleptic_gregorian', `noleap' or `365_day',
 `all_leap' or `366_day', `360_day', and `julian'.
 .IP "\fB-i\fP"
-Same as the '-t' option, except output time data as date-time strings
+Same as the '\-t' option, except output time data as date-time strings
 with ISO-8601 standard 'T' separator, instead of a blank.
 .IP "\fB-g\fP \fIgrp1,...\fP"
 For netCDF-4 files, the output will include data values only for the
@@ -235,14 +235,14 @@ The NcML output option currently only works for netCDF classic model data.
 Look at the structure of the data in the netCDF file `\fBfoo.nc\fP':
 .RS
 .HP
-ncdump -c foo.nc
+ncdump \-c foo.nc
 .RE
 .LP
 Produce an annotated CDL version of the structure and data in the
 netCDF file `\fBfoo.nc\fP', using C-style indexing for the annotations:
 .RS
 .HP
-ncdump -b c foo.nc > foo.cdl
+ncdump \-b c foo.nc > foo.cdl
 .RE
 .LP
 Output data for only the variables `uwind' and `vwind' from the netCDF file
@@ -250,7 +250,7 @@ Output data for only the variables `uwind' and `vwind' from the netCDF file
 digits of precision:
 .RS
 .HP
-ncdump -v uwind,vwind -p 3 foo.nc
+ncdump \-v uwind,vwind \-p 3 foo.nc
 .RE
 .LP
 Produce a fully-annotated (one data value per line) listing of the data for
@@ -258,7 +258,7 @@ the variable `omega', using Fortran conventions for indices, and changing the
 netCDF dataset name in the resulting CDL file to `omega':
 .RS
 .HP
-ncdump -v omega -f fortran -n omega foo.nc > Z.cdl
+ncdump \-v omega \-f fortran \-n omega foo.nc > Z.cdl
 .RE
 .SH "SEE ALSO"
 .LP

--- a/ncgen/ncgen.1
+++ b/ncgen/ncgen.1
@@ -6,15 +6,15 @@ ncgen \- From a CDL file generate a netCDF-3 file, a netCDF-4 file or a C progra
 .HP
 ncgen
 .nh
-\%[-b]
-\%[-c]
-\%[-f]
-\%[-k \fIformat_name\fP]
-\%[-\fIformat_code\fP]
-\%[-l \fIoutput language\fP]
-\%[-n]
-\%[-o \fInetcdf_filename\fP]
-\%[-x]
+\%[\-b]
+\%[\-c]
+\%[\-f]
+\%[\-k \fIformat_name\fP]
+\%[\-\fIformat_code\fP]
+\%[\-l \fIoutput language\fP]
+\%[\-n]
+\%[\-o \fInetcdf_filename\fP]
+\%[\-x]
 \%[\fIinput_file\fP]
 .hy
 .ft
@@ -53,27 +53,27 @@ Generate
 .B C
 source code that will create a netCDF file
 matching the netCDF specification.  The C source code is written to
-standard output; equivalent to -lc.
+standard output; equivalent to \-lc.
 .IP "\fB-f\fP"
 Generate
 .B FORTRAN 77
 source code that will create a netCDF file
 matching the netCDF specification.
 The source code is written to
-standard output; equivalent to -lf77.
+standard output; equivalent to \-lf77.
 .IP "\fB-o\fP \fRnetcdf_file\fP"
 Name of the file to pass to calls to "nc_create()".
 If this option is specified it implies
-(in the absense of any explicit -l flag) the "\fB-b\fP" option.
+(in the absense of any explicit \-l flag) the "\fB-b\fP" option.
 This option is necessary because netCDF files
 cannot be written directly to standard output, since standard output is not
 seekable.
 .IP "\fB-k \fIformat_name\fP"
 .IP "\fB-\fIformat_code\fP"
-The -k flag specifies the format of the file to be created and, by inference,
+The \-k flag specifies the format of the file to be created and, by inference,
 the data model accepted by ncgen (i.e. netcdf-3 (classic) versus
 netcdf-4). As a shortcut, a numeric \fIformat_code\fP may be specified instead.
-The possible \fIformat_name\fP values for the -k option are:
+The possible \fIformat_name\fP values for the \-k option are:
 .RS
 .RS
 .IP "'classic' or 'nc3' => netCDF classic format"
@@ -101,14 +101,14 @@ to the format names 'nc3', 'nc6', 'nc4', or 'nc7' respectively, are
 also still accepted but deprecated, due to easy confusion between
 format numbers and format names. Various old format name aliases are
 also accepted but deprecated, e.g. 'hdf5', 'enhanced-nc3', etc.
-Also, note that -v is accepted to mean the same thing as
--k for backward compatibility.
+Also, note that \-v is accepted to mean the same thing as
+\-k for backward compatibility.
 .IP "\fB-x\fP"
 Don't initialize data with fill values.  This can speed up creation of
 large netCDF files greatly, but later attempts to read unwritten data
 from the generated file will not be easily detectable.
 .IP "\fB-l \fRoutput_language\fP"
-The -l flag specifies the output language to use
+The \-l flag specifies the output language to use
 when generating source code that will create or define a netCDF file
 matching the netCDF specification.
 The output is written to standard output.
@@ -136,29 +136,29 @@ not just special performance-related attributes such as
 The rules are as follows, in order of application.
 .IP "\fB1.\fP"
 If either Fortran or Java output is specified,
-then -k flag value of 1 (classic model) will be used.
+then \-k flag value of 1 (classic model) will be used.
 Conflicts with the use of enhanced constructs
 in the CDL will report an error.
 .IP "\fB2.\fP"
-If both the -k flag and _Format attribute are specified,
+If both the \-k flag and _Format attribute are specified,
 the _Format flag will be ignored.
-If no -k flag is specified, and a _Format attribute value
-is specified, then the -k flag value 
+If no \-k flag is specified, and a _Format attribute value
+is specified, then the \-k flag value 
 will be set to that of the _Format attribute.
-Otherwise the -k flag is undefined.
+Otherwise the \-k flag is undefined.
 .IP "\fB3.\fP"
-If the -k option is defined and is consistent with the CDL,
+If the \-k option is defined and is consistent with the CDL,
 ncgen will output a file in the requested form,
 else an error will be reported.
 .IP "\fB4.\fP"
-If the -k flag is undefined,
+If the \-k flag is undefined,
 and if there are netCDF-4 constructs in the CDL,
-a -k flag value of 3 (enhanced model) will be used.
+a \-k flag value of 3 (enhanced model) will be used.
 .IP "\fB5.\fP"
 If special performance-related attributes are specified in the CDL, 
-a -k flag value of 4 (netCDF-4 classic model) will be used.
+a \-k flag value of 4 (netCDF-4 classic model) will be used.
 .IP "\fB6.\fP"
-Otherwise ncgen will set the -k flag to 1 (classic model).
+Otherwise ncgen will set the \-k flag to 1 (classic model).
 .RE
 .SH EXAMPLES
 .LP
@@ -172,7 +172,7 @@ From the CDL file `\fBfoo.cdl\fP', generate an equivalent binary netCDF file
 named `\fBx.nc\fP':
 .RS
 .HP
-ncgen -o x.nc foo.cdl
+ncgen \-o x.nc foo.cdl
 .RE
 .LP
 From the CDL file `\fBfoo.cdl\fP', generate a C program containing the
@@ -180,7 +180,7 @@ netCDF function invocations necessary to create an equivalent binary netCDF
 file named `\fBx.nc\fP':
 .RS
 .HP
-ncgen -lc foo.cdl >x.c
+ncgen \-lc foo.cdl >x.c
 .RE
 .LP
 .SH USAGE
@@ -223,12 +223,12 @@ netcdf foo {  // an example netCDF specification in CDL
 	// typed variable attributes
 	\fIstring\fP Z:units = "geopotential meters";
 	\fIfloat\fP Z:valid_range = 0., 5000.;
-	\fIdouble\fP p:_FillValue = -9999.;
-	\fIlong\fP rh:_FillValue = -1;
+	\fIdouble\fP p:_FillValue = \-9999.;
+	\fIlong\fP rh:_FillValue = \-1;
 	\fIvlen_t\fP :globalatt = {17, 18, 19};
 \fBdata\fP:
 	lat   = 0, 10, 20, 30, 40, 50, 60, 70, 80, 90;
-	lon   = -140, -118, -96, -84, -52;
+	lon   = \-140, \-118, \-96, \-84, \-52;
 \fBgroup\fP: g {
 \fBtypes\fP:
     \fIcompound\fP cmpd_t { \fIvlen_t\fP f1; \fIenum_t\fP f2;};
@@ -417,12 +417,12 @@ mays for character data.
 declarations in the output C code and to the nonstandard \fBBYTE\fP
 declaration in output Fortran code.
 .LP
-Shorts can hold values between -32768 and 32767.
+Shorts can hold values between \-32768 and 32767.
 \fBncgen\fP converts \fBshort\fP declarations to \fBshort\fP
 declarations in the output C code and to the nonstandard \fBINTEGER*2\fP
 declaration in output Fortran code.
 .LP
-Ints can hold values between -2147483648 and 2147483647.
+Ints can hold values between \-2147483648 and 2147483647.
 \fBncgen\fP converts \fBint\fP declarations to \fBint\fP
 declarations in the output C code and to \fBINTEGER\fP
 declarations in output Fortran code.  \fBlong\fP
@@ -430,20 +430,20 @@ is accepted as a synonym for \fBint\fP in CDL declarations, but is
 deprecated since there are now platforms with 64-bit representations
 for C longs.
 .LP
-Int64 can hold values between -9223372036854775808
+Int64 can hold values between \-9223372036854775808
 and 9223372036854775807.
 \fBncgen\fP converts \fBint64\fP declarations to \fBlonglong\fP
 declarations in the output C code.
 .\" and to \fBINTEGER\fP declarations in output Fortran code.
 .LP
-Floats can hold values between about -3.4+38 and 3.4+38.  Their
+Floats can hold values between about \-3.4+38 and 3.4+38.  Their
 external representation is as 32-bit IEEE normalized single-precision
 floating point numbers.  \fBncgen\fP converts \fBfloat\fP
 declarations to \fBfloat\fP declarations in the output C code and to
 \fBREAL\fP declarations in output Fortran code.  \fBreal\fP is accepted
 as a synonym for \fBfloat\fP in CDL declarations.
 .LP
-Doubles can hold values between about -1.7+308 and 1.7+308.  Their
+Doubles can hold values between about \-1.7+308 and 1.7+308.  Their
 external representation is as 64-bit IEEE standard normalized
 double-precision floating point numbers.  \fBncgen\fP converts
 \fBdouble\fP declarations to \fBdouble\fP declarations in the output C
@@ -490,8 +490,8 @@ constants include:
 .RS
 .nf
  0b             // a zero byte
- -1b            // -1 as an 8-bit byte
- 255b           // also -1 as a signed 8-bit byte
+ \-1b            // \-1 as an 8-bit byte
+ 255b           // also \-1 as a signed 8-bit byte
 .fi
 .RE
 .LP
@@ -502,7 +502,7 @@ begins with `0', it is interpreted as octal, except that if it begins with
 `0x', it is interpreted as a hexadecimal constant.  For example:
 .RS
 .nf
--2s	// a short -2
+\-2s	// a short \-2
 0123s	// octal
 0x7ffs  //hexadecimal
 .fi
@@ -518,7 +518,7 @@ constant (but see opaque constants below).
 Examples of valid \fIint\fP constants include:
 .RS
 .nf
--2
+\-2
 1234567890L
 0123		// octal
 0x7ff		// hexadecimal
@@ -532,7 +532,7 @@ begins with `0', it is interpreted as octal, except that if it begins with
 `0x', it is interpreted as a hexadecimal constant.  For example:
 .RS
 .nf
--2ll	// an unsigned -2
+\-2ll	// an unsigned \-2
 0123LL	// octal
 0x7ffLL  //hexadecimal
 .fi
@@ -545,7 +545,7 @@ constant with an `f' or `F' appended.  For example the following
 are all acceptable \fIfloat\fP constants:
 .RS
 .nf
--2.0f
+\-2.0f
 3.14159265358979f	// will be truncated to less precision
 1.f
 
@@ -559,7 +559,7 @@ floating point constant.  An optional `d' or `D' may be appended.
 For example the following are all acceptable \fIdouble\fP constants:
 .RS
 .nf
--2.0
+\-2.0
 3.141592653589793
 1.0e-20
 1.d

--- a/ncgen3/ncgen3.1
+++ b/ncgen3/ncgen3.1
@@ -7,13 +7,13 @@ a C program, or a Fortran program
 .HP
 ncgen3
 .nh
-\%[-b]
-\%[-c]
-\%[-f]
-\%[-k \fIkind_of_file\fP]
-\%[-x]
-\%[-n]
-\%[-o \fInetcdf_filename\fP]
+\%[\-b]
+\%[\-c]
+\%[\-f]
+\%[\-k \fIkind_of_file\fP]
+\%[\-x]
+\%[\-n]
+\%[\-o \fInetcdf_filename\fP]
 \%\fIinput_file\fP
 .hy
 .ft
@@ -58,15 +58,15 @@ the "\fB-b\fP" option.  (This option is necessary because netCDF files
 cannot be written directly to standard output, since standard output is not
 seekable.)
 .IP "\fB-k \fRkind_of_file\fP"
-Using -k2 or -k "64-bit offset" specifies that
+Using \-k2 or \-k "64-bit offset" specifies that
 generated file (or program) should use version 2 of format that
 employs 64-bit file offsets.  The default is to use version 1
 ("classic") format with 32-bit file offsets, although this limits the
 size of the netCDF file, variables, and records to the sizes supported
 by the classic format.  (NetCDF-4 will support additional kinds of
 netCDF files, "netCDF-4" and "netCDF-4 classic model".)
-Note: -v is also accepted to mean the same thing as
--k for backward compatibility, but -k is preferred, to match
+Note: \-v is also accepted to mean the same thing as
+\-k for backward compatibility, but \-k is preferred, to match
 the corresponding ncdump option. 
 .IP "\fB-x\fP"
 Don't initialize data with fill values.  This can speed up creation of
@@ -84,7 +84,7 @@ From the CDL file `\fBfoo.cdl\fP', generate an equivalent binary netCDF file
 named `\fBx.nc\fP':
 .RS
 .HP
-ncgen3 -o x.nc foo.cdl
+ncgen3 \-o x.nc foo.cdl
 .RE
 .LP
 From the CDL file `\fBfoo.cdl\fP', generate a C program containing the
@@ -92,7 +92,7 @@ netCDF function invocations necessary to create an equivalent binary netCDF
 file named `\fBx.nc\fP':
 .RS
 .HP
-ncgen3 -c -o x.nc foo.cdl
+ncgen3 \-c \-o x.nc foo.cdl
 .RE
 .LP
 .SH USAGE
@@ -126,12 +126,12 @@ attributes so that the data would be more completely self-describing.)
 	time:units = "seconds since 1992-1-1 00:00:00";
 	Z:units = "geopotential meters";
 	Z:valid_range = 0., 5000.;
-	p:_FillValue = -9999.;
-	rh:_FillValue = -1;
+	p:_FillValue = \-9999.;
+	rh:_FillValue = \-1;
 
 \fBdata\fP:
 	lat   = 0, 10, 20, 30, 40, 50, 60, 70, 80, 90;
-	lon   = -140, -118, -96, -84, -52;
+	lon   = \-140, \-118, \-96, \-84, \-52;
 }
 .fi
 .RE
@@ -235,12 +235,12 @@ does for character data.
 declarations in the output C code and to the nonstandard \fBBYTE\fP
 declaration in output Fortran code.
 .LP
-Shorts can hold values between -32768 and 32767.
+Shorts can hold values between \-32768 and 32767.
 \fBncgen3\fP converts \fBshort\fP declarations to \fBshort\fP
 declarations in the output C code and to the nonstandard \fBINTEGER*2\fP
 declaration in output Fortran code.
 .LP
-Longs can hold values between -2147483648 and 2147483647.
+Longs can hold values between \-2147483648 and 2147483647.
 \fBncgen3\fP converts \fBlong\fP declarations to \fBlong\fP
 declarations in the output C code and to \fBINTEGER\fP
 declarations in output Fortran code.  \fBint\fP and \fBinteger\fP are
@@ -248,14 +248,14 @@ accepted as synonyms for \fBlong\fP in CDL declarations.
 Now that there are platforms with 64-bit representations for C longs, it may
 be better to use the \fBint\fP synonym to avoid confusion.
 .LP
-Floats can hold values between about -3.4+38 and 3.4+38.  Their
+Floats can hold values between about \-3.4+38 and 3.4+38.  Their
 external representation is as 32-bit IEEE normalized single-precision
 floating point numbers.  \fBncgen3\fP converts \fBfloat\fP
 declarations to \fBfloat\fP declarations in the output C code and to
 \fBREAL\fP declarations in output Fortran code.  \fBreal\fP is accepted
 as a synonym for \fBfloat\fP in CDL declarations.
 .LP
-Doubles can hold values between about -1.7+308 and 1.7+308.  Their
+Doubles can hold values between about \-1.7+308 and 1.7+308.  Their
 external representation is as 64-bit IEEE standard normalized
 double-precision floating point numbers.  \fBncgen3\fP converts
 \fBdouble\fP declarations to \fBdouble\fP declarations in the output C
@@ -308,7 +308,7 @@ begins with `0', it is interpreted as octal, except that if it begins with
 `0x', it is interpreted as a hexadecimal constant.  For example:
 .RS
 .nf
--2s	// a short -2
+\-2s	// a short \-2
 0123s	// octal
 0x7ffs  //hexadecimal
 .fi
@@ -322,7 +322,7 @@ octal, except that if it begins with `0x', it is interpreted as a hexadecimal
 constant.  Examples of valid \fIlong\fP constants include:
 .RS
 .nf
--2
+\-2
 1234567890L
 0123		// octal
 0x7ff		// hexadecimal
@@ -336,7 +336,7 @@ constant with an `f' or `F' appended.  For example the following
 are all acceptable \fIfloat\fP constants:
 .RS
 .nf
--2.0f
+\-2.0f
 3.14159265358979f	// will be truncated to less precision
 1.f
 
@@ -350,7 +350,7 @@ floating point constant.  An optional `d' or `D' may be appended.
 For example the following are all acceptable \fIdouble\fP constants:
 .RS
 .nf
--2.0
+\-2.0
 3.141592653589793
 1.0e-20
 1.d


### PR DESCRIPTION
Fixes `-` signs on manpages.
See <https://lintian.debian.org/tags/hyphen-used-as-minus-sign.html>.