### PR TITLE
fix vpath build for regenerating c files from m4 files

### DIFF
--- a/libsrc/Makefile.am
+++ b/libsrc/Makefile.am
@@ -42,12 +42,12 @@ noinst_LTLIBRARIES = libnetcdf3.la
 # These files are cleaned on developer workstations (and then rebuilt
 # with m4), but they are included in the distribution so that the user
 # does not have to have m4.
-MAINTAINERCLEANFILES = $(man_MANS) attrx.c ncx.c putgetx.c
+MAINTAINERCLEANFILES = $(man_MANS) attr.c ncx.c putget.c
 EXTRA_DIST = attr.m4 ncx.m4 putget.m4 $(man_MANS) CMakeLists.txt XGetopt.c
 
 # This tells make how to turn .m4 files into .c files.
 .m4.c:
-	m4 $(AM_M4FLAGS) $(M4FLAGS) -s $< > $(top_srcdir)/libsrc/$@
+	m4 $(AM_M4FLAGS) $(M4FLAGS) -s $< > $(top_srcdir)/libsrc/$(@F)
 
 # The C API man page.
 man_MANS = netcdf.3


### PR DESCRIPTION
When doing vpath (out of tree) build and m4 files have been modifies, this PR fixes the full path names of target C files.