### PR TITLE
Important fix to d4rc.c

### DIFF
--- a/libdap4/d4rc.c
+++ b/libdap4/d4rc.c
@@ -23,8 +23,10 @@ static void rcorder(NClist* rc);
 static char* rcreadline(char**);
 static int rcsearch(const char* prefix, const char* rcname, char** pathp);
 static void rctrim(char* text);
-static void storedump(char* msg, NClist* triples);
 static int rcsetinfocurlflag(NCD4INFO*, const char* flag, const char* value);
+#ifdef D4DEBUG
+static void storedump(char* msg, NClist* triples);
+#endif
 
 /* Define default rc files and aliases, also defines search order*/
 static char* rcfilenames[] = {".daprc",".dodsrc",NULL};
@@ -97,7 +99,9 @@ rcorder(NClist* rc)
 	    }
 	}
     }
+#ifdef D4DEBUG
     storedump("reorder:",rc);
+#endif
 }
 
 
@@ -506,6 +510,7 @@ NCD4_rclookup(char* key, char* hostport)
     return (triple == NULL ? NULL : triple->value);
 }
 
+#ifdef D4DEBUG
 static void
 storedump(char* msg, NClist* triples)
 {
@@ -519,10 +524,11 @@ storedump(char* msg, NClist* triples)
     for(i=0;i<nclistlength(triples);i++) {
 	NCD4triple* t = (NCD4triple*)nclistget(triples,i);
         fprintf(stderr,"\t%s\t%s\t%s\n",
-                (strlen(t->host)==0?"--":t->host),t->key,t->value);
+                (t->host == NULL || strlen(t->host)==0?"--":t->host),t->key,t->value);
     }
     fflush(stderr);
 }
+#endif
 
 /**
  * Prefix must end in '/'

--- a/oc2/ocinternal.c
+++ b/oc2/ocinternal.c
@@ -606,7 +606,6 @@ ocset_curlproperties(OCstate* state)
         if(path == NULL) return OC_ENOMEM;
         occopycat(path,len,3,ocglobalstate.tempdir,"/","occookies");
         stat = ocmktmp(path,&name);
-fprintf(stderr,"%s => %s\n",state->uri->uri,name); fflush(stderr);
         free(path);
 	state->curlflags.cookiejar = name;
 	state->curlflags.createdflags |= COOKIECREATED;


### PR DESCRIPTION
It is imperative that this fix goes into
v4.5-release-candidate branch and master branch ASAP.

The bug occurs in d4rc.c where strcmp is being applied to NULL.
Also, the code in which it occurs is debugging code, so it needs
to be #ifdef'd.  This fix may cause minor conflicts with other
outstanding pull requests that fix the same bug. But the
conflicts should be minor and easy to resolve.