### PR TITLE
Fix incorrect array size specification

### DIFF
--- a/nc_test4/tst_files3.c
+++ b/nc_test4/tst_files3.c
@@ -99,8 +99,8 @@ int dump_hdf_file(const float *data, int docompression)
    hid_t file_spaceid, mem_spaceid, access_plistid, xfer_plistid;
    herr_t status;
    hsize_t dims[NDIMS] = {X_LEN, Y_LEN, Z_LEN};
-   hsize_t start[NC_MAX_DIMS] = {0, 0, 0};
-   hsize_t count[NC_MAX_DIMS] = {1, 1, Z_LEN};
+   hsize_t start[NDIMS] = {0, 0, 0};
+   hsize_t count[NDIMS] = {1, 1, Z_LEN};
 
    /* create file */
    file_id = H5Fcreate(FILE_NAME, H5F_ACC_TRUNC,


### PR DESCRIPTION
The count and start arrays are dimensioned to NC_MAX_DIMS even though the maximum size should be NDIMS which is set to 3; possibly, the maximum size could be 2 since only indices 0 and 1 are used to access both start and count.  I left it at NDIMS since that matches the number of items in the initialization and is consistent with other uses in the file.