### PR TITLE
Fix (I think) the --has-dap and --has-dap4 output

### DIFF
--- a/nc-config.cmake.in
+++ b/nc-config.cmake.in
@@ -22,7 +22,12 @@ else
     has_dap2="yes"
 fi
 
-has_dap4="@ENABLE_DAP4"
+has_dap4="@ENABLE_DAP4@"
+if [ -z $has_dap4 -o "$has_dap4" = "OFF" ]; then
+    has_dap4="no"
+else
+    has_dap4="yes"
+fi
 
 has_nc2="@BUILD_V2@"
 
@@ -128,7 +133,7 @@ Available values for OPTION include:
   --has-fortran whether Fortran API is installed
   --has-dap2    whether OPeNDAP (DAP2) is enabled in this build
   --has-dap4    whether DAP4 is enabled in this build
-  --has-dap     same as --has-dp (Deprecated)
+  --has-dap     same as --has-dap2 (Deprecated)
   --has-nc2     whether NetCDF-2 API is enabled
   --has-nc4     whether NetCDF-4/HDF-5 is enabled in this build
   --has-hdf5    whether HDF5 is used in build (always the same as --has-nc4)
@@ -202,7 +207,7 @@ if [ -f "$nfconf" ]; then
         echo "  --has-f03   -> $has_f03"
         echo
 fi
-        echo "  --has-dap   -> $has_dap"
+        echo "  --has-dap   -> $has_dap2"
         echo "  --has-dap2  -> $has_dap2"
         echo "  --has-dap4  -> $has_dap4"
         echo "  --has-nc2   -> $has_nc2"
@@ -252,7 +257,7 @@ while test $# -gt 0; do
 	;;
 
     --has-dap)
-       	echo $has_dap2 $has_dap4
+       	echo $has_dap2
        	;;
 
     --has-dap2)


### PR DESCRIPTION
The `has_dap4` define was missing trailing @.  I also added tests similar to other code to result in lowercase yes no for `--has_dap4`.

I'm not as sure about the `--has-dap` changes.  One place was outputting `$has_dap` which is never defined.  I think that the intent is that `--has-dap` returns the same as `--has-dap2` so made changes that did that.  If that isn't the intent, then let me know and I will back out those changes and only leave the dap4-related change.