### PR TITLE
fix for leaks in nc_create as seen in nc_test4/tst_files

### DIFF
--- a/libdispatch/dfile.c
+++ b/libdispatch/dfile.c
@@ -1748,7 +1748,10 @@ fprintf(stderr,"XXX: path0=%s path=%s\n",path0,path); fflush(stderr);
 	cmode &= ~(NC_64BIT_OFFSET); /*NC_64BIT_DATA=>NC_64BIT_OFFSET*/
 
    if((cmode & NC_MPIIO) && (cmode & NC_MPIPOSIX))
-      return  NC_EINVAL;
+   {
+       nullfree(path);       
+       return  NC_EINVAL;
+   }
 
    if (dispatcher == NULL)
    {
@@ -1767,7 +1770,10 @@ fprintf(stderr,"XXX: path0=%s path=%s\n",path0,path); fflush(stderr);
       if(model == (NC_FORMATX_NC3))
  	dispatcher = NC3_dispatch_table;
       else
-	 return NC_ENOTNC;
+      {
+	  nullfree(path);
+	  return NC_ENOTNC;
+      }
    }
 
    /* Create the NC* instance and insert its dispatcher */


### PR DESCRIPTION
Fix for the leaks in nc_create().

I thought I had got these in the last batch of memory fixes, but I missed it.

Fixes #506 (and this time I really mean it).
