### PR TITLE
Fix another hyphen-used-as-minus-sign issue in nccopy.1 man page.

### DIFF
--- a/ncdump/nccopy.1
+++ b/ncdump/nccopy.1
@@ -37,7 +37,7 @@ a netCDF-4 classic model file as well, permitting data compression,
 efficient schema changes, larger variable sizes, and use of other
 netCDF-4 features.
 .LP
-If no output format is specified, with either -k \fIkind_name\fP
+If no output format is specified, with either \-k \fIkind_name\fP
 or \fI-kind_code\fP, then the output will use the same
 format as the input, unless the input is classic or 64-bit offset
 and either chunking or compression is specified, in which case the


### PR DESCRIPTION
Most of these issues were fixed in #101, but the patch included in the Debian package and forwarded in the PR was updated afterward to include this remaining issue.