### PR TITLE
install .def to /bin

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -176,7 +176,7 @@ install-data-hook:
 #endif
 
 if BUILD_DLL
-	cp liblib/netcdfdll.def $(DESTDIR)${prefix}/lib
+	cp liblib/netcdfdll.def $(DESTDIR)${prefix}/bin
 endif # BUILD_DLL
 	@echo ''
 	@echo '+-------------------------------------------------------------+'


### PR DESCRIPTION
this is the standard, the .def along with the export lib .dll in /bin, and the import lib or static lib in /lib