### PR TITLE
patch for issue 384 - NC_ELATEFILL error for NetCDF-4 files

### DIFF
--- a/libsrc/Makefile.am
+++ b/libsrc/Makefile.am
@@ -47,7 +47,7 @@ EXTRA_DIST = attr.m4 ncx.m4 putget.m4 $(man_MANS) CMakeLists.txt XGetopt.c
 
 # This tells make how to turn .m4 files into .c files.
 .m4.c:
-	m4 $(AM_M4FLAGS) $(M4FLAGS) -s $< >${srcdir}/$@
+	m4 $(AM_M4FLAGS) $(M4FLAGS) -s $< > $@
 
 # The C API man page.
 man_MANS = netcdf.3

--- a/libsrc4/nc4file.c
+++ b/libsrc4/nc4file.c
@@ -2984,12 +2984,22 @@ static int NC4_enddef(int ncid)
 {
   NC *nc;
    NC_HDF5_FILE_INFO_T* nc4_info;
+   NC_GRP_INFO_T *grp;
+   int i;
 
    LOG((1, "%s: ncid 0x%x", __func__, ncid));
 
    if (!(nc = nc4_find_nc_file(ncid,&nc4_info)))
       return NC_EBADID;
    assert(nc4_info);
+
+   /* Find info for this file and group */
+   if (!(grp = nc4_rec_find_grp(nc4_info->root_grp, (ncid & GRP_ID_MASK))))
+      return NC_EBADGRPID;
+
+   /* when exiting define mode, mark all variable written */
+   for (i=0; i<grp->vars.nelems; i++)
+      grp->vars.value[i]->written_to = NC_TRUE;
 
    return nc4_enddef_netcdf4_file(nc4_info);
 }

--- a/libsrc4/nc4file.c
+++ b/libsrc4/nc4file.c
@@ -2129,7 +2129,7 @@ nc4_rec_read_metadata(NC_GRP_INFO_T *grp)
     hid_t pid = 0;
     unsigned crt_order_flags = 0;
     H5_index_t iter_index;
-    int retval = NC_NOERR; /* everything worked! */
+    int i, retval = NC_NOERR; /* everything worked! */
 
     assert(grp && grp->name);
     LOG((3, "%s: grp->name %s", __func__, grp->name));
@@ -2216,6 +2216,10 @@ nc4_rec_read_metadata(NC_GRP_INFO_T *grp)
     /* Scan the group for global (i.e. group-level) attributes. */
     if ((retval = read_grp_atts(grp)))
 	BAIL(retval);
+
+   /* when exiting define mode, mark all variable written */
+   for (i=0; i<grp->vars.nelems; i++)
+      grp->vars.value[i]->written_to = NC_TRUE;
 
 exit:
     /* Clean up local information on error, if anything remains */

--- a/nc_test4/tst_fill_attr_vanish.c
+++ b/nc_test4/tst_fill_attr_vanish.c
@@ -33,7 +33,7 @@
  */
 int main()
 {
-  int ncid, dimids[RANK_P], time_id, p_id, test_id;
+  int ncid, dimids[RANK_P], time_id, p_id, test_id, status;
   int ndims, dimids_in[RANK_P];
 
   int test_data[1] = {1};
@@ -95,8 +95,15 @@ int main()
 
   }
 
-  printf("**** Adding _FillValue attribute.\n");
-  if (nc_put_att_int(ncid, test_id, "_FillValue", NC_INT, 1, test_fill_val)) ERR;
+  printf("**** Expecting NC_ELATEFILL when adding _FillValue attribute if variable exists.\n");
+  status = nc_put_att_int(ncid, test_id, "_FillValue", NC_INT, 1, test_fill_val);
+  if (status != NC_ELATEFILL) {
+      fflush(stdout); /* Make sure our stdout is synced with stderr. */
+      err++;
+      fprintf(stderr, "Sorry! Expecting NC_ELATEFILL but got %s, at file %s line: %d\n",
+              nc_strerror(status), __FILE__, __LINE__);
+      return 2;
+  }
 
   /* Query existing attribute. */
   {

--- a/nc_test4/tst_vars2.c
+++ b/nc_test4/tst_vars2.c
@@ -61,13 +61,17 @@ main(int argc, char **argv)
 
       printf("**** testing simple fill value attribute creation...");
       {
+         int status;
          /* Create a netcdf-4 file with one scalar var. Add fill
           * value. */
          if (nc_create(FILE_NAME, cmode, &ncid)) ERR;
          if (nc_def_var(ncid, VAR_NAME, NC_BYTE, 0, NULL, &varid)) ERR;
+         if (nc_put_att_schar(ncid, varid, _FillValue, NC_BYTE, 1, &fill_value)) ERR;
          if (nc_enddef(ncid)) ERR;
          if (nc_redef(ncid)) ERR;
-         if (nc_put_att_schar(ncid, varid, _FillValue, NC_BYTE, 1, &fill_value)) ERR;
+         status = nc_put_att_schar(ncid, varid, _FillValue, NC_BYTE, 1, &fill_value);
+         if (status != NC_ELATEFILL)
+             printf("Error at line %d: expecting NC_ELATEFILL but got %s\n",__LINE__,nc_strerror(status));
          if (nc_close(ncid)) ERR;
 
          /* Open the file and check. */
@@ -94,8 +98,6 @@ main(int argc, char **argv)
          if (nc_create(FILE_NAME, cmode, &ncid)) ERR;
          if (nc_def_dim(ncid, DIM1_NAME, DIM1_LEN, &dimids[0])) ERR;
          if (nc_def_var(ncid, VAR_NAME, NC_BYTE, NUM_DIMS, dimids, &varid)) ERR;
-         if (nc_enddef(ncid)) ERR;
-         if (nc_redef(ncid)) ERR;
          if (nc_put_att_schar(ncid, varid, _FillValue, NC_BYTE, 1, &fill_value)) ERR;
          if (nc_enddef(ncid)) ERR;
 


### PR DESCRIPTION
This patch is for issue #384, NC_ELATEFILL error code is not properly returned.
In NC4_enddef() before nc_enddef() returns, the patch marks all variables "written".

I hope this is the right fix. It passed all tests.