### PR TITLE
Fix variable and dimension renaming for nc3 with hashmap

### DIFF
--- a/libsrc/dim.c
+++ b/libsrc/dim.c
@@ -475,10 +475,12 @@ NC3_rename_dim( int ncid, int dimid, const char *unewname)
 		free(newname);
 		if(newStr == NULL)
 			return NC_ENOMEM;
-		dimp->name = newStr;
 
 		/* Remove old name from hashmap; add new... */
 		NC_hashmapRemoveDim(&ncp->dims, old->cp);
+
+		dimp->name = newStr;
+
 		NC_hashmapAddDim(&ncp->dims, dimid, newStr->cp);
 		free_NC_string(old);
 
@@ -487,13 +489,15 @@ NC3_rename_dim( int ncid, int dimid, const char *unewname)
 
 	/* else, not in define mode */
 
+
+	/* Remove old name from hashmap; add new... */
+	NC_hashmapRemoveDim(&ncp->dims, old->cp);
+
 	status = set_NC_string(dimp->name, newname);
 	free(newname);
 	if(status != NC_NOERR)
 		return status;
 
-	/* Remove old name from hashmap; add new... */
-	NC_hashmapRemoveDim(&ncp->dims, old->cp);
 	NC_hashmapAddDim(&ncp->dims, dimid, dimp->name->cp);
 
 	set_NC_hdirty(ncp);

--- a/libsrc/var.c
+++ b/libsrc/var.c
@@ -740,14 +740,14 @@ NC3_rename_var(int ncid, int varid, const char *unewname)
 	    return NC_ENOMEM;
 	if(NC_indef(ncp))
 	{
+		/* Remove old name from hashmap; add new... */
+		NC_hashmapRemoveVar(&ncp->vars, old->cp);
+
 		newStr = new_NC_string(strlen(newname),newname);
 		free(newname);
 		if(newStr == NULL)
 			return(-1);
 		varp->name = newStr;
-
-		/* Remove old name from hashmap; add new... */
-		NC_hashmapRemoveVar(&ncp->vars, old->cp);
 		NC_hashmapAddVar(&ncp->vars, varid, newStr->cp);
 		free_NC_string(old);
 
@@ -755,13 +755,14 @@ NC3_rename_var(int ncid, int varid, const char *unewname)
 	}
 
 	/* else, not in define mode */
+	/* Remove old name from hashmap; add new... */
+	NC_hashmapRemoveVar(&ncp->vars, old->cp);
+
 	status = set_NC_string(varp->name, newname);
 	free(newname);
 	if(status != NC_NOERR)
 		return status;
 
-	/* Remove old name from hashmap; add new... */
-	NC_hashmapRemoveVar(&ncp->vars, old->cp);
 	NC_hashmapAddVar(&ncp->vars, varid, varp->name->cp);
 
 	set_NC_hdirty(ncp);


### PR DESCRIPTION
Pull request to fix issue #282 

Patch included in discussion of that issue, but easier to apply if supplied as pull request. 

The problem is that the name was being updated prior to the old
variable being removed from the hashmap. It checks whether the key and
the name of the variable being removed match, but since the name had
already been updated, the names did not match so the variable was not
removed. This patch removes the variable from the hashmap first,
then updates the name, and then adds the variable with the new name to
the hashmap.

Similar change for renaming dimensions.