### PR TITLE
DOCUMENTATION: add docs for nc_create_par() and other functions

### DIFF
--- a/include/netcdf_par.h
+++ b/include/netcdf_par.h
@@ -7,8 +7,8 @@
  *
  * This header file is for the parallel I/O functions of netCDF.
  *
+ * \author Ed Hartnett
  */
-/* "$Id: netcdf_par.h,v 1.1 2010/06/01 15:46:49 ed Exp $" */
 
 #ifndef NETCDF_PAR_H
 #define NETCDF_PAR_H 1
@@ -19,8 +19,9 @@
 extern "C" {
 #endif
 
-/* Use these with nc_var_par_access(). */
+/** Use with nc_var_par_access() to set parallel access to independent. */
 #define NC_INDEPENDENT 0
+/** Use with nc_var_par_access() to set parallel access to collective. */
 #define NC_COLLECTIVE 1
 
 /* Create a file and enable parallel I/O. */


### PR DESCRIPTION
Part of #253.

Added missing doxygen documentation for some parallel functions, including nc_create_par(), an important function that needs to be documented.

No code changes in this PR - documentation only.