### PR TITLE
Some small fixes for nc-config

### DIFF
--- a/nc-config.cmake.in
+++ b/nc-config.cmake.in
@@ -79,11 +79,11 @@ has_fortran="no"
 has_f90="no"
 has_f03="no"
 
-nfconf=$(which nf-config)
+nfconf=$(which nf-config 2>/dev/null)
 
 if [ -f "$nfconf" ]; then
-    echo "Using nf-config: $nfconf"
-    has_fortran="yes"
+  echo "Using nf-config: $nfconf"
+  has_fortran="yes"
   fc=`nf-config --fc`
   fflags=`nf-config --fflags`
   flibs=`nf-config --flibs`
@@ -112,6 +112,7 @@ Available values for OPTION include:
   --all         display all options
   --cc          C compiler
   --cflags      pre-processor and compiler flags
+  --has-fortran whether Fortran API is installed
   --has-dap     whether OPeNDAP is enabled in this build
   --has-nc2     whether NetCDF-2 API is enabled
   --has-nc4     whether NetCDF-4/HDF-5 is enabled in this build
@@ -123,6 +124,7 @@ Available values for OPTION include:
   --libs        library linking information for netcdf
   --prefix      Install prefix
   --includedir  Include directory
+  --libdir      Library directory
   --version     Library version
 
 EOF
@@ -171,6 +173,7 @@ all()
         echo "  --cxx4      -> $cxx4"
         echo
 
+        echo "  --has-fortran-> $has_fortran"
 if [ -f "$nfconf" ]; then
         echo "  --fc        -> $fc"
         echo "  --fflags    -> $fflags"
@@ -190,6 +193,7 @@ fi
 	echo
         echo "  --prefix    -> $prefix"
         echo "  --includedir-> $includedir"
+        echo "  --libdir    -> $libdir"
         echo "  --version   -> $version"
         echo
 }
@@ -269,6 +273,10 @@ while test $# -gt 0; do
        	echo "${includedir}"
        	;;
 
+    --libdir)
+       	echo "${libdir}"
+       	;;
+
     --version)
 	echo $version
 	;;
@@ -296,6 +304,10 @@ while test $# -gt 0; do
 #    --cxxlibs)
 #	echo $cxxlibs
 #	;;
+
+    --has-fortran)
+        echo $has_fortran
+        ;;
 
     --fc)
 	echo $fc

--- a/nc-config.cmake.in
+++ b/nc-config.cmake.in
@@ -95,9 +95,13 @@ has_cxx="no"
 has_cxx4="no"
 if type -p ncxx4-config > /dev/null 2>&1; then
   cxx4=`ncxx4-config --cxx`
+  cxx4flags=`ncxx4-config --cflags`
+  cxx4libs=`ncxx4-config --libs`
   has_cxx4="yes"
 elif type -p ncxx-config > /dev/null 2>&1; then
   cxx=`ncxx-config --cxx`
+  cxxflags=`ncxx-config --cflags`
+  cxxlibs=`ncxx-config --libs`
   has_cxx="yes"
 fi
 
@@ -112,6 +116,8 @@ Available values for OPTION include:
   --all         display all options
   --cc          C compiler
   --cflags      pre-processor and compiler flags
+  --has-c++     whether C++ API is installed
+  --has-c++4    whether netCDF-4 C++ API is installed
   --has-fortran whether Fortran API is installed
   --has-dap     whether OPeNDAP is enabled in this build
   --has-nc2     whether NetCDF-2 API is enabled
@@ -128,19 +134,17 @@ Available values for OPTION include:
   --version     Library version
 
 EOF
-# When supported by ncxx4-config and ncxx-config, add
-#  --cxxflags    flags needed to compile a netCDF-4 C++ program
-#  --cxxlibs     libraries needed to link a netCDF-4 C++ program
 if type -p ncxx4-config > /dev/null 2>&1; then
     cat <<EOF
-  --cxx4         C++ compiler for netCDF-4 C++ library
-  --has-c++4     whether netCDF-4 C++ API is installed
+  --cxx4        C++ compiler for netCDF-4 C++ library
+  --cxx4flags   flags needed to compile a C++ program
+  --cxx4libs    libraries needed to link a C++ program
 EOF
 elif type -p ncxx-config > /dev/null 2>&1; then
     cat <<EOF
   --cxx         C++ compiler
-  --has-c++     whether C++ API is installed
-
+  --cxxflags    flags needed to compile a C++ program
+  --cxxlibs     libraries needed to link a C++ program
 EOF
 fi
 if [ -f "$nfconf" ]; then
@@ -167,10 +171,17 @@ all()
         echo "  --has-c++   -> $has_cxx"
         echo "  --cxx       -> $cxx"
 
-#	echo "  --cxxflags  -> $cxxflags"
-#	echo "  --cxxlibs   -> $cxxlibs"
+if type -p ncxx-config > /dev/null 2>&1; then
+        echo "  --cxxflags  -> $cxxflags"
+        echo "  --cxxlibs   -> $cxxlibs"
+fi
+        echo
         echo "  --has-c++4  -> $has_cxx4"
         echo "  --cxx4      -> $cxx4"
+if type -p ncxx4-config > /dev/null 2>&1; then
+        echo "  --cxx4flags -> $cxx4flags"
+        echo "  --cxx4libs  -> $cxx4libs"
+fi
         echo
 
         echo "  --has-fortran-> $has_fortran"
@@ -289,6 +300,14 @@ while test $# -gt 0; do
 	echo $cxx
 	;;
 
+    --cxxflags)
+	echo $cxxflags
+	;;
+
+    --cxxlibs)
+	echo $cxxlibs
+	;;
+
     --has-c++4)
        	echo $has_cxx4
        	;;
@@ -297,13 +316,13 @@ while test $# -gt 0; do
 	echo $cxx4
 	;;
 
-#    --cxxflags)
-#	echo $cxxflags
-#	;;
-#
-#    --cxxlibs)
-#	echo $cxxlibs
-#	;;
+    --cxx4flags)
+	echo $cxx4flags
+	;;
+
+    --cxx4libs)
+	echo $cxx4libs
+	;;
 
     --has-fortran)
         echo $has_fortran

--- a/nc-config.in
+++ b/nc-config.in
@@ -5,12 +5,14 @@
 # contributed by netCDF user Arlindo DaSilva. Thanks Arlindo!
 
 prefix=@prefix@
-exec_prefix=${prefix}
-includedir=${prefix}/include
-
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
 
 cc="@CC@"
-cflags=" -I${includedir} @CPPFLAGS@"
+cflags="-I${includedir} @CPPFLAGS@"
+libs="-L${libdir} @NC_LIBS@"
+
 has_dap="@HAS_DAP@"
 has_nc2="@HAS_NC2@"
 has_nc4="@HAS_NC4@"

--- a/nc-config.in
+++ b/nc-config.in
@@ -205,7 +205,7 @@ while test $# -gt 0; do
        	;;
 
      --libs)
-       	PKG_CONFIG_PATH=${prefix}/lib/pkgconfig pkg-config netcdf --libs
+       	echo $libs
        	;;
 
     --prefix)

--- a/nc-config.in
+++ b/nc-config.in
@@ -42,9 +42,13 @@ has_cxx="no"
 has_cxx4="no"
 if type -p ncxx4-config > /dev/null 2>&1; then
   cxx4=`ncxx4-config --cxx`
+  cxx4flags=`ncxx4-config --cflags`
+  cxx4libs=`ncxx4-config --libs`
   has_cxx4="yes"
 elif type -p ncxx-config > /dev/null 2>&1; then
   cxx=`ncxx-config --cxx`
+  cxxflags=`ncxx-config --cflags`
+  cxxlibs=`ncxx-config --libs`
   has_cxx="yes"
 fi
 
@@ -59,6 +63,8 @@ Available values for OPTION include:
   --all         display all options
   --cc          C compiler
   --cflags      pre-processor and compiler flags
+  --has-c++     whether C++ API is installed
+  --has-c++4    whether netCDF-4 C++ API is installed
   --has-fortran whether Fortran API is installed
   --has-dap     whether OPeNDAP is enabled in this build
   --has-nc2     whether NetCDF-2 API is enabled
@@ -75,19 +81,17 @@ Available values for OPTION include:
   --version     Library version
 
 EOF
-# When supported by ncxx4-config and ncxx-config, add
-#  --cxxflags    flags needed to compile a netCDF-4 C++ program
-#  --cxxlibs     libraries needed to link a netCDF-4 C++ program
 if type -p ncxx4-config > /dev/null 2>&1; then
     cat <<EOF
-  --cxx4         C++ compiler for netCDF-4 C++ library
-  --has-c++4     whether netCDF-4 C++ API is installed
+  --cxx4        C++ compiler for netCDF-4 C++ library
+  --cxx4flags   flags needed to compile a C++ program
+  --cxx4libs    libraries needed to link a C++ program
 EOF
 elif type -p ncxx-config > /dev/null 2>&1; then
     cat <<EOF
   --cxx         C++ compiler
-  --has-c++     whether C++ API is installed
-
+  --cxxflags    flags needed to compile a C++ program
+  --cxxlibs     libraries needed to link a C++ program
 EOF
 fi
 if [ -f "$nfconf" ]; then
@@ -114,10 +118,17 @@ all()
         echo "  --has-c++   -> $has_cxx"
         echo "  --cxx       -> $cxx"
 
-#	echo "  --cxxflags  -> $cxxflags"
-#	echo "  --cxxlibs   -> $cxxlibs"
+if type -p ncxx-config > /dev/null 2>&1; then
+        echo "  --cxxflags  -> $cxxflags"
+        echo "  --cxxlibs   -> $cxxlibs"
+fi
+        echo
         echo "  --has-c++4  -> $has_cxx4"
         echo "  --cxx4      -> $cxx4"
+if type -p ncxx4-config > /dev/null 2>&1; then
+        echo "  --cxx4flags -> $cxx4flags"
+        echo "  --cxx4libs  -> $cxx4libs"
+fi
         echo
 
         echo "  --has-fortran-> $has_fortran"
@@ -236,6 +247,14 @@ while test $# -gt 0; do
 	echo $cxx
 	;;
 
+    --cxxflags)
+	echo $cxxflags
+	;;
+
+    --cxxlibs)
+	echo $cxxlibs
+	;;
+
     --has-c++4)
        	echo $has_cxx4
        	;;
@@ -244,6 +263,13 @@ while test $# -gt 0; do
 	echo $cxx4
 	;;
 
+    --cxx4flags)
+	echo $cxx4flags
+	;;
+
+    --cxx4libs)
+	echo $cxx4libs
+	;;
 
     --has-fortran)
         echo $has_fortran

--- a/nc-config.in
+++ b/nc-config.in
@@ -26,11 +26,11 @@ has_fortran="no"
 has_f90="no"
 has_f03="no"
 
-nfconf=$(which nf-config)
+nfconf=$(which nf-config 2>/dev/null)
 
 if [ -f "$nfconf" ]; then
-    echo "Using nf-config: $nfconf"
-    has_fortran="yes"
+  echo "Using nf-config: $nfconf"
+  has_fortran="yes"
   fc=`nf-config --fc`
   fflags=`nf-config --fflags`
   flibs=`nf-config --flibs`
@@ -59,6 +59,7 @@ Available values for OPTION include:
   --all         display all options
   --cc          C compiler
   --cflags      pre-processor and compiler flags
+  --has-fortran whether Fortran API is installed
   --has-dap     whether OPeNDAP is enabled in this build
   --has-nc2     whether NetCDF-2 API is enabled
   --has-nc4     whether NetCDF-4/HDF-5 is enabled in this build
@@ -70,6 +71,7 @@ Available values for OPTION include:
   --libs        library linking information for netcdf
   --prefix      Install prefix
   --includedir  Include directory
+  --libdir      Library directory
   --version     Library version
 
 EOF
@@ -118,6 +120,7 @@ all()
         echo "  --cxx4      -> $cxx4"
         echo
 
+        echo "  --has-fortran-> $has_fortran"
 if [ -f "$nfconf" ]; then
         echo "  --fc        -> $fc"
         echo "  --fflags    -> $fflags"
@@ -137,6 +140,7 @@ fi
 	echo
         echo "  --prefix    -> $prefix"
         echo "  --includedir-> $includedir"
+        echo "  --libdir    -> $libdir"
         echo "  --version   -> $version"
         echo
 }
@@ -216,6 +220,10 @@ while test $# -gt 0; do
        	echo "${includedir}"
        	;;
 
+    --libdir)
+       	echo "${libdir}"
+       	;;
+
     --version)
 	echo $version
 	;;
@@ -235,6 +243,11 @@ while test $# -gt 0; do
     --cxx4)
 	echo $cxx4
 	;;
+
+
+    --has-fortran)
+        echo $has_fortran
+        ;;
 
     --fc)
 	echo $fc


### PR DESCRIPTION
PR #235 fixed a couple of hard-coded paths in `nc-config.cmake.in`. This PR fixes them in `nc-config.in`, used by autotools. It also adds some flags which I think should be included: `--libdir`, by analogy with `--includedir`; `--has-fortran`, rather than the specific `--has-{f90,f03}`, which are only available if `nf-config` is found; and the flags/libs needed for the C++ API, which can be checked with `ncxx{,4}-config`, assuming it's been found (by analogy to the Fortran flags/libs).