### PR TITLE
fixed warnings in libdispatch

### DIFF
--- a/libdispatch/ddispatch.c
+++ b/libdispatch/ddispatch.c
@@ -167,7 +167,6 @@ fail:
 int
 nc__testurl(const char* path, char** basenamep)
 {
-    int stat = NC_NOERR;
     NCURI* uri;
     int ok = 0;
     if(ncuriparse(path,&uri) == NCU_OK) {

--- a/libdispatch/dfile.c
+++ b/libdispatch/dfile.c
@@ -170,11 +170,13 @@ NC_check_file_type(const char *path, int flags, void *parameters,
     int status = NC_NOERR;
 
     int diskless = ((flags & NC_DISKLESS) == NC_DISKLESS);
+#ifdef USE_PARALLEL
 #ifdef USE_STDIO
     int use_parallel = 0;
 #else
     int use_parallel = ((flags & NC_MPIIO) == NC_MPIIO);
 #endif
+#endif /* USE_PARALLEL */
     int inmemory = (diskless && ((flags & NC_INMEMORY) == NC_INMEMORY));
     struct MagicFile file;
 
@@ -2053,7 +2055,7 @@ openmagic(struct MagicFile* file)
 	/* Get its length */
 	NC_MEM_INFO* meminfo = (NC_MEM_INFO*)file->parameters;
 	file->filelen = (long long)meminfo->size;
-fprintf(stderr,"XXX: openmagic: memory=0x%llx size=%ld\n",meminfo->memory,meminfo->size);
+fprintf(stderr,"XXX: openmagic: memory=0x%llx size=%ld\n",(long long unsigned int)meminfo->memory,meminfo->size);
 	goto done;
     }
 #ifdef USE_PARALLEL
@@ -2119,7 +2121,7 @@ readmagic(struct MagicFile* file, long pos, char* magic)
     if(file->inmemory) {
 	char* mempos;
 	NC_MEM_INFO* meminfo = (NC_MEM_INFO*)file->parameters;
-fprintf(stderr,"XXX: readmagic: memory=0x%llx size=%ld\n",meminfo->memory,meminfo->size);
+	fprintf(stderr,"XXX: readmagic: memory=0x%llx size=%ld\n",(long long unsigned int)meminfo->memory,meminfo->size);
 fprintf(stderr,"XXX: readmagic: pos=%ld filelen=%lld\n",pos,file->filelen);
 	if((pos + MAGIC_NUMBER_LEN) > meminfo->size)
 	    {status = NC_EDISKLESS; goto done;}

--- a/libdispatch/drc.c
+++ b/libdispatch/drc.c
@@ -131,7 +131,7 @@ ncrc_lookup(NCTripleStore* store, char* key, char* tag)
 static const NCTriple*
 rc_locate(NCTripleStore* rc, char* key, char* tag)
 {
-    int i,found;
+    int i;
 
     if(ncrc_ignore || !ncrc_loaded || rc->triples == NULL)
 	return NULL;
@@ -139,14 +139,14 @@ rc_locate(NCTripleStore* rc, char* key, char* tag)
 
     if(tag == NULL) tag = "";
     /* Assume that the triple store has been properly sorted */
-    for(found=0,i=0;i<nclistlength(rc->triples);i++) {
+    for(i=0;i<nclistlength(rc->triples);i++) {
 	NCTriple* triple = (NCTriple*)nclistget(rc->triples,i);
         size_t taglen = strlen(triple->tag);
         int t;
         if(strcmp(key,triple->key) != 0) continue; /* keys do not match */
         /* If the triple entry has no tag, then use it
            (because we have checked all other cases)*/
-        if(taglen == 0) {found=1;break;}
+        if(taglen == 0) {break;}
         /* do tag match */
         t = strcmp(tag,triple->tag);
         if(t ==  0) return triple;

--- a/libdispatch/ncuri.c
+++ b/libdispatch/ncuri.c
@@ -304,7 +304,6 @@ ncuriparse(const char* uri0, NCURI** durip)
 	/* Check for leading user:pwd@ */
         char* newhost = strchr(tmp.host,'@');
         if(newhost != NULL) {
-	    size_t rem;
 	    if(newhost == tmp.host)
 		{THROW(NCU_EUSRPWD);} /* we have proto://@ */
 	    terminate(newhost); /* overwrite '@' */
@@ -781,7 +780,6 @@ ncuriencodeonly(char* s, char* allowable)
 	    *outptr++ = '+';
         } else {
             /* search allowable */
-            int c2;
 	    char* p = strchr(allowable,c);
 	    if(p != NULL) {
                 *outptr++ = (char)c;


### PR DESCRIPTION
Recent merges added some warnings to libdispatch. With the PR they are fixed and libdispatch once again builds warning-free with gcc -Wall.