### PR TITLE
fixed memory error in handling of (ignored) reference atts in HDF5 file

### DIFF
--- a/libsrc4/nc4file.c
+++ b/libsrc4/nc4file.c
@@ -89,12 +89,14 @@ att_read_var_callbk(hid_t loc_id, const char *att_name, const H5A_info_t *ainfo,
             {
 	      if ((retval = nc4_att_list_del(&att_info->var->att, att)))
 		BAIL(retval);
+	      att = NULL;
             }
 	  else
 	    BAIL(retval);
 	}
 
-      att->created = NC_TRUE;
+      if (att)
+	  att->created = NC_TRUE;
 
       if (attid > 0 && H5Aclose(attid) < 0)
 	BAIL2(NC_EHDFERR);


### PR DESCRIPTION
Fixes #507.

There is a memory error in the code when reading a file that contains attributes of type REFERENCE. In this case, the code tries to set a field in a struct that has already been freed.

This fix checks that the struct memory is still available before attempting to set the field.
