### PR TITLE
Update dispatch table documentation

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -74,6 +74,6 @@ IF(ENABLE_DOXYGEN)
 
 ENDIF(ENABLE_DOXYGEN)
 
-SET(CUR_EXTRA_DIST ${CUR_EXTRA_DIST} CMakeLists.txt Makefile.am netcdf.m4 DoxygenLayout.xml Doxyfile.in Doxyfile.guide.in footer.html mainpage.dox tutorial.dox dispatch.dox guide.dox types.dox notes.md cdl.dox architecture.dox internal.dox install-fortran.dox Doxyfile.in.cmake windows-binaries.md building-with-cmake.md install.md)
+SET(CUR_EXTRA_DIST ${CUR_EXTRA_DIST} CMakeLists.txt Makefile.am netcdf.m4 DoxygenLayout.xml Doxyfile.in Doxyfile.guide.in footer.html mainpage.dox tutorial.dox guide.dox types.dox notes.md cdl.dox architecture.dox internal.dox install-fortran.dox Doxyfile.in.cmake windows-binaries.md building-with-cmake.md install.md)
 
 ADD_EXTRA_DIST("${CUR_EXTRA_DIST}")

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -748,7 +748,6 @@ INPUT = \
     @abs_top_srcdir@/RELEASE_NOTES.md \
     @abs_top_srcdir@/docs/install.md \
     @abs_top_srcdir@/docs/install-fortran.md \
-    @abs_top_srcdir@/docs/dispatch.dox \
     @abs_top_srcdir@/docs/types.dox \
     @abs_top_srcdir@/docs/internal.dox \
     @abs_top_srcdir@/docs/windows-binaries.md \

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -5,7 +5,7 @@
 
 # These files will be included with the dist.
 EXTRA_DIST = netcdf.m4 DoxygenLayout.xml Doxyfile.in footer.html \
-    mainpage.dox tutorial.dox dispatch.dox \
+    mainpage.dox tutorial.dox \
     guide.dox types.dox cdl.dox \
     architecture.dox internal.dox windows-binaries.md \
     building-with-cmake.md CMakeLists.txt \

--- a/docs/internal.dox
+++ b/docs/internal.dox
@@ -6,23 +6,31 @@
 
 This document describes the architecture and details of the netCDF
 internal dispatch mechanism. The idea is that when a user opens or
-creates a netcdf file, a specific dispatch table is
-chosen. Subsequent netcdf API calls are then channeled through that
+creates a netcdf file, a specific dispatch table is chosen.
+A dispatch table is a struct containing an entry for every function
+in the netcdf-c API. 
+Subsequent netcdf API calls are then channeled through that
 dispatch table to the appropriate function for implementing that API
-call.
+call. The functions in the dispatch table are not quite the same
+as those defined in netcdf.h. For simplicity and compactness,
+some netcdf.h API calls are
+mapped to the same dispatch table function. In addition to
+the functions, the first entry in the table defines the model
+that this dispatch table implements. It will be one of the
+NC_FORMATX_XXX values.
 
-At least the following dispatch tables are supported.
+The list of supported dispatch tables will grow over time.
+To date, at least the following dispatch tables are supported.
 - netcdf classic files (netcdf-3)
 - netcdf enhanced files (netcdf-4)
-- OPeNDAP to netcdf-3
-- OPeNDAP to netcdf-4
+- DAP2 to netcdf-3
+- DAP4 to netcdf-4
+- pnetcdf (parallel cdf5)
 
 Internal Dispatch Tables
 - \subpage adding_dispatch
-- \subpage dispatch_notes
 - \subpage put_vara_dispatch
 - \subpage put_attr_dispatch
-
 
 The dispatch table represents a distillation of the netcdf API down to
 a minimal set of internal operations. The format of the dispatch table
@@ -36,12 +44,15 @@ table must define this minimal set of operations.
 In order to make this process concrete, let us assume we plan to add
 an in-memory implementation of netcdf-3.
 
-\section dispatch_step1 Step 1.
+\section dispatch_configure_ac Defining configure.ac flags
 
-Define a –enable flag and an AM_CONFIGURE flag in configure.ac. We
-will use the flags –enable-netcdfm and USE_NETCDFM respectively.
+Define a –-enable flag and an AM_CONFIGURE flag in configure.ac.
+For our example, we assume the option "--enable-ncm" and the AM_CONFIGURE
+flag "ENABLE_NCM". If you examine the existing configure.ac and see how,
+for example, dap2 is defined, then it should be clear how to do it for
+your code.
 
-\section dispatch_step2 Step 2.
+\section dispatch_namespace Defining a "name space"
 
 Choose some prefix of characters to identify the new dispatch
 system. In effect we are defining a name-space. For our in-memory
@@ -49,94 +60,66 @@ system, we will choose "NCM" and "ncm". NCM is used for non-static
 procedures to be entered into the dispatch table and ncm for all other
 non-static procedures.
 
-\section dispatch_step3 Step 3.
+\section dispatch_netcdf_h Extend include/netcdf.h
 
-Modify file libdispatch/ncdispatch.h as follows.
-
-    Add a index for this implementation:
+Modify file include/netcdf.h to add an NC_FORMATX_XXX flag
+by adding a flag for this dispatch format at the appropriate places.
 
 \code
-              #define NC_DISPATCH_NCM  5
+              #define NC_FORMATX_NCM  7
 \endcode
 
-    Define an external reference to the in-memory dispatch table.
+Add any format specific new error codes.
 
 \code
-              #ifdef USE_NETCDFM
+              #define NC_ENCM  (?)
+\endcode
+
+\section dispatch_ncdispatch Extend include/ncdispatch.h
+
+Modify file include/ncdispatch.h as follows.
+
+Add format specific data and functions; note the of our NCM namespace.
+
+\code
+              #ifdef ENABLE_NCM
               extern NC_Dispatch* NCM_dispatch_table;
+              extern int NCM_initialize(void);
               #endif
 \endcode
 
-\section dispatch_step4 Step 4.
-
-Modify file libdispatch/netcdf.c as follows.
-
-    Add a ptr to the in-memory dispatch table.
-
-\code
-              #ifdef USE_NETCDFM
-              NC_Dispatch* NCM_dispatch_table = NULL;
-              #endif
-\endcode
-
-    Add includes for any necessary header files as needed.
-
-\section dispatch_step5 Step 5.
+\section dispatch_define_code Define the dispatch table functions
 
 Define the functions necessary to fill in the dispatch table. As a
 rule, we assume that a new directory is defined, libsrcm, say. Within
-this directory, we need to define Makefile.am, the source files
+this directory, we need to define Makefile.am and CMakeLists.txt.
+We also need to define the source files
 containing the dispatch table and the functions to be placed in the
 dispatch table – call them ncmdispatch.c and ncmdispatch.h. Look at
-libsrc/nc3dispatch.[ch] for an example.
+libsrc/nc3dispatch.[ch] or libdap4/ncd4dispatch.[ch] for examples.
 
-As part of the ncmdispatch.c file, you must define the following.
+Similarly, it is best to take existing Makefile.am and CMakeLists.txt
+files (from libdap4 for example) and modify them.
 
-\code
-     NC_Dispatch NCM_dispatcher = {
-     NC_DISPATCH_NCM,
-     NCM_create,
-     NCM_open,
-     ...
-     };
-
-     int
-     NCM_initialize(void)
-     {
-         NCM_dispatch_table = &NCM_dispatcher;
-         return NC_NOERR;
-     }
-\endcode
-
-Assuming that the in-memory library does not require any external
-libraries, then the Makefile.am will look something like this.
-
-\code
-     NCM_SOURCES = ncmdispatch.c ncmdispatch.h ...
-     AM_CPPFLAGS +=  -I$(top_srcdir)/libsrc -I$(top_srcdir)/libdispatch
-     libnetcdfm_la_SOURCES = $(NCM_SOURCES)
-     noinst_LTLIBRARIES = libnetcdfm.la
-\endcode
-
-\section dispatch_step6 Step 6.
+\section dispatch_lib Adding the dispatch code to libnetcdf
 
 Provide for the inclusion of this library in the final libnetcdf
 library. This is accomplished by modifying liblib/Makefile.am by
 adding something like the following.
 
 \code
-     if USE_NETCDFM
+     if ENABLE_NCM
         libnetcdf_la_LIBADD += $(top_builddir)/libsrcm/libnetcdfm.la
      endif
 \endcode
 
-\section dispatch_step7 Step 7.
+\section dispatch_init Extend library initialization
 
-Modify the NC_initialize function in liblib/stub.c by adding
+Modify the NC_initialize function in liblib/nc_initialize.c by adding
 appropriate references to the NCM dispatch function.
 
 \code
-     #ifdef USE_NETCDFM
+     #ifdef ENABLE_NCM
      extern int NCM_initialize(void);
      #endif
      ...
@@ -150,7 +133,7 @@ appropriate references to the NCM dispatch function.
      }
 \endcode
 
-\section dispatch_step8 Step 8.
+\section dispatch_tests Testing the new dispatch table
 
 Add a directory of tests; ncm_test, say. The file ncm_test/Makefile.am
 will look something like this.
@@ -169,13 +152,13 @@ will look something like this.
      EXTRA_DIST = ...
 \endcode
 
-\section dispatch_step9 Step 9.
+\section dispatch_toplevel Top-Level build of the dispatch code
 
 Provide for libnetcdfm to be constructed by adding the following to
 the top-level Makefile.am.
 
 \code
-     if USE_NETCDFM
+     if ENABLE_NCM
      NCM=libsrcm
      NCMTESTDIR=ncm_test
      endif
@@ -186,29 +169,27 @@ the top-level Makefile.am.
 \section choosing_dispatch_table Choosing a Dispatch Table
 
 The dispatch table is chosen in the NC_create and the NC_open
-procedures in libdispatch/netcdf.c. The decision is currently based on
-the following pieces of information.
+procedures in libdispatch/netcdf.c.
+This can be, unfortunately, a complex process.
 
-The file path – this can be used to detect, for example, a DAP url
-versus a normal file system file.
+The decision is currently based on the following pieces of information.
+Using a mode flag is the most common mechanism, in which case
+netcdf.h needs to be modified to define the relevant mode flag.
 
-The mode argument – this can be used to detect, for example, what kind
+1. The mode argument – this can be used to detect, for example, what kind
 of file to create: netcdf-3, netcdf-4, 64-bit netcdf-3, etc.  For
 nc_open and when the file path references a real file, the contents of
 the file can also be used to determine the dispatch table.  Although
 currently not used, this code could be modified to also use other
 pieces of information such as environment variables.
 
-In addition to the above, there is one additional mechanism to force
-the use of a specific dispatch table. The procedure
-"NC_set_dispatch_override()" can be invoked to specify a dispatch
-table.
+2. The file path – this can be used to detect, for example, a DAP url
+versus a normal file system file.
 
 When adding a new dispatcher, it is necessary to modify NC_create and
-NC_open in libdispatch/netcdf.c to detect when it is appropriate to
+NC_open in libdispatch/dfile.c to detect when it is appropriate to
 use the NCM dispatcher. Some possibilities are as follows.
 - Add a new mode flag: say NC_NETCDFM.
-- Use an environment variable.
 - Define a special file path format that indicates the need to use a
   special dispatch table.
 
@@ -217,65 +198,35 @@ use the NCM dispatcher. Some possibilities are as follows.
 Several of the entries in the dispatch table are significantly
 different than those of the external API.
 
-\section create_open_dispatch Create/Open
+\subsection create_open_dispatch Create/Open
 
-The create table entry and the open table entry have the following
-signatures respectively.
+The create table entry and the open table entry in the dispatch table
+have the following signatures respectively.
 
 \code
      int (*create)(const char *path, int cmode,
                 size_t initialsz, int basepe, size_t *chunksizehintp,
-                int useparallel, MPI_Comm comm, MPI_Info info,
-                struct NC_Dispatch*, struct NC** ncp);
+                int useparallel, void* parameters,
+                struct NC_Dispatch* table, NC* ncp);
 \endcode
 
 \code
      int (*open)(const char *path, int mode,
               int basepe, size_t *chunksizehintp,
-              int use_parallel, MPI_Comm comm, MPI_Info info,
-              NC_Dispatch*, NC** ncp);
+              int use_parallel, void* parameters,
+              struct NC_Dispatch* table, NC* ncp);
 \endcode
 
 The key difference is that these are the union of all the possible
-create/open signatures from the netcdf.h API. Note especially the last
-two parameters. The dispatch table is included in case the create
+create/open signatures from the include/netcdfXXX.h files. Note especially the last
+three parameters. The parameters argument is a pointer to arbitrary data
+to provide extra info to the dispatcher.
+The table argument is included in case the create
 function (e.g. NCM_create) needs to invoke other dispatch
-functions. The very last parameter is a pointer to a pointer to an NC
-instance. It is expected that the create function will allocate and
-fill in an instance of an "NC" object and return a pointer to it in
-the ncp parameter.
-
-\page dispatch_notes Dispatch Programming Notes
-
-As with the existing code, and when MPI is not being used, the comm
-and info parameters should be passed in as 0. This is taken care of in
-the nc_open() and nc_create() API procedures in libdispatch/netcdf.c.
-
-In fact, the object returned in the ncp parameter does not actually
-have to be an instance of struct NC. It only needs to "look like it
-for the first few fields. This is, in effect, a fake version of
-subclassing. Let us suppose that the NCM_create function uses a struct
-NCM object. The initial part of the definition of NCM must match the
-fields at the beginning of struct NC between the comments BEGIN_COMMON
-and END_COMMON. So, we would have the following.
-
-\code
-              typedef struct NCM {
-              /*BEGIN COMMON*/
-                      int ext_ncid; /* uid Â«Â« 16 */
-                      int int_ncid; /* unspecified other id */
-                      struct NC_Dispatch* dispatch;
-              #ifdef USE_DAP
-                      struct NCDRNO* drno;
-              #endif
-              /*END COMMON*/
-              ...
-              } NCM;
-\endcode
-
-This allows the pointer to the NCM object to be cast as an instance of
-NC* and its pointer returned in the ncp file. Eventually, this will be
-replaced with a separate structure containing the common fields.
+functions. The very last argument, ncp, is a pointer to an NC
+instance. The raw NC instance will have been created by libdispatch/dfile.c
+and is passed to e.g. open with the expectation that it will be filled in
+by the dispatch open function.
 
 \page put_vara_dispatch Accessing Data with put_vara() and get_vara()
 

--- a/docs/mainpage.dox
+++ b/docs/mainpage.dox
@@ -63,7 +63,6 @@ to be used for different types of back-ends, for example, the HDF5
 library, or a DAP client accessing remote data.
 - \ref nc_dispatch
 - \ref adding_dispatch
-- \ref dispatch_notes
 - \ref put_vara_dispatch
 - \ref put_attr_dispatch
 

--- a/libdispatch/dfile.c
+++ b/libdispatch/dfile.c
@@ -1610,11 +1610,10 @@ Create a file, calling the appropriate dispatch create call.
 
 For create, we have the following pieces of information to use to
 determine the dispatch table:
-- table specified by override
 - path
 - cmode
 
-\param path The file name of the new netCDF dataset.
+\param path0 The file name of the new netCDF dataset.
 
 \param cmode The creation mode flag, the same as in nc_create().
 


### PR DESCRIPTION
re: issues https://github.com/Unidata/netcdf-c/issues/493 and https://github.com/Unidata/netcdf-c/issues/474

Update docs/internal.dox to
provide a more accurate description
of how to add a new dispatch table.
Also remove dispatch.dox as superfluous.