### PR TITLE
Fix bug in ncgen handling of global, enum valued, attribute.

### DIFF
--- a/cf
+++ b/cf
@@ -4,7 +4,7 @@ DB=1
 #X=-x
 #FAST=1
 
-#HDF5=1
+HDF5=1
 DAP=1
 #HDF4=1
 #PNETCDF=1

--- a/ncgen/CMakeLists.txt
+++ b/ncgen/CMakeLists.txt
@@ -70,5 +70,5 @@ ADD_CUSTOM_TARGET(makeparser DEPENDS ncgentab.h)
 
 ## Specify files to be distributed by 'make dist'
 FILE(GLOB CUR_EXTRA_DIST RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/*.c ${CMAKE_CURRENT_SOURCE_DIR}/*.h ${CMAKE_CURRENT_SOURCE_DIR}/*.sh)
-SET(CUR_EXTRA_DIST ${CUR_EXTRA_DIST} ncgen.y ncgenl.c ncgen.l internals.html c0.cdl c0_4.cdl ref_camrun.cdl ncf199.cdl CMakeLists.txt Makefile.am ncgen.1)
+SET(CUR_EXTRA_DIST ${CUR_EXTRA_DIST} ncgen.y ncgenl.c ncgen.l internals.html c0.cdl c0_4.cdl ref_camrun.cdl ncf199.cdl tst_gattenum.cdl CMakeLists.txt Makefile.am ncgen.1)
 ADD_EXTRA_DIST("${CUR_EXTRA_DIST}")

--- a/ncgen/Makefile.am
+++ b/ncgen/Makefile.am
@@ -37,7 +37,7 @@ endif # USE_NETCDF4
 
 CLEANFILES = c0.nc c0_64.nc c0_4.nc c0_4c.nc ref_camrun.c \
 		ncf199.nc c5.nc compound_datasize_test.nc compound_datasize_test2.nc \
-		tst_compound_datasize_test.cdl tst_compound_datasize_test2.cdl tst_ncf199.cdl tst_gattenum.nc \
+		tst_compound_datasize_test.cdl tst_compound_datasize_test2.cdl tst_ncf199.cdl tst_tst_gattenum.nc \
 		tst_c0.cdl tst_c0_4.cdl tst_c0_4c.cdl tst_c0_64.cdl
 
 # These rules are used if someone wants to rebuild ncgenl.c or ncgeny.c

--- a/ncgen/Makefile.am
+++ b/ncgen/Makefile.am
@@ -37,7 +37,8 @@ endif # USE_NETCDF4
 
 CLEANFILES = c0.nc c0_64.nc c0_4.nc c0_4c.nc ref_camrun.c \
 		ncf199.nc c5.nc compound_datasize_test.nc compound_datasize_test2.nc \
-		tst_compound_datasize_test.cdl tst_compound_datasize_test2.cdl tst_ncf199.cdl tst_tst_gattenum.nc \
+		tst_compound_datasize_test.cdl tst_compound_datasize_test2.cdl tst_ncf199.cdl \
+		tst_tst_gattenum.cdl tst_gattenum.nc \
 		tst_c0.cdl tst_c0_4.cdl tst_c0_4c.cdl tst_c0_64.cdl
 
 # These rules are used if someone wants to rebuild ncgenl.c or ncgeny.c

--- a/ncgen/Makefile.am
+++ b/ncgen/Makefile.am
@@ -24,7 +24,7 @@ man_MANS = ncgen.1
 EXTRA_DIST = ncgen.y ncgen.l ncgenl.c $(man_MANS) internals.html	\
 run_tests.sh run_nc4_tests.sh c0.cdl c0_4.cdl ref_camrun.cdl \
 ncf199.cdl CMakeLists.txt XGetopt.c c5.cdl \
-compound_datasize_test.cdl compound_datasize_test2.cdl
+compound_datasize_test.cdl compound_datasize_test2.cdl tst_gattenum.cdl
 
 # This shell script causes ncgen to build a classic and a 64-bit
 # offset file from a cdl file shipped with the distribution.
@@ -37,7 +37,7 @@ endif # USE_NETCDF4
 
 CLEANFILES = c0.nc c0_64.nc c0_4.nc c0_4c.nc ref_camrun.c \
 		ncf199.nc c5.nc compound_datasize_test.nc compound_datasize_test2.nc \
-		tst_compound_datasize_test.cdl tst_compound_datasize_test2.cdl tst_ncf199.cdl \
+		tst_compound_datasize_test.cdl tst_compound_datasize_test2.cdl tst_ncf199.cdl tst_gattenum.nc \
 		tst_c0.cdl tst_c0_4.cdl tst_c0_4c.cdl tst_c0_64.cdl
 
 # These rules are used if someone wants to rebuild ncgenl.c or ncgeny.c

--- a/ncgen/run_nc4_tests.sh
+++ b/ncgen/run_nc4_tests.sh
@@ -54,5 +54,8 @@ validateNC "compound_datasize_test" "compound_datasize_test" -k nc4
 echo "*** github issue 323 test 2"
 validateNC "compound_datasize_test2" "compound_datasize_test2"  -k nc4
 
+echo "*** Global Attribute with Enum type"
+validateNC "tst_gattenum" "tst_gattenum"  -k nc4
+
 echo "*** Test successful!"
 exit 0

--- a/ncgen/run_tests.sh
+++ b/ncgen/run_tests.sh
@@ -2,8 +2,6 @@
 # This shell script runs the ncgen tests.
 # $Id: run_tests.sh,v 1.10 2010/04/04 22:06:03 dmh Exp $
 
-export SETX=1
-
 if test "x$srcdir" = x ; then
 srcdir=`pwd`
 fi

--- a/ncgen/run_tests.sh
+++ b/ncgen/run_tests.sh
@@ -2,6 +2,8 @@
 # This shell script runs the ncgen tests.
 # $Id: run_tests.sh,v 1.10 2010/04/04 22:06:03 dmh Exp $
 
+export SETX=1
+
 if test "x$srcdir" = x ; then
 srcdir=`pwd`
 fi

--- a/ncgen/semantics.c
+++ b/ncgen/semantics.c
@@ -422,6 +422,11 @@ processeconstrefs(void)
 {
     unsigned long i;
     /* locate all the datalist and walk them recursively */
+    for(i=0;i<listlength(gattdefs);i++) {
+	Symbol* att = (Symbol*)listget(gattdefs,i);
+	if(att->data != NULL && listlength(att->data) > 0)
+	    processeconstrefsR(att->data);
+    }
     for(i=0;i<listlength(attdefs);i++) {
 	Symbol* att = (Symbol*)listget(attdefs,i);
 	if(att->data != NULL && listlength(att->data) > 0)

--- a/ncgen/tst_gattenum.cdl
+++ b/ncgen/tst_gattenum.cdl
@@ -1,0 +1,8 @@
+netcdf tst_gattenum {
+types:
+  ubyte enum Bradys {Mike = 0, Carol = 1, Greg = 2, Marsha = 3, Peter = 4, 
+      Jan = 5, Bobby = 6, Whats-her-face = 7, Alice = 8} ;
+
+// global attributes:
+		Bradys :brady_attribute = Mike, Marsha, Alice;
+}


### PR DESCRIPTION
Apparently we have no .cdl test cases that have a global attribute whose type is an enum.

Turns out this case fails because of an oversight in ncgen.

This pr fixes that problem (in semantics.c).

Also added test case .cdl file: tst_gattenum.cdl
