### PR TITLE
Check for valid MPI_Comm before freeing

### DIFF
--- a/libsrc4/nc4file.c
+++ b/libsrc4/nc4file.c
@@ -3086,7 +3086,8 @@ close_netcdf4_file(NC_HDF5_FILE_INFO_T *h5, int abort)
       /* Free the MPI Comm & Info objects, if we opened the file in parallel */
       if(h5->parallel)
       {
-          MPI_Comm_free(&h5->comm);
+          if(MPI_COMM_NULL != h5->comm)
+              MPI_Comm_free(&h5->comm);
           if(MPI_INFO_NULL != h5->info)
               MPI_Info_free(&h5->info);
       }


### PR DESCRIPTION
If in parallel mode and the H5Fcreate fails, then the h5->comm field may/will point to MPI_COMM_NULL instead of to a valid communicator.  If that is passed to MPI_Comm_free, then the code will core dump down in the MPI_Comm_free function and not return a valid return status to the caller routine. If communicator is checked, then execution proceeds back up the call tree and caller can report a better error message about the failed file create.