### PR TITLE
Fix att_name size

### DIFF
--- a/libsrc4/nc4hdf.c
+++ b/libsrc4/nc4hdf.c
@@ -1952,7 +1952,7 @@ write_nc3_strict_att(hid_t hdf_grpid)
 {
   hid_t attid = 0, spaceid = 0;
   int one = 1, num, a;
-  char att_name[NC_MAX_NAME + 1];
+  char att_name[NC_MAX_HDF5_NAME + 1];
   int retval = NC_NOERR;
 
   /* If the attribute already exists, call that a success and return


### PR DESCRIPTION
There was a mismatch between the allocated size of att_name and the size that H5Aget_name was told the size was.