### PR TITLE
Fix 'atttributes' typo, replace with 'attributes'.

### DIFF
--- a/ncgen/ncgen.1
+++ b/ncgen/ncgen.1
@@ -751,7 +751,7 @@ matching one of `classic', `64-bit offset', `64-bit data', `netCDF-4', or
 The rest of the special attributes are all variable attributes.
 Essentially all of then map to some corresponding `nc_def_var_XXX'
 function as defined in the netCDF-4 API.
-For the atttributes that are essentially boolean (_Fletcher32, _Shuffle,
+For the attributes that are essentially boolean (_Fletcher32, _Shuffle,
 and _NOFILL), the value true can be specified by using the strings
 `true' or `1', or by using the integer 1.
 The value false expects either `false', `0', or the integer 0.


### PR DESCRIPTION
The lintian QA tool reported this typo during the Debian package build process.