### PR TITLE
Fix dap legal name character handling

### DIFF
--- a/oc2/daplex.c
+++ b/oc2/daplex.c
@@ -40,16 +40,28 @@ static char* ddsworddelims =
   "{}[]:;=,";
 
 /* Define 1 and > 1st legal characters */
+/* Note: for some reason I added # and removed !~'"
+   what was I thinking?
+*/
 static char* ddswordchars1 =
-  "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-+_/%\\.*";
+  "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+  "-+_/%\\.*!~'\"";
 static char* ddswordcharsn =
-  "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-+_/%\\.*#";
+  "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+  "-+_/%\\.*!~'\"";
+
+/* This includes sharp and colon for historical reasons */
 static char* daswordcharsn =
-  "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-+_/%\\.*#:";
+  "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+  "-+_/%\\.*#:!~'\"";
+
+/* Need to remove '.' to allow for fqns */
 static char* cewordchars1 =
-  "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-+_/%\\";
+  "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+  "-+_/%\\*!~'\"";
 static char* cewordcharsn =
-  "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-+_/%\\";
+  "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+  "-+_/%\\*!~'\"";
 
 /* Current sets of legal characters */
 /*


### PR DESCRIPTION
Fixes https://github.com/Unidata/netcdf-c/issues/569

Serious bad on my part. For some reason, I changed the set of
characters allowed n a DAP name. In particular, characters that
are legal according to the DAP spec were removed. So when one of
this removed characters was encountered, it produced a parse
error.

In this case, the offending character was a single quote character in the name:
Blackadar's_mixing_length_scale_hybrid

The reason it worked for java is because the escape character set
is correct and different than the one in the netcdf-c dap code.