### PR TITLE
Gh206

### DIFF
--- a/cf
+++ b/cf
@@ -4,7 +4,7 @@ DB=1
 #X=-x
 #FAST=1
 
-#HDF5=1
+HDF5=1
 DAP=1
 #PNETCDF=1
 #PAR4=1

--- a/libdap2/dapcvt.c
+++ b/libdap2/dapcvt.c
@@ -203,8 +203,9 @@ dapcvtattrval(nc_type etype, void* dst, NClist* src)
     char* dstmem = (char*)dst;
 
     for(i=0;i<nvalues;i++) {
-
 	char* s = (char*)nclistget(src,i);
+	size_t slen = strlen(s);
+        int nread = 0; /* # of chars read by sscanf */
 
 	ok = 0;
 	switch (etype) {
@@ -213,60 +214,60 @@ dapcvtattrval(nc_type etype, void* dst, NClist* src)
 		
 		unsigned char* p = (unsigned char*)dstmem;
 #ifdef _MSC_VER
-		ok = sscanf(s,"%hC",p);
+		ok = sscanf(s,"%hC%n",p,&nread);
 		_ASSERTE(_CrtCheckMemory());
 #else	
-		ok = sscanf(s,"%hhu",p);
+		ok = sscanf(s,"%hhu%n",p,&nread);
 #endif
 	    } break;
 	case NC_CHAR: {
 	    signed char* p = (signed char*)dstmem;
-	    ok = sscanf(s,"%c",p);
+	    ok = sscanf(s,"%c%n",p,&nread);
 	    } break;
 	case NC_SHORT: {
 	    short* p = (short*)dstmem;
-	    ok = sscanf(s,"%hd",p);
+	    ok = sscanf(s,"%hd%n",p,&nread);
 	    } break;
 	case NC_INT: {
 	    int* p = (int*)dstmem;
-	    ok = sscanf(s,"%d",p);
+	    ok = sscanf(s,"%d%n",p,&nread);
 	    } break;
 	case NC_FLOAT: {
 	    float* p = (float*)dstmem;
-	    ok = sscanf(s,"%g",p);
+	    ok = sscanf(s,"%g%n",p,&nread);
 	    } break;
 	case NC_DOUBLE: {
 	    double* p = (double*)dstmem;
-	    ok = sscanf(s,"%lg",p);
+	    ok = sscanf(s,"%lg%n",p,&nread);
 	    } break;
 	case NC_UBYTE: {
 	    unsigned char* p = (unsigned char*)dstmem;
 #ifdef _MSC_VER
-		ok = sscanf(s, "%hc", p);
+		ok = sscanf(s, "%hc%n", p,&nread);
 		_ASSERTE(_CrtCheckMemory());
 #else
-	    ok = sscanf(s,"%hhu",p);
+	    ok = sscanf(s,"%hhu%n",p,&nread);
 #endif
 		} break;
 	case NC_USHORT: {
 	    unsigned short* p = (unsigned short*)dstmem;
-	    ok = sscanf(s,"%hu",p);
+	    ok = sscanf(s,"%hu%n",p,&nread);
 	    } break;
 	case NC_UINT: {
 	    unsigned int* p = (unsigned int*)dstmem;
-	    ok = sscanf(s,"%u",p);
+	    ok = sscanf(s,"%u%n",p,&nread);
 	    } break;
 	case NC_INT64: {
 	    long long* p = (long long*)dstmem;
 #ifdef _MSC_VER
-		ok = sscanf(s, "%I64d", p);
+		ok = sscanf(s, "%I64d%n", p,&nread);
 #else
-		ok = sscanf(s,"%lld",p);
+		ok = sscanf(s,"%lld%n",p,&nread);
 #endif
 	} break;
 	case NC_UINT64: {
 	    unsigned long long* p = (unsigned long long*)dstmem;
-	    ok = sscanf(s,"%llu",p);
+	    ok = sscanf(s,"%llu%n",p,&nread);
 	    } break;
 	case NC_STRING: case NC_URL: {
 	    char** p = (char**)dstmem;
@@ -276,7 +277,7 @@ dapcvtattrval(nc_type etype, void* dst, NClist* src)
 	default:
    	    PANIC1("unexpected nc_type: %d",(int)etype);
 	}
-	if(ok != 1) {ncstat = NC_EINVAL; goto done;}
+	if(ok != 1 || nread != slen) {ncstat = NC_EINVAL; goto done;}
 	dstmem += memsize;
     }
 done:

--- a/libdap2/env
+++ b/libdap2/env
@@ -1,12 +1,20 @@
-#TOP="/home/dmh/git/netcdf-c"
-TOP="/cygdrive/f/git/netcdf-c"
 
 alias xx="cd ..;make; cd libdap2"
 
 PARMS=""; ARGS=""; CON="" ; CE="";  OCON="" ; VAR=""; SHARP='#'
 alias q0=;alias qq=;alias qv=;alias q=;alias  qh=;alias qqh=;alias qall=;alias qv=;alias qo=;
 
-F="http://remotetest.unidata.ucar.edu/dts/test.01"
+F="https://eosdap.hdfgroup.org:8080/opendap/data/test/kent/ceres-converted/edition_4/CER_SSF1deg-Hour_Terra-MODIS_TestSuite_000000.200407D01.hdf"
+
+if test -e "/cygdrive/f/git/netcdf-c" ; then
+TOP="/cygdrive/f/git/netcdf-c"
+elif test -e "/cygdrive/d/git/netcdf-c" ; then
+TOP="/cygdrive/d/git/netcdf-c"
+elif test -e "/home/dmh/git/netcdf-c" ; then
+TOP="/home/dmh/git/netcdf-c"
+else
+echo "cannot locate ncdump"
+fi
 
 if test -f ./ncd ; then
 PROG=./ncd

--- a/libdap2/ncd2dispatch.c
+++ b/libdap2/ncd2dispatch.c
@@ -929,6 +929,7 @@ buildattribute(NCDAPCOMMON* dapcomm, NCattribute* att, nc_type vartype, int vari
 	else
 	    ncstat = nc_put_att_text(drno->substrate,varid,att->name,strlen(newstring),newstring);
 	free(newstring);
+        if(ncstat) goto done;
     } else {
 	nc_type atype;
 	unsigned int typesize;
@@ -955,13 +956,14 @@ buildattribute(NCDAPCOMMON* dapcomm, NCattribute* att, nc_type vartype, int vari
 #ifdef _MSC_VER
 	_ASSERTE(_CrtCheckMemory());
 #endif
+    if(ncstat) {nullfree(mem); goto done;}
     ncstat = nc_put_att(drno->substrate,varid,att->name,atype,nvalues,mem);
 #ifdef _MSC_VER
 	_ASSERTE(_CrtCheckMemory());
 #endif
-	if (mem != NULL)
-		free(mem);
-	}
+    if(ncstat) {nullfree(mem); goto done;}
+    }
+done:
     return THROW(ncstat);
 }
 

--- a/libsrc4/nc4var.c
+++ b/libsrc4/nc4var.c
@@ -858,6 +858,12 @@ nc_def_var_extra(int ncid, int varid, int *shuffle, int *deflate,
 	  (*contiguous != NC_CHUNKED && fletcher32))
 	 return NC_EINVAL;
 
+   /* Can't turn on parallel and deflate/fletcher32/szip/shuffle. */
+   if (nc->mode & (NC_MPIIO | NC_MPIPOSIX)) {
+      if (deflate || fletcher32 || shuffle)
+	 return NC_EINVAL;
+   }
+
    /* If the HDF5 dataset has already been created, then it is too
     * late to set all the extra stuff. */
    if (var->created)

--- a/nc_test4/Make0
+++ b/nc_test4/Make0
@@ -1,0 +1,31 @@
+# Test c output
+T=tst_mode
+#CMD=valgrind --leak-check=full
+CMD=gdb --args
+
+PAR=1
+
+CFLAGS=-g -O0 -I.. -I../include
+
+ifdef PAR
+CC=mpicc
+#CC=/usr/local/bin/mpicc
+LDFLAGS=-L/usr/local/lib -lhdf5_hl -lhdf5 -lz  ../liblib/.libs/libnetcdf.a -ldl -lcurl -lpnetcdf -lmpich -lm
+else
+CC=gcc
+#LDFLAGS=../liblib/.libs/libnetcdf.a  -L/usr/local/lib -lhdf5_hl -lhdf5 -lz -lm -lcurl
+LDFLAGS=-L/usr/local/lib -lhdf5_hl -lhdf5 -lz  ../liblib/.libs/libnetcdf.a -ldl -lm -lcurl
+endif
+
+#	cd .. ; ${MAKE} all
+
+LLP=/usr/local/lib:${LD_LIBRARY_PATH}
+
+all::
+	echo ${LD_RUN_PATH}
+	export LD_LIBRARY_PATH=${LLP}; export CFLAGS; export LDFLAGS; \
+	${CC} -o t ${CFLAGS} ${T}.c ${LDFLAGS}; \
+	${CMD} ./t
+
+cpp::
+	${CC} -E ${CFLAGS} ${T}.c > ${T}.txt

--- a/nc_test4/Makefile.am
+++ b/nc_test4/Makefile.am
@@ -108,7 +108,7 @@ endif # USE_VALGRIND_TESTS
 # with --enable-parallel-tests.
 if TEST_PARALLEL4
 check_PROGRAMS += tst_mpi_parallel tst_parallel tst_parallel3	\
-tst_parallel4 tst_nc4perf
+tst_parallel4 tst_nc4perf tst_mode
 TESTS += run_par_test.sh
 endif
 

--- a/nc_test4/run_par_test.sh
+++ b/nc_test4/run_par_test.sh
@@ -4,6 +4,9 @@
 
 set -e
 echo
+echo "Testing MPI parallel I/O with various other mode flags..."
+mpiexec -n 1 ./tst_mode
+echo
 echo "Testing MPI parallel I/O without netCDF..."
 mpiexec -n 4 ./tst_mpi_parallel
 echo
@@ -18,6 +21,7 @@ mpiexec -n 1 ./tst_parallel4
 mpiexec -n 2 ./tst_parallel4
 mpiexec -n 4 ./tst_parallel4
 mpiexec -n 8 ./tst_parallel4
+
 #mpiexec -n 16 ./tst_parallel4
 #mpiexec -n 32 ./tst_parallel4
 #mpiexec -n 64 ./tst_parallel4

--- a/nc_test4/tst_mode.c
+++ b/nc_test4/tst_mode.c
@@ -1,0 +1,41 @@
+/**
+ * @file 
+ * Test some illegal mode combinations
+ *
+ */
+
+#include "nc_tests.h"
+#include "netcdf_par.h"
+
+#define FILE_NAME "tst_mode.nc"
+
+int
+main(int argc, char** argv)
+{
+   int ncid,varid;
+   int retval; 
+
+   printf("\n*** Testing illegal mode combinations\n");
+
+   MPI_Init(&argc,&argv);
+
+   printf("*** Testing create + MPIO + fletcher32\n");
+   if ((retval = nc_create_par(FILE_NAME, NC_CLOBBER|NC_NETCDF4|NC_MPIIO, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid))) ERR;
+   if ((retval = nc_def_var(ncid,"whatever",NC_INT,0,NULL,&varid))) ERR;
+   retval = nc_def_var_fletcher32(ncid,varid,NC_FLETCHER32);
+   if(retval != NC_EINVAL) ERR;
+   if ((retval = nc_abort(ncid))) ERR;
+
+   printf("*** Testing create + MPIO + deflation\n");
+   if ((retval = nc_create_par(FILE_NAME, NC_CLOBBER|NC_NETCDF4|NC_MPIIO, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid))) ERR;
+   if ((retval = nc_def_var(ncid,"whatever",NC_INT,0,NULL,&varid))) ERR;
+   retval = nc_def_var_deflate(ncid,varid, NC_NOSHUFFLE, 1, 1);
+   if(retval != NC_EINVAL) ERR;
+   if ((retval = nc_abort(ncid))) ERR;
+
+   MPI_Finalize();
+
+   SUMMARIZE_ERR;
+   FINAL_RESULTS;
+}
+


### PR DESCRIPTION
Github issue: https://github.com/Unidata/netcdf-c/issues/206
Re e-eupport VGQ-678069
It was noticed that an attribute value of "nan." was being treated as
legal (it should be "nan"). The reason is that sscanf was not be checked
to see that all the attribute value characters were being read.
Solution is to verify that all characters were being consumed.