### PR TITLE
Fix memory leak in NC4_put_propattr()

### DIFF
--- a/libsrc4/nc4info.c
+++ b/libsrc4/nc4info.c
@@ -170,11 +170,8 @@ NC4_put_propattr(NC_HDF5_FILE_INFO_T* h5)
       herr = 0;
     }
  done:
-    if(ncstat != NC_NOERR) {
-      if(text != NULL) {
-        free(text);
-        text = NULL;
-      }
+    if(text != NULL) {
+      free(text);
     }
 
     if(attid >= 0) HCHECK((H5Aclose(attid)));


### PR DESCRIPTION
Current code only frees char* text in error cases. It should
also free it in success case.

Otherwise Valgrind reports a leak:

==28536== 64 bytes in 1 blocks are definitely lost in loss record 4 of 13
==28536==    at 0x4C2DB8F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==28536==    by 0xE673496: NC4_buildpropinfo (nc4info.c:239)
==28536==    by 0xE67313B: NC4_put_propattr (nc4info.c:162)
==28536==    by 0xE65BF35: nc4_create_file (nc4file.c:468)
==28536==    by 0xE65C0AC: NC4_create (nc4file.c:564)
==28536==    by 0xE608A08: NC_create (dfile.c:1773)
==28536==    by 0xE607E6A: nc__create (dfile.c:511)
==28536==    by 0xE607E23: nc_create (dfile.c:440)

Credit to OSS Fuzz