### PR TITLE
Make it clear that limits are not enforced

### DIFF
--- a/include/netcdf.h
+++ b/include/netcdf.h
@@ -254,11 +254,14 @@ These maximums are not used for netCDF-4/HDF5 files unless they were
 created with the ::NC_CLASSIC_MODEL flag.
 
 As a rule, NC_MAX_VAR_DIMS <= NC_MAX_DIMS.
+
+NOTE: The NC_MAX_DIMS, NC_MAX_ATTRS, and NC_MAX_VARS limits 
+      are *not* enforced after version 4.5.0
 */
 /**@{*/
-#define NC_MAX_DIMS     1024
-#define NC_MAX_ATTRS    8192
-#define NC_MAX_VARS     8192
+#define NC_MAX_DIMS     1024 /* not enforced after 4.5.0 */
+#define NC_MAX_ATTRS    8192 /* not enforced after 4.5.0 */
+#define NC_MAX_VARS     8192 /* not enforced after 4.5.0 */
 #define NC_MAX_NAME     256
 #define NC_MAX_VAR_DIMS 1024 /**< max per variable dimensions */
 /**@}*/


### PR DESCRIPTION
Make it clear that NC_MAX_DIMS, NC_MAX_VARS, and NC_MAX_ATTRS limits are not enforced after netcdf-4.5.0 to avoid confusion