### PR TITLE
struct stat.st_size is of type off_t

### DIFF
--- a/libsrc/posixio.c
+++ b/libsrc/posixio.c
@@ -118,16 +118,16 @@ static int ncio_spx_close(ncio *nciop, int doUnlink);
  * @par fd File Descriptor.
  * @return -1 on error, length of file (in bytes) otherwise.
  */
-static size_t nc_get_filelen(const int fd) {
+static off_t nc_get_filelen(const int fd) {
 
-  size_t flen;
+  off_t flen;
 
 #ifdef HAVE_FILE_LENGTH_I64
   __int64 file_len = 0;
   if ((file_len = _filelengthi64(fd)) < 0) {
     return file_len;
   }
-  flen = (size_t)file_len;
+  flen = (off_t)file_len;
 
 #else
   int res = 0;
@@ -243,7 +243,7 @@ fgrow2(const int fd, const off_t len)
   */
 
 
-  size_t file_len = nc_get_filelen(fd);
+  off_t file_len = nc_get_filelen(fd);
   if(file_len < 0) return errno;
   if(len <= file_len)
     return NC_NOERR;


### PR DESCRIPTION
The member st_size of struct stat is of type off_t.
This patch silences the following compile warning.
```
netcdf-c/libsrc/posixio.c:247:15: warning: 
      comparison of unsigned expression < 0 is always false
      [-Wtautological-compare]
  if(file_len < 0) return errno;
     ~~~~~~~~ ^ ~
1 warning generated.
```