### PR TITLE
Replace linked list with array for var storage in netcdf-4 format

### DIFF
--- a/include/nc4internal.h
+++ b/include/nc4internal.h
@@ -146,7 +146,6 @@ typedef struct NC_ATT_INFO
 /* This is a struct to handle the var metadata. */
 typedef struct NC_VAR_INFO
 {
-   NC_LIST_NODE_T l;            /* Use generic doubly-linked list (must be first) */
    char *name;
    char *hdf5_name; /* used if different from name */
    int ndims;
@@ -268,19 +267,6 @@ typedef struct NC_VAR_ARRAY_T {
 	NC_VAR_INFO_T **value;
 } NC_VAR_ARRAY_T;
 
-extern void
-free_NC_VAR_ARRAY_V0(NC_VAR_ARRAY_T *ncap);
-
-extern void
-free_NC_VAR_ARRAY_V(NC_VAR_ARRAY_T *ncap);
-
-extern int
-dup_NC_VAR_ARRAY_V(NC_VAR_ARRAY_T *ncap, const NC_VAR_ARRAY_T *ref);
-
-extern NC_VAR_INFO_T *
-elem_NC_VAR_ARRAY(const NC_VAR_ARRAY_T *ncap, size_t elem);
-
-
 /* This holds information for one group. Groups reproduce with
  * parthenogenesis. */
 typedef struct NC_GRP_INFO
@@ -293,7 +279,6 @@ typedef struct NC_GRP_INFO
    struct NC_GRP_INFO *parent;
    struct NC_GRP_INFO *children;
    NC_VAR_ARRAY_T vars;
-   NC_VAR_INFO_T *var;
    NC_DIM_INFO_T *dim;
    NC_ATT_INFO_T *att;
    NC_TYPE_INFO_T *type;
@@ -405,8 +390,8 @@ int nc4_type_free(NC_TYPE_INFO_T *type);
 
 /* These list functions add and delete vars, atts. */
 int nc4_nc4f_list_add(NC *nc, const char *path, int mode);
-int nc4_var_list_add(NC_VAR_INFO_T **list, NC_VAR_INFO_T **var);
-int nc4_var_list_del(NC_VAR_INFO_T **list, NC_VAR_INFO_T *var);
+int nc4_var_add(NC_VAR_INFO_T **var);
+int nc4_var_del(NC_VAR_INFO_T *var);
 int nc4_dim_list_add(NC_DIM_INFO_T **list, NC_DIM_INFO_T **dim);
 int nc4_dim_list_del(NC_DIM_INFO_T **list, NC_DIM_INFO_T *dim);
 int nc4_att_list_add(NC_ATT_INFO_T **list, NC_ATT_INFO_T **att);

--- a/include/nc4internal.h
+++ b/include/nc4internal.h
@@ -262,6 +262,25 @@ typedef struct NC_TYPE_INFO
    } u;                         /* Union of structs, for each type/class */
 } NC_TYPE_INFO_T;
 
+typedef struct NC_VAR_ARRAY_T {
+	size_t nalloc;		/* number allocated >= nelems */
+	size_t nelems;		/* length of the array */
+	NC_VAR_INFO_T **value;
+} NC_VAR_ARRAY_T;
+
+extern void
+free_NC_VAR_ARRAY_V0(NC_VAR_ARRAY_T *ncap);
+
+extern void
+free_NC_VAR_ARRAY_V(NC_VAR_ARRAY_T *ncap);
+
+extern int
+dup_NC_VAR_ARRAY_V(NC_VAR_ARRAY_T *ncap, const NC_VAR_ARRAY_T *ref);
+
+extern NC_VAR_INFO_T *
+elem_NC_VAR_ARRAY(const NC_VAR_ARRAY_T *ncap, size_t elem);
+
+
 /* This holds information for one group. Groups reproduce with
  * parthenogenesis. */
 typedef struct NC_GRP_INFO
@@ -273,6 +292,7 @@ typedef struct NC_GRP_INFO
    struct NC_HDF5_FILE_INFO *nc4_info;
    struct NC_GRP_INFO *parent;
    struct NC_GRP_INFO *children;
+   NC_VAR_ARRAY_T vars;
    NC_VAR_INFO_T *var;
    NC_DIM_INFO_T *dim;
    NC_ATT_INFO_T *att;

--- a/libsrc4/nc4attr.c
+++ b/libsrc4/nc4attr.c
@@ -261,14 +261,12 @@ nc4_put_att(int ncid, NC *nc, int varid, const char *name,
       attlist = &grp->att;
    else
    {
-     for (var = grp->var; var; var = var->l.next)
-       if (var->varid == varid)
-         {
-           attlist = &var->att;
-           break;
-         }
-     if (!var)
-       return NC_ENOTVAR;
+      if (varid < 0 || varid >= grp->vars.nelems)
+	return NC_ENOTVAR;
+      var = grp->vars.value[varid];
+      if (!var) return NC_ENOTVAR;
+      attlist = &var->att;
+      assert(var->varid == varid);
    }
 
    for (att = *attlist; att; att = att->l.next)
@@ -666,14 +664,12 @@ NC4_rename_att(int ncid, int varid, const char *name,
    }
    else
    {
-      for (var = grp->var; var; var = var->l.next)
-	 if (var->varid == varid)
-	 {
-	    list = var->att;
-	    break;
-	 }
-      if (!var)
-	 return NC_ENOTVAR;
+      if (varid < 0 || varid >= grp->vars.nelems)
+	return NC_ENOTVAR;
+      var = grp->vars.value[varid];
+      if (!var) return NC_ENOTVAR;
+      assert(var->varid == varid);
+      list = var->att;
    }
    for (att = list; att; att = att->l.next)
       if (!strncmp(att->name, norm_newname, NC_MAX_NAME))
@@ -777,16 +773,12 @@ NC4_del_att(int ncid, int varid, const char *name)
    }
    else
    {
-      for(var = grp->var; var; var = var->l.next)
-      {
-	 if (var->varid == varid)
-	 {
-	    attlist = &var->att;
-	    break;
-	 }
-      }
-      if (!var)
-	 return NC_ENOTVAR;
+      if (varid < 0 || varid >= grp->vars.nelems)
+	return NC_ENOTVAR;
+      var = grp->vars.value[varid];
+      if (!var) return NC_ENOTVAR;
+      attlist = &var->att;
+      assert(var->varid == varid);
       if (var->created)
 	 locid = var->hdf_datasetid;
    }

--- a/libsrc4/nc4attr.c
+++ b/libsrc4/nc4attr.c
@@ -42,7 +42,6 @@ nc4_get_att(int ncid, NC *nc, int varid, const char *name,
    char norm_name[NC_MAX_NAME + 1];
    int i;
    int retval = NC_NOERR;
-   const char** sp;
 
    if (attnum) {
       my_attnum = *attnum;
@@ -362,7 +361,6 @@ nc4_put_att(int ncid, NC *nc, int varid, const char *name,
     * attribute). */
    if (!strcmp(att->name, _FillValue) && varid != NC_GLOBAL)
    {
-      NC_ATT_INFO_T *varatt;
       int size;
 
       /* Fill value must be same type and have exactly one value */

--- a/libsrc4/nc4file.c
+++ b/libsrc4/nc4file.c
@@ -2602,6 +2602,8 @@ nc4_open_hdf4_file(const char *path, int mode, NC *nc)
       var->created = NC_TRUE;
       var->written_to = NC_TRUE;
 
+      nc4_vararray_add(grp, var);
+
       /* Open this dataset in HDF4 file. */
       if ((var->sdsid = SDselect(h5->sdid, v)) == FAIL)
 	return NC_EVARMETA;

--- a/libsrc4/nc4file.c
+++ b/libsrc4/nc4file.c
@@ -3230,8 +3230,9 @@ NC4_inq(int ncid, int *ndimsp, int *nvarsp, int *nattsp, int *unlimdimidp)
    }
    if (nvarsp)
    {
+      int i;
       *nvarsp = 0;
-      for (int i=0; i < grp->vars.nelems; i++)
+      for (i=0; i < grp->vars.nelems; i++)
       {
 	if (grp->vars.value[i])
 	  (*nvarsp)++;

--- a/libsrc4/nc4file.c
+++ b/libsrc4/nc4file.c
@@ -509,7 +509,6 @@ NC4_create(const char* path, int cmode, size_t initialsz, int basepe,
    MPI_Comm comm = MPI_COMM_WORLD;
    MPI_Info info = MPI_INFO_NULL;
    int res;
-   NC* nc;
 
    assert(nc_file && path);
 
@@ -3210,7 +3209,6 @@ NC4_inq(int ncid, int *ndimsp, int *nvarsp, int *nattsp, int *unlimdimidp)
    NC_GRP_INFO_T *grp;
    NC_DIM_INFO_T *dim;
    NC_ATT_INFO_T *att;
-   NC_VAR_INFO_T *var;
    int retval;
 
    LOG((2, "%s: ncid 0x%x", __func__, ncid));

--- a/libsrc4/nc4file.c
+++ b/libsrc4/nc4file.c
@@ -16,6 +16,9 @@ COPYRIGHT file for copying and redistribution conditions.
 #include "nc4internal.h"
 #include "nc4dispatch.h"
 
+extern int nc4_vararray_add(NC_GRP_INFO_T *grp,
+			    NC_VAR_INFO_T *var);
+
 /* must be after nc4internal.h */
 #include <H5DSpublic.h>
 #include <H5Fpublic.h>
@@ -1809,6 +1812,8 @@ read_var(NC_GRP_INFO_T *grp, hid_t datasetid, const char *obj_name,
 	 att->created = NC_TRUE;
       } /* endif not HDF5 att */
    } /* next attribute */
+
+   nc4_vararray_add(grp, var);
 
    /* Is this a deflated variable with a chunksize greater than the
     * current cache size? */

--- a/libsrc4/nc4file.c
+++ b/libsrc4/nc4file.c
@@ -1537,7 +1537,7 @@ read_var(NC_GRP_INFO_T *grp, hid_t datasetid, const char *obj_name,
    LOG((4, "%s: obj_name %s", __func__, obj_name));
 
    /* Add a variable to the end of the group's var list. */
-   if ((retval = nc4_var_list_add(&grp->var, &var)))
+   if ((retval = nc4_var_add(&var)))
       BAIL(retval);
 
    /* Fill in what we already know. */
@@ -1825,7 +1825,7 @@ exit:
    {
        if (incr_id_rc && H5Idec_ref(datasetid) < 0)
           BAIL2(NC_EHDFERR);
-       if (var && nc4_var_list_del(&grp->var, var))
+       if (var && nc4_var_del(var))
           BAIL2(NC_EHDFERR);
    }
    if (access_pid && H5Pclose(access_pid) < 0)
@@ -2595,8 +2595,8 @@ nc4_open_hdf4_file(const char *path, int mode, NC *nc)
       size_t var_type_size;
       int a;
 
-      /* Add a variable to the end of the group's var list. */
-      if ((retval = nc4_var_list_add(&grp->var, &var)))
+      /* Add a variable. */
+      if ((retval = nc4_var_add(&var)))
 	return retval;
 
       var->varid = grp->nvars++;
@@ -3231,8 +3231,11 @@ NC4_inq(int ncid, int *ndimsp, int *nvarsp, int *nattsp, int *unlimdimidp)
    if (nvarsp)
    {
       *nvarsp = 0;
-      for (var = grp->var; var; var= var->l.next)
-	(*nvarsp)++;
+      for (int i=0; i < grp->vars.nelems; i++)
+      {
+	if (grp->vars.value[i])
+	  (*nvarsp)++;
+      }
    }
    if (nattsp)
      {

--- a/libsrc4/nc4grp.c
+++ b/libsrc4/nc4grp.c
@@ -413,14 +413,13 @@ NC4_inq_varids(int ncid, int *nvars, int *varids)
    {
       /* This is a netCDF-4 group. Round up them doggies and count
        * 'em. The list is in correct (i.e. creation) order. */
-      if (grp->var)
+      for (int i=0; i < grp->vars.nelems; i++)
       {
-	 for (var = grp->var; var; var = var->l.next)
-	 {
-	    if (varids)
-	       varids[num_vars] = var->varid;
-	    num_vars++;
-	 }
+	var = grp->vars.value[i];
+	if (!var) continue;
+	if (varids)
+	  varids[num_vars] = var->varid;
+	num_vars++;
       }
    }
 

--- a/libsrc4/nc4grp.c
+++ b/libsrc4/nc4grp.c
@@ -392,6 +392,7 @@ NC4_inq_varids(int ncid, int *nvars, int *varids)
    NC_VAR_INFO_T *var;
    int v, num_vars = 0;
    int retval;
+   int i;
 
    LOG((2, "nc_inq_varids: ncid 0x%x", ncid));
 
@@ -413,7 +414,7 @@ NC4_inq_varids(int ncid, int *nvars, int *varids)
    {
       /* This is a netCDF-4 group. Round up them doggies and count
        * 'em. The list is in correct (i.e. creation) order. */
-      for (int i=0; i < grp->vars.nelems; i++)
+      for (i=0; i < grp->vars.nelems; i++)
       {
 	var = grp->vars.value[i];
 	if (!var) continue;

--- a/libsrc4/nc4hdf.c
+++ b/libsrc4/nc4hdf.c
@@ -81,7 +81,7 @@ rec_reattach_scales(NC_GRP_INFO_T *grp, int dimid, hid_t dimscaleid)
       return retval;
 
   /* Find any vars that use this dimension id. */
-  for (i=0; i < grp->vars.nelems; i++) 
+  for (i=0; i < grp->vars.nelems; i++)
   {
     var = grp->vars.value[i];
     if (!var) continue;
@@ -124,7 +124,7 @@ rec_detach_scales(NC_GRP_INFO_T *grp, int dimid, hid_t dimscaleid)
       return retval;
 
   /* Find any vars that use this dimension id. */
-  for (i=0; i < grp->vars.nelems; i++) 
+  for (i=0; i < grp->vars.nelems; i++)
   {
     var = grp->vars.value[i];
     if (!var) continue;
@@ -2065,7 +2065,7 @@ attach_dimscales(NC_GRP_INFO_T *grp)
   int retval = NC_NOERR;
 
   /* Attach dimension scales. */
-  for (i=0; i < grp->vars.nelems; i++) 
+  for (i=0; i < grp->vars.nelems; i++)
     {
       var = grp->vars.value[i];
       if (!var) continue;
@@ -2448,7 +2448,7 @@ write_dim(NC_DIM_INFO_T *dim, NC_GRP_INFO_T *grp, nc_bool_t write_dimid)
       /* If this is a dimension without a variable, then update
        * the secret length information at the end of the NAME
        * attribute. */
-      for (i=0; i < grp->vars.nelems; i++) 
+      for (i=0; i < grp->vars.nelems; i++)
       {
 	if (grp->vars.value[i] && !strcmp(grp->vars.value[i]->name, dim->name))
 	{
@@ -2509,7 +2509,7 @@ nc4_rec_detect_need_to_preserve_dimids(NC_GRP_INFO_T *grp, nc_bool_t *bad_coord_
   int i;
 
   /* Iterate over variables in this group */
-  for (i=0; i < grp->vars.nelems; i++) 
+  for (i=0; i < grp->vars.nelems; i++)
     {
       var = grp->vars.value[i];
       if (!var) continue;
@@ -3664,7 +3664,7 @@ nc4_rec_match_dimscales(NC_GRP_INFO_T *grp)
 
   /* Check all the vars in this group. If they have dimscale info,
    * try and find a dimension for them. */
-  for (i=0; i < grp->vars.nelems; i++) 
+  for (i=0; i < grp->vars.nelems; i++)
     {
       var = grp->vars.value[i];
       if (!var) continue;

--- a/libsrc4/nc4hdf.c
+++ b/libsrc4/nc4hdf.c
@@ -873,7 +873,7 @@ int
 nc4_get_vara(NC *nc, int ncid, int varid, const size_t *startp,
              const size_t *countp, nc_type mem_nc_type, int is_long, void *data)
 {
-  NC_GRP_INFO_T *grp, *g;
+  NC_GRP_INFO_T *grp;
   NC_HDF5_FILE_INFO_T *h5;
   NC_VAR_INFO_T *var;
   NC_DIM_INFO_T *dim;
@@ -1526,13 +1526,11 @@ write_netcdf4_dimid(hid_t datasetid, int dimid)
 static int
 var_create_dataset(NC_GRP_INFO_T *grp, NC_VAR_INFO_T *var, nc_bool_t write_dimid)
 {
-  NC_GRP_INFO_T *g;
   hid_t plistid = 0, access_plistid = 0, typeid = 0, spaceid = 0;
   hsize_t chunksize[H5S_MAX_RANK], dimsize[H5S_MAX_RANK], maxdimsize[H5S_MAX_RANK];
   int d;
   void *fillp = NULL;
   NC_DIM_INFO_T *dim = NULL;
-  int dims_found = 0;
   char *name_to_use;
   int retval = NC_NOERR;
 
@@ -2060,7 +2058,6 @@ attach_dimscales(NC_GRP_INFO_T *grp)
 {
   NC_VAR_INFO_T *var;
   NC_DIM_INFO_T *dim1;
-  NC_GRP_INFO_T *g;
   int d, i;
   int retval = NC_NOERR;
 
@@ -2459,7 +2456,6 @@ write_dim(NC_DIM_INFO_T *dim, NC_GRP_INFO_T *grp, nc_bool_t write_dimid)
       if (v1)
         {
           hsize_t *new_size = NULL;
-          NC_DIM_INFO_T *dim1;
           int d1;
 
           /* Extend the dimension scale dataset to reflect the new
@@ -4001,7 +3997,6 @@ reportopenobjectsT(int log, hid_t fid, int ntypes, unsigned int* otypes)
     idlist = (hid_t*)malloc(sizeof(hid_t)*maxobjs);
     for(t=0;t<ntypes;t++) {
 	unsigned int ot = otypes[t];
-	if(ot < 0) break;
         ocount = H5Fget_obj_ids(fid,ot,maxobjs,idlist);
 	for(i=0;i<ocount;i++) {
 	    hid_t o = idlist[i];
@@ -4088,11 +4083,8 @@ done:
 static int
 NC4_get_strict_att(NC_HDF5_FILE_INFO_T* h5)
 {
-    int ncstat = NC_NOERR;
-    size_t size;
     hid_t grp = -1;
     hid_t attid = -1;
-    herr_t herr = 0;
 
     /* Get root group */
     grp = h5->root_grp->hdf_grpid; /* get root group */

--- a/libsrc4/nc4hdf.c
+++ b/libsrc4/nc4hdf.c
@@ -69,7 +69,7 @@ rec_reattach_scales(NC_GRP_INFO_T *grp, int dimid, hid_t dimscaleid)
 {
   NC_VAR_INFO_T *var;
   NC_GRP_INFO_T *child_grp;
-  int d;
+  int d, i;
   int retval;
 
   assert(grp && grp->name && dimid >= 0 && dimscaleid >= 0);
@@ -81,7 +81,7 @@ rec_reattach_scales(NC_GRP_INFO_T *grp, int dimid, hid_t dimscaleid)
       return retval;
 
   /* Find any vars that use this dimension id. */
-  for (int i=0; i < grp->vars.nelems; i++) 
+  for (i=0; i < grp->vars.nelems; i++) 
   {
     var = grp->vars.value[i];
     if (!var) continue;
@@ -112,7 +112,7 @@ rec_detach_scales(NC_GRP_INFO_T *grp, int dimid, hid_t dimscaleid)
 {
   NC_VAR_INFO_T *var;
   NC_GRP_INFO_T *child_grp;
-  int d;
+  int d, i;
   int retval;
 
   assert(grp && grp->name && dimid >= 0 && dimscaleid >= 0);
@@ -124,7 +124,7 @@ rec_detach_scales(NC_GRP_INFO_T *grp, int dimid, hid_t dimscaleid)
       return retval;
 
   /* Find any vars that use this dimension id. */
-  for (int i=0; i < grp->vars.nelems; i++) 
+  for (i=0; i < grp->vars.nelems; i++) 
   {
     var = grp->vars.value[i];
     if (!var) continue;
@@ -2061,11 +2061,11 @@ attach_dimscales(NC_GRP_INFO_T *grp)
   NC_VAR_INFO_T *var;
   NC_DIM_INFO_T *dim1;
   NC_GRP_INFO_T *g;
-  int d;
+  int d, i;
   int retval = NC_NOERR;
 
   /* Attach dimension scales. */
-  for (int i=0; i < grp->vars.nelems; i++) 
+  for (i=0; i < grp->vars.nelems; i++) 
     {
       var = grp->vars.value[i];
       if (!var) continue;
@@ -2363,6 +2363,7 @@ static int
 write_dim(NC_DIM_INFO_T *dim, NC_GRP_INFO_T *grp, nc_bool_t write_dimid)
 {
   int retval;
+  int i;
 
   /* If there's no dimscale dataset for this dim, create one,
    * and mark that it should be hidden from netCDF as a
@@ -2447,7 +2448,7 @@ write_dim(NC_DIM_INFO_T *dim, NC_GRP_INFO_T *grp, nc_bool_t write_dimid)
       /* If this is a dimension without a variable, then update
        * the secret length information at the end of the NAME
        * attribute. */
-      for (int i=0; i < grp->vars.nelems; i++) 
+      for (i=0; i < grp->vars.nelems; i++) 
       {
 	if (grp->vars.value[i] && !strcmp(grp->vars.value[i]->name, dim->name))
 	{
@@ -2505,9 +2506,10 @@ nc4_rec_detect_need_to_preserve_dimids(NC_GRP_INFO_T *grp, nc_bool_t *bad_coord_
   NC_GRP_INFO_T *child_grp;
   int last_dimid = -1;
   int retval;
+  int i;
 
   /* Iterate over variables in this group */
-  for (int i=0; i < grp->vars.nelems; i++) 
+  for (i=0; i < grp->vars.nelems; i++) 
     {
       var = grp->vars.value[i];
       if (!var) continue;
@@ -3650,7 +3652,8 @@ nc4_rec_match_dimscales(NC_GRP_INFO_T *grp)
   NC_VAR_INFO_T *var;
   NC_DIM_INFO_T *dim;
   int retval = NC_NOERR;
-
+  int i;
+  
   assert(grp && grp->name);
   LOG((4, "%s: grp->name %s", __func__, grp->name));
 
@@ -3661,7 +3664,7 @@ nc4_rec_match_dimscales(NC_GRP_INFO_T *grp)
 
   /* Check all the vars in this group. If they have dimscale info,
    * try and find a dimension for them. */
-  for (int i=0; i < grp->vars.nelems; i++) 
+  for (i=0; i < grp->vars.nelems; i++) 
     {
       var = grp->vars.value[i];
       if (!var) continue;

--- a/libsrc4/nc4info.c
+++ b/libsrc4/nc4info.c
@@ -25,7 +25,6 @@ NC4_fileinfo_init(void)
 {
     int stat = NC_NOERR;
     unsigned major,minor,release;
-    int super;
 
     /* Build nc properties */
     memset((void*)&globalpropinfo,0,sizeof(globalpropinfo));
@@ -145,10 +144,7 @@ int
 NC4_put_propattr(NC_HDF5_FILE_INFO_T* h5)
 {
     int ncstat = NC_NOERR;
-    H5T_class_t t_class;
-    size_t size;
     hid_t grp = -1;
-    hid_t exists = -1;
     hid_t attid = -1;
     hid_t aspace = -1;
     hid_t atype = -1;

--- a/libsrc4/nc4internal.c
+++ b/libsrc4/nc4internal.c
@@ -1122,7 +1122,7 @@ int
 nc4_rec_grp_del(NC_GRP_INFO_T **list, NC_GRP_INFO_T *grp)
 {
    NC_GRP_INFO_T *g, *c;
-   NC_VAR_INFO_T *v, *var;
+   NC_VAR_INFO_T *var;
    NC_ATT_INFO_T *a, *att;
    NC_DIM_INFO_T *d, *dim;
    NC_TYPE_INFO_T *type, *t;

--- a/libsrc4/nc4internal.c
+++ b/libsrc4/nc4internal.c
@@ -1128,7 +1128,7 @@ nc4_rec_grp_del(NC_GRP_INFO_T **list, NC_GRP_INFO_T *grp)
    NC_TYPE_INFO_T *type, *t;
    int retval;
    int i;
-   
+
    assert(grp);
    LOG((3, "%s: grp->name %s", __func__, grp->name));
 
@@ -1160,7 +1160,7 @@ nc4_rec_grp_del(NC_GRP_INFO_T **list, NC_GRP_INFO_T *grp)
    {
       var = grp->vars.value[i];
       if (!var) continue;
-     
+
       LOG((4, "%s: deleting var %s", __func__, var->name));
       /* Close HDF5 dataset associated with this var, unless it's a
        * scale. */

--- a/libsrc4/nc4internal.c
+++ b/libsrc4/nc4internal.c
@@ -373,11 +373,12 @@ nc4_find_dim(NC_GRP_INFO_T *grp, int dimid, NC_DIM_INFO_T **dim,
 int
 nc4_find_var(NC_GRP_INFO_T *grp, const char *name, NC_VAR_INFO_T **var)
 {
+  int i;
    assert(grp && var && name);
 
    /* Find the var info. */
    *var = NULL;
-   for (int i=0; i < grp->vars.nelems; i++)
+   for (i=0; i < grp->vars.nelems; i++)
    {
      if (0 == strcmp(name, grp->vars.value[i]->name))
      {
@@ -501,6 +502,7 @@ nc4_find_dim_len(NC_GRP_INFO_T *grp, int dimid, size_t **len)
    NC_GRP_INFO_T *g;
    NC_VAR_INFO_T *var;
    int retval;
+   int i;
 
    assert(grp && len);
    LOG((3, "nc4_find_dim_len: grp->name %s dimid %d", grp->name, dimid));
@@ -513,7 +515,7 @@ nc4_find_dim_len(NC_GRP_INFO_T *grp, int dimid, size_t **len)
 
    /* For all variables in this group, find the ones that use this
     * dimension, and remember the max length. */
-   for (int i=0; i < grp->vars.nelems; i++)
+   for (i=0; i < grp->vars.nelems; i++)
    {
      size_t mylen;
      var = grp->vars.value[i];
@@ -770,6 +772,7 @@ nc4_check_dup_name(NC_GRP_INFO_T *grp, char *name)
    NC_GRP_INFO_T *g;
    NC_VAR_INFO_T *var;
    uint32_t hash;
+   int i;
    
    /* Any types of this name? */
    for (type = grp->type; type; type = type->l.next)
@@ -783,7 +786,7 @@ nc4_check_dup_name(NC_GRP_INFO_T *grp, char *name)
 
    /* Any variables of this name? */
    hash =  hash_fast(name, strlen(name));
-   for (int i=0; i < grp->vars.nelems; i++)
+   for (i=0; i < grp->vars.nelems; i++)
    {
       var = grp->vars.value[i];
       if (!var) continue;
@@ -1124,7 +1127,8 @@ nc4_rec_grp_del(NC_GRP_INFO_T **list, NC_GRP_INFO_T *grp)
    NC_DIM_INFO_T *d, *dim;
    NC_TYPE_INFO_T *type, *t;
    int retval;
-
+   int i;
+   
    assert(grp);
    LOG((3, "%s: grp->name %s", __func__, grp->name));
 
@@ -1152,7 +1156,7 @@ nc4_rec_grp_del(NC_GRP_INFO_T **list, NC_GRP_INFO_T *grp)
    }
 
    /* Delete all vars. */
-   for (int i=0; i < grp->vars.nelems; i++)
+   for (i=0; i < grp->vars.nelems; i++)
    {
       var = grp->vars.value[i];
       if (!var) continue;
@@ -1463,7 +1467,7 @@ rec_print_metadata(NC_GRP_INFO_T *grp, int tab_count)
    char tabs[MAX_NESTS] = "";
    char *dims_string = NULL;
    char temp_string[10];
-   int t, retval, d;
+   int t, retval, d, i;
 
    /* Come up with a number of tabs relative to the group. */
    for (t = 0; t < tab_count && t < MAX_NESTS; t++)
@@ -1480,7 +1484,7 @@ rec_print_metadata(NC_GRP_INFO_T *grp, int tab_count)
       LOG((2, "%s DIMENSION - dimid: %d name: %s len: %d unlimited: %d",
 	   tabs, dim->dimid, dim->name, dim->len, dim->unlimited));
 
-   for (int i=0; i < grp->vars.nelems; i++)
+   for (i=0; i < grp->vars.nelems; i++)
    {
       var = grp->vars.value[i];
       if (!var) continue;

--- a/libsrc4/nc4var.c
+++ b/libsrc4/nc4var.c
@@ -1158,6 +1158,7 @@ NC4_inq_varid(int ncid, const char *name, int *varidp)
    char norm_name[NC_MAX_NAME + 1];
    int retval;
    uint32_t nn_hash;
+   int i;
    
    if (!name)
       return NC_EINVAL;
@@ -1177,7 +1178,7 @@ NC4_inq_varid(int ncid, const char *name, int *varidp)
    nn_hash = hash_fast(norm_name, strlen(norm_name));
 
    /* Find var of this name. */
-   for (int i=0; i < grp->vars.nelems; i++)
+   for (i=0; i < grp->vars.nelems; i++)
       {
 	var = grp->vars.value[i];
 	if (!var) continue;
@@ -1203,7 +1204,8 @@ NC4_rename_var(int ncid, int varid, const char *name)
    NC_VAR_INFO_T *var, *tmp_var;
    uint32_t nn_hash;
    int retval = NC_NOERR;
-
+   int i;
+   
    LOG((2, "%s: ncid 0x%x varid %d name %s",
         __func__, ncid, varid, name));
 
@@ -1229,7 +1231,7 @@ NC4_rename_var(int ncid, int varid, const char *name)
    /* Check if name is in use, and retain a pointer to the correct variable */
    nn_hash = hash_fast(name, strlen(name));
    tmp_var = NULL;
-   for (int i=0; i < grp->vars.nelems; i++)
+   for (i=0; i < grp->vars.nelems; i++)
    {
       var = grp->vars.value[i];
       if (!var) continue;

--- a/libsrc4/nc4var.c
+++ b/libsrc4/nc4var.c
@@ -444,8 +444,8 @@ nc_def_var_nc4(int ncid, const char *name, nc_type xtype,
    }
 #endif
 
-   /* Add the var to the end of the list. */
-   if ((retval = nc4_var_list_add(&grp->var, &var)))
+   /* Add a new var. */
+   if ((retval = nc4_var_add(&var)))
       BAIL(retval);
 
    /* Now fill in the values in the var info structure. */

--- a/libsrc4/nc4var.c
+++ b/libsrc4/nc4var.c
@@ -94,11 +94,11 @@ NC4_set_var_chunk_cache(int ncid, int varid, size_t size, size_t nelems,
    assert(nc && grp && h5);
 
    /* Find the var. */
-   for (var = grp->var; var; var = var->l.next)
-      if (var->varid == varid)
-         break;
-   if (!var)
-      return NC_ENOTVAR;
+   if (varid < 0 || varid >= grp->vars.nelems)
+     return NC_ENOTVAR;
+   var = grp->vars.value[varid];
+   if (!var) return NC_ENOTVAR;
+   assert(var->varid == varid);
 
    /* Set the values. */
    var->chunk_cache_size = size;
@@ -157,11 +157,11 @@ NC4_get_var_chunk_cache(int ncid, int varid, size_t *sizep,
    assert(nc && grp && h5);
 
    /* Find the var. */
-   for (var = grp->var; var; var = var->l.next)
-      if (var->varid == varid)
-         break;
-   if (!var)
-      return NC_ENOTVAR;
+   if (varid < 0 || varid >= grp->vars.nelems)
+     return NC_ENOTVAR;
+   var = grp->vars.value[varid];
+   if (!var) return NC_ENOTVAR;
+   assert(var->varid == varid);
 
    /* Give the user what they want. */
    if (sizep)
@@ -340,6 +340,37 @@ nc4_find_default_chunksizes2(NC_GRP_INFO_T *grp, NC_VAR_INFO_T *var)
    return NC_NOERR;
 }
 
+#define NC_ARRAY_GROWBY 4
+int nc4_vararray_add(NC_GRP_INFO_T *grp,
+		     NC_VAR_INFO_T *var)
+{
+  NC_VAR_INFO_T **vp = NULL;
+
+  if (grp->vars.nalloc == 0) {
+    assert(grp->vars.nelems == 0);
+    vp = (NC_VAR_INFO_T **) malloc(NC_ARRAY_GROWBY * sizeof(NC_VAR_INFO_T *));
+    if(vp == NULL)
+      return NC_ENOMEM;
+    grp->vars.value = vp;
+    grp->vars.nalloc = NC_ARRAY_GROWBY;
+  }
+  else if(grp->vars.nelems +1 > grp->vars.nalloc) {
+    vp = (NC_VAR_INFO_T **) realloc(grp->vars.value,
+			     (grp->vars.nalloc + NC_ARRAY_GROWBY) * sizeof(NC_VAR_INFO_T *));
+    if(vp == NULL)
+      return NC_ENOMEM;
+    grp->vars.value = vp;
+    grp->vars.nalloc += NC_ARRAY_GROWBY;
+  }
+
+  if(var != NULL) {
+    assert(var->varid == grp->vars.nelems);
+    grp->vars.value[grp->vars.nelems] = var;
+    grp->vars.nelems++;
+  }
+  return NC_NOERR;
+}
+
 /* This is called when a new netCDF-4 variable is defined. Break it
  * down! */
 static int
@@ -425,6 +456,8 @@ nc_def_var_nc4(int ncid, const char *name, nc_type xtype,
    var->varid = grp->nvars++;
    var->ndims = ndims;
    var->is_new_var = NC_TRUE;
+
+   nc4_vararray_add(grp, var);
 
    /* If this is a user-defined type, there is a type_info struct with
     * all the type information. For atomic types, fake up a type_info
@@ -671,13 +704,11 @@ NC4_inq_var_all(int ncid, int varid, char *name, nc_type *xtypep,
    }
 
    /* Find the var. */
-   for (var = grp->var; var; var = var->l.next)
-      if (var->varid == varid)
-         break;
-
-   /* Oh no! Maybe we couldn't find it (*sob*)! */
-   if (!var)
-      return NC_ENOTVAR;
+   if (varid < 0 || varid >= grp->vars.nelems)
+     return NC_ENOTVAR;
+   var = grp->vars.value[varid];
+   if (!var) return NC_ENOTVAR;
+   assert(var->varid == varid);
 
    /* Copy the data to the user's data buffers. */
    if (name)
@@ -821,13 +852,11 @@ nc_def_var_extra(int ncid, int varid, int *shuffle, int *deflate,
    assert(nc && grp && h5);
 
    /* Find the var. */
-   for (var = grp->var; var; var = var->l.next)
-      if (var->varid == varid)
-         break;
-
-   /* Oh no! Maybe we couldn't find it (*sob*)! */
-   if (!var)
-      return NC_ENOTVAR;
+   if (varid < 0 || varid >= grp->vars.nelems)
+     return NC_ENOTVAR;
+   var = grp->vars.value[varid];
+   if (!var) return NC_ENOTVAR;
+   assert(var->varid == varid);
 
    /* Can't turn on contiguous and deflate/fletcher32/szip. */
    if (contiguous)
@@ -1148,13 +1177,16 @@ NC4_inq_varid(int ncid, const char *name, int *varidp)
    nn_hash = hash_fast(norm_name, strlen(norm_name));
 
    /* Find var of this name. */
-   for (var = grp->var; var; var = var->l.next)
-      if (nn_hash == var->hash && !(strcmp(var->name, norm_name)))
+   for (int i=0; i < grp->vars.nelems; i++)
       {
-         *varidp = var->varid;
-         return NC_NOERR;
+	var = grp->vars.value[i];
+	if (!var) continue;
+        if (nn_hash == var->hash && !(strcmp(var->name, norm_name)))
+          {
+             *varidp = var->varid;
+             return NC_NOERR;
+          }
       }
-
    return NC_ENOTVAR;
 }
 
@@ -1197,8 +1229,10 @@ NC4_rename_var(int ncid, int varid, const char *name)
    /* Check if name is in use, and retain a pointer to the correct variable */
    nn_hash = hash_fast(name, strlen(name));
    tmp_var = NULL;
-   for (var = grp->var; var; var = var->l.next)
+   for (int i=0; i < grp->vars.nelems; i++)
    {
+      var = grp->vars.value[i];
+      if (!var) continue;
       if (nn_hash == var->hash && !strncmp(var->name, name, NC_MAX_NAME))
          return NC_ENAMEINUSE;
       if (var->varid == varid)
@@ -1293,11 +1327,11 @@ NC4_var_par_access(int ncid, int varid, int par_access)
       return NC_ENOPAR;
 
    /* Find the var, and set its preference. */
-   for (var = grp->var; var; var = var->l.next)
-      if (var->varid == varid)
-         break;
-   if (!var)
-      return NC_ENOTVAR;
+   if (varid < 0 || varid >= grp->vars.nelems)
+     return NC_ENOTVAR;
+   var = grp->vars.value[varid];
+   if (!var) return NC_ENOTVAR;
+   assert(var->varid == varid);
 
    if (par_access)
       var->parallel_access = NC_COLLECTIVE;

--- a/libsrc4/nc4var.c
+++ b/libsrc4/nc4var.c
@@ -1205,7 +1205,7 @@ NC4_rename_var(int ncid, int varid, const char *name)
    uint32_t nn_hash;
    int retval = NC_NOERR;
    int i;
-   
+
    LOG((2, "%s: ncid 0x%x varid %d name %s",
         __func__, ncid, varid, name));
 


### PR DESCRIPTION
The use of the linked list for var storage on nc4-format files can cause slowdowns for files with several variables.  We have seen read/write times of 10s of minutes for some complex files.  Reading/writing the same files with these changes applied has reduced the read/write times to a few seconds.

Basically, the change replaces the linked_list with an array.  Currently only done for vars, but a similar change could be done for dims.

All tests pass and the changes have been in production use for a few months at out site.

This is discussed in #234 