### PR TITLE
reset ncp->begin_var if errors occur when calling NC_begins()

### DIFF
--- a/libsrc/nc3internal.c
+++ b/libsrc/nc3internal.c
@@ -214,6 +214,7 @@ fprintf(stderr, "    VAR %d %s: %ld\n", ii, (*vpp)->name->cp, (long)index);
 #endif
                 if( sizeof_off_t == 4 && (index > X_OFF_MAX || index < 0) )
 		{
+                    ncp->begin_var = 0;
 		    return NC_EVARSIZE;
                 }
 		(*vpp)->begin = index;
@@ -284,6 +285,7 @@ fprintf(stderr, "    REC %d %s: %ld\n", ii, (*vpp)->name->cp, (long)index);
 #endif
                 if( sizeof_off_t == 4 && (index > X_OFF_MAX || index < 0) )
 		{
+                    ncp->begin_var = 0;
 		    return NC_EVARSIZE;
                 }
 		(*vpp)->begin = index;
@@ -306,6 +308,7 @@ fprintf(stderr, "    REC %d %s: %ld\n", ii, (*vpp)->name->cp, (long)index);
 #if SIZEOF_OFF_T == SIZEOF_SIZE_T && SIZEOF_SIZE_T == 4
 		if( ncp->recsize > X_UINT_MAX - (*vpp)->len )
 		{
+                    ncp->begin_var = 0;
 		    return NC_EVARSIZE;
 		}
 #endif

--- a/libsrc/nc3internal.c
+++ b/libsrc/nc3internal.c
@@ -155,6 +155,7 @@ NC_begins(NC3_INFO* ncp,
 	size_t ii, j;
 	int sizeof_off_t;
 	off_t index = 0;
+	off_t old_ncp_begin_var;
 	NC_var **vpp;
 	NC_var *last = NULL;
 	NC_var *first_var = NULL;       /* first "non-record" var */
@@ -175,6 +176,8 @@ NC_begins(NC3_INFO* ncp,
 
 	if(ncp->vars.nelems == 0)
 		return NC_NOERR;
+
+        old_ncp_begin_var = ncp->begin_var;
 
 	/* only (re)calculate begin_var if there is not sufficient space in header
 	   or start of non-record variables is not aligned as requested by valign */
@@ -214,7 +217,7 @@ fprintf(stderr, "    VAR %d %s: %ld\n", ii, (*vpp)->name->cp, (long)index);
 #endif
                 if( sizeof_off_t == 4 && (index > X_OFF_MAX || index < 0) )
 		{
-                    ncp->begin_var = 0;
+                    ncp->begin_var = old_ncp_begin_var;
 		    return NC_EVARSIZE;
                 }
 		(*vpp)->begin = index;
@@ -285,7 +288,7 @@ fprintf(stderr, "    REC %d %s: %ld\n", ii, (*vpp)->name->cp, (long)index);
 #endif
                 if( sizeof_off_t == 4 && (index > X_OFF_MAX || index < 0) )
 		{
-                    ncp->begin_var = 0;
+                    ncp->begin_var = old_ncp_begin_var;
 		    return NC_EVARSIZE;
                 }
 		(*vpp)->begin = index;
@@ -308,7 +311,7 @@ fprintf(stderr, "    REC %d %s: %ld\n", ii, (*vpp)->name->cp, (long)index);
 #if SIZEOF_OFF_T == SIZEOF_SIZE_T && SIZEOF_SIZE_T == 4
 		if( ncp->recsize > X_UINT_MAX - (*vpp)->len )
 		{
-                    ncp->begin_var = 0;
+                    ncp->begin_var = old_ncp_begin_var;
 		    return NC_EVARSIZE;
 		}
 #endif

--- a/nc_test/CMakeLists.txt
+++ b/nc_test/CMakeLists.txt
@@ -30,7 +30,7 @@ TARGET_LINK_LIBRARIES(nc_test
   )
 
 # Some extra stand-alone tests
-SET(TESTS t_nc tst_small tst_misc tst_norm tst_names tst_nofill tst_nofill2 tst_nofill3 tst_meta tst_inq_type tst_global_fillval)
+SET(TESTS t_nc tst_small tst_misc tst_norm tst_names tst_nofill tst_nofill2 tst_nofill3 tst_meta tst_inq_type tst_global_fillval tst_err_enddef)
 
 IF(NOT HAVE_BASH)
   SET(TESTS ${TESTS} tst_atts3)

--- a/nc_test/Makefile.am
+++ b/nc_test/Makefile.am
@@ -25,7 +25,7 @@ check_PROGRAMS =
 TESTPROGRAMS = t_nc tst_small nc_test tst_misc tst_norm \
 	tst_names tst_nofill tst_nofill2 tst_nofill3 tst_atts3 \
 	tst_meta tst_inq_type tst_utf8_validate tst_utf8_phrases \
-	tst_global_fillval
+	tst_global_fillval tst_err_enddef
 
 if USE_NETCDF4
 TESTPROGRAMS += tst_atts tst_put_vars tst_elatefill

--- a/nc_test/tst_err_enddef.c
+++ b/nc_test/tst_err_enddef.c
@@ -1,0 +1,53 @@
+#include <stdio.h>
+#include <netcdf.h>
+
+#define CHECK_ERR { \
+    if (err != NC_NOERR) { \
+        nerrs++; \
+        printf("Error at line %d in %s: (%s)\n", \
+        __LINE__,__FILE__,nc_strerror(err)); \
+    } \
+}
+
+#define EXP_ERR(exp) { \
+    if (err != exp) { \
+        nerrs++; \
+        printf("Error at line %d in %s: expecting %s but got %s\n", \
+        __LINE__,__FILE__,nc_strerror(exp), nc_strerror(err)); \
+    } \
+}
+
+int main(int argc, char** argv)
+{
+    char *filename="tst_err_enddef.nc";
+    int err, nerrs=0, ncid, cmode, varid, dimid[3];
+
+    if (argc == 2) filename = argv[1];
+    printf("*** TESTING error code returned from nc__enddef and nc_close ");
+
+    cmode = NC_CLOBBER;
+    err = nc_create(filename, cmode, &ncid); CHECK_ERR
+    err = nc_set_fill(ncid, NC_NOFILL, NULL); CHECK_ERR
+
+    err = nc_def_dim(ncid, "X", 5,      &dimid[0]); CHECK_ERR
+    err = nc_def_dim(ncid, "YY", 66661, &dimid[1]); CHECK_ERR
+    err = nc_def_dim(ncid, "XX", 66661, &dimid[2]); CHECK_ERR
+
+    err = nc_def_var(ncid, "var", NC_INT, 1, dimid, &varid); CHECK_ERR
+    err = nc_def_var(ncid, "var_big", NC_FLOAT, 2, dimid+1, &varid); CHECK_ERR
+
+    /* make the file header size larger than 2 GiB */
+    err = nc__enddef(ncid, 2147483648LL, 1, 1, 1);
+    EXP_ERR(NC_EVARSIZE)
+
+    /* the above error keeps the program in define mode, thus close will
+     * call enddef again, but this time no error is expected
+     */
+    err = nc_close(ncid); CHECK_ERR
+
+    if (nerrs) printf(".... failed with %d errors\n",nerrs);
+    else       printf(".... pass\n");
+
+    return (nerrs > 0);
+}
+


### PR DESCRIPTION
When encountering an error in NC_begins, ncp->begin_var may have already been set.
This PR suggests to reset it to 0 before returning the error code.

A test program is added, tst_err_enddef.c.
Line 40 expects error code NC_EVARSIZE.
40    err = nc__enddef(ncid, 2147483648LL, 1, 1, 1);

The following call to nc_close() in line 46 will again return the same error code.
This because the failure in line 40 leaves the dataset in define mode and nc_enddef will be called inside nc_clode()
46    err = nc_close(ncid); CHECK_ERR

