### PR TITLE
Fix incorrect test

### DIFF
--- a/libsrc4/nc4hdf.c
+++ b/libsrc4/nc4hdf.c
@@ -1987,12 +1987,12 @@ write_nc3_strict_att(hid_t hdf_grpid)
     BAIL(NC_EFILEMETA);
 
  exit:
-  if (spaceid && (H5Sclose(spaceid) < 0))
+  if (spaceid > 0 && (H5Sclose(spaceid) < 0))
     BAIL2(NC_EFILEMETA);
 #ifdef EXTRA_TESTS
   num_spaces--;
 #endif
-  if (attid && (H5Aclose(attid) < 0))
+  if (attid > 0 && (H5Aclose(attid) < 0))
     BAIL2(NC_EFILEMETA);
   return retval;
 }


### PR DESCRIPTION
If H5Aopen_idx on line 1964 fails, then attid will be < 0.  The BAIL will goto exit at line 1989 and then the test of "if (attid ...)" at line 1995 will pass (attd != 0) and then call H5Aclose(attid) with a negative attid.    Similar issue for spaceid.  

Result of function if probably the same since there is a failure somewhere, but more difficult to track down if looks like failure is happening in the wrong place.