### PR TITLE
Remove error check for NC_INT64 type

### DIFF
--- a/libsrc5/nc5dispatch.c
+++ b/libsrc5/nc5dispatch.c
@@ -564,10 +564,6 @@ NC5_get_vara(int ncid,
     nc5 = NC5_DATA(nc);
     assert(nc5);
 
-    /* No NC_LONG for parallel-netcdf library! */
-    if(memtype == NC_INT64)
-	 return NC_EINVAL;
-
     /* get variable's rank */
     status= ncmpi_inq_varndims(nc->int_ncid, varid, &rank);
     if(status) return status;
@@ -644,10 +640,6 @@ NC5_put_vara(int ncid,
 
     nc5 = NC5_DATA(nc);
     assert(nc5);
-
-    /* No NC_LONG for parallel-netcdf library! */
-    if(memtype == NC_INT64)
-	 return NC_EINVAL;
 
     /* get variable's rank */
     status = ncmpi_inq_varndims(nc->int_ncid, varid, &rank);


### PR DESCRIPTION
There is a case that handles a memtype of NC_INT64, so the code
should not error out if that memtype is passed in.  This type is also handled in the other file types, so not sure why it should
cause invalid values error in parallel-netcdf mode.