### PR TITLE
Classic h5  -- Fix compliance with classic model when using netcdf-4-classic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,14 @@ SET(netCDF_LIB_VERSION 7.3.0)
 SET(netCDF_SO_VERSION 7)
 SET(PACKAGE_VERSION ${VERSION})
 
+#####
+# System inspection checks
+#####
+INCLUDE_DIRECTORIES(${CMAKE_SOURCE_DIR}/include)
+INCLUDE_DIRECTORIES(${CMAKE_SOURCE_DIR}/oc2)
+INCLUDE_DIRECTORIES(${CMAKE_SOURCE_DIR}/libsrc)
+SET(CMAKE_REQUIRED_INCLUDES ${CMAKE_SOURCE_DIR}/libsrc)
+
 # Get system configuration, Use it to determine osname, os release, cpu. These
 # will be used when committing to CDash.
 find_program(UNAME NAMES uname)
@@ -986,13 +994,6 @@ MARK_AS_ADVANCED(ENABLE_DOXYGEN_BUILD_RELEASE_DOCS DOXYGEN_ENABLE_TASKS ENABLE_D
 # Option checks
 ################################
 
-#####
-# System inspection checks
-#####
-INCLUDE_DIRECTORIES(${CMAKE_SOURCE_DIR}/include)
-INCLUDE_DIRECTORIES(${CMAKE_SOURCE_DIR}/oc2)
-INCLUDE_DIRECTORIES(${CMAKE_SOURCE_DIR}/libsrc)
-SET(CMAKE_REQUIRED_INCLUDES ${CMAKE_SOURCE_DIR}/libsrc)
 
 #
 # Library include checks

--- a/libsrc4/nc4var.c
+++ b/libsrc4/nc4var.c
@@ -391,8 +391,8 @@ nc_def_var_nc4(int ncid, const char *name, nc_type xtype,
       BAIL(NC_EINVAL);
 
    /* Classic model files have a limit on number of vars. */
-   if(h5->cmode & NC_CLASSIC_MODEL && grp->nvars >= NC_MAX_VARS)
-     BAIL(NC_EMAXVARS);
+   if(h5->cmode & NC_CLASSIC_MODEL && h5->nvars >= NC_MAX_VARS)
+      BAIL(NC_EMAXVARS);
 
    /* Check that this name is not in use as a var, grp, or type. */
    if ((retval = nc4_check_dup_name(grp, norm_name)))

--- a/libsrc4/nc4var.c
+++ b/libsrc4/nc4var.c
@@ -391,8 +391,8 @@ nc_def_var_nc4(int ncid, const char *name, nc_type xtype,
       BAIL(NC_EINVAL);
 
    /* Classic model files have a limit on number of vars. */
-   if(h5->cmode & NC_CLASSIC_MODEL && h5->nvars >= NC_MAX_VARS)
-      BAIL(NC_EMAXVARS);
+   if(h5->cmode & NC_CLASSIC_MODEL && grp->nvars >= NC_MAX_VARS)
+     BAIL(NC_EMAXVARS);
 
    /* Check that this name is not in use as a var, grp, or type. */
    if ((retval = nc4_check_dup_name(grp, norm_name)))


### PR DESCRIPTION
Fix compliance with classic model -- The check to determine whether NC_MAX_VARS has been 
exceeded was using h5->nvars which seems to be unused.  The variable count instead is maintained
in grp->nvars for each group (in classic mode, there is only one group)

It may be that the real bug is that h5->nvars is not being incremented correctly and it is supposed
to contain the global var count (sum of the groups var counts).

If h5->nvars is not supposed to be used and grp->nvars is the new way of maintaing the count, then perhaps "nvars" should be removed from the h5 struct to avoid future confusion.

