### PR TITLE
Eliminate warning from clang compilers.

### DIFF
--- a/libdispatch/ncuri.c
+++ b/libdispatch/ncuri.c
@@ -911,7 +911,8 @@ collectprefixparams(char* text, char** nextp)
     for(;;) {
 	char* p; char* q;
 	/* by construction, here we are at an LBRACKET: compress it out */
-	for(p=sp,q=sp+1;(*p++=*q++););	
+	for(p=sp,q=sp+1;(*p++=*q++);)
+	    ;	
         /* locate the next RRACKET */
         ep = nclocate(sp,RBRACKETSTR);
 	if(ep == NULL) break;/* we are done */


### PR DESCRIPTION
Eliminate this warning from clang:
```
TPL/netcdf/netcdf-c/libdispatch/ncuri.c:914:31: warning: for loop has empty body [-Wempty-body]
        for(p=sp,q=sp+1;(*p++=*q++););
                                     ^
TPL/netcdf/netcdf-c/libdispatch/ncuri.c:914:31: note: put the semicolon on a separate line to silence this warning
1 warning generated.
```