### PR TITLE
Fix bad output from nc-config

### DIFF
--- a/nc-config.cmake.in
+++ b/nc-config.cmake.in
@@ -27,54 +27,53 @@ has_dap4="@ENABLE_DAP4"
 has_nc2="@BUILD_V2@"
 
 
-if [ -z $has_nc2 -o "$has_nc2" = "OFF" ]; then
+if [ -z "$has_nc2" -o "$has_nc2" = "OFF" ]; then
     has_nc2="no"
 else
     has_nc2="yes"
 fi
 
 has_nc4="@USE_NETCDF4@"
-if [ -z $has_nc4 ]; then
+if [ -z "$has_nc4" -o "$has_nc4" = "OFF" ]; then
     has_nc4="no"
 else
     has_nc4="yes"
 fi
 
 has_logging="@ENABLE_LOGGING@"
-if [ -z $has_logging ]; then
+if [ -z "$has_logging" -o "$has_logging" = "OFF" ]; then
     has_logging="no"
 else
     has_logging="yes"
 fi
 
 has_hdf4="@USE_HDF4@"
-if [ -z $has_hdf4 ]; then
+if [ -z "$has_hdf4" -o "$has_hdf4" = "OFF" ]; then
     has_hdf4="no"
 else
     has_hdf4="yes"
 fi
 
 has_pnetcdf="@USE_PNETCDF@"
-if [ -z $has_pnetcdf ]; then
+if [ -z "$has_pnetcdf" -o "$has_pnetcdf" = "OFF" ]; then
     has_pnetcdf="no"
 else
     has_pnetcdf="yes"
 fi
 
 has_hdf5="@USE_HDF5@"
-if [ -z $has_hdf5 -o "$has_hdf5" = "OFF" ]; then
+if [ -z "$has_hdf5" -o "$has_hdf5" = "OFF" ]; then
     has_hdf5="no"
 else
     has_hdf5="yes"
 fi
 
 has_szlib="@USE_SZLIB@"
-if [ -z $has_szlib ]; then
+if [ -z "$has_szlib" -o "$has_szlib" = "OFF" ]; then
     has_szlib="no"
 else
     has_szlib="yes"
 fi
-
 
 version="@PACKAGE@ @VERSION@"
 


### PR DESCRIPTION
I was getting "yes" output from some of the options which were not enabled.  This was due to two reasons:
* If CMake set the variable to "OFF", then the `-z $var test` would fail and `$var` would be set to "yes" even though it should be "no"
* If CMake set the variable to empty string (`has_var=""`), then the `-z $has_var` test would also fail and set it to yes instead of no.

With these changes, it looks like I am getting the correct output from nc-config consistent with my configuration options.