### PR TITLE
Suppress selected orphan opendap attributes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,8 +11,8 @@ This file contains a high-level description of this package's evolution. Release
 
 ## 4.4.2 - TBD
 
-* [Upgrade] Update utf8proc.[ch] to use the version now maintained by the
-Julia Language project (https://github.com/JuliaLang/utf8proc/blob/master/LICENSE.md).
+* [Upgrade][Bug] Corrected an issue regarding how "orphaned" DAS attributes were handled. See [GitHub #376](https://github.com/Unidata/netcdf-c/pull/376) for more information.
+* [Upgrade] Update utf8proc.[ch] to use the version now maintained by the Julia Language project (https://github.com/JuliaLang/utf8proc/blob/master/LICENSE.md).
 * [Bug] Addressed conversion problem with Windows sscanf.  This primarily affected some OPeNDAP URLs on Windows.  See [GitHub #365](https://github.com/Unidata/netcdf-c/issues/365) and [GitHub #366](https://github.com/Unidata/netcdf-c/issues/366) for more information.
 * [Enhancement] Added support for HDF5 collective metadata operations when available. Patch submitted by Greg Sjaardema, see [Pull request #335](https://github.com/Unidata/netcdf-c/pull/335) for more information.
 * [Bug] Addressed a potential type punning issue. See [GitHub #351](https://github.com/Unidata/netcdf-c/issues/351) for more information.

--- a/libdap2/env
+++ b/libdap2/env
@@ -4,12 +4,12 @@ alias xx="cd ..;make; cd libdap2"
 PARMS=""; ARGS=""; CON="" ; CE="";  OCON="" ; VAR=""; SHARP='#'
 alias q0=;alias qq=;alias qv=;alias q=;alias  qh=;alias qqh=;alias qall=;alias qv=;alias qo=;
 
-F="http://www.esrl.noaa.gov/psd/thredds/dodsC/Datasets/ncep.reanalysis.dailyavgs/pressure/air.1947.nc"
+F='https://cida.usgs.gov/thredds/dodsC/new_gmo?longitude[0:1:461],latitude[0:1:221],time[0:1:22644]'
 
-if test -e "/cygdrive/f/git/netcdf-c" ; then
-TOP="/cygdrive/f/git/netcdf-c"
-elif test -e "/cygdrive/d/git/netcdf-c" ; then
+if test -e "/cygdrive/d/git/netcdf-c" ; then
 TOP="/cygdrive/d/git/netcdf-c"
+elif test -e "/cygdrive/f/git/netcdf-c" ; then
+TOP="/cygdrive/f/git/netcdf-c"
 elif test -e "/home/dmh/git/netcdf-c" ; then
 TOP="/home/dmh/git/netcdf-c"
 else
@@ -25,15 +25,15 @@ fi
 P=`pwd`
 
 PARMS="log"
-#PARMS="${PARMS}&netcdf3"
-#PARMS="${PARMS}&fetch=disk"
-#PARMS="${PARMS}&cache"
-#PARMS="${PARMS}&nocache"
-#PARMS="${PARMS}&wholevar"
-PARMS="${PARMS}&show=fetch"
-#PARMS="${PARMS}&noprefetch"
-#PARMS="${PARMS}&prefetch"
-#PARMS="${PARMS}&prefetch=eager"
+#PARMS="${PARMS}[netcdf3]"
+#PARMS="${PARMS}[fetch=disk]"
+#PARMS="${PARMS}[cache]"
+#PARMS="${PARMS}[nocache]"
+#PARMS="${PARMS}[wholevar]"
+PARMS="${PARMS}[show=fetch]"
+#PARMS="${PARMS}[noprefetch]"
+#PARMS="${PARMS}[prefetch]"
+#PARMS="${PARMS}[prefetch=eager]"
 PARMS="[log][cache][noprefetch]"
 
 VARGS="--leak-check=full"
@@ -52,10 +52,9 @@ if test "x$PROG" = x ; then
  PROG="../ncdump/ncdump"
 fi
 
-if test "x$PARMS" != "x" ; then PARMS="\#$PARMS"; fi
 U="$F"
 if test "x$CON" != "x" ; then U="$U?$CON"; fi
-UALL="$U${PARMS}"
+UALL="${PARMS}$U"
 #ARGS="-h $ARGS"
 #ARGS="-w $ARGS"
 #ARGS="-c $ARGS"
@@ -133,4 +132,5 @@ F="http://nomads.ncep.noaa.gov:9090/dods/gens/gens20140123/gep_all_12z"
 VAR=prmslmsl 
 F="http://data.nodc.noaa.gov/thredds/dodsC/testdata/pathfinderAgg/pathFinderV5.2_night.ncml"
 CON="sst_dtime.sst_dtime"
+F="http://www.esrl.noaa.gov/psd/thredds/dodsC/Datasets/ncep.reanalysis.dailyavgs/pressure/air.1947.nc"
 fi

--- a/libdap2/ncd2dispatch.c
+++ b/libdap2/ncd2dispatch.c
@@ -769,8 +769,6 @@ fprintf(stderr,"buildvars.candidate=|%s|\n",var->ncfullname);
  	    }
         }
 
-
-
 	definename = getdefinename(var);
 
 #ifdef DEBUG1

--- a/libdap2/ncd2dispatch.c
+++ b/libdap2/ncd2dispatch.c
@@ -769,6 +769,8 @@ fprintf(stderr,"buildvars.candidate=|%s|\n",var->ncfullname);
  	    }
         }
 
+
+
 	definename = getdefinename(var);
 
 #ifdef DEBUG1

--- a/ncdap_test/expectremote3/test.01.1.dmp
+++ b/ncdap_test/expectremote3/test.01.1.dmp
@@ -7,10 +7,6 @@ variables:
 			"Ph.D" ;
 		:Facility.DataCenter = "COAS Environmental Computer Facility" ;
 		:Facility.DrifterType = "MetOcean WOCE/OCM" ;
-		:b.Description = "A test byte" ;
-		:b.units = "unknown" ;
-		:i32.Description = "A 32 bit test server int" ;
-		:i32.units = "unknown" ;
 data:
 
  f64 = 1000 ;

--- a/ncdap_test/expectremote3/test.07.1.dmp
+++ b/ncdap_test/expectremote3/test.07.1.dmp
@@ -9,10 +9,6 @@ variables:
 			"Ph.D" ;
 		:Facility.DataCenter = "COAS Environmental Computer Facility" ;
 		:Facility.DrifterType = "MetOcean WOCE/OCM" ;
-		:b.Description = "A test byte" ;
-		:b.units = "unknown" ;
-		:i32.Description = "A 32 bit test server int" ;
-		:i32.units = "unknown" ;
 data:
 
  person.age = 1, 2, 3, 5, 8 ;

--- a/ncdap_test/expectremote3/test.07.3.dmp
+++ b/ncdap_test/expectremote3/test.07.3.dmp
@@ -11,10 +11,6 @@ variables:
 			"Ph.D" ;
 		:Facility.DataCenter = "COAS Environmental Computer Facility" ;
 		:Facility.DrifterType = "MetOcean WOCE/OCM" ;
-		:b.Description = "A test byte" ;
-		:b.units = "unknown" ;
-		:i32.Description = "A 32 bit test server int" ;
-		:i32.units = "unknown" ;
 data:
 
  person.name =

--- a/ncdap_test/expectremote3/test.07.4.dmp
+++ b/ncdap_test/expectremote3/test.07.4.dmp
@@ -9,10 +9,6 @@ variables:
 			"Ph.D" ;
 		:Facility.DataCenter = "COAS Environmental Computer Facility" ;
 		:Facility.DrifterType = "MetOcean WOCE/OCM" ;
-		:b.Description = "A test byte" ;
-		:b.units = "unknown" ;
-		:i32.Description = "A 32 bit test server int" ;
-		:i32.units = "unknown" ;
 data:
 
  types.f32 = 0, 0.9999833, 1.999867, 2.99955, 3.998933 ;

--- a/ncdap_test/tst_remote.sh
+++ b/ncdap_test/tst_remote.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-set -x
+
 set -e
 
 quiet=0

--- a/oc2/ocnode.c
+++ b/oc2/ocnode.c
@@ -6,13 +6,22 @@
 #include "occompile.h"
 #include "ocdebug.h"
 
+/* If enabled, then DAS attributes that cannot
+   be connected to any variable will be shown as
+   global attributes. No obvious reason to enable
+   except possibly for debugging purposes.
+*/
+#undef SHOWORPHAN
+
 static const unsigned int MAX_UINT = 0xffffffff;
 
 static OCerror mergedas1(OCnode* dds, OCnode* das);
 static OCerror mergedods1(OCnode* dds, OCnode* das);
-static OCerror mergeother1(OCnode* root, OCnode* das);
 static char* pathtostring(OClist* path, char* separator);
 static void computefullname(OCnode* node);
+#ifdef SHOWORPHAN
+static OCerror mergeother1(OCnode* root, OCnode* das);
+#endif
 
 /* Process ocnodes to fix various semantic issues*/
 void
@@ -334,6 +343,8 @@ ocddsdasmerge(OCstate* state, OCnode* dasroot, OCnode* ddsroot)
 	if(das == NULL) continue;
 	mergedods1(ddsroot,das);
     }
+
+#ifdef SHOWORPHAN
     /* 6. Assign other orphan attributes, which means
 	  construct their full name and assign as a global attribute. */
     for(i=0;i<oclistlength(dasnodes);i++) {
@@ -341,6 +352,7 @@ ocddsdasmerge(OCstate* state, OCnode* dasroot, OCnode* ddsroot)
 	if(das == NULL) continue;
 	mergeother1(ddsroot, das);
     }
+#endif
 
 done:
     /* cleanup*/
@@ -406,6 +418,7 @@ mergedods1(OCnode* dds, OCnode* dods)
     return OCTHROW(stat);
 }
 
+#ifdef SHOWORPHAN
 static OCerror
 mergeother1(OCnode* root, OCnode* das)
 {
@@ -433,6 +446,7 @@ mergeother1(OCnode* root, OCnode* das)
 	stat = OC_EDAS;
     return OCTHROW(stat);
 }
+#endif
 
 static void
 ocuncorrelate(OCnode* root)

--- a/oc2/ocnode.h
+++ b/oc2/ocnode.h
@@ -37,6 +37,7 @@ typedef struct OCattinfo {
     int isglobal; /* is this supposed to be a global attribute set?*/
     int isdods;   /* is this a global DODS_XXX  attribute set */
     OClist* values; /* oclist<char*>*/
+    struct OCnode* var; /* containing var else null */
 } OCattinfo;
 
 /*! Specifies the OCnode. */


### PR DESCRIPTION
Re: github issue https://github.com/Unidata/netcdf-c/issues/373
    
Github issue https://github.com/Unidata/netcdf-c/issues/152
requested that "orphaned" DAS attributes be included in the netcdf
metadata as global variables. The term orphaned here meant that
they were not connected to any variable in the DDS.
This was done in pull request https://github.com/Unidata/netcdf-c/pull/164
 
However, some servers (e.g. Thredds) include attributes for variables not
specified in a constraint expression, but which exist in the full DDS.
So I was adding these to the set of global attributes, but in retrospect
this should not have been done: they should have been elided.
    
Solution: modify oc2 code to be more discriminatory about
 which orphaned attributes to include. Specifically elide orphan
attributes that appear to be associated with DDS variables.
