### PR TITLE
Use dim field of var instead of finding dim from var->dimids.

### DIFF
--- a/libsrc4/nc4file.c
+++ b/libsrc4/nc4file.c
@@ -661,12 +661,13 @@ exit:
 /* This function reads the hacked in coordinates attribute I use for
  * multi-dimensional coordinates. */
 static int
-read_coord_dimids(NC_VAR_INFO_T *var)
+read_coord_dimids(NC_GRP_INFO_T *grp, NC_VAR_INFO_T *var)
 {
    hid_t coord_att_typeid = -1, coord_attid = -1, spaceid = -1;
    hssize_t npoints;
    int ret = 0;
-
+   int d;
+   
    /* There is a hidden attribute telling us the ids of the
     * dimensions that apply to this multi-dimensional coordinate
     * variable. Read it. */
@@ -686,6 +687,12 @@ read_coord_dimids(NC_VAR_INFO_T *var)
 
    if (!ret && H5Aread(coord_attid, coord_att_typeid, var->dimids) < 0) ret++;
    LOG((4, "dimscale %s is multidimensional and has coords", var->name));
+
+   /* Update var->dim field based on the var->dimids */
+   for (d = 0; d < var->ndims; d++) {
+     /* Ok if does not find a dim at this time, but if found set it */
+     nc4_find_dim(grp, var->dimids[d], &var->dim[d], NULL);
+   }
 
    /* Set my HDF5 IDs free! */
    if (spaceid >= 0 && H5Sclose(spaceid) < 0) ret++;
@@ -1679,7 +1686,7 @@ read_var(NC_GRP_INFO_T *grp, hid_t datasetid, const char *obj_name,
       var->dimscale = NC_TRUE;
       if (var->ndims > 1)
       {
-	 if ((retval = read_coord_dimids(var)))
+	 if ((retval = read_coord_dimids(grp, var)))
 	    BAIL(retval);
       }
       else
@@ -2676,6 +2683,7 @@ nc4_open_hdf4_file(const char *path, int mode, NC *nc)
 
 	 /* Tell the variable the id of this dimension. */
 	 var->dimids[d] = dim->dimid;
+	 var->dim[d] = dim;
       }
 
       /* Read the atts. */

--- a/libsrc4/nc4var.c
+++ b/libsrc4/nc4var.c
@@ -919,8 +919,7 @@ nc_def_var_extra(int ncid, int varid, int *shuffle, int *deflate,
      if (!ishdf4) {
       for (d = 0; d < var->ndims; d++)
       {
-	 if ((retval = nc4_find_dim(grp, var->dimids[d], &dim, NULL)))
-	    return retval;
+	 dim = var->dim[d];
 	 if (dim->unlimited)
 	    return NC_EINVAL;
       }


### PR DESCRIPTION
The var struct has a 'dim' field which was not being used
Instead, the dimids field would always search for the dim
with the matching dimid.  For db with large numbers of dims,
this could be a significant time sync.

Modified code to always set var-dim[i] when var->dimids[i] was
set (if the dim existed at that point).  Then use the var->dim
field instead of var->dimids and search whenever requested.

All var->dim accesses are protected by asserts that verify
non-null and that the var->dim[]->dimid == var->dimids[].