### PR TITLE
DOXUMENTATION: fixed doxygen warnings by adding docs in dfile.c, dparallel.c, and dvarget.c

### DIFF
--- a/libdispatch/dfile.c
+++ b/libdispatch/dfile.c
@@ -340,14 +340,10 @@ Note that nc_create(path,cmode,ncidp) is equivalent to the invocation of
 nc__create(path,cmode,NC_SIZEHINT_DEFAULT,NULL,ncidp).
 
 \returns ::NC_NOERR No error.
-
 \returns ::NC_ENOMEM System out of memory.
-
 \returns ::NC_EHDFERR HDF5 error (netCDF-4 files only).
-
 \returns ::NC_EFILEMETA Error writing netCDF-4 file-level metadata in
 HDF5 file. (netCDF-4 files only).
-
 \returns ::NC_EDISKLESS if there was an error in creating the
 in-memory file.
 
@@ -490,6 +486,14 @@ stored.
 \note This function uses the same return codes as the nc_create()
 function.
 
+\returns ::NC_NOERR No error.
+\returns ::NC_ENOMEM System out of memory.
+\returns ::NC_EHDFERR HDF5 error (netCDF-4 files only).
+\returns ::NC_EFILEMETA Error writing netCDF-4 file-level metadata in
+HDF5 file. (netCDF-4 files only).
+\returns ::NC_EDISKLESS if there was an error in creating the
+in-memory file.
+
 <h1>Examples</h1>
 
 In this example we create a netCDF dataset named foo_large.nc; we want
@@ -511,7 +515,7 @@ and initial size for the file.
 \endcode
 
 \ingroup datasets
-
+\author Glenn Davis, Russ Rew, Dennis Heimbigner
 */
 int
 nc__create(const char *path, int cmode, size_t initialsz,

--- a/libdispatch/dparallel.c
+++ b/libdispatch/dparallel.c
@@ -77,15 +77,10 @@ occurred. Otherwise, the returned status indicates an error. Possible
 causes of errors include:
 
 \returns ::NC_NOERR No error.
-
 \returns ::NC_EINVAL Invalid parameters.
-
 \returns ::NC_ENOTNC Not a netCDF file.
-
 \returns ::NC_ENOMEM Out of memory.
-
 \returns ::NC_EHDFERR HDF5 error. (NetCDF-4 files only.)
-
 \returns ::NC_EDIMMETA Error in netCDF-4 dimension metadata. (NetCDF-4
 files only.)
 
@@ -130,10 +125,39 @@ nc_open_par(const char *path, int mode, MPI_Comm comm,
 #endif /* USE_PARALLEL */
 }
 
-/*! \ingroup datasets
+/**
 
- Fortran needs to pass MPI comm/info as integers.
+Fortran needs to pass MPI comm/info as integers.
 
+\param path File name for netCDF dataset to be opened. 
+
+\param mode The mode flag may include NC_WRITE (for read/write
+access), NC_MPIIO or NC_MPIPOSIX (not both) for parallel netCDF-4 I/O,
+or NC_PNETCDF for parallel-netcdf parallel I/O access for a netCDF
+classic or CDF5 file.
+
+\param comm the MPI communicator to be used.
+
+\param info MPI info or MPI_INFO_NULL.
+
+\param ncidp Pointer to location where returned netCDF ID is to be
+stored.
+
+nc_open_par() returns the value NC_NOERR if no errors
+occurred. Otherwise, the returned status indicates an error. Possible
+causes of errors include:
+
+\returns ::NC_NOERR No error.
+\returns ::NC_EINVAL Invalid parameters.
+\returns ::NC_ENOTNC Not a netCDF file.
+\returns ::NC_ENOMEM Out of memory.
+\returns ::NC_EHDFERR HDF5 error. (NetCDF-4 files only.)
+\returns ::NC_EDIMMETA Error in netCDF-4 dimension metadata. (NetCDF-4
+files only.)
+
+\ingroup datasets
+\internal
+\author Ed Hartnett, Dennis Heimbigner
 */
 int
 nc_open_par_fortran(const char *path, int mode, int comm,

--- a/libdispatch/dvarget.c
+++ b/libdispatch/dvarget.c
@@ -102,8 +102,31 @@ NC_get_vara(int ncid, int varid,
    return stat;
 }
 
-/** \ingroup variables
+/** 
+Get data for a variable.
+
+\param ncid NetCDF or group ID.
+
+\param varid Variable ID
+
+\param value Pointer where the data will be copied. Memory must be
+allocated by the user before this function is called.
+
+\param memtype the NC type of the data after it is read into
+memory. Data are converted from the variable's type to the memtype as
+they are read.
+
+\returns ::NC_NOERR No error.
+\returns ::NC_ENOTVAR Variable not found.
+\returns ::NC_EINVALCOORDS Index exceeds dimension bound.
+\returns ::NC_EEDGE Start+count exceeds dimension bound.
+\returns ::NC_ERANGE One or more of the values are out of range.
+\returns ::NC_EINDEFINE Operation not allowed in define mode.
+\returns ::NC_EBADID Bad ncid.
+
+\ingroup variables
 \internal
+\author Dennis Heimbigner
  */
 static int
 NC_get_var(int ncid, int varid, void *value, nc_type memtype)
@@ -529,9 +552,38 @@ NCDEFAULT_get_varm(int ncid, int varid, const size_t *start,
    return status;
 }
 
-/** \ingroup variables
+/** 
+Called by externally visible nc_get_vars_xxx routines.
+
+\param ncid NetCDF or group ID.
+
+\param varid Variable ID
+
+\param start start indices.
+
+\param edges count indices.
+
+\param stride data strides.
+
+\param value Pointer where the data will be copied. Memory must be
+allocated by the user before this function is called.
+
+\param memtype the NC type of the data after it is read into
+memory. Data are converted from the variable's type to the memtype as
+they are read.
+
+\returns ::NC_NOERR No error.
+\returns ::NC_ENOTVAR Variable not found.
+\returns ::NC_EINVALCOORDS Index exceeds dimension bound.
+\returns ::NC_EEDGE Start+count exceeds dimension bound.
+\returns ::NC_ERANGE One or more of the values are out of range.
+\returns ::NC_EINDEFINE Operation not allowed in define mode.
+\returns ::NC_EBADID Bad ncid.
+
+\ingroup variables
 \internal
-Called by externally visible nc_get_vars_xxx routines */
+\author Dennis Heimbigner
+*/
 static int
 NC_get_vars(int ncid, int varid, const size_t *start,
 	    const size_t *edges, const ptrdiff_t *stride, void *value,
@@ -547,9 +599,41 @@ NC_get_vars(int ncid, int varid, const size_t *start,
    return ncp->dispatch->get_vars(ncid,varid,start,edges,stride,value,memtype);
 }
 
-/** \ingroup variables
+/** 
+Called by externally visible nc_get_varm_xxx routines. Note that the
+varm routines are deprecated. Use the vars routines instead for new
+code.
+
+\param ncid NetCDF or group ID.
+
+\param varid Variable ID
+
+\param start start indices.
+
+\param edges count indices.
+
+\param stride data strides.
+
+\param map mapping of dimensions.
+
+\param value Pointer where the data will be copied. Memory must be
+allocated by the user before this function is called.
+
+\param memtype the NC type of the data after it is read into
+memory. Data are converted from the variable's type to the memtype as
+they are read.
+
+\returns ::NC_NOERR No error.
+\returns ::NC_ENOTVAR Variable not found.
+\returns ::NC_EINVALCOORDS Index exceeds dimension bound.
+\returns ::NC_EEDGE Start+count exceeds dimension bound.
+\returns ::NC_ERANGE One or more of the values are out of range.
+\returns ::NC_EINDEFINE Operation not allowed in define mode.
+\returns ::NC_EBADID Bad ncid.
+
+\ingroup variables
 \internal
-Called by externally visible nc_get_varm_xxx routines
+\author Dennis Heimbigner
  */
 static int
 NC_get_varm(int ncid, int varid, const size_t *start,


### PR DESCRIPTION
Part of #640.

Added some missing doxygen documentation. No code changes in this PR, just documentation.

This PR cleans up the warnings in these three files. More to come in future PRs for the warnings in the other files.
