### PR TITLE
Eliminate c++ or c99-style comment

### DIFF
--- a/include/netcdf.h
+++ b/include/netcdf.h
@@ -1948,7 +1948,7 @@ ncrecget(int ncid, long recnum, void **datap);
 EXTERNL int
 ncrecput(int ncid, long recnum, void *const *datap);
 
-  //EXTERNL int nc_finalize();
+/* EXTERNL int nc_finalize(); */
 
 /* End v2.4 backward compatibility */
 #endif /*!NO_NETCDF_2*/


### PR DESCRIPTION
The single commented out line was the only use of a c-99 or c++ style comment in the entire file.  Either remove line completely or change to c-89 style comment to permit use with projects that still require c89 compatible code.