### PR TITLE
fixed CDF5 test

### DIFF
--- a/include/nc_tests.h
+++ b/include/nc_tests.h
@@ -26,6 +26,9 @@ for conditions of use.
 #define NC_TESTS_MAX_DIMS 1024 /**< NC_MAX_DIMS for tests.  Allows different NC_MAX_DIMS values without breaking this test with a heap or stack overflow. */
 #define MAX_NUM_FORMATS 5 /**< Max number of available binary formats. */
 
+/* Prototype for function to determine available formats for testing. */
+void determine_test_formats(int *num_formats, int *format);
+
 /** Useful define for tests. */
 /** \{ */
 #define MEGABYTE 1048576

--- a/nc_test/Makefile.am
+++ b/nc_test/Makefile.am
@@ -22,6 +22,9 @@ tst_nofill tst_nofill2 tst_nofill3 tst_atts3 tst_meta tst_inq_type      \
 tst_utf8_validate tst_utf8_phrases tst_global_fillval                   \
 tst_max_var_dims tst_formats
 
+tst_formats_SOURCES = tst_formats.c tst_common.c
+tst_global_fillval_SOURCES = tst_global_fillval.c tst_common.c
+
 if USE_NETCDF4
 TESTPROGRAMS += tst_atts tst_put_vars tst_elatefill
 endif

--- a/nc_test/tst_common.c
+++ b/nc_test/tst_common.c
@@ -1,0 +1,50 @@
+/* This is part of the netCDF package. Copyright 2005-2007 University
+   Corporation for Atmospheric Research/Unidata. See COPYRIGHT file
+   for conditions of use.
+
+   Common code shared by several tests.
+
+   Ed Hartnett, 12/19/17
+*/
+
+#include "config.h"
+#include <nc_tests.h>
+
+/**
+ * Determine how many formats are available, and what they are. 
+ *
+ * @param num_formats Pointer that gets the number of available formats.
+ * @param format Array that gets the available formats.
+ *
+ * @author Ed Hartnett
+ */
+void
+determine_test_formats(int *num_formats, int *format)
+{
+   int ind = 0;
+   int num;
+
+   /* Check inputs. */
+   assert(num_formats && format);
+
+   /* We always have classic and 64-bit offset */
+   num = 2;
+   format[ind++] = NC_FORMAT_CLASSIC;
+   format[ind++] = NC_FORMAT_64BIT_OFFSET;
+
+   /* Do we have netCDF-4 and netCDF-4 classic? */
+#ifdef USE_NETCDF4
+   num += 2;
+   format[ind++] = NC_FORMAT_NETCDF4;
+   format[ind++] = NC_FORMAT_NETCDF4_CLASSIC;
+#endif /* USE_NETCDF4 */
+
+   /* Do we have CDF5? */
+#ifdef ENABLE_CDF5
+   num++;
+   format[ind++] = NC_FORMAT_CDF5;
+#endif /* ENABLE_CDF5 */
+
+   *num_formats = num;
+}
+

--- a/nc_test/tst_formats.c
+++ b/nc_test/tst_formats.c
@@ -14,37 +14,6 @@
 #define FILE_NAME_BASE "tst_formats"
 #define HDF4_FILE "ref_contiguous.hdf4"
 
-/* Determine how many formats are available, and what they are. */
-void
-determine_test_formats(int *num_formats, int *format)
-{
-   int ind = 0;
-   int num;
-
-   /* Check inputs. */
-   assert(num_formats && format);
-
-   /* We always have classic and 64-bit offset */
-   num = 2;
-   format[ind++] = NC_FORMAT_CLASSIC;
-   format[ind++] = NC_FORMAT_64BIT_OFFSET;
-
-   /* Do we have netCDF-4 and netCDF-4 classic? */
-#ifdef USE_NETCDF4
-   num += 2;
-   format[ind++] = NC_FORMAT_NETCDF4;
-   format[ind++] = NC_FORMAT_NETCDF4_CLASSIC;
-#endif /* USE_NETCDF4 */
-
-   /* Do we have CDF5? */
-#ifdef ENABLE_CDF5
-   num++;
-   format[ind++] = NC_FORMAT_CDF5;
-#endif /* ENABLE_CDF5 */
-
-   *num_formats = num;
-}
-
 /* Function to test nc_inq_format(). */
 int
 check_inq_format(int ncid, int expected_format, int expected_extended_format, int expected_mode)

--- a/nc_test/tst_global_fillval.c
+++ b/nc_test/tst_global_fillval.c
@@ -12,7 +12,7 @@
 
    Modified by Ed Hartnett, see:
    https://github.com/Unidata/netcdf-c/issues/392
-   */
+*/
 
 #include "config.h"
 #include <nc_tests.h>
@@ -20,54 +20,31 @@
 
 #define FILE_NAME "tst_global_fillval.nc"
 
-/* Unweildy, but currently this structure must be used
-   to accomodate Visual Studio */
-#if defined USE_NETCDF4 && USE_CDF5
-#define num_formats 5
-#elif USE_NETCDF4
-#define num_formats 4
-#elif USE_CDF
-#define num_formats 3
-#else
-#define num_formats 2
-#endif
-
 int
 main(int argc, char **argv)
 {
-    printf("*** testing proper elatefill return...");
-    {
+   int format[MAX_NUM_FORMATS];
+   int num_formats;
 
-	int n = 0;
-        int i;
+   /* How many formats to be tested? */
+   determine_test_formats(&num_formats, format);
 
-	/* Determine how many formats are in use. */
-#ifdef USE_CDF5
-	num_formats++;
-#endif
+   printf("*** testing proper elatefill return...");
+   {
 
-	int formats[num_formats];
-	formats[n++] = 0;
-	formats[n++] = NC_64BIT_OFFSET;
-#ifdef USE_CDF5
-	formats[n++] = NC_64BIT_DATA;
-#endif
-#ifdef USE_NETCDF4
-	formats[n++] = NC_NETCDF4;
-	formats[n++] = NC_CLASSIC_MODEL | NC_NETCDF4;
-#endif
+      int i;
 
-	for (i = 0; i < num_formats; i++)
-	{
-	    int ncid, cmode, fillv = 9;
+      for (i = 0; i < num_formats; i++)
+      {
+         int ncid, fillv = 9;
 
-	    cmode = NC_CLOBBER | formats[i];
-	    if (nc_create(FILE_NAME, cmode, &ncid)) ERR;
-	    if (nc_put_att_int(ncid, NC_GLOBAL, "_FillValue", NC_INT, 1, &fillv)) ERR;
-	    if (nc_close(ncid)) ERR;
+         if (nc_set_default_format(format[i], NULL)) ERR;
+         if (nc_create(FILE_NAME, 0, &ncid)) ERR;
+         if (nc_put_att_int(ncid, NC_GLOBAL, "_FillValue", NC_INT, 1, &fillv)) ERR;
+         if (nc_close(ncid)) ERR;
 
-	}
-    }
-    SUMMARIZE_ERR;
-    FINAL_RESULTS;
+      }
+   }
+   SUMMARIZE_ERR;
+   FINAL_RESULTS;
 }


### PR DESCRIPTION
The problem comes in determining the number of formats available for testing in nc_test/tst_global_fillval.c.

Fixes #723 

Now that CDF5 is in the mix, determining the number of available formats for testing got much more complicated. It used to be 2 (classic formats), 3 (+ netcdf4) or 4 (+ netCDF4 classic_model).

Now CDF5 may be present, and netCDF-4 may be present. 

We have a very similar problem with PIO, and the best answer is a function that determines the available formats. I already added such a function in tst_formats.c; in this PR I move it to tst_common.c, so that it can be shared with many tests. The function is called determine_test_formats() and it's very simple:

```
/**
 * Determine how many formats are available, and what they are. 
 *
 * @param num_formats Pointer that gets the number of available formats.
 * @param format Array that gets the available formats.
 *
 * @author Ed Hartnett
 */
void
determine_test_formats(int *num_formats, int *format)
{
   int ind = 0;
   int num;

   /* Check inputs. */
   assert(num_formats && format);

   /* We always have classic and 64-bit offset */
   num = 2;
   format[ind++] = NC_FORMAT_CLASSIC;
   format[ind++] = NC_FORMAT_64BIT_OFFSET;

   /* Do we have netCDF-4 and netCDF-4 classic? */
#ifdef USE_NETCDF4
   num += 2;
   format[ind++] = NC_FORMAT_NETCDF4;
   format[ind++] = NC_FORMAT_NETCDF4_CLASSIC;
#endif /* USE_NETCDF4 */

   /* Do we have CDF5? */
#ifdef ENABLE_CDF5
   num++;
   format[ind++] = NC_FORMAT_CDF5;
#endif /* ENABLE_CDF5 */

   *num_formats = num;
}

```
I then changes tst_global_fillval.c to use this function to determine how many and what formats are available for testing. I expect I will be using this function in other tests as well.

Only problem is I don't know how to modify the CMake file so that tst_common.c is compiled and linked with tst_global_fillval.c and tst_formats.c. I have done this in the makefile like this:

```
tst_formats_SOURCES = tst_formats.c tst_common.c
tst_global_fillval_SOURCES = tst_global_fillval.c tst_common.c

```

But I am not sure how to do this in the CMake file.