### PR TITLE
Switch NC_CHAR on netCDF4 to use ASCII

### DIFF
--- a/docs/file_format_specifications.md
+++ b/docs/file_format_specifications.md
@@ -625,7 +625,7 @@ data are written). In that case the specified endian type will be used
 in HDF5 (for example, a H5T_STD_I16LE will be used for NC_SHORT, if
 little-endian has been specified for that variable.)
 - NC_BYTE = H5T_NATIVE_SCHAR
-- NC_UBYTE = H5T_NATIVE_SCHAR
+- NC_UBYTE = H5T_NATIVE_UCHAR
 - NC_CHAR = H5T_C_S1
 - NC_STRING = variable length array of H5T_C_S1
 - NC_SHORT = H5T_NATIVE_SHORT

--- a/libsrc4/nc4hdf.c
+++ b/libsrc4/nc4hdf.c
@@ -325,7 +325,7 @@ nc4_get_hdf_typeid(NC_HDF5_FILE_INFO_T *h5, nc_type xtype,
             return NC_EHDFERR;
           if (H5Tset_strpad(typeid, H5T_STR_NULLTERM) < 0)
             BAIL(NC_EVARMETA);
-	  if(H5Tset_cset(typeid, H5T_CSET_UTF8) < 0)
+	  if(H5Tset_cset(typeid, H5T_CSET_ASCII) < 0)
 	    BAIL(NC_EVARMETA);
 
           /* Take ownership of the newly created HDF5 datatype */

--- a/nc_test4/tst_strings2.c
+++ b/nc_test4/tst_strings2.c
@@ -27,8 +27,9 @@ main(int argc, char **argv)
       int ncid, i;
       char *data_in[ATT_LEN];
       char *data[ATT_LEN] = {"An appeaser is one who feeds a crocodile — "
-			     "hoping it will eat him last."};
-
+                             "hoping it will eat him last. "
+                             "Here are some non-ASCII characters: "
+                             "\x00\xAA\xBB\xFF"};
 
       if (nc_create(FILE_NAME, NC_NETCDF4, &ncid)) ERR;
       if (nc_put_att(ncid, NC_GLOBAL, ATT_NAME, NC_STRING, ATT_LEN, data)) ERR;


### PR DESCRIPTION
Fixes #298

The new test, a minor modification of `tst_strings2.c` to use `NC_CHAR` and some non-ASCII characters, passes on Travis-CI. Let me know if you need anything else.

You'll notice that I didn't modify the reading code at all -- older versions of netCDF4 already read fixed width ASCII as NC_CHAR. Thus this should present no backwards compatibility concerns.
