### PR TITLE
Potentially confusing use of NC_MAX_DIMS

### DIFF
--- a/nc_test4/tst_compounds.c
+++ b/nc_test4/tst_compounds.c
@@ -417,7 +417,7 @@ main(int argc, char **argv)
       size_t size;
       nc_type xtype;
       int dimids[] = {0};
-      int field_ndims, field_sizes[NC_MAX_DIMS];
+      int field_ndims, field_sizes[1];
       size_t offset;
       nc_type field_typeid;
       int dim_sizes[] = {NUM_DIMENSIONS};


### PR DESCRIPTION
The use of NC_MAX_DIMS in this instance is arbitrary and has no relation to the reason the NC_MAX_DIMS variable is defined.  The test is testing compound types which only exist in netcdf-4 non-classic model files which have no limits related to NC_MAX_DIMS. 

It is true that all that is needed is that the size of the array be at least as large as is needed, but the use of NC_MAX_DIMS here can cause confusion to programmers who may be looking for examples to use in their own programs.  The correct usage would be to query the size via a call to nc_inq_compound_field with the field_sizes argument set to NULL (or some other more appropriate function call) and then allocate the space required or at least check that the allocated size is large enough to hold the number of values.

Although this is only a test, it should not use arbitrary potentially confusing values just because they are probably large enough.  For example, the array could be dimensioned `field_sizes[NC_COMPOUND]` and the test would continue to work correctly; however, it would be very confusing.

It may be better to have a define for the array size instead of a hard-coded '1', but I could not find an already defined constant in the file that would not be confusing, and I didn't know whether it was beneficial to define a new constant just to avoid the hard-coded 1