### PR TITLE
data type of stat.st_size

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -25,6 +25,7 @@ disbled until the testserver situation is resolved.
 * [Upgrade] The bash based test scripts have been upgraded to use a common test_common.sh include file that isolates build specific information.
 * [Refactor] the oc2 library is no longer independent of the main netcdf-c library. For example, it now uses ncuri, nclist, and ncbytes instead of its homegrown equivalents.
 * [Bug Fix] `NC_EGLOBAL` is now properly returned when attempting to set a global `_FillValue` attribute. See [GitHub #388](https://github.com/Unidata/netcdf-c/issues/388) and [GitHub #389](https://github.com/Unidata/netcdf-c/issues/389) for more information.
+* [Bug Fix] Corrected an issue where data loss would occur when `_FillValue` was mistakenly allowed to be redefined.  See [Github #390](https://github.com/Unidata/netcdf-c/issues/390), [GitHub #387](https://github.com/Unidata/netcdf-c/pull/387) for more information.
 * [Upgrade][Bug] Corrected an issue regarding how "orphaned" DAS attributes were handled. See [GitHub #376](https://github.com/Unidata/netcdf-c/pull/376) for more information.
 * [Upgrade] Update utf8proc.[ch] to use the version now maintained by the Julia Language project (https://github.com/JuliaLang/utf8proc/blob/master/LICENSE.md).
 * [Bug] Addressed conversion problem with Windows sscanf.  This primarily affected some OPeNDAP URLs on Windows.  See [GitHub #365](https://github.com/Unidata/netcdf-c/issues/365) and [GitHub #366](https://github.com/Unidata/netcdf-c/issues/366) for more information.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -25,7 +25,6 @@ disbled until the testserver situation is resolved.
 * [Upgrade] The bash based test scripts have been upgraded to use a common test_common.sh include file that isolates build specific information.
 * [Refactor] the oc2 library is no longer independent of the main netcdf-c library. For example, it now uses ncuri, nclist, and ncbytes instead of its homegrown equivalents.
 * [Bug Fix] `NC_EGLOBAL` is now properly returned when attempting to set a global `_FillValue` attribute. See [GitHub #388](https://github.com/Unidata/netcdf-c/issues/388) and [GitHub #389](https://github.com/Unidata/netcdf-c/issues/389) for more information.
-* [Bug Fix] Corrected an issue where data loss would occur when `_FillValue` was mistakenly allowed to be redefined.  See [Github #390](https://github.com/Unidata/netcdf-c/issues/390), [GitHub #387](https://github.com/Unidata/netcdf-c/pull/387) for more information.
 * [Upgrade][Bug] Corrected an issue regarding how "orphaned" DAS attributes were handled. See [GitHub #376](https://github.com/Unidata/netcdf-c/pull/376) for more information.
 * [Upgrade] Update utf8proc.[ch] to use the version now maintained by the Julia Language project (https://github.com/JuliaLang/utf8proc/blob/master/LICENSE.md).
 * [Bug] Addressed conversion problem with Windows sscanf.  This primarily affected some OPeNDAP URLs on Windows.  See [GitHub #365](https://github.com/Unidata/netcdf-c/issues/365) and [GitHub #366](https://github.com/Unidata/netcdf-c/issues/366) for more information.

--- a/libsrc/posixio.c
+++ b/libsrc/posixio.c
@@ -118,16 +118,16 @@ static int ncio_spx_close(ncio *nciop, int doUnlink);
  * @par fd File Descriptor.
  * @return -1 on error, length of file (in bytes) otherwise.
  */
-static size_t nc_get_filelen(const int fd) {
+static off_t nc_get_filelen(const int fd) {
 
-  size_t flen;
+  off_t flen;
 
 #ifdef HAVE_FILE_LENGTH_I64
   __int64 file_len = 0;
   if ((file_len = _filelengthi64(fd)) < 0) {
     return file_len;
   }
-  flen = (size_t)file_len;
+  flen = (off_t)file_len;
 
 #else
   int res = 0;
@@ -243,7 +243,7 @@ fgrow2(const int fd, const off_t len)
   */
 
 
-  size_t file_len = nc_get_filelen(fd);
+  off_t file_len = nc_get_filelen(fd);
   if(file_len < 0) return errno;
   if(len <= file_len)
     return NC_NOERR;

--- a/nc_test/Makefile.am
+++ b/nc_test/Makefile.am
@@ -109,7 +109,7 @@ EXTRA_DIST += ref_tst_diskless2.cdl tst_diskless5.cdl CMakeLists.txt
 #MAINTAINERCLEANFILES = test_get.c test_put.c
 
 all:
-	cp $(top_srcdir)/libsrc/ncx.c .
+	cp $(top_builddir)/libsrc/ncx.c .
 
 CLEANFILES += ncx.c
 


### PR DESCRIPTION
The member st_size of struct stat is of type off_t.
This patch silences the following compile warning.
```
netcdf-c/libsrc/posixio.c:247:15: warning: 
      comparison of unsigned expression < 0 is always false
      [-Wtautological-compare]
  if(file_len < 0) return errno;
     ~~~~~~~~ ^ ~
1 warning generated.
```