### PR TITLE
correct logical mistakes on nc_def_var_deflate

### DIFF
--- a/libsrc4/nc4var.c
+++ b/libsrc4/nc4var.c
@@ -861,7 +861,7 @@ nc_def_var_extra(int ncid, int varid, int *shuffle, int *deflate,
       return NC_ELATEDEF;
 
    /* Check compression options. */
-   if (deflate && !deflate_level)
+   if (!deflate || !deflate_level)
       return NC_EINVAL;      
        
    /* Valid deflate level? */


### PR DESCRIPTION
I expected that turn off the deflate filter
if deflate argument is zero with non-zero deflate_level value.