### PR TITLE
Defining _WINSOCKAPI_ causes curl.h to throw syntax error

### DIFF
--- a/include/nctestserver.h
+++ b/include/nctestserver.h
@@ -2,7 +2,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+/* _WINSOCKAPI_ causes curl.h to throw a syntax error */
+#undef _WINSOCKAPI_
 #include <curl/curl.h>
+
 #include "netcdf.h"
 
 #define MAXSERVERURL 4096

--- a/libdap4/d4includes.h
+++ b/libdap4/d4includes.h
@@ -15,6 +15,8 @@
 #include <unistd.h>
 #endif
 
+/* _WINSOCKAPI_ causes curl.h to throw a syntax error */
+#undef _WINSOCKAPI_
 #include <curl/curl.h>
 
 #ifdef HAVE_SYS_TIME_H

--- a/oc2/occurlflags.c
+++ b/oc2/occurlflags.c
@@ -2,7 +2,6 @@
    See the COPYRIGHT file for more information. */
 
 #include "config.h"
-#include <curl/curl.h>
 #include "ocinternal.h"
 #include "ocdebug.h"
 

--- a/oc2/ocdebug.h
+++ b/oc2/ocdebug.h
@@ -14,8 +14,6 @@
 #include <stdarg.h>
 #endif
 
-#include <curl/curl.h>
-
 #include "oc.h"
 #include "ocinternal.h"
 

--- a/oc2/ocinternal.h
+++ b/oc2/ocinternal.h
@@ -6,7 +6,6 @@
 
 #include "config.h"
 
-
 #if defined(_WIN32) || defined(_WIN64)
 #include <malloc.h>
 #endif
@@ -38,6 +37,9 @@
 #endif
 
 #define CURL_DISABLE_TYPECHECK 1
+
+/* _WINSOCKAPI_ causes curl.h to throw a syntax error */
+#undef _WINSOCKAPI_
 #include <curl/curl.h>
 
 #include "netcdf.h"


### PR DESCRIPTION
The recent change that added
#define _WINSOCKAPI_
in the latest config.h.cmake.in causes (all?/some?) versions of
curl.h to throw a syntax error when compiling with Visual
Studio.

I did a quick test by removing the #define _WINSOCKAPI_ from
config.h.cmake.in and the syntax error went away.

I do not know if the latest version of libcurl (7.57?) still has
this problem.

Ideally, curl.h should be fixed, but this will take time.

The next best fix (implemented in this pr) is to modify all
headers that have
#include <curl/curl.h>
to place
#undef _WINSOCKAPI_
before the
#include <curl/curl.h>