### PR TITLE
Update comment in netcdf_meta.h.in

### DIFF
--- a/include/netcdf_meta.h.in
+++ b/include/netcdf_meta.h.in
@@ -47,6 +47,6 @@
 #define NC_HAS_MMAP      @NC_HAS_MMAP@ /*!< mmap support. */
 #define NC_HAS_JNA       @NC_HAS_JNA@ /*!< jna support. */
 #define NC_HAS_PNETCDF   @NC_HAS_PNETCDF@ /*!< pnetcdf support. */
-#define NC_HAS_PARALLEL  @NC_HAS_PARALLEL@ /*!< parallel IO support via hdf5. */
+#define NC_HAS_PARALLEL  @NC_HAS_PARALLEL@ /*!< parallel IO support via hdf5 and/or pnetcdf. */
 
 #endif


### PR DESCRIPTION
If pnetcdf support is enabled, then  NC_HAS_PARALLEL is defined to 1 even if HDF5 is not enabled.  Fix comment to make this clearer.