### PR TITLE
Reclaim DAP temporary files

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -804,11 +804,10 @@ AC_ARG_ENABLE([diskless],
 test "x$enable_diskless" = xno || enable_diskless=yes
 AC_MSG_RESULT($enable_diskless)
 
-# Check for enable DAP
-if test "x$enable_dap" = "xyes" -a "xenable_diskless" = xno  ; then
-AC_MSG_NOTICE([--enable-dap requires --enable-diskless])
-AC_MSG_NOTICE([dap support disabled])
-enable_dap=no
+# If DAP enabled and diskless not enabled, then warn of consequences
+if test "x$enable_dap" = "xyes" -a "x$enable_diskless" = xno  ; then
+AC_MSG_NOTICE([Warning: DAP support is enabled but diskless support is disabled.])
+AC_MSG_NOTICE([=> temporary files will be created + reclaimed when using DAP.])
 fi
 
 # disable dap4 if netcdf-4 is disabled

--- a/dap4_test/test_meta.sh
+++ b/dap4_test/test_meta.sh
@@ -15,7 +15,7 @@ STEM=`echo $f | cut -d. -f 1`
 if test -e ${CDLTESTFILES}/${STEM}.cdl ; then
   CDL="${CDL} ${STEM}"
 else
-  echo "Not found: ${CDLTESTFILES}/${STEM}.cdl"
+  echo "Not found: ${CDLTESTFILES}/${STEM}.cdl; ignored"
 fi
 done
 

--- a/libdap2/nccommon.h
+++ b/libdap2/nccommon.h
@@ -126,7 +126,11 @@ typedef struct NCDAPCOMMON {
     NCCDF cdf;
     NCOC oc;
     NCCONTROLS controls; /* Control flags and parameters */
-    int nc3id; /* nc3 file ncid used to hold metadata */
+    struct {
+	int realfile; /* 1 => we created actual temp file */
+	char* filename; /* of the substrate file */
+        int nc3id; /* substrate nc4 file ncid used to hold metadata; not same as external id  */
+    } substrate;
 } NCDAPCOMMON;
 
 /**************************************************/
@@ -306,6 +310,6 @@ extern int nc__opendap(void);
 
 #define getncid(drno) (((NC*)drno)->ext_ncid)
 #define getdap(drno) ((NCDAPCOMMON*)((NC*)drno)->dispatchdata)
-#define getnc3id(drno) (getdap(drno)->nc3id)
+#define getnc3id(drno) (getdap(drno)->substrate.nc3id)
 
 #endif /*NCCOMMON_H*/

--- a/libdap2/ncd2dispatch.c
+++ b/libdap2/ncd2dispatch.c
@@ -364,26 +364,34 @@ NCD2_open(const char * path, int mode,
         /* Create fake file name: exact name must be unique,
            but is otherwise irrelevant because we are using NC_DISKLESS
         */
-        snprintf(tmpname,sizeof(tmpname),"%d",drno->int_ncid);
+        snprintf(tmpname,sizeof(tmpname),"tmp_%d",drno->int_ncid);
 
         /* Now, use the file to create the hidden, in-memory netcdf file.
 	   We want this hidden file to always be NC_CLASSIC, so we need to
            force default format temporarily in case user changed it.
+	   If diskless is enabled, then create file in-memory, else
+           create an actual temporary file in the file system.
 	*/
 	{
 	    int new = 0; /* format netcdf-3 */
 	    int old = 0;
+	    int ncflags = NC_CLOBBER|NC_CLASSIC_MODEL;
+#ifdef USE_DISKLESS
+	    ncflags |= NC_DISKLESS;
+#endif
 	    nc_set_default_format(new,&old); /* save and change */
-            ncstat = nc_create(tmpname,NC_DISKLESS|NC_CLASSIC_MODEL,&nc3id);
+            ncstat = nc_create(tmpname,ncflags,&nc3id);
 	    nc_set_default_format(old,&new); /* restore */
+	    dapcomm->substrate.realfile = ((ncflags & NC_DISKLESS) != 0);
+	    dapcomm->substrate.filename = strdup(tmpname);
+	    if(tmpname == NULL) ncstat = NC_ENOMEM;
+	    dapcomm->substrate.nc3id = nc3id;
 	}
         if(ncstat != NC_NOERR) {THROWCHK(ncstat); goto done;}
-	dapcomm->nc3id = nc3id;
 	/* Avoid fill */
 	nc_set_fill(nc3id,NC_NOFILL,NULL);
 
     }
-
     dapcomm->oc.dapconstraint = (DCEconstraint*)dcecreate(CES_CONSTRAINT);
     dapcomm->oc.dapconstraint->projections = nclistnew();
     dapcomm->oc.dapconstraint->selections = nclistnew();
@@ -673,7 +681,7 @@ builddims(NCDAPCOMMON* dapcomm)
     if(dapcomm->cdf.recorddim != NULL) {
 	CDFnode* unlimited = dapcomm->cdf.recorddim;
 	definename = getdefinename(unlimited);
-        ncstat = nc_def_dim(dapcomm->nc3id,
+        ncstat = nc_def_dim(dapcomm->substrate.nc3id,
 			definename,
 			NC_UNLIMITED,
 			&unlimited->ncid);
@@ -681,7 +689,7 @@ builddims(NCDAPCOMMON* dapcomm)
         if(ncstat != NC_NOERR) {THROWCHK(ncstat); goto done;}
 
         /* get the id for the substrate */
-        ncstat = NC_check_id(dapcomm->nc3id,&ncsub);
+        ncstat = NC_check_id(dapcomm->substrate.nc3id,&ncsub);
         if(ncstat != NC_NOERR) {THROWCHK(ncstat); goto done;}
 #if 0
 	nc3sub = (NC3_INFO*)&ncsub->dispatchdata;
@@ -700,7 +708,7 @@ builddims(NCDAPCOMMON* dapcomm)
 fprintf(stderr,"define: dim: %s=%ld\n",dim->ncfullname,(long)dim->dim.declsize);
 #endif
 	definename = getdefinename(dim);
-        ncstat = nc_def_dim(dapcomm->nc3id,definename,dim->dim.declsize,&dimid);
+        ncstat = nc_def_dim(dapcomm->substrate.nc3id,definename,dim->dim.declsize,&dimid);
         if(ncstat != NC_NOERR) {
           THROWCHK(ncstat); nullfree(definename); goto done;
 	}
@@ -772,7 +780,7 @@ fprintf(stderr,"[%ld]",dim->dim.declsize);
  }
 fprintf(stderr,"\n");
 #endif
-        ncstat = nc_def_var(dapcomm->nc3id,
+        ncstat = nc_def_var(dapcomm->substrate.nc3id,
 		        definename,
                         var->externaltype,
                         ncrank,
@@ -833,7 +841,7 @@ buildglobalattrs(NCDAPCOMMON* dapcomm, CDFnode* root)
 	    }
 	}
         if(ncbyteslength(buf) > 0) {
-            ncstat = nc_put_att_text(dapcomm->nc3id,NC_GLOBAL,"_sequence_dimensions",
+            ncstat = nc_put_att_text(dapcomm->substrate.nc3id,NC_GLOBAL,"_sequence_dimensions",
 	           ncbyteslength(buf),ncbytescontents(buf));
 	}
     }
@@ -844,12 +852,12 @@ buildglobalattrs(NCDAPCOMMON* dapcomm, CDFnode* root)
 
     if(dapparamcheck(dapcomm,"show","translate")) {
         /* Add a global attribute to show the translation */
-        ncstat = nc_put_att_text(dapcomm->nc3id,NC_GLOBAL,"_translate",
+        ncstat = nc_put_att_text(dapcomm->substrate.nc3id,NC_GLOBAL,"_translate",
 	           strlen("netcdf-3"),"netcdf-3");
     }
     if(dapparamcheck(dapcomm,"show","url")) {
 	if(dapcomm->oc.rawurltext != NULL)
-            ncstat = nc_put_att_text(dapcomm->nc3id,NC_GLOBAL,"_url",
+            ncstat = nc_put_att_text(dapcomm->substrate.nc3id,NC_GLOBAL,"_url",
 				       strlen(dapcomm->oc.rawurltext),dapcomm->oc.rawurltext);
     }
     if(dapparamcheck(dapcomm,"show","dds")) {
@@ -860,7 +868,7 @@ buildglobalattrs(NCDAPCOMMON* dapcomm, CDFnode* root)
 	    /* replace newlines with spaces*/
 	    nltxt = nulldup(txt);
 	    for(p=nltxt;*p;p++) {if(*p == '\n' || *p == '\r' || *p == '\t') {*p = ' ';}};
-            ncstat = nc_put_att_text(dapcomm->nc3id,NC_GLOBAL,"_dds",strlen(nltxt),nltxt);
+            ncstat = nc_put_att_text(dapcomm->substrate.nc3id,NC_GLOBAL,"_dds",strlen(nltxt),nltxt);
 	    nullfree(nltxt);
 	}
     }
@@ -871,7 +879,7 @@ buildglobalattrs(NCDAPCOMMON* dapcomm, CDFnode* root)
 	if(txt != NULL) {
 	    nltxt = nulldup(txt);
 	    for(p=nltxt;*p;p++) {if(*p == '\n' || *p == '\r' || *p == '\t') {*p = ' ';}};
-            ncstat = nc_put_att_text(dapcomm->nc3id,NC_GLOBAL,"_das",strlen(nltxt),nltxt);
+            ncstat = nc_put_att_text(dapcomm->substrate.nc3id,NC_GLOBAL,"_das",strlen(nltxt),nltxt);
 	    nullfree(nltxt);
 	}
     }
@@ -913,9 +921,9 @@ buildattribute(NCDAPCOMMON* dapcomm, NCattribute* att, nc_type vartype, int vari
 	}
         dapexpandescapes(newstring);
 	if(newstring[0]=='\0')
-	    ncstat = nc_put_att_text(dapcomm->nc3id,varid,att->name,1,newstring);
+	    ncstat = nc_put_att_text(dapcomm->substrate.nc3id,varid,att->name,1,newstring);
 	else
-	    ncstat = nc_put_att_text(dapcomm->nc3id,varid,att->name,strlen(newstring),newstring);
+	    ncstat = nc_put_att_text(dapcomm->substrate.nc3id,varid,att->name,strlen(newstring),newstring);
 	free(newstring);
         if(ncstat) goto done;
     } else {
@@ -945,7 +953,7 @@ buildattribute(NCDAPCOMMON* dapcomm, NCattribute* att, nc_type vartype, int vari
 	_ASSERTE(_CrtCheckMemory());
 #endif
     if(ncstat) {nullfree(mem); goto done;}
-    ncstat = nc_put_att(dapcomm->nc3id,varid,att->name,atype,nvalues,mem);
+    ncstat = nc_put_att(dapcomm->substrate.nc3id,varid,att->name,atype,nvalues,mem);
 #ifdef _MSC_VER
 	_ASSERTE(_CrtCheckMemory());
 #endif
@@ -1763,6 +1771,11 @@ freeNCDAPCOMMON(NCDAPCOMMON* dapcomm)
 
     dcefree((DCEnode*)dapcomm->oc.dapconstraint);
     dapcomm->oc.dapconstraint = NULL;
+
+    /* Note that the ncio layer will figure out that the tmp file needs to be deleted,
+       so we do not have to do it.
+    */
+    nullfree(dapcomm->substrate.filename); /* always reclaim */
 
     free(dapcomm);
 

--- a/libdap4/d4read.c
+++ b/libdap4/d4read.c
@@ -167,7 +167,6 @@ readfile(const NCURI* uri, const char* suffix, NCbytes* packet)
 #ifdef O_BINARY
     flags |= O_BINARY;
 #endif
-fprintf(stderr,"XXX: flags=0x%x file=%s\n",flags,filename);
     fd = NCopen2(filename,flags);
     if(fd < 0) {
 	nclog(NCLOGERR,"open failed:%s",filename);

--- a/libdap4/ncd4types.h
+++ b/libdap4/ncd4types.h
@@ -217,7 +217,8 @@ typedef struct NCD4serial {
 /* This will be passed out of the parse */
 struct NCD4meta {
     NCD4INFO* controller;
-    int ncid; /* root ncid of the substrate netcdf-4 file; copy of NCD4parse argument*/
+    int ncid; /* root ncid of the substrate netcdf-4 file;
+		 warning: copy of NCD4Info.substrate.nc4id */
     NCD4node* root;
     NCD4mode  mode; /* Are we reading DMR (only) or DAP (includes DMR) */
     NClist* allnodes; /*list<NCD4node>*/
@@ -345,6 +346,7 @@ struct NCD4INFO {
         long daplastmodified;
     } data;
     struct {
+	int realfile; /* 1 => we created actual temp file */
 	char* filename; /* of the substrate file */
         int nc4id; /* substrate nc4 file ncid used to hold metadata; not same as external id  */
 	NCD4meta* metadata;

--- a/libdispatch/dfile.c
+++ b/libdispatch/dfile.c
@@ -1659,6 +1659,10 @@ NC_create(const char *path0, int cmode, size_t initialsz,
 	 return stat;
    }
 
+#ifndef USE_DISKLESS
+   cmode &= (~ NC_DISKLESS); /* Force off */
+#endif
+
 #ifdef WINPATH
    /* Need to do path conversion */
    path = NCpathcvt(path0);
@@ -1811,8 +1815,8 @@ NC_open(const char *path0, int cmode,
    int stat = NC_NOERR;
    NC* ncp = NULL;
    NC_Dispatch* dispatcher = NULL;
-   int inmemory = ((cmode & NC_INMEMORY) == NC_INMEMORY);
-   int diskless = ((cmode & NC_DISKLESS) == NC_DISKLESS);
+   int inmemory = 0;
+   int diskless = 0;
    /* Need pieces of information for now to decide model*/
    int model = 0;
    int isurl = 0;
@@ -1825,6 +1829,14 @@ NC_open(const char *path0, int cmode,
       stat = nc_initialize();
       if(stat) return stat;
    }
+
+#ifndef USE_DISKLESS
+   /* Clean up cmode */
+   cmode &= (~ NC_DISKLESS);
+#endif
+
+   inmemory = ((cmode & NC_INMEMORY) == NC_INMEMORY);
+   diskless = ((cmode & NC_DISKLESS) == NC_DISKLESS);
 
 #ifdef WINPATH
    /* Need to do path conversion */

--- a/libsrc4/nc4file.c
+++ b/libsrc4/nc4file.c
@@ -25,10 +25,7 @@ extern int nc4_vararray_add(NC_GRP_INFO_T *grp,
 #ifdef USE_HDF4
 #include <mfhdf.h>
 #endif
-
-#ifdef USE_DISKLESS
 #include <hdf5_hl.h>
-#endif
 
 /* When we have open objects at file close, should
    we log them or print to stdout. Default is to log
@@ -302,9 +299,7 @@ nc_check_for_hdf(const char *path, int flags, void* parameters, int *hdf_file)
    MPI_Info info = MPI_INFO_NULL;
 #endif
    int inmemory = ((flags & NC_INMEMORY) == NC_INMEMORY);
-#ifdef USE_DISKLESS
    NC_MEM_INFO* meminfo = (NC_MEM_INFO*)parameters;
-#endif
 
 #ifdef USE_PARALLEL4
    if(use_parallel) {
@@ -2231,9 +2226,7 @@ nc4_open_file(const char *path, int mode, void* parameters, NC *nc)
    int retval;
    NC_HDF5_FILE_INFO_T* nc4_info = NULL;
    int inmemory = ((mode & NC_INMEMORY) == NC_INMEMORY);
-#ifdef USE_DISKLESS
    NC_MEM_INFO* meminfo = (NC_MEM_INFO*)parameters;
-#endif
 #ifdef USE_PARALLEL4
    NC_MPI_INFO* mpiinfo = (NC_MPI_INFO*)parameters;
    int comm_duped = 0;          /* Whether the MPI Communicator was duplicated */


### PR DESCRIPTION
If DAP (2 or 4) is enabled, but diskless is disabled, then the
dap code will create a real temporary file in which to store the
converted metadata for the DAP .dds or .dmr.

It was assumed that the nc_close code would reclaim the
temporary file. For DAP2, reclamation occurs in the ncio
code. For DAP4, it was assumed that the libsrc4 code would do
the reclamation, but for whatever reason, this is not happening.
Thus, in this situation, a temporary file is left in the file
system. Aside from being irritating to users, this screws up
'make distcheck'.

So the DAP4 code is fixed to ensure that the temporary file is
properly reclaimed independent of the libsrc4 code.