### PR TITLE
Generate correct results from cmake-generated nc-config

### DIFF
--- a/nc-config.cmake.in
+++ b/nc-config.cmake.in
@@ -22,7 +22,7 @@ fi
 
 has_nc2="@BUILD_V2@"
 
-if [ -z $has_nc2 ]; then
+if [ -z $has_nc2 -o "$has_nc2" = "OFF" ]; then
     has_nc2="no"
 else
     has_nc2="yes"
@@ -50,7 +50,7 @@ else
 fi
 
 has_hdf5="@USE_HDF5@"
-if [ -z $has_hdf5 ]; then
+if [ -z $has_hdf5 -o "$has_hdf5" = "OFF" ]; then
     has_hdf5="no"
 else
     has_hdf5="yes"


### PR DESCRIPTION
A couple of the `has_XX` variables seem to have values of OFF or ON instead of `empty` or ON which causes incorrect output from the nc-config script since it is using `-z` to test whether the variable is non-empty.  This causes nc-config to incorrectly report that the library supports HDF5 or has the version 2 api.

I think these are the only tests that need the extra testing against OFF and I think that the value will always be ON or OFF and not some other variant (FALSE, NO, ...).