### PR TITLE
Eliminate compiler warning

### DIFF
--- a/nc_test4/tst_empty_vlen_unlim.c
+++ b/nc_test4/tst_empty_vlen_unlim.c
@@ -80,7 +80,7 @@ int main() {
     }
 
     printf("\t* Puting data in secondary variable:\tnc_put_vara().\n");
-    if (nc_put_vara(ncid,varid2,&startp2,&countp2,data2)) ERR;
+    if (nc_put_vara(ncid,varid2,startp2,countp2,data2)) ERR;
 
     /***********/
     /* Actually unnecessary to recreate the issue. */
@@ -172,7 +172,7 @@ int main() {
     }
 
     printf("\t* Puting data in secondary variable:\tnc_put_vara().\n");
-    if (nc_put_vara(ncid,varid2,&startp2,&countp2,data2)) ERR;
+    if (nc_put_vara(ncid,varid2,startp2,countp2,data2)) ERR;
 
     /***********/
     /* Actually unnecessary to recreate the issue. */


### PR DESCRIPTION
Fix argument to nc_put_vara function to eliminate compiler warning about incompatible types.  Was passing address of argument instead of just passing argument.