### PR TITLE
Fix undefined left shift in ncx_get_size_t()

### DIFF
--- a/libsrc/ncx.m4
+++ b/libsrc/ncx.m4
@@ -999,7 +999,11 @@ get_ix_int(const void *xp, ix_int *ip)
 {
 	const uchar *cp = (const uchar *) xp;
 
+#if INT_MAX  >= X_INT_MAX
+	*ip = (ix_int)((unsigned)(*cp++) << 24);
+#else
 	*ip = *cp++ << 24;
+#endif
 #if SIZEOF_IX_INT > X_SIZEOF_INT
 	if (*ip & 0x80000000)
 	{

--- a/libsrc/ncx.m4
+++ b/libsrc/ncx.m4
@@ -2196,7 +2196,7 @@ APIPrefix`x_get_size_t'(const void **xpp,  size_t *ulp)
 	/* similar to get_ix_int */
 	const uchar *cp = (const uchar *) *xpp;
 
-	*ulp  = (unsigned)(*cp++ << 24);
+	*ulp  = (unsigned)(*cp++) << 24;
 	*ulp |= (*cp++ << 16);
 	*ulp |= (*cp++ << 8);
 	*ulp |= *cp;


### PR DESCRIPTION
Running a build on the .nc file corresponding to the below ncdump output
with -fsanitize=undefined raises

libsrc/ncx.c:4722:26: runtime error: left shift of 255 by 24 places cannot be represented in type 'int'

This is due to *cp being promoted to int before doing the left shift, instead
of the intended unsigned. So do the cast to unsigned internally rather than
externally

ncdump file to reproduce:

netcdf temp {
dimensions:
	y = UNLIMITED ; // (0 currently)
	x = 109067 ;
variables:
	byte t(y, x, x) ;
data:
}

Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=2265

Credit to OSS Fuzz