### PR TITLE
typedef schar to signed char

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -853,7 +853,7 @@ AC_FUNC_ALLOCA
 AC_CHECK_DECLS([isnan, isinf, isfinite, signbit],,,[#include <math.h>])
 AC_STRUCT_ST_BLKSIZE
 UD_CHECK_IEEE
-AC_CHECK_TYPES([size_t, ssize_t, ptrdiff_t, uchar, longlong, ushort, uint, int64, uint64 off_t])
+AC_CHECK_TYPES([size_t, ssize_t, ptrdiff_t, schar, uchar, longlong, ushort, uint, int64, uint64 off_t])
 AC_TYPE_SIZE_T
 AC_TYPE_OFF_T
 AC_C_CHAR_UNSIGNED

--- a/libsrc/ncx.h
+++ b/libsrc/ncx.h
@@ -156,15 +156,9 @@
 
 /* End ncx_len */
 
-#ifdef __CHAR_UNSIGNED__
-	/* 'char' is unsigned, declare ncbyte as 'signed char' */
+#ifndef HAVE_SCHAR
 typedef signed char schar;
-
-#else
-	/* 'char' is signed */
-typedef char schar;
-
-#endif	/* __CHAR_UNSIGNED__ */
+#endif
 
 /*
  * Primitive numeric conversion functions.


### PR DESCRIPTION
I believe it is safe to type define "schar" to "signed char" no matter char is signed or unsigned. This patch silence the following compile warnings.
```
netcdf-c/libsrc/nc3internal.c:1778:80: warning: passing 'signed char *' to parameter of
type 'schar *' (aka 'char *') converts between pointers to integer types with different sign
[-Wpointer-sign]
            case NC_BYTE:   return ncx_getn_schar_schar        (&xp, 1,        (signed char*)fill_value);
                                                                               ^~~~~~~~~~~~~~~~~~~~~~~~
netcdf-c/libsrc/ncx.h:332:64: note: passing argument to parameter 'ip' here
ncx_getn_schar_schar (const void **xpp, size_t nelems, schar  *ip);
                                                               ^
1 warning generated.
```