### PR TITLE
avoid calling NC3_inq_var_fill when ERANGE_FILL is enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1027,6 +1027,7 @@ SET(STATUS_ERANGE_FILL "OFF")
 OPTION(ENABLE_ERANGE_FILL "Enable use of fill value when out-of-range type conversion causes NC_ERANGE error." OF)
 IF(ENABLE_ERANGE_FILL)
   SET(STATUS_ERANGE_FILL "ON")
+  ADD_DEFINITIONS(-DERANGE_FILL)
 ENDIF()
 
 # Options to use a more relaxed coordinate argument boundary check

--- a/configure.ac
+++ b/configure.ac
@@ -1192,6 +1192,7 @@ if test "x$enable_erange_fill" = xyes ; then
    else
       M4FLAGS="$M4FLAGS -DERANGE_FILL"
    fi
+   AC_DEFINE([ERANGE_FILL], [1], [if true, use _FillValue for NC_ERANGE data elements])
 fi
 AC_SUBST(M4FLAGS)
 

--- a/libsrc/putget.m4
+++ b/libsrc/putget.m4
@@ -704,15 +704,15 @@ putNCvx_$1_$2(NC3_INFO* ncp, const NC_var *varp,
 	size_t remaining = varp->xsz * nelems;
 	int status = NC_NOERR;
 	void *xp;
-        void *fillp;
+        void *fillp=NULL;
 
 	if(nelems == 0)
 		return NC_NOERR;
 
 	assert(value != NULL);
 
-        fillp = malloc(varp->xsz);
-	status = NC3_inq_var_fill(varp, fillp);
+        ifdef(`ERANGE_FILL',`fillp = malloc(varp->xsz);
+        status = NC3_inq_var_fill(varp, fillp);')
 
 	for(;;)
 	{
@@ -741,7 +741,7 @@ putNCvx_$1_$2(NC3_INFO* ncp, const NC_var *varp,
 		value += nput;
 
 	}
-        free(fillp);
+        ifdef(`ERANGE_FILL',`free(fillp);')
 
 	return status;
 }

--- a/libsrc/putget.m4
+++ b/libsrc/putget.m4
@@ -711,8 +711,10 @@ putNCvx_$1_$2(NC3_INFO* ncp, const NC_var *varp,
 
 	assert(value != NULL);
 
-        ifdef(`ERANGE_FILL',`fillp = malloc(varp->xsz);
-        status = NC3_inq_var_fill(varp, fillp);')
+#ifdef ERANGE_FILL
+        fillp = malloc(varp->xsz);
+        status = NC3_inq_var_fill(varp, fillp);
+#endif
 
 	for(;;)
 	{
@@ -741,7 +743,9 @@ putNCvx_$1_$2(NC3_INFO* ncp, const NC_var *varp,
 		value += nput;
 
 	}
-        ifdef(`ERANGE_FILL',`free(fillp);')
+#ifdef ERANGE_FILL
+        free(fillp);
+#endif
 
 	return status;
 }


### PR DESCRIPTION
This pull request is to silence the NC_EBADTYPE error that NCO ncpdq encountered when built with netcdf 4.5.0-rc2. 

Please note this PR does not resolve the fundamental issue of whether or not the data type of a variable's _FillValue attribute should match with the variable's.

See discussion in #458 