### PR TITLE
Fix invalid array access

### DIFF
--- a/ncdump/vardata.c
+++ b/ncdump/vardata.c
@@ -64,7 +64,7 @@ lput(const char *cp) {
 	linep = (int)strlen(LINEPIND) + indent_get();
     }
     (void) fputs(cp,stdout);
-    if (cp[nn - 1] == '\n') {
+    if (nn > 0 && cp[nn - 1] == '\n') {
 	linep = indent_get();
     } else
 	linep += nn;


### PR DESCRIPTION
If an empty line is passed to this routine, then there is an invalid memory access at the cp[nn-1] line.  This becomes cp[-1] which is invalid.