### PR TITLE
Nc3 hashmap fix

### DIFF
--- a/include/nc3internal.h
+++ b/include/nc3internal.h
@@ -187,9 +187,6 @@ typedef struct NC_vararray {
 
 /* Begin defined in lookup3.c */
 
-extern uint32_t
-hash_fast(const void *key, size_t length);
-
 /* End defined in lookup3.c */
 
 /* Begin defined in var.c */

--- a/include/nc_hashmap.h
+++ b/include/nc_hashmap.h
@@ -1,24 +1,37 @@
 #ifndef HASHMAP_H_INCLUDED
 #define HASHMAP_H_INCLUDED
+#include <stdlib.h>
+
+typedef struct NC_vararray NC_vararray;
+typedef struct NC_dimarray NC_dimarray;
 
 /** Hashmap structure (forward declaration) */
 struct s_hashmap;
 typedef struct s_hashmap NC_hashmap;
 
 /** Creates a new hashmap near the given size. */
-extern NC_hashmap* NC_hashmapCreate(int startsize);
+extern NC_hashmap* NC_hashmapCreate(unsigned long startsize);
 
 /** Inserts a new element into the hashmap. */
-extern void NC_hashmapInsert(NC_hashmap*, int data, unsigned long key);
+extern void NC_hashmapAddDim(const NC_dimarray*, long data, const char *name);
 
 /** Removes the storage for the element of the key and returns the element. */
-extern int NC_hashmapRemove(NC_hashmap*, unsigned long key);
+extern long NC_hashmapRemoveDim(const NC_dimarray*, const char *name);
 
 /** Returns the element for the key. */
-extern int NC_hashmapGet(NC_hashmap*, unsigned long key);
+extern long NC_hashmapGetDim(const NC_dimarray*, const char *name);
+
+/** Inserts a new element into the hashmap. */
+extern void NC_hashmapAddVar(const NC_vararray*, long data, const char *name);
+
+/** Removes the storage for the element of the key and returns the element. */
+extern long NC_hashmapRemoveVar(const NC_vararray*, const char *name);
+
+/** Returns the element for the key. */
+extern long NC_hashmapGetVar(const NC_vararray*, const char *name);
 
 /** Returns the number of saved elements. */
-extern long NC_hashmapCount(NC_hashmap*);
+extern unsigned long NC_hashmapCount(NC_hashmap*);
 
 /** Removes the hashmap structure. */
 extern void NC_hashmapDelete(NC_hashmap*);

--- a/libsrc/dim.c
+++ b/libsrc/dim.c
@@ -126,7 +126,6 @@ NC_finddim(const NC_dimarray *ncap, const char *uname, NC_dim **dimpp)
 {
 
    int dimid;
-   uint32_t shash;
    NC_dim ** loc;
    char *name;
 
@@ -143,9 +142,7 @@ NC_finddim(const NC_dimarray *ncap, const char *uname, NC_dim **dimpp)
       name = (char *)utf8proc_NFC((const unsigned char *)uname);
       if(name == NULL)
 	 return NC_ENOMEM;
-      shash = hash_fast(name, strlen(name));
-      shash = hash_fast(name, strlen(name));
-      dimid = NC_hashmapGet(ncap->hashmap, shash);
+      dimid = (int)NC_hashmapGetDim(ncap, name);
       free(name);
       if (dimid >= 0) {
 	if (dimpp != NULL)
@@ -293,9 +290,7 @@ incr_NC_dimarray(NC_dimarray *ncap, NC_dim *newelemp)
 
 	if(newelemp != NULL)
 	{
-	  uint32_t key = hash_fast(newelemp->name->cp,
-				   strlen(newelemp->name->cp));
-		NC_hashmapInsert(ncap->hashmap, ncap->nelems, key);
+		NC_hashmapAddDim(ncap, (long)ncap->nelems, newelemp->name->cp);
 		ncap->value[ncap->nelems] = newelemp;
 		ncap->nelems++;
 	}
@@ -449,7 +444,6 @@ NC3_rename_dim( int ncid, int dimid, const char *unewname)
 	int existid;
 	NC_dim *dimp;
 	char *newname;		/* normalized */
-	uint32_t old_hash_key, dim_hash;
 
 	status = NC_check_id(ncid, &nc); 
 	if(status != NC_NOERR)
@@ -472,10 +466,7 @@ NC3_rename_dim( int ncid, int dimid, const char *unewname)
 		return NC_EBADDIM;
 
 	NC_string *old = dimp->name;
-	old_hash_key = hash_fast(old->cp, strlen(old->cp));
-
 	newname = (char *)utf8proc_NFC((const unsigned char *)unewname);
-	dim_hash = hash_fast(newname, strlen(newname));
 	if(newname == NULL)
 	    return NC_ENOMEM;
 	if(NC_indef(ncp))
@@ -485,11 +476,11 @@ NC3_rename_dim( int ncid, int dimid, const char *unewname)
 		if(newStr == NULL)
 			return NC_ENOMEM;
 		dimp->name = newStr;
-		free_NC_string(old);
 
 		/* Remove old name from hashmap; add new... */
-		NC_hashmapRemove(ncp->dims.hashmap, old_hash_key);
-		NC_hashmapInsert(ncp->dims.hashmap, dimid, dim_hash);
+		NC_hashmapRemoveDim(&ncp->dims, old->cp);
+		NC_hashmapAddDim(&ncp->dims, dimid, newname);
+		free_NC_string(old);
 
 		return NC_NOERR;
 	}
@@ -502,8 +493,8 @@ NC3_rename_dim( int ncid, int dimid, const char *unewname)
 		return status;
 
 	/* Remove old name from hashmap; add new... */
-	NC_hashmapRemove(ncp->dims.hashmap, old_hash_key);
-	NC_hashmapInsert(ncp->dims.hashmap, dimid, dim_hash);
+	NC_hashmapRemoveDim(&ncp->dims, old->cp);
+	NC_hashmapAddDim(&ncp->dims, dimid, newname);
 
 	set_NC_hdirty(ncp);
 

--- a/libsrc/dim.c
+++ b/libsrc/dim.c
@@ -479,7 +479,7 @@ NC3_rename_dim( int ncid, int dimid, const char *unewname)
 
 		/* Remove old name from hashmap; add new... */
 		NC_hashmapRemoveDim(&ncp->dims, old->cp);
-		NC_hashmapAddDim(&ncp->dims, dimid, newname);
+		NC_hashmapAddDim(&ncp->dims, dimid, newStr->cp);
 		free_NC_string(old);
 
 		return NC_NOERR;
@@ -494,7 +494,7 @@ NC3_rename_dim( int ncid, int dimid, const char *unewname)
 
 	/* Remove old name from hashmap; add new... */
 	NC_hashmapRemoveDim(&ncp->dims, old->cp);
-	NC_hashmapAddDim(&ncp->dims, dimid, newname);
+	NC_hashmapAddDim(&ncp->dims, dimid, dimp->name->cp);
 
 	set_NC_hdirty(ncp);
 

--- a/libsrc/v1hpg.c
+++ b/libsrc/v1hpg.c
@@ -576,10 +576,8 @@ v1h_get_NC_dimarray(v1hs *gsp, NC_dimarray *ncap)
 				return status;
 			}
 			{
-			  uint32_t key = hash_fast((*dpp)->name->cp,
-						   (*dpp)->name->nchars);
 			  int dimid = (size_t)(dpp - ncap->value);
-			  NC_hashmapInsert(ncap->hashmap, dimid, key);
+			  NC_hashmapAddDim(ncap, dimid, (*dpp)->name->cp);
 			}
 		}
 	}
@@ -1172,10 +1170,8 @@ v1h_get_NC_vararray(v1hs *gsp, NC_vararray *ncap)
 				return status;
 			}
 			{
-			  uint32_t key = hash_fast((*vpp)->name->cp,
-						   (*vpp)->name->nchars);
 			  int varid = (size_t)(vpp - ncap->value);
-			  NC_hashmapInsert(ncap->hashmap, varid, key);
+			  NC_hashmapAddVar(ncap, varid, (*vpp)->name->cp);
 			}
 		}
 	}

--- a/libsrc/var.c
+++ b/libsrc/var.c
@@ -730,7 +730,7 @@ NC3_rename_var(int ncid, int varid, const char *unewname)
 	if(status != NC_NOERR)
 	{
 		/* invalid varid */
-      return status;
+		return status;
 	}
 
 
@@ -748,7 +748,7 @@ NC3_rename_var(int ncid, int varid, const char *unewname)
 
 		/* Remove old name from hashmap; add new... */
 		NC_hashmapRemoveVar(&ncp->vars, old->cp);
-		NC_hashmapAddVar(&ncp->vars, varid, newname);
+		NC_hashmapAddVar(&ncp->vars, varid, newStr->cp);
 		free_NC_string(old);
 
 		return NC_NOERR;
@@ -762,7 +762,7 @@ NC3_rename_var(int ncid, int varid, const char *unewname)
 
 	/* Remove old name from hashmap; add new... */
 	NC_hashmapRemoveVar(&ncp->vars, old->cp);
-	NC_hashmapAddVar(&ncp->vars, varid, newname);
+	NC_hashmapAddVar(&ncp->vars, varid, varp->name->cp);
 
 	set_NC_hdirty(ncp);
 


### PR DESCRIPTION
The addition of the nc_hashmap to facilitate quick
retrieval of var and dim by name did not take into
account key collisions -- two or more var or dim names hashed
to the same value.  If the keys matched, it assumed
that the names matched also.

This change fixes this incorrect assumption and
checks the key (which is the hash of the name)
and if the keys match, it also checks that the names
match.

While there have been no instances of duplicate keys,
they are certain to occur and cause difficult to
debug issues. This fix eliminates that defect.