### PR TITLE
Add missing #include "err_macros.h" to tst_h_par.c

### DIFF
--- a/h5_test/tst_h_par.c
+++ b/h5_test/tst_h_par.c
@@ -11,6 +11,7 @@
    $Id: tst_h_par.c,v 1.15 2010/05/25 13:53:04 ed Exp $
 */
 #include <nc_tests.h>
+#include "err_macros.h"
 #include <hdf5.h>
 
 /* Defining USE_MPE causes the MPE trace library to be used (and you


### PR DESCRIPTION
This fixes the following compile error when building parallel tests:
```
mpicc -DHAVE_CONFIG_H -I. -I../../h5_test -I..  -I../../include -I../../oc2  -I/usr/include/hdf  -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -m32 -march=i686 -mtune=atom -fasynchronous-unwind-tables -c -o tst_h_par.o ../../h5_test/tst_h_par.c
../../h5_test/tst_h_par.c: In function 'main':
../../h5_test/tst_h_par.c:89:55: error: 'ERR' undeclared (first use in this function)
       if ((fapl_id = H5Pcreate(H5P_FILE_ACCESS)) < 0) ERR;
                                                       ^~~
../../h5_test/tst_h_par.c:89:55: note: each undeclared identifier is reported only once for each function it appears in
../../h5_test/tst_h_par.c:226:7: error: 'SUMMARIZE_ERR' undeclared (first use in this function)
       SUMMARIZE_ERR;
       ^~~~~~~~~~~~~
../../h5_test/tst_h_par.c:231:7: error: 'FINAL_RESULTS' undeclared (first use in this function)
       FINAL_RESULTS;
       ^~~~~~~~~~~~~
```