### PR TITLE
BUGFIX: fixed pnetcdf issues

### DIFF
--- a/libsrcp/ncpdispatch.c
+++ b/libsrcp/ncpdispatch.c
@@ -1173,7 +1173,6 @@ NCP_inq_var_all(int ncid, int varid, char *name, nc_type *xtypep,
     if(contiguousp) *contiguousp = NC_CONTIGUOUS;
     if(no_fill) *no_fill = 1;
     if(endiannessp) return NC_ENOTNC4;
-    if(options_maskp) return NC_ENOTNC4;
     return NC_NOERR;
 }
 
@@ -1502,6 +1501,12 @@ NCP_def_var_endian(int ncid, int varid, int endianness)
     return NC_ENOTNC4;
 }
 
+static int
+NCP_def_var_filter(int ncid, int varid, unsigned int id, size_t nparams, const unsigned int* parms)
+{
+    return NC_ENOTNC4;
+}
+
 #endif /*USE_NETCDF4*/
 
 /**************************************************/
@@ -1593,6 +1598,7 @@ NCP_def_var_fletcher32,
 NCP_def_var_chunking,
 NCP_def_var_fill,
 NCP_def_var_endian,
+NCP_def_var_filter,
 NCP_set_var_chunk_cache,
 NCP_get_var_chunk_cache,
 #endif /*USE_NETCDF4*/

--- a/libsrcp/ncpdispatch.c
+++ b/libsrcp/ncpdispatch.c
@@ -1173,6 +1173,9 @@ NCP_inq_var_all(int ncid, int varid, char *name, nc_type *xtypep,
     if(contiguousp) *contiguousp = NC_CONTIGUOUS;
     if(no_fill) *no_fill = 1;
     if(endiannessp) return NC_ENOTNC4;
+    if(idp) return NC_ENOTNC4;
+    if(nparamsp) return NC_ENOTNC4;
+    if(params) return NC_ENOTNC4;
     return NC_NOERR;
 }
 


### PR DESCRIPTION
Fixes #647.

Several fixes needed to get pnetcdf build working. @DennisHeimbigner please glance at the code and tell me if you think it is correct WRT the options_maskp argument. (I surmise that you took that out of the parameters and now pass it in with params in the HDF4 code?)

Also had to add the new nc_def_var_filter() function to the dispatch table for pnetcdf.

@WardF please make this PR a priority since my pnetcdf CI build will be broken until this is merged. I believe there is no other pnetcdf CI build at the moment.