### PR TITLE
Replace NC_MAX_DIMS with correct NC_MAX_VAR_DIMS

### DIFF
--- a/nc_test4/bm_file.c
+++ b/nc_test4/bm_file.c
@@ -77,7 +77,7 @@ get_starts_counts(int ndims, size_t *dimlen, int p, int my_rank,
 		  size_t *last_count, size_t *start, size_t *count)
 {
    int extra_step = 0;
-   int total[NC_MAX_DIMS];
+   int total[NC_MAX_VAR_DIMS];
    int total_len;
    int s, d;
 
@@ -263,8 +263,8 @@ cmp_file(char *file1, char *file2, int *meta_read_us, int *data_read_us,
    void *data = NULL, *data2 = NULL;
    int a, v, d;
    nc_type xtype, xtype2;
-   int nvars, ndims, dimids[NC_MAX_DIMS], natts, real_ndims;
-   int nvars2, ndims2, dimids2[NC_MAX_DIMS], natts2;
+   int nvars, ndims, dimids[NC_MAX_VAR_DIMS], natts, real_ndims;
+   int nvars2, ndims2, dimids2[NC_MAX_VAR_DIMS], natts2;
    size_t *count = NULL, *start = NULL;
    int slice_len = 1;
    size_t *dimlen = NULL, type_size = 0;
@@ -567,7 +567,7 @@ int copy_file(char *file_name_in, char *file_name_out, int cmode_out,
 	 char name[NC_MAX_NAME + 1];
 	 char att_name[NC_MAX_NAME + 1];
 	 nc_type xtype;
-	 int ndims, dimids[NC_MAX_DIMS], natts;
+	 int ndims, dimids[NC_MAX_VAR_DIMS], natts;
 	 int varid_out;
 	 int a, o1;
 	 int ret = NC_NOERR;
@@ -636,7 +636,7 @@ int copy_file(char *file_name_in, char *file_name_out, int cmode_out,
    {
       char name[NC_MAX_NAME + 1];
       nc_type xtype;
-      int ndims, dimids[NC_MAX_DIMS], natts, real_ndims;
+      int ndims, dimids[NC_MAX_VAR_DIMS], natts, real_ndims;
       int d;
       void *data = NULL;
       size_t *count = NULL, *start = NULL;


### PR DESCRIPTION
The constant NC_MAX_DIMS is used to dimension the `dimids` arrays which are use to retrieve the dimension ids corresponding to the variables dimensions.  By definition, the maximum number of dimension ids is `NC_MAX_VAR_DIMS` as is documented in the `nc_inq_var` documentation:
http://www.unidata.ucar.edu/software/netcdf/netcdf-4/newdocs/netcdf-c/nc_005finq_005fvar.html

dimids   Returned vector of *ndimsp dimension IDs corresponding to the variable dimensions. The caller must allocate enough space for a vector of at least *ndimsp integers to be returned. The maximum possible number of dimensions for a variable is given by the predefined constant NC_MAX_VAR_DIMS. 

Although the default or standard values of NC_MAX_DIMS and NC_MAX_VAR_DIMS are the same, the correct value to be used here is NC_MAX_VAR_DIMS and not NC_MAX_DIMS.  Even though this currently works, it could fail if either NC_MAX_VAR_DIMS or NC_MAX_DIMS is changed and it can also provide an incorrect function usage example that may mislead developers trying to determine the correct usage of the function.