### PR TITLE
set DOXYGEN_SERVER_BASED_SEARCH in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -140,6 +140,7 @@ else
    AC_SUBST([DOXYGEN_HEADER_FILE], [])
    AC_SUBST([DOXYGEN_SEARCHENGINE], ["YES"])
 fi
+AC_SUBST([DOXYGEN_SERVER_BASED_SEARCH], ["NO"])
 
 AC_ARG_ENABLE([doxygen-pdf-output],
     [AS_HELP_STRING([--enable-doxygen-pdf-output],


### PR DESCRIPTION
Fixes #638.

Set an automake variable that was being set in CMake build, but not autotools build.

Clears up a doxygen warning.