### PR TITLE
Fix spelling errors.

### DIFF
--- a/docs/netcdf.m4
+++ b/docs/netcdf.m4
@@ -774,15 +774,15 @@ Learn about a compound type.
 .HP
 FDECL(def_vlen, (INCID(), INAME(), INCTYPE(base_typeid), ONCTYPE(xtypep)))
 .sp
-Create a varaible length array type.
+Create a variable length array type.
 .HP
 FDECL(inq_vlen, (INCID(), INCTYPE(), ONAME(), OSIZET(datum_sizep), ONCTYPE(base_nc_typep)))
 .sp
-Learn about a varaible length array type.
+Learn about a variable length array type.
 .HP
 FDECL(free_vlen, (nc_vlen_t *vl))
 .sp
-Free memory comsumed by reading data of a varaible length array type.
+Free memory comsumed by reading data of a variable length array type.
 .HP
 FDECL(put_vlen_element, (INCID(), INCTYPE(), IVOIDP(vlen_element), ISIZET(len), IVOIDP(data)))
 .sp

--- a/docs/old/netcdf-f90.texi
+++ b/docs/old/netcdf-f90.texi
@@ -5180,7 +5180,7 @@ rh in an existing netCDF dataset named foo.nc:
 @findex NF90_INQ_VARID 
 @cindex NF90_INQ_VARID, example
 
-Given the name of a varaible, nf90_inq_varid finds the variable ID.
+Given the name of a variable, nf90_inq_varid finds the variable ID.
 
 @heading Usage 
 @example

--- a/ncgen/ncgen.1
+++ b/ncgen/ncgen.1
@@ -864,7 +864,7 @@ There are three other cases of note.
 .IP 1. 3
 If there is only a single, unlimited dimension,
 then all of the constants are concatenated
-and fill characers are added to the
+and fill characters are added to the
 end of the resulting string to make its
 length be that of the unlimited dimension.
 If the length is larger than


### PR DESCRIPTION
The lintian QA tool reported a couple of spelling errors for the most recent Debian package build:

 * characers -> characters
 * varaible  -> variable