### PR TITLE
cause nc_create to return NC_ENOTBUILT if used with NC_NETCDF4 on non-netcdf4 library

### DIFF
--- a/include/netcdf.h
+++ b/include/netcdf.h
@@ -451,8 +451,8 @@ by the desired type. */
 #define NC_EDISKLESS     (-129)    /**< Error in using diskless  access. */
 #define NC_ECANTEXTEND   (-130)    /**< Attempt to extend dataset during ind. I/O operation. */
 #define NC_EMPI          (-131)    /**< MPI operation failed. */
-
-#define NC4_LAST_ERROR   (-131)
+#define NC_ENOTENABLED   (-132)    /**< Feature not supported in this build. */
+#define NC4_LAST_ERROR   (-132)   
 
 /* This is used in netCDF-4 files for dimensions without coordinate
  * vars. */

--- a/libdispatch/dfile.c
+++ b/libdispatch/dfile.c
@@ -1664,6 +1664,13 @@ NC_create(const char *path0, int cmode, size_t initialsz,
 #ifndef USE_DISKLESS
    cmode &= (~ NC_DISKLESS); /* Force off */
 #endif
+   
+#ifndef USE_NETCDF4
+   /* If the user ask for a netCDF-4 file, and the library was built
+    * without netCDF-4, then return an error.*/
+   if (cmode & NC_NETCDF4)
+       return NC_EINVAL;
+#endif /* USE_NETCDF4 undefined */   
 
 #ifdef WINPATH
    /* Need to do path conversion */

--- a/libdispatch/dfile.c
+++ b/libdispatch/dfile.c
@@ -1669,7 +1669,7 @@ NC_create(const char *path0, int cmode, size_t initialsz,
    /* If the user ask for a netCDF-4 file, and the library was built
     * without netCDF-4, then return an error.*/
    if (cmode & NC_NETCDF4)
-       return NC_EINVAL;
+       return NC_ENOTBUILT;
 #endif /* USE_NETCDF4 undefined */   
 
 #ifdef WINPATH

--- a/nc_test/tst_global_fillval.c
+++ b/nc_test/tst_global_fillval.c
@@ -9,55 +9,55 @@
 
    * https://github.com/Unidata/netcdf-c/issues/388
    * https://github.com/Unidata/netcdf-c/pull/389
-*/
+
+   Modified by Ed Hartnett, see:
+   https://github.com/Unidata/netcdf-c/issues/392
+   */
 
 #include "config.h"
 #include <nc_tests.h>
-#include <stdio.h>
-#include <netcdf.h>
-
-#ifdef USE_CDF5
-#define NUMFORMATS 5
-#else
-#define NUMFORMATS 4
-#endif
+#include "err_macros.h"
 
 #define FILE_NAME "tst_global_fillval.nc"
 
-#define ERR {if(err!=NC_NOERR){printf("Error at line %d: %s\n",__LINE__,nc_strerror(err)); toterrs++; break;}}
 int
 main(int argc, char **argv)
 {
-    int i, ncid, cmode, err, fillv=9;
-    int toterrs = 0;
-    int formats[NUMFORMATS]={0,
-                             NC_64BIT_OFFSET,
+    printf("*** testing proper elatefill return...");    
+    {
+	int num_formats = 2;
+	int n = 0;
+
+	/* Determine how many formats are in use. */
 #ifdef USE_CDF5
-                             NC_64BIT_DATA,
+	num_formats++;
 #endif
-                             NC_NETCDF4,
-                             NC_CLASSIC_MODEL | NC_NETCDF4};
-    char *formatnames[NUMFORMATS]={"CDF-1",
-                                   "CDF-2",
+#ifdef USE_NETCDF4
+	num_formats += 2;
+#endif
+    
+	int formats[num_formats];
+	formats[n++] = 0;
+	formats[n++] = NC_64BIT_OFFSET;
 #ifdef USE_CDF5
-                                   "CDF-5",
+	formats[n++] = NC_64BIT_DATA;
 #endif
-                                   "NETCDF4",
-                                   "CLASSIC_MODEL"};
+#ifdef USE_NETCDF4
+	formats[n++] = NC_NETCDF4;
+	formats[n++] = NC_CLASSIC_MODEL | NC_NETCDF4;
+#endif
 
-    for (i=0; i<NUMFORMATS; i++) {
-        cmode = NC_CLOBBER | formats[i];
-        err = nc_create(FILE_NAME, cmode, &ncid); ERR
+	for (int i = 0; i < num_formats; i++)
+	{
+	    int ncid, cmode, fillv = 9;
+	
+	    cmode = NC_CLOBBER | formats[i];
+	    if (nc_create(FILE_NAME, cmode, &ncid)) ERR;
+	    if (nc_put_att_int(ncid, NC_GLOBAL, "_FillValue", NC_INT, 1, &fillv)) ERR;
+	    if (nc_close(ncid)) ERR;
 
-        err = nc_put_att_int(ncid, NC_GLOBAL, "_FillValue", NC_INT, 1, &fillv);
-        if (err != 0) {
-          toterrs++;
-          printf("%13s Error at line %d: expecting 0 but got %d\n",
-                   formatnames[i],__LINE__,err);
-        }
-        err = nc_close(ncid); ERR;
-
+	}
     }
-    printf("Total errors: %d\n",toterrs);
-    return toterrs;
+    SUMMARIZE_ERR;
+    FINAL_RESULTS;    
 }

--- a/nc_test/tst_misc.c
+++ b/nc_test/tst_misc.c
@@ -61,8 +61,21 @@ main(int argc, char **argv)
    }
 
    SUMMARIZE_ERR;
+#ifndef USE_NETCDF4   
+   printf("*** Trying to create netCDF-4 file without netCDF-4...");
+   {
+       int ncid;
+       int ret;
+       
+       if (!(ret = nc_create(FILE_NAME, NC_CLOBBER|NC_NETCDF4, &ncid)))
+	   ERR;
+   }
+   SUMMARIZE_ERR;
+#endif /* USE_NETCDF4 undefined */
+   
 #ifdef TEST_PNETCDF
    MPI_Finalize();
 #endif
+   
    FINAL_RESULTS;
 }


### PR DESCRIPTION

Fixes #392.