### PR TITLE
BUGFIX: Fixes 3 memory leaks, in tst_filterparser.c, nc4internal.c, and dfilter.c

### DIFF
--- a/libdispatch/dfilter.c
+++ b/libdispatch/dfilter.c
@@ -166,8 +166,10 @@ NC_parsefilterspec(const char* spec, unsigned int* idp, size_t* nparamsp, unsign
     /* Now return results */
     if(idp) *idp = id;
     if(nparamsp) *nparamsp = nparams;
-    if(paramsp) *paramsp = ulist;
-    ulist = NULL; /* avoid duplicate free */
+    if(paramsp) {
+       *paramsp = ulist;
+       ulist = NULL; /* avoid duplicate free */
+    }
     if(sdata) free(sdata);
     if(ulist) free(ulist);
     return 1;

--- a/libsrc4/nc4internal.c
+++ b/libsrc4/nc4internal.c
@@ -1071,6 +1071,10 @@ nc4_var_del(NC_VAR_INFO_T *var)
    if (var->dimscale_attached)
       free(var->dimscale_attached);
 
+   /* Release parameter information. */
+   if (var->params)
+      free(var->params);
+
    /* Delete the var. */
    free(var);
 

--- a/nc_test4/tst_filterparser.c
+++ b/nc_test4/tst_filterparser.c
@@ -59,7 +59,9 @@ static int nerrs = 0;
 static int parsefilterspec(const char* spec, unsigned int* idp, size_t* nparamsp, unsigned int** paramsp);
 #endif
 
+#ifdef WORD_BIGENDIAN
 static void byteswap8(unsigned char* mem);
+#endif
 
 static void
 report(const char* which)
@@ -72,7 +74,7 @@ report(const char* which)
 static void
 mismatch(size_t i, unsigned int baseline, unsigned int params)
 {
-    fprintf(stderr,"mismatch: [%d] baseline=%ud spec=%ud\n",i,baseline,params);
+   fprintf(stderr,"mismatch: [%d] baseline=%ud spec=%ud\n",(int)i,baseline,params);
     fflush(stderr);
     nerrs++;
 }
@@ -85,6 +87,8 @@ main(int argc, char **argv)
     unsigned int id = 0;
     size_t i,nparams = 0;
     unsigned int* params = NULL;
+
+    printf("\nTesting filter parser.\n");
 
 #ifdef USE_INTERNAL
     stat = parsefilterspec(spec,&id,&nparams,&params);
@@ -125,9 +129,16 @@ main(int argc, char **argv)
     if(ul.ull != 18446744073709551615ULL)
 	report("ul.ull");
 
+    if (params)
+       free(params);
+
+    if (!nerrs)
+       printf("SUCCESS!!\n");
+
     return (nerrs > 0 ? 1 : 0);
 }
 
+#ifdef WORD_BIGENDIAN
 /* Byte swap an 8-byte integer in place */
 static void
 byteswap8(unsigned char* mem)
@@ -146,6 +157,7 @@ byteswap8(unsigned char* mem)
     mem[3] = mem[4];
     mem[4] = c;
 }
+#endif
 
 #ifdef USE_INTERNAL
 static int


### PR DESCRIPTION
Fixes 3 memory leaks, in tst_filterparser.c, nc4internal.c, and dfilter.c.

Fixes #648.
Fixes #645.

@WardF it would be helpful if you could merge this PR next, then my CI address sanitizer build will work again, and I can continue to spot any memory errors introduced by merges. Otherwise they will accumulate and be harder to fix.