### PR TITLE
Fix segfault in reading .dodsrc by dap4 code

### DIFF
--- a/dap4_test/Makefile.am
+++ b/dap4_test/Makefile.am
@@ -58,8 +58,11 @@ CLEANFILES = *.exe
 # One last thing
 BUILT_SOURCES = .daprc
 
+# Make sure we have a non-empty .daprc to do minimal rc testing
 .daprc:
 	echo "#DAPRC" >.daprc
+	echo "MISC.PROP1=prop1" > .dodsrc
+	echo "[http://ucar.edu]MISC.PROP2=prop2" > .dodsrc
 
 clean-local: clean-local-check
 

--- a/libdap4/d4rc.c
+++ b/libdap4/d4rc.c
@@ -174,7 +174,7 @@ rccompile(const char* path)
         rctrim(triple->value);
 #ifdef D4DEBUG
 	fprintf(stderr,"rc: host=%s key=%s value=%s\n",
-		triple->host,triple->key,triple->valu);
+		triple->host?triple->host:"--",triple->key,triple->value);
 #endif
 	nclistpush(rc,triple);
 	triple = NULL;
@@ -518,8 +518,10 @@ storedump(char* msg, NClist* triples)
     }
     for(i=0;i<nclistlength(triples);i++) {
 	NCD4triple* t = (NCD4triple*)nclistget(triples,i);
-        fprintf(stderr,"\t%s\t%s\t%s\n",
-                (strlen(t->host)==0?"--":t->host),t->key,t->value);
+	const char* host = "--";
+	if(t->host != NULL && strlen(t->host) > 0)
+	    host = t->host;
+        fprintf(stderr,"\t%s\t%s\t%s\n",host,t->key,t->value);
     }
     fflush(stderr);
 }

--- a/libdap4/d4rc.c
+++ b/libdap4/d4rc.c
@@ -23,8 +23,10 @@ static void rcorder(NClist* rc);
 static char* rcreadline(char**);
 static int rcsearch(const char* prefix, const char* rcname, char** pathp);
 static void rctrim(char* text);
-static void storedump(char* msg, NClist* triples);
 static int rcsetinfocurlflag(NCD4INFO*, const char* flag, const char* value);
+#ifdef D4DEBUG
+static void storedump(char* msg, NClist* triples);
+#endif
 
 /* Define default rc files and aliases, also defines search order*/
 static char* rcfilenames[] = {".daprc",".dodsrc",NULL};
@@ -97,7 +99,9 @@ rcorder(NClist* rc)
 	    }
 	}
     }
+#ifdef D4DEBUG
     storedump("reorder:",rc);
+#endif
 }
 
 
@@ -506,6 +510,7 @@ NCD4_rclookup(char* key, char* hostport)
     return (triple == NULL ? NULL : triple->value);
 }
 
+#ifdef D4DEBUG
 static void
 storedump(char* msg, NClist* triples)
 {
@@ -525,6 +530,7 @@ storedump(char* msg, NClist* triples)
     }
     fflush(stderr);
 }
+#endif
 
 /**
  * Prefix must end in '/'

--- a/ncdap_test/Makefile.am
+++ b/ncdap_test/Makefile.am
@@ -97,6 +97,8 @@ BUILT_SOURCES = .dodsrc
 
 .dodsrc:
 	echo "#DODSRC" >.dodsrc
+	echo "MISC.PROP1=prop1" > .dodsrc
+	echo "[http://ucar.edu]MISC.PROP2=prop2" > .dodsrc
 
 clean-local: clean-local-check
 

--- a/oc2/ocrc.c
+++ b/oc2/ocrc.c
@@ -585,14 +585,14 @@ ocrc_locate(char* key, char* hostport)
     if(hostport == NULL) hostport = "";
     /* Assume that the triple store has been properly sorted */
     for(found=0,i=0;i<ocrc->ntriples;i++,triple++) {
-        size_t hplen = strlen(triple->host);
+        size_t hplen = (triple->host?strlen(triple->host):0);
         int t;
         if(strcmp(key,triple->key) != 0) continue; /* keys do not match */
         /* If the triple entry has no url, then use it
            (because we have checked all other cases)*/
         if(hplen == 0) {found=1;break;}
         /* do hostport match */
-        t = strcmp(hostport,triple->host);
+        t = strcmp(hostport,triple->host?triple->host:"");
         if(t ==  0) {found=1; break;}
     }
     return (found?triple:NULL);
@@ -746,11 +746,14 @@ ocrc_triple_iterate(char* key, char* url, struct OCTriple* prev)
     if(next == NULL)
       return NULL;
     for(; strlen(next->key) > 0; next++) {
+      const char* host = "";
       /* See if key as prefix still matches */
       int cmp = strcmp(key,next->key);
       if(cmp != 0) {next = NULL; break;} /* key mismatch */
       /* compare url */
-      cmp = ocstrncmp(url,next->host,strlen(next->host));
+      if(next->host != NULL)
+	host = next->host;
+      cmp = ocstrncmp(url,host,strlen(host));
       if(cmp ==  0) break;
     }
     return next;


### PR DESCRIPTION
re: e-support FLB-437472

Note: base branch for this is currently master rather than v4.5.

The storedump function is apparently failing on a very simple .dodsrc:
> HTTP.COOKIEJAR=/home/aswin/.rda_cookies
> HTTP.NETRC=/home/aswin/.netrc

It turns out that the problem is that I was forgetting to test
that the host field of a triple was null before trying to get
the length of the host field. Searched and fixed a couple of
similar situations in libdap4 and oc2.

Added a test of sorts by creating a more complex fake .dodsrc
file that would fail the old code.

Also, make use of storedump() conditional on the definition of D4DEBUG.




