### PR TITLE
mutiple typedefs causing compile problems

### DIFF
--- a/libdap2/dceparselex.h
+++ b/libdap2/dceparselex.h
@@ -40,12 +40,12 @@ typedef struct DCElexstate {
 } DCElexstate;
 
 /*! Specifies DCEparsestate. */
-typedef struct DCEparsestate {
+struct DCEparsestate {
     DCEconstraint* constraint;
     char errorbuf[1024];
     int errorcode;
     DCElexstate* lexstate;
-} DCEparsestate;
+};
 
 /* Define a generic object carrier; this serves
    essentially the same role as the typical bison %union


### PR DESCRIPTION
A couple of people have reported that the multiple definitions of
    typedef struct DCEparsestate
near lines 10 and 42 causes compiler
problems with some versions of gcc.
remove the second typedef.