### PR TITLE
fixed names of output files to enable parallel make check in nc_test4

### DIFF
--- a/nc_test4/tst_atts1.c
+++ b/nc_test4/tst_atts1.c
@@ -4,7 +4,7 @@
 
    Test attributes.
 
-   $Id$
+   @author Ed Hartnett
 */
 
 #include <nc_tests.h>
@@ -12,7 +12,7 @@
 #include "netcdf.h"
 #include <signal.h>
 
-#define FILE_NAME "tst_atts.nc"
+#define FILE_NAME "tst_atts1.nc"
 #define FILE_NAME2 "tst_atts_2.nc"
 #define VAR1_NAME "Horace_Rumpole"
 #define VAR2_NAME "Claude_Erskine-Brown"

--- a/nc_test4/tst_files5.c
+++ b/nc_test4/tst_files5.c
@@ -9,7 +9,7 @@
 #include "err_macros.h"
 #include "netcdf.h"
 
-#define FILE_NAME "tst_files.nc"
+#define FILE_NAME "tst_files5.nc"
 
 int
 main(int argc, char **argv)

--- a/nc_test4/tst_grps2.c
+++ b/nc_test4/tst_grps2.c
@@ -4,14 +4,14 @@
 
    Test netcdf-4 group code some more.
 
-   $Id$
+   @author Ed Hartnett
 */
 
 #include <nc_tests.h>
 #include "err_macros.h"
 #include "netcdf.h"
 
-#define FILE_NAME "tst_grps.nc"
+#define FILE_NAME "tst_grps2.nc"
 #define DIM1_NAME "kingdom"
 #define DIM1_LEN 3
 #define DIM2_NAME "year"

--- a/nc_test4/tst_h_files3.c
+++ b/nc_test4/tst_h_files3.c
@@ -3,7 +3,7 @@
    See COPYRIGHT file for conditions of use.
 
    Test netcdf-4 variables.
-   $Id: tst_h_files3.c,v 1.2 2010/02/05 17:06:28 ed Exp $
+   @author Ed Hartnett
 */
 
 #include <nc_tests.h>
@@ -17,7 +17,7 @@
 
 #define MAX_LEN 30
 #define TMP_FILE_NAME "tst_files2_tmp.out"
-#define FILE_NAME "tst_files2_1.nc"
+#define FILE_NAME "tst_h_files3.nc"
 #define MILLION 1000000
 
 void *last_sbrk;

--- a/nc_test4/tst_h_vl2.c
+++ b/nc_test4/tst_h_vl2.c
@@ -4,13 +4,13 @@
 
    This program excersizes HDF5 variable length array code.
 
-   $Id: tst_h_vl2.c,v 1.5 2010/06/01 15:34:52 ed Exp $
+   @author Ed Hartnett
 */
 #include <nc_tests.h>
 #include <hdf5.h>
 #include <nc_logging.h>
 
-#define FILE_NAME "tst_vl.nc"
+#define FILE_NAME "tst_h_vl.nc"
 int
 main()
 {

--- a/nc_test4/tst_interops3.c
+++ b/nc_test4/tst_interops3.c
@@ -4,6 +4,8 @@
 
    Test that NetCDF-4 can read a bunch of HDF4 files pulled in from
    the FTP site.
+
+   @author Ed Hartnett
 */
 
 #include <config.h>
@@ -11,7 +13,7 @@
 #include "err_macros.h"
 #include <mfhdf.h>
 
-#define FILE_NAME "tst_interops2.h4"
+#define FILE_NAME "tst_interops3.h4"
 
 int
 main(int argc, char **argv)

--- a/nc_test4/tst_large3.c
+++ b/nc_test4/tst_large3.c
@@ -6,7 +6,7 @@
  features. It turns off fill mode to quickly create an 8 gb file, and
  write one value is written, nothing is read.
 
- $Id$
+ @author Ed Hartnett
 */
 #include <config.h>
 #include <nc_tests.h>
@@ -32,7 +32,7 @@
 #define QTR_CLASSIC_MAX (MAX_CLASSIC_BYTES/4)
 
 /* We will create this file. */
-#define FILE_NAME "tst_large.nc"
+#define FILE_NAME "tst_large3.nc"
 
 int
 main(int argc, char **argv)


### PR DESCRIPTION
Fixes #617.

Fix all the data file names in nc_test4 tests.

This allows make -j check to succeed in nc_test4.