### PR TITLE
HDF5 generates unnecessary error messages when netcdf4 logging enabled

### DIFF
--- a/cf
+++ b/cf
@@ -1,6 +1,6 @@
 #!/bin/bash
 #NB=1
-#DB=1
+DB=1
 #X=-x
 #FAST=1
 

--- a/libdap2/ncd2dispatch.c
+++ b/libdap2/ncd2dispatch.c
@@ -2420,7 +2420,7 @@ NCD2_var_par_access(int ncid, int p2, int p3)
 
 #ifdef USE_NETCDF4
 
-EXTERNL int
+int
 NCD2_inq_ncid(int ncid, const char* name, int* grp_ncid)
 {
     NC* drno;
@@ -2430,6 +2430,7 @@ NCD2_inq_ncid(int ncid, const char* name, int* grp_ncid)
     return THROW(ret);
 }
 
+int
 NCD2_show_metadata(int ncid)
 {
     NC* drno;

--- a/libsrc4/nc4attr.c
+++ b/libsrc4/nc4attr.c
@@ -73,10 +73,15 @@ nc4_get_att(int ncid, NC *nc, int varid, const char *name,
     }
 #endif
 
-   /* Find the attribute, if it exists. If we don't find it, we are
-      major failures. */
-   if ((retval = nc4_find_grp_att(grp, varid, norm_name, my_attnum, &att)))
+   /* Find the attribute, if it exists.
+      <strike>If we don't find it, we are major failures.</strike>
+   */
+   if ((retval = nc4_find_grp_att(grp, varid, norm_name, my_attnum, &att))) {
+     if(retval == NC_ENOTATT)
+	return retval;
+     else
       BAIL(retval);
+   }
 
    /* If mem_type is NC_NAT, it means we want to use the attribute's
     * file type as the mem type as well. */

--- a/libsrc4/nc4file.c
+++ b/libsrc4/nc4file.c
@@ -602,8 +602,7 @@ read_scale(NC_GRP_INFO_T *grp, hid_t datasetid, const char *obj_name,
       BAIL(NC_EHDFERR);
    if (attr_exists)
    {
-      if ((attid = H5Aopen_by_name(datasetid, ".", NC_DIMID_ATT_NAME,
-				   H5P_DEFAULT, H5P_DEFAULT)) < 0)
+      if ((attid = H5Aopen_name(datasetid, NC_DIMID_ATT_NAME)) < 0)
          BAIL(NC_EHDFERR);
 
       if (H5Aread(attid, H5T_NATIVE_INT, &new_dim->dimid) < 0)

--- a/libsrc4/nc4info.c
+++ b/libsrc4/nc4info.c
@@ -127,8 +127,8 @@ NC4_get_propattr(NC_HDF5_FILE_INFO_T* h5)
     /* Get root group */
     grp = h5->root_grp->hdf_grpid; /* get root group */
     /* Try to extract the NCPROPS attribute */
-    attid = H5Aopen_name(grp, NCPROPS);
-    if(attid >= 0) {
+    if(H5Aexists(grp,NCPROPS) > 0) { /* Does exist */
+        attid = H5Aopen_name(grp, NCPROPS);
 	herr = -1;
 	aspace = H5Aget_space(attid); /* dimensions of attribute data */
         atype = H5Aget_type(attid);
@@ -170,8 +170,7 @@ NC4_put_propattr(NC_HDF5_FILE_INFO_T* h5)
     /* Get root group */
     grp = h5->root_grp->hdf_grpid; /* get root group */
     /* See if the NCPROPS attribute exists */
-    exists = H5Aopen_name(grp, NCPROPS);
-    if(exists < 0) {/* Does not exist */
+    if(H5Aexists(grp,NCPROPS) == 0) { /* Does not exist */
 	herr = -1;
         /* Create a datatype to refer to. */
         HCHECK((atype = H5Tcopy(H5T_C_S1)));
@@ -183,7 +182,6 @@ NC4_put_propattr(NC_HDF5_FILE_INFO_T* h5)
 	herr = 0;
     }
 done:
-    if(exists >= 0) HCHECK((H5Aclose(exists)));
     if(attid >= 0) HCHECK((H5Aclose(attid)));
     if(aspace >= 0) HCHECK((H5Sclose(aspace)));
     if(atype >= 0) HCHECK((H5Tclose(atype)));

--- a/nc_test4/Make0
+++ b/nc_test4/Make0
@@ -1,5 +1,5 @@
 # Test c output
-T=tst_chunk_hdf4
+T=tst_misc
 #CMD=valgrind --leak-check=full
 CMD=gdb --args
 

--- a/nc_test4/tst_empty_vlen_unlim.c
+++ b/nc_test4/tst_empty_vlen_unlim.c
@@ -120,7 +120,7 @@ int main() {
 
     /* Close File. */
     printf("\t* Closing file:\tnc_close().\n");
-    if (stat = nc_close(ncid)) ERR;
+    if ((stat = nc_close(ncid))) ERR;
 
 
   }
@@ -212,7 +212,7 @@ int main() {
 
     /* Close File. */
     printf("\t* Closing file:\tnc_close().\n");
-    if (stat = nc_close(ncid)) ERR;
+    if ((stat = nc_close(ncid))) ERR;
 
 
   }

--- a/nc_test4/tst_misc.sh
+++ b/nc_test4/tst_misc.sh
@@ -11,7 +11,7 @@ set -e
 
 echo "*** Testing phony dimension creation on pure h5 file"
 rm -f ./tmp
-if ../ncdump/ncdump -K ${srcdir}/tdset.h5 >./tmp ; then
+if ../ncdump/ncdump -L0 -K ${srcdir}/tdset.h5 >./tmp ; then
 echo "*** Pass: phony dimension creation"
 ECODE=0
 else

--- a/ncdump/ncdump.c
+++ b/ncdump/ncdump.c
@@ -118,10 +118,11 @@ usage(void)
   [-w]             With client-side caching of variables for DAP URLs\n\
   [-x]             Output XML (NcML) instead of CDL\n\
   [-Xp]            Unconditionally suppress output of the properties attribute\n\
+  [-Ln]            Set log level to n (>= 0); ignore if logging not enabled.\n\
   file             Name of netCDF file (or URL if DAP access enabled)\n"
 
     (void) fprintf(stderr,
-		   "%s [-c|-h] [-v ...] [[-b|-f] [c|f]] [-l len] [-n name] [-p n[,n]] [-k] [-x] [-s] [-t|-i] [-g ...] [-w] file\n%s",
+		   "%s [-c|-h] [-v ...] [[-b|-f] [c|f]] [-l len] [-n name] [-p n[,n]] [-k] [-x] [-s] [-t|-i] [-g ...] [-w] [-Ln] file\n%s",
 		   progname,
 		   USAGE);
 
@@ -2112,7 +2113,7 @@ main(int argc, char *argv[])
        exit(EXIT_SUCCESS);
     }
 
-    while ((c = getopt(argc, argv, "b:cd:f:g:hikl:n:p:stv:xwKX:")) != EOF)
+    while ((c = getopt(argc, argv, "b:cd:f:g:hikl:n:p:stv:xwKL:X:")) != EOF)
       switch(c) {
 	case 'h':		/* dump header only, no data */
 	  formatting_specs.header_only = true;
@@ -2212,6 +2213,15 @@ main(int argc, char *argv[])
 	      error("invalid value for -X option: %s", optarg);
 	      break;
 	  }
+	  break;
+        case 'L':
+#ifdef LOGGING
+	  {
+	  int level = atoi(optarg);
+	  if(level >= 0)
+	    nc_set_log_level(level);
+	  }
+#endif
 	  break;
         case '?':
 	  usage();


### PR DESCRIPTION
re: github netcdf-c issue #271

This occurs for several reasons, including:
1. using H5Aopen_name instead of H5Aexists to test if attribute exists.
2. using H5Eset_auto instead of H5Eset_auto2.
There are probably others that will have to be extinguished as encountered.
p.s Hope I did not overdo this and kill too much.