### PR TITLE
fix compile warnings when using gcc flag -Wfatal-errors

### DIFF
--- a/libdap2/dapdump.c
+++ b/libdap2/dapdump.c
@@ -156,10 +156,10 @@ dumpdata1(nc_type nctype, size_t index, char* data)
 	fprintf(stdout,"'%c' %hhd",data[index],data[index]);
 	break;
     case NC_BYTE:
-	fprintf(stdout,"%hdB",((signed char*)data)[index]);
+	fprintf(stdout,"%hhdB",((signed char*)data)[index]);
 	break;
     case NC_UBYTE:
-	fprintf(stdout,"%huB",((unsigned char*)data)[index]);
+	fprintf(stdout,"%hhuB",((unsigned char*)data)[index]);
 	break;
     case NC_SHORT:
 	fprintf(stdout,"%hdS",((short*)data)[index]);

--- a/libdap4/d4meta.c
+++ b/libdap4/d4meta.c
@@ -729,7 +729,7 @@ compileAttrValues(NCD4meta* builder, NCD4node* basetype, NClist* values, void** 
     if(!ISTYPE(truebase->sort) || (truebase->meta.id > NC_MAX_ATOMIC_TYPE))
         FAIL(NC_EBADTYPE,"Illegal attribute type: %s",basetype->name);
     size = NCD4_typesize(truebase->meta.id);
-    if((memory = (char*)d4alloc(count*size))==NULL)
+    if((memory = (unsigned char*)d4alloc(count*size))==NULL)
         return THROW(NC_ENOMEM);
     p = memory;
     for(i=0;i<count;i++) {
@@ -780,17 +780,17 @@ convertString(union ATOMICS* converter, NCD4node* type, const char* s)
     case NC_SHORT:
     case NC_INT:
     case NC_INT64:
-	if(sscanf(s,"%lld",&converter->i64) != 1) return THROW(NC_ERANGE);
+	if(sscanf(s,"%lld",&converter->i64[0]) != 1) return THROW(NC_ERANGE);
 	break;
     case NC_UBYTE:
     case NC_USHORT:
     case NC_UINT:
     case NC_UINT64:
-	if(sscanf(s,"%llu",&converter->u64) != 1) return THROW(NC_ERANGE);
+	if(sscanf(s,"%llu",&converter->u64[0]) != 1) return THROW(NC_ERANGE);
 	break;
     case NC_FLOAT:
     case NC_DOUBLE:
-	if(sscanf(s,"%lf",&converter->f64) != 1) return THROW(NC_ERANGE);
+	if(sscanf(s,"%lf",&converter->f64[0]) != 1) return THROW(NC_ERANGE);
 	break;
     case NC_CHAR:
 	converter->i8[0] = s[0];

--- a/libdap4/d4parser.c
+++ b/libdap4/d4parser.c
@@ -525,7 +525,7 @@ parseSequence(NCD4parser* parser, NCD4node* container, ezxml_t xml, NCD4node** n
 	vlentype->basetype = var->basetype;
 	/* Use name <fqnname>_t */
 	strncpy(name,fqnname,sizeof(name));
-	strncat(name,"_t",sizeof(name));	
+	strncat(name,"_t", sizeof(name) - strlen(name) - 1);
         SETNAME(vlentype,name);
         /* Set the basetype */
         var->basetype = vlentype;
@@ -540,7 +540,7 @@ parseSequence(NCD4parser* parser, NCD4node* container, ezxml_t xml, NCD4node** n
         classify(group,structtype);
 	/* Use name <fqnname>_base */
 	strncpy(name,fqnname,sizeof(name));
-	strncat(name,"_base",sizeof(name));	
+	strncat(name,"_base", sizeof(name) - strlen(name) - 1);
         SETNAME(structtype,name);
         /* Parse Fields into type */
         if((ret = parseFields(parser,structtype,xml))) goto done;    
@@ -549,7 +549,7 @@ parseSequence(NCD4parser* parser, NCD4node* container, ezxml_t xml, NCD4node** n
         classify(group,vlentype);
 	/* Use name <xname>_t */
 	strncpy(name,fqnname,sizeof(name));
-	strncat(name,"_t",sizeof(name));	
+	strncat(name,"_t", sizeof(name) - strlen(name) - 1);
         SETNAME(vlentype,name);
 	vlentype->basetype = structtype;
         /* Set the basetype */

--- a/libdap4/d4rc.c
+++ b/libdap4/d4rc.c
@@ -459,8 +459,8 @@ NCD4_rcprocess(NCD4INFO* info)
 	if(userpwd == NULL && user != NULL && pwd != NULL) {
 	    char creds[NC_MAX_PATH];
 	    strncpy(creds,user,sizeof(creds));
-	    strncat(creds,":",sizeof(creds));
-	    strncat(creds,pwd,sizeof(creds));	  
+	    strncat(creds,":", sizeof(creds) - strlen(creds) - 1);
+	    strncat(creds,pwd, sizeof(creds) - strlen(creds) - 1);
             rcsetinfocurlflag(info,"HTTP.USERPASSWORD",creds);
 	} else if(userpwd != NULL)
             rcsetinfocurlflag(info,"HTTP.USERPASSWORD",userpwd);

--- a/libdap4/d4read.c
+++ b/libdap4/d4read.c
@@ -153,7 +153,7 @@ readfile(const NCURI* uri, const char* suffix, NCbytes* packet)
     char buf[1024];
     int fd = -1;
     int flags = 0;
-    d4size_t filesize = 0;
+    off_t filesize = 0;
     d4size_t totalread = 0;
     NCbytes* tmp = ncbytesnew();
     char* filename = NULL;
@@ -187,7 +187,7 @@ fprintf(stderr,"XXX: flags=0x%x file=%s\n",flags,filename);
     (void)lseek(fd,(d4size_t)0,SEEK_SET);
     stat = NC_NOERR;
     for(totalread=0;;) {
-	d4size_t count = (d4size_t)read(fd,buf,sizeof(buf));
+	ssize_t count = (d4size_t)read(fd,buf,sizeof(buf));
 	if(count == 0)
 	    break; /*eof*/
 	else if(count <  0) {

--- a/libdap4/d4util.c
+++ b/libdap4/d4util.c
@@ -361,7 +361,7 @@ NCD4_mktmp(const char* base, char** tmpnamep)
 
     strncpy(tmp,base,sizeof(tmp));
 #ifdef HAVE_MKSTEMP
-    strncat(tmp,"XXXXXX",sizeof(tmp));
+    strncat(tmp,"XXXXXX", sizeof(tmp) - strlen(tmp) - 1);
     /* Note Potential problem: old versions of this function
        leave the file in mode 0666 instead of 0600 */
     mask=umask(0077);


### PR DESCRIPTION
Below are the compile warning messages.
```
netcdf-c/libdap2/dapdump.c:159:24: warning: format
      specifies type 'short' but the argument has type 'signed char' [-Wformat]
        fprintf(stdout,"%hdB",((signed char*)data)[index]);
                        ~~~   ^~~~~~~~~~~~~~~~~~~~~~~~~~~
                        %hhd
netcdf-c/libdap2/dapdump.c:162:24: warning: format
      specifies type 'unsigned short' but the argument has type 'unsigned char'
      [-Wformat]
        fprintf(stdout,"%huB",((unsigned char*)data)[index]);
                        ~~~   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                        %hhu

netcdf-c/libdap4/d4meta.c:732:16: warning: assigning
      to 'unsigned char *' from 'char *' converts between pointers to integer types
      with different sign [-Wpointer-sign]
    if((memory = (char*)d4alloc(count*size))==NULL)
               ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~
netcdf-c/libdap4/d4meta.c:783:21: warning: format
      specifies type 'long long *' but the argument has type 'long long (*)[1]'
      [-Wformat]
        if(sscanf(s,"%lld",&converter->i64) != 1) return THROW(NC_ERANGE);
                     ~~~~  ^~~~~~~~~~~~~~~
netcdf-c/libdap4/d4meta.c:789:21: warning: format
      specifies type 'unsigned long long *' but the argument has type
      'unsigned long long (*)[1]' [-Wformat]
        if(sscanf(s,"%llu",&converter->u64) != 1) return THROW(NC_ERANGE);
                     ~~~~  ^~~~~~~~~~~~~~~
netcdf-c/libdap4/d4meta.c:793:20: warning: format
      specifies type 'double *' but the argument has type 'double (*)[1]' [-Wformat]
        if(sscanf(s,"%lf",&converter->f64) != 1) return THROW(NC_ERANGE);
                     ~~~  ^~~~~~~~~~~~~~~

netcdf-c/libdap4/d4parser.c:528:20: warning: the
      value of the size argument in 'strncat' is too large, might lead to a buffer
      overflow [-Wstrncat-size]
        strncat(name,"_t",sizeof(name));        
                          ^~~~~~~~~~~~
netcdf-c/libdap4/d4parser.c:528:20: note: change the
      argument to be the free space in the destination buffer minus the terminating
      null byte
        strncat(name,"_t",sizeof(name));        
                          ^~~~~~~~~~~~
                          sizeof(name) - strlen(name) - 1
netcdf-c/libdap4/d4parser.c:543:23: warning: the
      value of the size argument in 'strncat' is too large, might lead to a buffer
      overflow [-Wstrncat-size]
        strncat(name,"_base",sizeof(name));     
                             ^~~~~~~~~~~~
netcdf-c/libdap4/d4parser.c:543:23: note: change the
      argument to be the free space in the destination buffer minus the terminating
      null byte
        strncat(name,"_base",sizeof(name));     
                             ^~~~~~~~~~~~
                             sizeof(name) - strlen(name) - 1
netcdf-c/libdap4/d4parser.c:552:20: warning: the
      value of the size argument in 'strncat' is too large, might lead to a buffer
      overflow [-Wstrncat-size]
        strncat(name,"_t",sizeof(name));        
                          ^~~~~~~~~~~~
netcdf-c/libdap4/d4parser.c:552:20: note: change the
      argument to be the free space in the destination buffer minus the terminating
      null byte
        strncat(name,"_t",sizeof(name));        
                          ^~~~~~~~~~~~
                          sizeof(name) - strlen(name) - 1

netcdf-c/libdap4/d4rc.c:462:24: warning: the value of
      the size argument in 'strncat' is too large, might lead to a buffer overflow
      [-Wstrncat-size]
            strncat(creds,":",sizeof(creds));
                              ^~~~~~~~~~~~~
netcdf-c/libdap4/d4rc.c:462:24: note: change the
      argument to be the free space in the destination buffer minus the terminating
      null byte
            strncat(creds,":",sizeof(creds));
                              ^~~~~~~~~~~~~
                              sizeof(creds) - strlen(creds) - 1
netcdf-c/libdap4/d4rc.c:463:24: warning: the value of
      the size argument in 'strncat' is too large, might lead to a buffer overflow
      [-Wstrncat-size]
            strncat(creds,pwd,sizeof(creds));     
                              ^~~~~~~~~~~~~
netcdf-c/libdap4/d4rc.c:463:24: note: change the
      argument to be the free space in the destination buffer minus the terminating
      null byte
            strncat(creds,pwd,sizeof(creds));     
                              ^~~~~~~~~~~~~
                              sizeof(creds) - strlen(creds) - 1

netcdf-c/libdap4/d4read.c:181:17: warning: 
      comparison of unsigned expression < 0 is always false [-Wtautological-compare]
    if(filesize < 0) {
       ~~~~~~~~ ^ ~
netcdf-c/libdap4/d4read.c:193:16: warning: 
      comparison of unsigned expression < 0 is always false [-Wtautological-compare]
        else if(count <  0) {
                ~~~~~ ^  ~

netcdf-c/libdap4/d4util.c:364:26: warning: the value
      of the size argument in 'strncat' is too large, might lead to a buffer overflow
      [-Wstrncat-size]
    strncat(tmp,"XXXXXX",sizeof(tmp));
                         ^~~~~~~~~~~
netcdf-c/libdap4/d4util.c:364:26: note: change the
      argument to be the free space in the destination buffer minus the terminating
      null byte
    strncat(tmp,"XXXXXX",sizeof(tmp));
                         ^~~~~~~~~~~
                         sizeof(tmp) - strlen(tmp) - 1
```