### PR TITLE
Add --is-parallel option and output to nc-config

### DIFF
--- a/nc-config.cmake.in
+++ b/nc-config.cmake.in
@@ -80,6 +80,12 @@ else
     has_szlib="yes"
 fi
 
+has_parallel="@USE_PARALLEL@"
+if [ -z $has_parallel ]; then
+    has_parallel="no"
+else
+    has_parallel="yes"
+fi
 
 version="@PACKAGE@ @VERSION@"
 
@@ -124,28 +130,29 @@ Usage: nc-config [OPTION]
 
 Available values for OPTION include:
 
-  --help        display this help message and exit
-  --all         display all options
-  --cc          C compiler
-  --cflags      pre-processor and compiler flags
-  --has-c++     whether C++ API is installed
-  --has-c++4    whether netCDF-4 C++ API is installed
-  --has-fortran whether Fortran API is installed
-  --has-dap2    whether OPeNDAP (DAP2) is enabled in this build
-  --has-dap4    whether DAP4 is enabled in this build
-  --has-dap     same as --has-dap2 (Deprecated)
-  --has-nc2     whether NetCDF-2 API is enabled
-  --has-nc4     whether NetCDF-4/HDF-5 is enabled in this build
-  --has-hdf5    whether HDF5 is used in build (always the same as --has-nc4)
-  --has-hdf4    whether HDF4 was used in build
-  --has-logging whether logging is enabled with --enable-logging.
-  --has-pnetcdf whether parallel-netcdf (a.k.a. pnetcdf) was used in build
-  --has-szlib   whether szlib is included in build
-  --libs        library linking information for netcdf
-  --prefix      Install prefix
-  --includedir  Include directory
-  --libdir      Library directory
-  --version     Library version
+  --help         display this help message and exit
+  --all          display all options
+  --cc           C compiler
+  --cflags       pre-processor and compiler flags
+  --has-c++      whether C++ API is installed
+  --has-c++4     whether netCDF-4 C++ API is installed
+  --has-fortran  whether Fortran API is installed
+  --has-dap2     whether OPeNDAP (DAP2) is enabled in this build
+  --has-dap4     whether DAP4 is enabled in this build
+  --has-dap      same as --has-dap2 (Deprecated)
+  --has-nc2      whether NetCDF-2 API is enabled
+  --has-nc4      whether NetCDF-4/HDF-5 is enabled in this build
+  --has-hdf5     whether HDF5 is used in build (always the same as --has-nc4)
+  --has-hdf4     whether HDF4 was used in build
+  --has-logging  whether logging is enabled with --enable-logging.
+  --has-pnetcdf  whether parallel-netcdf (a.k.a. pnetcdf) was used in build
+  --has-szlib    whether szlib is included in build
+  --has-parallel whether has parallel IO support via hdf5 and/or pnetcdf
+  --libs         library linking information for netcdf
+  --prefix       Install prefix
+  --includedir   Include directory
+  --libdir       Library directory
+  --version      Library version
 
 EOF
 if [ -f "$ncxx4conf" ]; then
@@ -217,6 +224,7 @@ fi
         echo "  --has-logging-> $has_logging"
         echo "  --has-pnetcdf-> $has_pnetcdf"
         echo "  --has-szlib -> $has_szlib"
+	echo "  --has-parallel-> $has_parallel"
 	echo
         echo "  --prefix    -> $prefix"
         echo "  --includedir-> $includedir"
@@ -296,7 +304,11 @@ while test $# -gt 0; do
        	echo $has_szlib
        	;;
 
-     --libs)
+    --has-parallel)
+	echo $has_parallel
+	;;
+
+    --libs)
        	echo $libs
        	;;
 


### PR DESCRIPTION
It is useful to be able to determine whether the netcdf library has parallel capabilities enabled.  Currently can look at netcdf_meta.h, but would be useful be able to get information from nc-config since that is how most other options settings are displayed.