### PR TITLE
Fix some tests use of ENABLE_CDF5

### DIFF
--- a/include/nc_tests.h
+++ b/include/nc_tests.h
@@ -24,6 +24,7 @@ for conditions of use.
 
 
 #define NC_TESTS_MAX_DIMS 1024 /**< NC_MAX_DIMS for tests.  Allows different NC_MAX_DIMS values without breaking this test with a heap or stack overflow. */
+#define MAX_NUM_FORMATS 5 /**< Max number of available binary formats. */
 
 /** Useful define for tests. */
 /** \{ */

--- a/nc_test/tst_inq_type.c
+++ b/nc_test/tst_inq_type.c
@@ -184,3 +184,4 @@ int main(int argc, char **argv) {
 
    FINAL_RESULTS;
 }
+

--- a/nc_test/tst_inq_type.c
+++ b/nc_test/tst_inq_type.c
@@ -22,144 +22,165 @@
 
 #define FILE_NAME "tst_inq_type.nc"
 
-void
-check_err(const int stat, const int line, const char *file) {
-   if (stat != NC_NOERR) {
-      (void)fprintf(stderr,"line %d of %s: %s\n", line, file, nc_strerror(stat));
-      fflush(stderr);
-      exit(1);
-   }
-}
-
-
 int test_type_should_fail(int ncid, int type, char* tstring) {
 
-  printf("\t* Testing Type (Should Fail) %s:\t",tstring);
-  if(!nc_inq_type(ncid,type,NULL,NULL)) ERR;
-  else printf("expected failure.\n");
+   printf("\t* Testing Type (Should Fail) %s:\t",tstring);
+   if(!nc_inq_type(ncid,type,NULL,NULL)) ERR;
+   else printf("expected failure.\n");
 
-  return 0;
+   return 0;
 }
 
 int test_type(int ncid, int type, char* tstring) {
 
-  printf("\t* Testing Type %s:\t",tstring);
-  if(nc_inq_type(ncid,type,NULL,NULL)) ERR;
-  else printf("success.\n");
+   printf("\t* Testing Type %s:\t",tstring);
+   if(nc_inq_type(ncid,type,NULL,NULL)) ERR;
+   else printf("success.\n");
 
-  return 0;
+   return 0;
 }
-
-
 
 int main(int argc, char **argv) {
 
-  int ncid=0;
+   int ncid=0;
 
-  {
-    printf("\n* Testing nc_inq_type with netcdf-3\n");
+   printf("\n* Testing nc_inq_type with netcdf-3\n");
+   {
+      if(nc_create(FILE_NAME,NC_CLOBBER,&ncid)) ERR;
 
-    if(nc_create(FILE_NAME,NC_CLOBBER,&ncid)) ERR;
+      test_type(ncid, NC_BYTE,"NC_BYTE");
+      test_type(ncid, NC_CHAR,"NC_CHAR");
+      test_type(ncid, NC_SHORT,"NC_SHORT");
+      test_type(ncid, NC_INT,"NC_INT");
+      test_type(ncid, NC_LONG,"NC_LONG");
+      test_type(ncid, NC_FLOAT,"NC_FLOAT");
+      test_type(ncid, NC_DOUBLE,"NC_DOUBLE");
 
-    test_type(ncid, NC_BYTE,"NC_BYTE");
-    test_type(ncid, NC_CHAR,"NC_CHAR");
-    test_type(ncid, NC_SHORT,"NC_SHORT");
-    test_type(ncid, NC_INT,"NC_INT");
-    test_type(ncid, NC_LONG,"NC_LONG");
-    test_type(ncid, NC_FLOAT,"NC_FLOAT");
-    test_type(ncid, NC_DOUBLE,"NC_DOUBLE");
+      /* Not Valid for Classic */
+      /* Valid now, see https://github.com/Unidata/netcdf-c/issues/240 for more
+	 information. The types are not valid for use in Classic,
+	 but nc_inq_type should return valid info. */
+      test_type(ncid, NC_UBYTE,"NC_UBYTE");
+      test_type(ncid, NC_USHORT,"NC_USHORT");
+      test_type(ncid, NC_UINT,"NC_UINT");
+      test_type(ncid, NC_INT64,"NC_INT64");
+      test_type(ncid, NC_UINT64,"NC_UINT64");
+      test_type(ncid, NC_STRING,"NC_STRING");
 
-    /* Not Valid for Classic */
-    /* Valid now, see https://github.com/Unidata/netcdf-c/issues/240 for more
-       information. The types are not valid for use in Classic,
-       but nc_inq_type should return valid info. */
-    test_type(ncid, NC_UBYTE,"NC_UBYTE");
-    test_type(ncid, NC_USHORT,"NC_USHORT");
-    test_type(ncid, NC_UINT,"NC_UINT");
-    test_type(ncid, NC_INT64,"NC_INT64");
-    test_type(ncid, NC_UINT64,"NC_UINT64");
-    test_type(ncid, NC_STRING,"NC_STRING");
+      /* Invoke a true negative */
+      test_type_should_fail(ncid, 9999, "NC_GARBAGE");
+      test_type_should_fail(ncid, -1, "NC_GARBAGE_NEGATIVE");
 
-    /* Invoke a true negative */
-    test_type_should_fail(ncid, 9999, "NC_GARBAGE");
-    test_type_should_fail(ncid, -1, "NC_GARBAGE_NEGATIVE");
+      if(nc_close(ncid)) ERR;
 
+      /* Reopen file to check that we can. */
+      if (nc_create(FILE_NAME, 0, &ncid)) ERR;
+      if (nc_close(ncid)) ERR;
+      if (nc_create(FILE_NAME, NC_WRITE, &ncid)) ERR;
+      if (nc_close(ncid)) ERR;
+   }
+   SUMMARIZE_ERR;
 
-    if(nc_close(ncid)) ERR;
-  }
+#ifdef ENABLE_CDF5
+   printf("\n* Testing nc_inq_type with CDF5\n");
+   {
+      if(nc_create(FILE_NAME,NC_CLOBBER|NC_CDF5,&ncid)) ERR;
 
-  {
-    printf("\n* Testing nc_inq_type with CDF5\n");
+      test_type(ncid, NC_BYTE,"NC_BYTE");
+      test_type(ncid, NC_CHAR,"NC_CHAR");
+      test_type(ncid, NC_SHORT,"NC_SHORT");
+      test_type(ncid, NC_INT,"NC_INT");
+      test_type(ncid, NC_LONG,"NC_LONG");
+      test_type(ncid, NC_FLOAT,"NC_FLOAT");
+      test_type(ncid, NC_DOUBLE,"NC_DOUBLE");
+      test_type(ncid, NC_UBYTE,"NC_UBYTE");
+      test_type(ncid, NC_USHORT,"NC_USHORT");
+      test_type(ncid, NC_UINT,"NC_UINT");
+      test_type(ncid, NC_INT64,"NC_INT64");
+      test_type(ncid, NC_UINT64,"NC_UINT64");
+      test_type(ncid, NC_STRING,"NC_STRING");
 
-    if(nc_create(FILE_NAME,NC_CLOBBER|NC_CDF5,&ncid)) ERR;
+      if(nc_close(ncid)) ERR;
 
-    test_type(ncid, NC_BYTE,"NC_BYTE");
-    test_type(ncid, NC_CHAR,"NC_CHAR");
-    test_type(ncid, NC_SHORT,"NC_SHORT");
-    test_type(ncid, NC_INT,"NC_INT");
-    test_type(ncid, NC_LONG,"NC_LONG");
-    test_type(ncid, NC_FLOAT,"NC_FLOAT");
-    test_type(ncid, NC_DOUBLE,"NC_DOUBLE");
-    test_type(ncid, NC_UBYTE,"NC_UBYTE");
-    test_type(ncid, NC_USHORT,"NC_USHORT");
-    test_type(ncid, NC_UINT,"NC_UINT");
-    test_type(ncid, NC_INT64,"NC_INT64");
-    test_type(ncid, NC_UINT64,"NC_UINT64");
-    test_type(ncid, NC_STRING,"NC_STRING");
-
-    if(nc_close(ncid)) ERR;
-  }
+      /* Reopen file to check that we can. */
+      if (nc_open(FILE_NAME, NC_CDF5, &ncid)) ERR;
+      if (nc_close(ncid)) ERR;
+      if (nc_open(FILE_NAME, 0, &ncid)) ERR;
+      if (nc_close(ncid)) ERR;
+      if (nc_open(FILE_NAME, NC_WRITE, &ncid)) ERR;
+      if (nc_close(ncid)) ERR;
+   }
+   SUMMARIZE_ERR;
+#endif /* ENABLE_CDF5 */
 
 #ifdef USE_NETCDF4
+   printf("\n* Testing nc_inq_type with netcdf-4 + Classic Model\n");
+   {
+      if(nc_create(FILE_NAME,NC_CLOBBER|NC_NETCDF4|NC_CLASSIC_MODEL,&ncid)) ERR;
 
-  {
-    printf("\n* Testing nc_inq_type with netcdf-4 + Classic Model\n");
+      test_type(ncid, NC_BYTE,"NC_BYTE");
+      test_type(ncid, NC_CHAR,"NC_CHAR");
+      test_type(ncid, NC_SHORT,"NC_SHORT");
+      test_type(ncid, NC_INT,"NC_INT");
+      test_type(ncid, NC_LONG,"NC_LONG");
+      test_type(ncid, NC_FLOAT,"NC_FLOAT");
+      test_type(ncid, NC_DOUBLE,"NC_DOUBLE");
+      test_type(ncid, NC_UBYTE,"NC_UBYTE");
+      test_type(ncid, NC_USHORT,"NC_USHORT");
+      test_type(ncid, NC_UINT,"NC_UINT");
+      test_type(ncid, NC_INT64,"NC_INT64");
+      test_type(ncid, NC_UINT64,"NC_UINT64");
+      test_type(ncid, NC_STRING,"NC_STRING");
 
-    if(nc_create(FILE_NAME,NC_CLOBBER|NC_NETCDF4|NC_CLASSIC_MODEL,&ncid)) ERR;
+      if(nc_close(ncid)) ERR;
 
-    test_type(ncid, NC_BYTE,"NC_BYTE");
-    test_type(ncid, NC_CHAR,"NC_CHAR");
-    test_type(ncid, NC_SHORT,"NC_SHORT");
-    test_type(ncid, NC_INT,"NC_INT");
-    test_type(ncid, NC_LONG,"NC_LONG");
-    test_type(ncid, NC_FLOAT,"NC_FLOAT");
-    test_type(ncid, NC_DOUBLE,"NC_DOUBLE");
-    test_type(ncid, NC_UBYTE,"NC_UBYTE");
-    test_type(ncid, NC_USHORT,"NC_USHORT");
-    test_type(ncid, NC_UINT,"NC_UINT");
-    test_type(ncid, NC_INT64,"NC_INT64");
-    test_type(ncid, NC_UINT64,"NC_UINT64");
-    test_type(ncid, NC_STRING,"NC_STRING");
+      /* Re-open file to be sure we can. */
+      if (nc_open(FILE_NAME, NC_NETCDF4|NC_CLASSIC_MODEL, &ncid)) ERR;
+      if (nc_close(ncid)) ERR;
+      if (nc_open(FILE_NAME, NC_NETCDF4, &ncid)) ERR;
+      if (nc_close(ncid)) ERR;
+      if (nc_open(FILE_NAME, NC_CLASSIC_MODEL, &ncid)) ERR;
+      if (nc_close(ncid)) ERR;
+      if (nc_open(FILE_NAME, 0, &ncid)) ERR;
+      if (nc_close(ncid)) ERR;
+      if (nc_open(FILE_NAME, NC_WRITE, &ncid)) ERR;
+      if (nc_close(ncid)) ERR;
+   }
+   SUMMARIZE_ERR;
 
+   printf("\n* Testing nc_inq_type with netcdf-4\n");
+   {
 
-    if(nc_close(ncid)) ERR;
-  }
+      if(nc_create(FILE_NAME,NC_CLOBBER|NC_NETCDF4,&ncid)) ERR;
 
-  {
-    printf("\n* Testing nc_inq_type with netcdf-4\n");
+      test_type(ncid, NC_BYTE,"NC_BYTE");
+      test_type(ncid, NC_CHAR,"NC_CHAR");
+      test_type(ncid, NC_SHORT,"NC_SHORT");
+      test_type(ncid, NC_INT,"NC_INT");
+      test_type(ncid, NC_LONG,"NC_LONG");
+      test_type(ncid, NC_FLOAT,"NC_FLOAT");
+      test_type(ncid, NC_DOUBLE,"NC_DOUBLE");
+      test_type(ncid, NC_UBYTE,"NC_UBYTE");
+      test_type(ncid, NC_USHORT,"NC_USHORT");
+      test_type(ncid, NC_UINT,"NC_UINT");
+      test_type(ncid, NC_INT64,"NC_INT64");
+      test_type(ncid, NC_UINT64,"NC_UINT64");
+      test_type(ncid, NC_STRING,"NC_STRING");
+      if(nc_close(ncid)) ERR;
 
-    if(nc_create(FILE_NAME,NC_CLOBBER|NC_NETCDF4,&ncid)) ERR;
-
-    test_type(ncid, NC_BYTE,"NC_BYTE");
-    test_type(ncid, NC_CHAR,"NC_CHAR");
-    test_type(ncid, NC_SHORT,"NC_SHORT");
-    test_type(ncid, NC_INT,"NC_INT");
-    test_type(ncid, NC_LONG,"NC_LONG");
-    test_type(ncid, NC_FLOAT,"NC_FLOAT");
-    test_type(ncid, NC_DOUBLE,"NC_DOUBLE");
-    test_type(ncid, NC_UBYTE,"NC_UBYTE");
-    test_type(ncid, NC_USHORT,"NC_USHORT");
-    test_type(ncid, NC_UINT,"NC_UINT");
-    test_type(ncid, NC_INT64,"NC_INT64");
-    test_type(ncid, NC_UINT64,"NC_UINT64");
-    test_type(ncid, NC_STRING,"NC_STRING");
-    if(nc_close(ncid)) ERR;
-  }
+      /* Re-open file to be sure we can. */
+      if (nc_open(FILE_NAME, NC_NETCDF4, &ncid)) ERR;
+      if (nc_close(ncid)) ERR;
+      if (nc_open(FILE_NAME, 0, &ncid)) ERR;
+      if (nc_close(ncid)) ERR;
+      if (nc_open(FILE_NAME, NC_WRITE, &ncid)) ERR;
+      if (nc_close(ncid)) ERR;
+   }
+   SUMMARIZE_ERR;
 
 #endif // USE_NETCDF4
 
-  printf("* Finished.\n");
+   printf("* Finished.\n");
 
-  SUMMARIZE_ERR;
-  FINAL_RESULTS;
+   FINAL_RESULTS;
 }

--- a/nc_test4/tst_converts.c
+++ b/nc_test4/tst_converts.c
@@ -22,25 +22,58 @@
 #define VAR2_NAME "var2"
 
 /* This is handy for print statements. */
-static char *format_name[] = {"", "classic", "64-bit offset", "netCDF-4",
-			      "netCDF-4 classic model"};
+static char *format_name[MAX_NUM_FORMATS] = {"classic", "64-bit offset", "netCDF-4",
+                                             "netCDF-4 classic model", "CDF5"};
 
 int check_file(int format, unsigned char *uchar_out);
 int create_file(int format, unsigned char *uchar_out);
+
+/* Determine how many formats are available, and what they are. */
+void
+determine_test_formats(int *num_formats, int *format)
+{
+   int ind = 0;
+   int num;
+
+   /* Check inputs. */
+   assert(num_formats && format);
+
+   /* We always have classic and 64-bit offset */
+   num = 2;
+   format[ind++] = NC_FORMAT_CLASSIC;
+   format[ind++] = NC_FORMAT_64BIT_OFFSET;
+
+   /* Do we have netCDF-4 and netCDF-4 classic? */
+#ifdef USE_NETCDF4
+   num += 2;
+   format[ind++] = NC_FORMAT_NETCDF4_CLASSIC;
+   format[ind++] = NC_FORMAT_NETCDF4;
+#endif /* USE_NETCDF4 */
+
+   /* Do we have CDF5? */
+#ifdef ENABLE_CDF5
+   num++;
+   format[ind++] = NC_FORMAT_CDF5;
+#endif /* ENABLE_CDF5 */
+
+   *num_formats = num;
+}
 
 int
 main(int argc, char **argv)
 {
    unsigned char uchar_out[DIM1_LEN] = {0, 128, 255};
-   int format;
+   int format[MAX_NUM_FORMATS];
+   int num_formats;
 
    printf("\n*** Testing netcdf data conversion.\n");
+   determine_test_formats(&num_formats, format);
 
-   for (format = 1; format < 5; format++)
+   for (int f = 0; f < num_formats; f++)
    {
-      printf("*** Testing conversion in netCDF %s files... ", format_name[format]);
-      create_file(format, uchar_out);
-      check_file(format, uchar_out);
+      printf("*** Testing conversion in netCDF %s files... ", format_name[f]);
+      create_file(format[f], uchar_out);
+      check_file(format[f], uchar_out);
       SUMMARIZE_ERR;
    }
 
@@ -72,7 +105,7 @@ create_file(int format, unsigned char *uchar_out)
    retval = nc_put_var_uchar(ncid, varid, uchar_out);
    if (format == NC_FORMAT_NETCDF4 || format == NC_FORMAT_64BIT_DATA)
    {
-     if (retval != NC_ERANGE) ERR;
+      if (retval != NC_ERANGE) ERR;
    }
    else if (retval != NC_NOERR) ERR;
 
@@ -83,7 +116,6 @@ create_file(int format, unsigned char *uchar_out)
 int
 check_file(int format, unsigned char *uchar_out)
 {
-
    int ncid;
    int ndims, natts;
    int dimids_var[1], var_type;


### PR DESCRIPTION
Only test code changes in this PR - no library code.

Some tests were using NC_CDF5 without checking ENABLE_CDF5. Fixed in this PR, as well as a similar case with NC_NETCDF4.

Fixes #590. This passes my CI testing, which currently tests 15 different configurations (except the --disable-utilities built until a pending PR is merged).