### PR TITLE
Remove useless checks

### DIFF
--- a/libdispatch/dparallel.c
+++ b/libdispatch/dparallel.c
@@ -113,16 +113,6 @@ nc_open_par(const char *path, int mode, MPI_Comm comm,
    return NC_ENOPAR;
 #else
    NC_MPI_INFO mpi_data;
-
-   /* One of these two parallel IO modes must be chosen by the user,
-    * or else pnetcdf must be in use. */
-   if ((mode & NC_MPIIO) || (mode & NC_MPIPOSIX)) {
-	/* ok */
-   } else if(mode & NC_PNETCDF) {
-	/* ok */
-   } else
-      return NC_EINVAL;
-
    mpi_data.comm = comm;
    mpi_data.info = info;
 


### PR DESCRIPTION
The requirement that `mode` is equal to `NC_MPIIO` or `NC_MPIPOSIX` or `NC_PNETCDF` is checked, but is not ever used after this point.  `NC_MPIIO` is now the same as `NC_PNETCDF` and `NC_MPIPOSIX` is deprecated.

Once the execution gets down into `NC_open`, the mode has `NC_MPIIO` set automatically (`if(useparallel) flags |= NC_MPIIO;`) where `flags` is the same as `mode`.