### PR TITLE
Fix inconsistent return type.

### DIFF
--- a/oc2/oc.h
+++ b/oc2/oc.h
@@ -537,7 +537,7 @@ extern OCerror oc_svcerrordata(OClink link, char** codep,
    note that this may or may not be the same as returned
    by oc_svcerrordata.
  */
-extern int oc_httpcode(OClink);
+extern OCerror oc_httpcode(OClink);
 
 /*
 (Re-)initialize the oc library as if nothing had been called.

--- a/oc2/ochttp.c
+++ b/oc2/ochttp.c
@@ -88,11 +88,11 @@ fail:
 	return OCTHROW(OC_ECURL);
 }
 
-int
+OCerror
 ocfetchurl(CURL* curl, const char* url, OCbytes* buf, long* filetime,
            struct OCcredentials* creds)
 {
-	int stat = OC_NOERR;
+	OCerror stat = OC_NOERR;
 	CURLcode cstat = CURLE_OK;
 	size_t len;
         long httpcode = 0;

--- a/oc2/ocrc.c
+++ b/oc2/ocrc.c
@@ -408,10 +408,10 @@ done:
     return stat;
 }
 
-int
+OCerror
 ocrc_process(OCstate* state)
 {
-    int stat = 0;
+    OCerror stat = OC_NOERR;
     char* value = NULL;
     OCURI* uri = state->uri;
     char* url_userpwd = NULL;


### PR DESCRIPTION
As reported in [Debian Bug #749511](https://bugs.debian.org/749511), inconsistent return types can cause the build to fail (when using tools from the [cbmc](https://tracker.debian.org/pkg/cbmc) package).

This PR forwards the three patches by Michael Tautschnig, who also reported the issue in Debian.