### PR TITLE
Eliminate potential buffer overflow

### DIFF
--- a/libdispatch/dutil.c
+++ b/libdispatch/dutil.c
@@ -209,7 +209,7 @@ NC_mktmp(const char* base)
     cvtpath = NCpathcvt(base);
     strncpy(tmp,cvtpath,sizeof(tmp));
     nullfree(cvtpath);
-	strncat(tmp, "XXXXXX", sizeof(tmp));
+	strncat(tmp, "XXXXXX", sizeof(tmp) - strlen(tmp) - 1);
 
 #ifdef HAVE_MKSTEMP
     /* Note Potential problem: old versions of this function


### PR DESCRIPTION
I realize strncat is being eliminated, but in case the elimination isn't done prior to release, this patch should be applied.