### PR TITLE
NetCDF-c Github issue #178

### DIFF
--- a/cf
+++ b/cf
@@ -3,9 +3,6 @@
 DB=1
 #X=-x
 FAST=1
-#CYGWIN=1
-
-FAST=1
 
 HDF5=1
 DAP=1
@@ -130,10 +127,6 @@ FLAGS="$FLAGS --enable-jna"
 
 if test "x$PAR4" != x1 ; then
 FLAGS="$FLAGS --disable-parallel4"
-fi
-
-if test "x$CYGWIN" = x1 ; then
-FLAGS="$FLAGS --enable-workaround"
 fi
 
 if test "x${DB}" = x1 ; then

--- a/ncdump/cdl/Makefile.am
+++ b/ncdump/cdl/Makefile.am
@@ -24,7 +24,7 @@ ref_tst_opaque_data.cdl  \
 ref_tst_vlen_data.cdl ref_tst_vlen_data2.cdl \
 ref_niltest.cdl ref_tst_h_scalar.cdl ref_tst_econst.cdl \
 ref_tst_nul3.cdl ref_tst_nul4.cdl ref_tst_names.cdl \
-ref_tst_long_charconst.cdl tst_chararray.cdl \
+ref_tst_long_charconst.cdl tst_chararray.cdl ref_keyword.cdl \
 CMakeLists.txt
 
 

--- a/ncdump/cdl/ref_keyword.cdl
+++ b/ncdump/cdl/ref_keyword.cdl
@@ -1,0 +1,9 @@
+netcdf file {
+variables:
+int data;
+data : _FillValue = 0;
+
+data:
+
+data = 177;
+}

--- a/ncdump/expected/Makefile.am
+++ b/ncdump/expected/Makefile.am
@@ -20,7 +20,7 @@ ref_solar.dmp unlimtest1.dmp unlimtest2.dmp \
 ref_tst_vlen_data.dmp ref_tst_vlen_data2.dmp \
 ref_niltest.dmp ref_tst_h_scalar.dmp ref_tst_econst.dmp \
 ref_tst_nul3.dmp ref_tst_nul4.dmp ref_tst_names.dmp \
-ref_tst_long_charconst.dmp tst_chararray.dmp \
+ref_tst_long_charconst.dmp tst_chararray.dmp ref_keyword.dmp \
 CMakeLists.txt
 
 # These do not exist because they are not run as usual tests

--- a/ncdump/expected/ref_keyword.dmp
+++ b/ncdump/expected/ref_keyword.dmp
@@ -1,0 +1,8 @@
+netcdf ref_keyword {
+variables:
+	int data ;
+		data :_FillValue = 0 ;
+data:
+
+ data = 177 ;
+}

--- a/ncdump/ncdump.c
+++ b/ncdump/ncdump.c
@@ -53,6 +53,27 @@ typedef int ssize_t;
 #define int64_t long long
 #define uint64_t unsigned long long
 
+/* If we have a variable named one of these:
+   we need to be careful about printing their attributes.
+*/
+static const char* keywords[] = {
+"variable",
+"dimension",
+"data",
+"group",
+"types",
+NULL
+};
+
+static int iskeyword(const char* kw)
+{
+    const char** p;
+    for(p=keywords;*p;p++) {
+	if(strcmp(kw,*p)==0) return 1;
+    }    
+    return 0;
+}
+
 /* globals */
 char *progname;
 fspec_t formatting_specs =	/* defaults, overridden by command-line options */
@@ -751,6 +772,8 @@ pr_att(
     }
     /* 	printf ("\t\t%s:%s = ", varname, att.name); */
     print_name(varname);
+    if(iskeyword(varname)) /* see discussion about escapes in ncgen man page*/
+	printf(" ");    
     printf(":");
     print_name(att.name);
     printf(" = ");

--- a/ncdump/tst_ncgen_shared.sh
+++ b/ncdump/tst_ncgen_shared.sh
@@ -47,7 +47,8 @@ ref_tst_chardata \
 ref_tst_nul3 \
 ref_tst_long_charconst \
 tst_chararray \
-unlimtest1"
+unlimtest1 \
+ref_keyword"
 
 NONCLASSIC3="\
 test0 \


### PR DESCRIPTION
NetCDF-c Github issue #178 / esupport BNL-694121

The ncgen man pages says:
> Note also that the words variable',dimension', data',group', and
> `types' are legal CDL names, but be careful that there is a space be-
> tween them and any following colon character when used as a variable
> name. This is mostly an issue with attribute declarations.

Ncdump does not obey this rule.
The fix is to modify ncdump/ncdump.c to check if a variable name is
a keyword.

Also added test case.