### PR TITLE
Handle disabling ENABLE_FILEINFO in CMake build

### DIFF
--- a/libsrc4/CMakeLists.txt
+++ b/libsrc4/CMakeLists.txt
@@ -1,6 +1,10 @@
 # Process these files with m4.
 
-SET(libsrc4_SOURCES nc4dispatch.c nc4attr.c nc4dim.c nc4file.c nc4grp.c nc4type.c nc4var.c ncfunc.c nc4internal.c nc4hdf.c nc4info.c)
+SET(libsrc4_SOURCES nc4dispatch.c nc4attr.c nc4dim.c nc4file.c nc4grp.c nc4type.c nc4var.c ncfunc.c nc4internal.c nc4hdf.c)
+
+IF(ENABLE_FILEINFO)
+  SET(libsrc4_SOURCES ${libsrc4_SOURCES} nc4info.c)
+ENDIF()
 
 IF(LOGGING)
   SET(libsrc4_SOURCES ${libsrc4_SOURCES} error4.c)


### PR DESCRIPTION
If ENABLE_FILEINFO is set to NO or disabled, then the nc4info.c file should not be compiled.  This was not being handled correctly in the CMake-based build as nc4info.c was compiled even if ENABLE_FILEINFO was set to NO.