### PR TITLE
Usage function called wrong in nc-config

### DIFF
--- a/nc-config.cmake.in
+++ b/nc-config.cmake.in
@@ -350,9 +350,8 @@ while test $# -gt 0; do
 
     *)
         echo "unknown option: $1"
-	usage
-	exit 1
-	;;
+	    usage 1
+	    ;;
     esac
     shift
 done

--- a/nc-config.in
+++ b/nc-config.in
@@ -297,9 +297,8 @@ while test $# -gt 0; do
 
     *)
         echo "unknown option: $1"
-	usage
-	exit 1
-	;;
+	    usage 1
+	    ;;
     esac
     shift
 done


### PR DESCRIPTION
Another trivial patch, I'm afraid. `usage` needs to be called with an exit value. Incorrect options won't set the exit value, so are trickier to detect, i.e. you currently can't do something like

    if [[ nc-config --wrong-option ]]; then

to detect wrong options.