### PR TITLE
Use HDF5 collective metadata operations if available.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -663,6 +663,9 @@ IF(USE_HDF5 OR ENABLE_NETCDF_4)
       SET(USE_PARALLEL_POSIX ON)
     ENDIF()
 
+    #Check to see if HDF5 library has collective metadata APIs, (HDF5 >= 1.10.0)
+    CHECK_LIBRARY_EXISTS(${HDF5_C_LIBRARY} H5Pset_all_coll_metadata_ops "" HDF5_HAS_COLL_METADATA_OPS)
+
     OPTION(ENABLE_DYNAMIC_LOADING "Enable Dynamic Loading" ON)
     IF(ENABLE_DYNAMIC_LOADING)
       SET(USE_LIBDL ON CACHE BOOL "")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -635,6 +635,9 @@ IF(USE_HDF5 OR ENABLE_NETCDF_4)
       ENDIF()
 
     ENDIF(MSVC)
+    IF(NOT HDF5_C_LIBRARY)
+      SET(HDF5_C_LIBRARY hdf5)
+    ENDIF()
   ENDIF(HDF5_C_LIBRARY AND HDF5_HL_LIBRARY AND HDF5_INCLUDE_DIR)
 
   ###
@@ -644,8 +647,8 @@ IF(USE_HDF5 OR ENABLE_NETCDF_4)
     # Find out if HDF5 was built with parallel support.
     # Do that by checking for the targets H5Pget_fapl_mpiposx and
     # H5Pget_fapl_mpio in ${HDF5_LIB}.
-    CHECK_LIBRARY_EXISTS(hdf5 H5Pget_fapl_mpiposix "" HDF5_IS_PARALLEL_MPIPOSIX)
-    CHECK_LIBRARY_EXISTS(hdf5 H5Pget_fapl_mpio "" HDF5_IS_PARALLEL_MPIO)
+    CHECK_LIBRARY_EXISTS(${HDF5_C_LIBRARY} H5Pget_fapl_mpiposix "" HDF5_IS_PARALLEL_MPIPOSIX)
+    CHECK_LIBRARY_EXISTS(${HDF5_C_LIBRARY} H5Pget_fapl_mpio "" HDF5_IS_PARALLEL_MPIO)
     IF(HDF5_IS_PARALLEL_MPIPOSIX OR HDF5_IS_PARALLEL_MPIO)
       SET(HDF5_PARALLEL ON)
     ELSE()
@@ -664,7 +667,6 @@ IF(USE_HDF5 OR ENABLE_NETCDF_4)
     IF(ENABLE_DYNAMIC_LOADING)
       SET(USE_LIBDL ON CACHE BOOL "")
     ENDIF()
-    SET(HDF5_C_LIBRARY hdf5)
   ENDIF(NOT MSVC)
 
   #Check to see if H5Z_SZIP exists in HDF5_Libraries. If so, we must use szip.

--- a/config.h.cmake.in
+++ b/config.h.cmake.in
@@ -97,6 +97,7 @@ are set when opening a binary file on Windows. */
 #cmakedefine USE_PARALLEL_MPIO 1
 #cmakedefine HDF5_HAS_H5FREE 1
 #cmakedefine HDF5_HAS_LIBVER_BOUNDS 1
+#cmakedefine HDF5_HAS_COLL_METADATA_OPS 1
 #cmakedefine HDF5_PARALLEL 1
 #cmakedefine USE_PARALLEL 1
 #cmakedefine USE_PARALLEL4 1

--- a/configure.ac
+++ b/configure.ac
@@ -923,7 +923,7 @@ if test "x$enable_netcdf_4" = xyes; then
    [AC_MSG_ERROR([Can't find or link to the hdf5 high-level. Use --disable-netcdf-4, or see config.log for errors.])])
 
    AC_CHECK_HEADERS([hdf5.h], [], [AC_MSG_ERROR([Compiling a test with HDF5 failed.  Either hdf5.h cannot be found, or config.log should be checked for other reason.])])
-   AC_CHECK_FUNCS([H5Pget_fapl_mpiposix H5Pget_fapl_mpio H5Pset_deflate H5Z_SZIP H5free_memory])
+   AC_CHECK_FUNCS([H5Pget_fapl_mpiposix H5Pget_fapl_mpio H5Pset_deflate H5Z_SZIP H5free_memory H5Pset_all_coll_metadata_ops])
 
    # The user may have parallel HDF5 based on MPI POSIX.
    if test "x$ac_cv_func_H5Pget_fapl_mpiposix" = xyes; then
@@ -933,6 +933,11 @@ if test "x$enable_netcdf_4" = xyes; then
    # The user may have parallel HDF5 based on MPI mumble mumble.
    if test "x$ac_cv_func_H5Pget_fapl_mpio" = xyes; then
       AC_DEFINE([USE_PARALLEL_MPIO], [1], [if true, compile in parallel netCDF-4 based on MPI/IO])
+   fi
+
+   # Check to see if HDF5 library has collective metadata APIs, (HDF5 >= 1.10.0)
+   if test "x$ac_cv_func_H5Pset_all_coll_metadata_ops" = xyes; then
+      AC_DEFINE([HDF5_HAS_COLL_METADATA_OPS], [1], [if true, use collective metadata ops in parallel netCDF-4])
    fi
 
    # If parallel is available in hdf5, enable it in the C code. Also add some stuff to netcdf.h.

--- a/libsrc4/nc4file.c
+++ b/libsrc4/nc4file.c
@@ -364,10 +364,6 @@ nc4_create_file(const char *path, int cmode, MPI_Comm comm, MPI_Info info,
 #endif /* EXTRA_TESTS */
 
 #ifdef USE_PARALLEL4
-#ifdef HDF5_HAS_COLL_METADATA_OPS
-   H5Pset_all_coll_metadata_ops(fapl_id, 1 );
-   H5Pset_coll_metadata_write(fapl_id, 1);
-#endif
    /* If this is a parallel file create, set up the file creation
       property list. */
    if ((cmode & NC_MPIIO) || (cmode & NC_MPIPOSIX))
@@ -450,6 +446,11 @@ nc4_create_file(const char *path, int cmode, MPI_Comm comm, MPI_Info info,
       BAIL(NC_EHDFERR);
 
    /* Create the file. */
+#ifdef HDF5_HAS_COLL_METADATA_OPS
+   H5Pset_all_coll_metadata_ops(fapl_id, 1 );
+   H5Pset_coll_metadata_write(fapl_id, 1);
+#endif
+
    if ((nc4_info->hdfid = H5Fcreate(path, flags, fcpl_id, fapl_id)) < 0)
         /*Change the return error from NC_EFILEMETADATA to
           System error EACCES because that is the more likely problem */
@@ -2265,9 +2266,6 @@ nc4_open_file(const char *path, int mode, void* parameters, NC *nc)
 #endif
 
 #ifdef USE_PARALLEL4
-#ifdef HDF5_HAS_COLL_METADATA_OPS
-   H5Pset_all_coll_metadata_ops(fapl_id, 1 );
-#endif
    /* If this is a parallel file create, set up the file creation
       property list. */
    if (mode & NC_MPIIO || mode & NC_MPIPOSIX)
@@ -2322,6 +2320,9 @@ nc4_open_file(const char *path, int mode, void* parameters, NC *nc)
    /* The NetCDF-3.x prototype contains an mode option NC_SHARE for
       multiple processes accessing the dataset concurrently.  As there
       is no HDF5 equivalent, NC_SHARE is treated as NC_NOWRITE. */
+#ifdef HDF5_HAS_COLL_METADATA_OPS
+   H5Pset_all_coll_metadata_ops(fapl_id, 1 );
+#endif
    if(inmemory) {
        if((nc4_info->hdfid = H5LTopen_file_image(meminfo->memory,meminfo->size,
 			H5LT_FILE_IMAGE_DONT_COPY|H5LT_FILE_IMAGE_DONT_RELEASE

--- a/libsrc4/nc4file.c
+++ b/libsrc4/nc4file.c
@@ -364,9 +364,10 @@ nc4_create_file(const char *path, int cmode, MPI_Comm comm, MPI_Info info,
 #endif /* EXTRA_TESTS */
 
 #ifdef USE_PARALLEL4
+#ifdef HDF5_HAS_COLL_METADATA_OPS
    H5Pset_all_coll_metadata_ops(fapl_id, 1 );
    H5Pset_coll_metadata_write(fapl_id, 1);
-
+#endif
    /* If this is a parallel file create, set up the file creation
       property list. */
    if ((cmode & NC_MPIIO) || (cmode & NC_MPIPOSIX))
@@ -2264,8 +2265,9 @@ nc4_open_file(const char *path, int mode, void* parameters, NC *nc)
 #endif
 
 #ifdef USE_PARALLEL4
+#ifdef HDF5_HAS_COLL_METADATA_OPS
    H5Pset_all_coll_metadata_ops(fapl_id, 1 );
-
+#endif
    /* If this is a parallel file create, set up the file creation
       property list. */
    if (mode & NC_MPIIO || mode & NC_MPIPOSIX)

--- a/libsrc4/nc4file.c
+++ b/libsrc4/nc4file.c
@@ -364,6 +364,9 @@ nc4_create_file(const char *path, int cmode, MPI_Comm comm, MPI_Info info,
 #endif /* EXTRA_TESTS */
 
 #ifdef USE_PARALLEL4
+   H5Pset_all_coll_metadata_ops(fapl_id, 1 );
+   H5Pset_coll_metadata_write(fapl_id, 1);
+
    /* If this is a parallel file create, set up the file creation
       property list. */
    if ((cmode & NC_MPIIO) || (cmode & NC_MPIPOSIX))
@@ -2261,6 +2264,8 @@ nc4_open_file(const char *path, int mode, void* parameters, NC *nc)
 #endif
 
 #ifdef USE_PARALLEL4
+   H5Pset_all_coll_metadata_ops(fapl_id, 1 );
+
    /* If this is a parallel file create, set up the file creation
       property list. */
    if (mode & NC_MPIIO || mode & NC_MPIPOSIX)


### PR DESCRIPTION
In HDF5-1.10 and later, the group implemented collective metadata operations. The rationale and discussion is at https://support.hdfgroup.org/HDF5/docNewFeatures/NewFeaturesCollectiveMetadataIoDocs.html

Another discussion showing some CGNS timings is at https://hdfgroup.org/wp/2015/08/parallel-and-large-scale-simulation-enhancements-to-cgns/

We have also noticed the slow file open and close times with exodus when running on processor counts exceeding 1024. As an example, with a run on 32,768 processors, the time to open the files was 827.7 seconds.  With the changes in this pull request implemented, the time dropped to 15 seconds.  The time seems to increase as num_proc^2 at large num_proc without these changes.

The changes to CMakeLists.txt include the changes from hdf5 to ${HDF5_C_LIBRARY} which were rejected in a previous pull request.  I am fine with those not being included, but without them the building of a parallel netcdf doesn't work for a user-specified hdf5 library (unless I am doing somehting wrong).

I have tested the cmake changes quite a bit and they seem to work correctly.  I have only tested the configure changes in one build, so hopefully they are correct.
