### PR TITLE
The name hash for hdf4 variables was not being computed.

### DIFF
--- a/cf
+++ b/cf
@@ -6,6 +6,7 @@ DB=1
 
 HDF5=1
 DAP=1
+HDF4=1
 #PNETCDF=1
 #PAR4=1
 

--- a/configure.ac
+++ b/configure.ac
@@ -72,7 +72,7 @@ AC_CONFIG_LINKS([nc_test4/ref_hdf5_compat2.nc:nc_test4/ref_hdf5_compat2.nc])
 AC_CONFIG_LINKS([nc_test4/ref_hdf5_compat3.nc:nc_test4/ref_hdf5_compat3.nc])
 
 # This call is required by automake.
-AM_INIT_AUTOMAKE([foreign dist-zip subdir-objects serial-tests])
+AM_INIT_AUTOMAKE([foreign dist-zip subdir-objects])
 
 # Check for the existence of this file before proceeding.
 AC_CONFIG_SRCDIR([include/netcdf.h])

--- a/libsrc4/nc4file.c
+++ b/libsrc4/nc4file.c
@@ -2618,6 +2618,8 @@ nc4_open_hdf4_file(const char *path, int mode, NC *nc)
       if (SDgetinfo(var->sdsid, var->name, &rank, NULL, &data_type, &num_atts))
 	return NC_EVARMETA;
 
+      var->hash = hash_fast(var->name, strlen(var->name));
+
       if(!(dimsize = (int32*)malloc(sizeof(int32)*rank)))
 	return NC_ENOMEM;
 

--- a/nc_test4/CMakeLists.txt
+++ b/nc_test4/CMakeLists.txt
@@ -77,7 +77,7 @@ IF(USE_HDF4_FILE_TESTS AND NOT MSVC)
     build_bin_test(tst_chunk_hdf4)
     add_sh_test(nc_test4 run_chunk_hdf4)
     add_bin_test(nc_test4 tst_h4_lendian)
-
+    add_sh_test(nc_test4 tst_hdf4_read_var)
 ENDIF()
 
 

--- a/nc_test4/Makefile.am
+++ b/nc_test4/Makefile.am
@@ -89,7 +89,7 @@ if USE_HDF4
 check_PROGRAMS += tst_interops2 tst_chunk_hdf4 tst_h4_lendian
 TESTS += tst_interops2  tst_formatx_hdf4.sh run_chunk_hdf4.sh tst_h4_lendian
 if USE_HDF4_FILE_TESTS
-check_PROGRAMS += tst_interops3
+check_PROGRAMS += tst_interops3 tst_hdf4_read_var.sh
 TESTS += run_get_hdf4_files.sh tst_interops3
 endif # USE_HDF4_FILE_TESTS
 #tst_interops2_LDADD = ${lib_LTLIBRARIES} -lmfhdf -ldf -ljpeg -lhdf5_hl	\
@@ -125,7 +125,7 @@ run_grp_rename.sh tst_formatx_hdf4.sh                                   \
 run_chunk_hdf4.sh contiguous.hdf4 chunked.hdf4 \
 tst_h5_endians.c tst_h4_lendian.c tst_atts_string_rewrite.c \
 tst_put_vars_two_unlim_dim.c tst_empty_vlen_unlim.c run_empty_vlen_test.sh \
-ref_hdf5_compat1.nc ref_hdf5_compat2.nc ref_hdf5_compat3.nc tst_misc.sh tdset.h5
+ref_hdf5_compat1.nc ref_hdf5_compat2.nc ref_hdf5_compat3.nc tst_misc.sh tdset.h5 tst_hdf4_read_var.sh
 
 CLEANFILES = tst_mpi_parallel.bin cdm_sea_soundings.nc bm_chunking.nc	\
 bm_radar.nc bm_radar1.nc radar_3d_compression_test.txt			\

--- a/nc_test4/Makefile.am
+++ b/nc_test4/Makefile.am
@@ -89,8 +89,8 @@ if USE_HDF4
 check_PROGRAMS += tst_interops2 tst_chunk_hdf4 tst_h4_lendian
 TESTS += tst_interops2  tst_formatx_hdf4.sh run_chunk_hdf4.sh tst_h4_lendian
 if USE_HDF4_FILE_TESTS
-check_PROGRAMS += tst_interops3 tst_hdf4_read_var.sh
-TESTS += run_get_hdf4_files.sh tst_interops3
+check_PROGRAMS += tst_interops3
+TESTS += run_get_hdf4_files.sh tst_interops3 tst_hdf4_read_var.sh
 endif # USE_HDF4_FILE_TESTS
 #tst_interops2_LDADD = ${lib_LTLIBRARIES} -lmfhdf -ldf -ljpeg -lhdf5_hl	\
 #-lhdf5 -lz

--- a/nc_test4/tst_hdf4_read_var.sh
+++ b/nc_test4/tst_hdf4_read_var.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# This shell script tests that an hdf4 file can be read a
+# variable at a time.
+#
+# this was added in support of https://github.com/Unidata/netcdf-c/issues/264
+
+FILE=tst_interops2.h4
+
+set -e
+
+echo ""
+echo "*** Testing reading an individual variable from an HDF4 file."
+
+../ncdump/ncdump -v hdf4_dataset_type_0 $FILE
+../ncdump/ncdump -v hdf4_dataset_type_1 $FILE
+../ncdump/ncdump -v hdf4_dataset_type_2 $FILE
+../ncdump/ncdump -v hdf4_dataset_type_3 $FILE
+../ncdump/ncdump -v hdf4_dataset_type_4 $FILE
+../ncdump/ncdump -v hdf4_dataset_type_5 $FILE
+../ncdump/ncdump -v hdf4_dataset_type_6 $FILE
+../ncdump/ncdump -v hdf4_dataset_type_7 $FILE
+
+echo "*** Success."

--- a/ncdump/Make0
+++ b/ncdump/Make0
@@ -1,8 +1,9 @@
 # Test c output
-T=tst_fileinfo
+T=t
 #CMD=valgrind --leak-check=full
 CMD=gdb --args
 
+HDF4=1
 #PAR=1
 
 CFLAGS=-Wall -g -O0 -I.. -I../include
@@ -12,9 +13,14 @@ CC=mpicc
 #CC=/usr/local/bin/mpicc
 LDFLAGS=../liblib/.libs/libnetcdf.a -L/usr/local/lib -lhdf5_hl -lhdf5 -lz  -ldl -lcurl -lpnetcdf -lmpich -lm
 else
+ifdef HDF4
+CC=gcc
+LDFLAGS=../liblib/.libs/libnetcdf.a -L/usr/local/lib -lhdf5_hl -lhdf5 -lmfhdf -ldf -lz  -ldl -lm -lcurl -ljpeg
+else
 CC=gcc
 #LDFLAGS=../liblib/.libs/libnetcdf.a  -L/usr/local/lib -lhdf5_hl -lhdf5 -lz -lm -lcurl
 LDFLAGS=../liblib/.libs/libnetcdf.a -L/usr/local/lib -lhdf5_hl -lhdf5 -lz  -ldl -lm -lcurl
+endif
 endif
 
 #	cd .. ; ${MAKE} all


### PR DESCRIPTION
Fix in nc4file.c.
Not sure how this ever worked for any variable.
What is also weird is that the dim hash is
apparently being computed.