### PR TITLE
Fixes of warnings, check return values, added guards for headers that needed them, remove unneeded HDF4 checks

### DIFF
--- a/include/rnd.h
+++ b/include/rnd.h
@@ -7,8 +7,8 @@
  * Glenn Davis, 1996
  */
 
-#ifndef _RND_
-#define _RND_
+#ifndef _RND_H
+#define _RND_H
 
 /* useful for aligning memory */
 #define	_RNDUP(x, unit)  ((((x) + (unit) - 1) / (unit)) \
@@ -19,4 +19,4 @@
 #define	M_RNDUP(x) _RNDUP(x, M_RND_UNIT)
 #define	M_RNDDOWN(x)  __RNDDOWN(x, M_RND_UNIT)
 
-#endif /* _RND_ */
+#endif /* _RND_H */

--- a/include/rnd.h
+++ b/include/rnd.h
@@ -1,9 +1,14 @@
-/*
- *	Copyright 1996, University Corporation for Atmospheric Research
- *      See netcdf/COPYRIGHT file for copying and redistribution conditions.
+/* Copyright 1996-2018, University Corporation for Atmospheric
+ * Research See netcdf/COPYRIGHT file for copying and redistribution
+ * conditions.
+ *
+ * This header file contains some macros for rounding numbers.
+ *
+ * Glenn Davis, 1996
  */
-/* $Id: rnd.h,v 2.13 1996/12/11 05:46:54 davis Exp $ */
-#ifndef _RNDUP
+
+#ifndef _RND_
+#define _RND_
 
 /* useful for aligning memory */
 #define	_RNDUP(x, unit)  ((((x) + (unit) - 1) / (unit)) \
@@ -14,4 +19,4 @@
 #define	M_RNDUP(x) _RNDUP(x, M_RND_UNIT)
 #define	M_RNDDOWN(x)  __RNDDOWN(x, M_RND_UNIT)
 
-#endif
+#endif /* _RND_ */

--- a/libsrc4/nc4file.c
+++ b/libsrc4/nc4file.c
@@ -2870,7 +2870,7 @@ nc4_open_hdf4_file(const char *path, int mode, NC *nc)
 
       /* Add a var to the variable array, growing it as needed. */
       if ((retval = nc4_vararray_add(grp, var)))
-         BAIL(retval);
+         return retval;
 
       /* Open this dataset in HDF4 file. */
       if ((var->sdsid = SDselect(h5->sdid, v)) == FAIL)

--- a/libsrc4/nc4file.c
+++ b/libsrc4/nc4file.c
@@ -2028,7 +2028,9 @@ read_var(NC_GRP_INFO_T *grp, hid_t datasetid, const char *obj_name,
                     att_read_var_callbk, &att_info)) < 0)
       BAIL(NC_EATTMETA);
 
-   nc4_vararray_add(grp, var);
+   /* Add a var to the variable array, growing it as needed. */
+   if ((retval = nc4_vararray_add(grp, var)))
+      BAIL(retval);
 
    /* Is this a deflated variable with a chunksize greater than the
     * current cache size? */
@@ -2866,7 +2868,9 @@ nc4_open_hdf4_file(const char *path, int mode, NC *nc)
       var->created = NC_TRUE;
       var->written_to = NC_TRUE;
 
-      nc4_vararray_add(grp, var);
+      /* Add a var to the variable array, growing it as needed. */
+      if ((retval = nc4_vararray_add(grp, var)))
+         BAIL(retval);
 
       /* Open this dataset in HDF4 file. */
       if ((var->sdsid = SDselect(h5->sdid, v)) == FAIL)

--- a/libsrc4/nc4var.c
+++ b/libsrc4/nc4var.c
@@ -534,7 +534,7 @@ NC4_def_var(int ncid, const char *name, nc_type xtype,
          BAIL(retval);
 
    /* These degrubbing messages sure are handy! */
-   LOG((3, "%s: name %s type %d ndims %d", __func__, norm_name, xtype, ndims));
+   LOG((2, "%s: name %s type %d ndims %d", __func__, norm_name, xtype, ndims));
 #ifdef LOGGING
    {
       int dd;
@@ -597,7 +597,7 @@ NC4_def_var(int ncid, const char *name, nc_type xtype,
          BAIL(NC_EBADTYPE);
    }
 
-   /* Add a new var. */
+   /* Create a new var and fill in some HDF5 cache setting values. */
    if ((retval = nc4_var_add(&var)))
       BAIL(retval);
 
@@ -673,14 +673,9 @@ NC4_def_var(int ncid, const char *name, nc_type xtype,
          }
       }
 
-      /* Check for unlimited dimension and turn off contiguous storage */
-      /* (unless HDF4 file) */
-#ifdef USE_HDF4
-      if (dim->unlimited && !h5->hdf4)
-#else
-         if (dim->unlimited)
-#endif
-            var->contiguous = NC_FALSE;
+      /* Check for unlimited dimension and turn off contiguous storage. */
+      if (dim->unlimited)
+         var->contiguous = NC_FALSE;
 
       /* Track dimensions for variable */
       var->dimids[d] = dimidsp[d];
@@ -975,6 +970,10 @@ nc_def_var_extra(int ncid, int varid, int *shuffle, int *deflate,
    int retval;
    nc_bool_t ishdf4 = NC_FALSE; /* Use this to avoid so many ifdefs */
 
+   /* All or none of these will be provided. */
+   assert((deflate && deflate_level && shuffle) ||
+          (!deflate && !deflate_level && !shuffle));
+
    LOG((2, "%s: ncid 0x%x varid %d", __func__, ncid, varid));
 
    /* Find info for this file and group, and set pointer to each. */
@@ -982,21 +981,15 @@ nc_def_var_extra(int ncid, int varid, int *shuffle, int *deflate,
       return retval;
    assert(nc && grp && h5);
 
-#ifdef USE_HDF4
-   ishdf4 = h5->hdf4;
-#endif
+   /* Trying to write to a read-only file? No way, Jose! */
+   if (h5->no_write)
+      return NC_EPERM;
 
    /* Find the var. */
    if (varid < 0 || varid >= grp->vars.nelems)
       return NC_ENOTVAR;
    var = grp->vars.value[varid];
    assert(var && var->varid == varid);
-
-   /* Can't turn on contiguous and deflate/fletcher32/szip. */
-   if (contiguous)
-      if ((*contiguous != NC_CHUNKED && deflate) ||
-          (*contiguous != NC_CHUNKED && fletcher32))
-         return NC_EINVAL;
 
    /* Can't turn on parallel and deflate/fletcher32/szip/shuffle. */
    if (nc->mode & (NC_MPIIO | NC_MPIPOSIX)) {
@@ -1056,19 +1049,14 @@ nc_def_var_extra(int ncid, int varid, int *shuffle, int *deflate,
       if (var->deflate || var->fletcher32 || var->shuffle)
          return NC_EINVAL;
 
-      if (!ishdf4) {
-         for (d = 0; d < var->ndims; d++)
-         {
-            dim = var->dim[d];
-            if (dim->unlimited)
-               return NC_EINVAL;
-         }
-         var->contiguous = NC_TRUE;
-      }
+      for (d = 0; d < var->ndims; d++)
+         if (var->dim[d]->unlimited)
+            return NC_EINVAL;
+      var->contiguous = NC_TRUE;
    }
 
    /* Chunksizes anyone? */
-   if (!ishdf4 && contiguous && *contiguous == NC_CHUNKED)
+   if (contiguous && *contiguous == NC_CHUNKED)
    {
       var->contiguous = NC_FALSE;
 
@@ -1079,10 +1067,9 @@ nc_def_var_extra(int ncid, int varid, int *shuffle, int *deflate,
 
          if ((retval = check_chunksizes(grp, var, chunksizes)))
             return retval;
-         for (d = 0; d < var->ndims; d++) {
-            if(var->dim[d]->len > 0 && chunksizes[d] > var->dim[d]->len)
+         for (d = 0; d < var->ndims; d++)
+            if (var->dim[d]->len > 0 && chunksizes[d] > var->dim[d]->len)
                return NC_EBADCHUNK;
-         }
 
          /* Set the chunksizes for this variable. */
          for (d = 0; d < var->ndims; d++)
@@ -1092,7 +1079,7 @@ nc_def_var_extra(int ncid, int varid, int *shuffle, int *deflate,
 
    /* Is this a variable with a chunksize greater than the current
     * cache size? */
-   if (!var->contiguous && (chunksizes || deflate || contiguous))
+   if (!var->contiguous && (deflate || contiguous))
    {
       /* Determine default chunksizes for this variable (do nothing
        * for scalar vars). */
@@ -1569,8 +1556,11 @@ NC4_rename_var(int ncid, int varid, const char *name)
    int retval = NC_NOERR;
    int i;
 
-   LOG((2, "%s: ncid 0x%x varid %d name %s",
-        __func__, ncid, varid, name));
+   if (!name)
+      return NC_EINVAL;
+   
+   LOG((2, "%s: ncid 0x%x varid %d name %s", __func__, ncid, varid,
+        name));
 
    /* Find info for this file and group, and set pointer to each. */
    if ((retval = nc4_find_nc_grp_h5(ncid, &nc, &grp, &h5)))

--- a/libsrc4/nc4var.c
+++ b/libsrc4/nc4var.c
@@ -610,7 +610,9 @@ NC4_def_var(int ncid, const char *name, nc_type xtype,
    var->ndims = ndims;
    var->is_new_var = NC_TRUE;
 
-   nc4_vararray_add(grp, var);
+   /* Add a var to the variable array, growing it as needed. */
+   if ((retval = nc4_vararray_add(grp, var)))
+      BAIL(retval);
 
    /* Point to the type, and increment its ref. count */
    var->type_info = type_info;

--- a/nc_test4/Makefile.am
+++ b/nc_test4/Makefile.am
@@ -96,7 +96,7 @@ check_PROGRAMS += tst_interops2 tst_chunk_hdf4 tst_h4_lendian
 
 if BUILD_UTILITIES
 # This test script depends on ncdump.
-TESTS += tst_formatx_hdf4.sh
+TESTS += tst_interops2 tst_formatx_hdf4.sh
 endif # BUILD_UTILITIES
 
 TESTS += run_chunk_hdf4.sh tst_h4_lendian

--- a/nc_test4/tst_chunk_hdf4.c
+++ b/nc_test4/tst_chunk_hdf4.c
@@ -3,6 +3,8 @@
    COPYRIGHT file for conditions of use.
 
    Test that NetCDF-4 can read HDF4 files.
+   
+   Dennis Heimbigner, Ward Fisher, Ed Hartnett
 */
 #include <config.h>
 #include <nc_tests.h>
@@ -32,9 +34,8 @@ main(int argc, char **argv)
    int d;
    int storage;
    size_t chunksizes[NC_MAX_VAR_DIMS];
-   const char* srcdir = ".";
 
-   printf("\n*** Testing HDF4/NetCDF-4 chunking API: chunked...\n");
+   printf("\n*** Testing HDF4/NetCDF-4 chunking API: chunked...");
    {
 
       /* Open with netCDF */
@@ -51,20 +52,21 @@ main(int argc, char **argv)
       if(nc_inq_var_chunking(ncid,varid,&storage,chunksizes)) ERR;
 
       if(storage == NC_CONTIGUOUS) {
-	fprintf(stderr,"nc_inq_var_chunking did not return CHUNKED\n");
-	ERR;
+         fprintf(stderr,"nc_inq_var_chunking did not return CHUNKED\n");
+         ERR;
       }
 
       for(d=0;d<rank;d++) {
-	if(EXPECTED_CHUNKSIZES[d] != chunksizes[d]) {
-	    fprintf(stderr,"chunk size mismatch: [%d] %ld :: %ld\n",d,chunksizes[d],EXPECTED_CHUNKSIZES[d]);
-	    ERR;
-	}
+         if(EXPECTED_CHUNKSIZES[d] != chunksizes[d]) {
+            fprintf(stderr,"chunk size mismatch: [%d] %ld :: %ld\n",d,chunksizes[d],EXPECTED_CHUNKSIZES[d]);
+            ERR;
+         }
       }
       if (nc_close(ncid)) ERR;
    }
+   SUMMARIZE_ERR;
 
-   printf("\n*** Testing HDF4/NetCDF-4 chunking API: contiguous...\n");
+   printf("*** Testing HDF4/NetCDF-4 chunking API: contiguous...");
    {
       /* Open with netCDF */
       if (nc_open(CONTIGFILE, NC_NOWRITE, &ncid)) ERR;
@@ -80,13 +82,23 @@ main(int argc, char **argv)
       if(nc_inq_var_chunking(ncid,varid,&storage,chunksizes)) ERR;
 
       if(storage != NC_CONTIGUOUS) {
-	fprintf(stderr,"nc_inq_var_chunking did not return CONTIGUOUS\n");
-	ERR;
+         fprintf(stderr,"nc_inq_var_chunking did not return CONTIGUOUS\n");
+         ERR;
       }
 
       if (nc_close(ncid)) ERR;
    }
+   SUMMARIZE_ERR;
+   printf("*** Testing HDF4/NetCDF-4 chunking API: contiguous...");
+   {
+      /* Open with netCDF */
+      if (nc_open(CONTIGFILE, 0, &ncid)) ERR;
 
+      if (nc_inq_varid(ncid, CONTIGVAR, &varid)) ERR;
+      if (nc_def_var_deflate(ncid, varid, 0, 1, 4) != NC_EPERM) ERR;
+
+      if (nc_close(ncid)) ERR;
+   }
    SUMMARIZE_ERR;
    FINAL_RESULTS;
 }

--- a/nc_test4/tst_interops2.c
+++ b/nc_test4/tst_interops2.c
@@ -3,6 +3,7 @@
    COPYRIGHT file for conditions of use.
 
    Test that NetCDF-4 can read HDF4 files.
+   Ed Hartnett
 */
 #include <config.h>
 #include <nc_tests.h>
@@ -10,6 +11,7 @@
 #include <hdf5.h>
 #include <H5DSpublic.h>
 #include <mfhdf.h>
+#include <netcdf_f.h>
 
 #define FILE_NAME "tst_interops2.h4"
 
@@ -56,6 +58,15 @@ main(int argc, char **argv)
       if (nc_inq_dim(ncid, 1, NULL, &len_in)) ERR;
       if (len_in != LON_LEN) ERR;
 
+      /* THese won't work. */
+      if (nc_redef(ncid) != NC_EPERM) ERR;
+      if (nc_def_var(ncid, "wow", NC_INT, 0, NULL, NULL) != NC_EPERM) ERR;
+      if (nc_def_var_chunking(ncid, 0, NC_CONTIGUOUS, NULL) != NC_EPERM) ERR;
+
+      /* Expected this to return NC_EPERM, but instead it returns
+       * success. See github issue #744. */
+      if (nc_def_var_chunking_ints(ncid, 0, NC_CONTIGUOUS, NULL)) ERR;
+      
       /* Read the data through a vara function from the netCDF API. */
       if (nc_get_vara(ncid, 0, nstart, ncount, data_in)) ERR;
       for (i = 0; i < LAT_LEN; i++)

--- a/ncdap_test/t_dap3a.c
+++ b/ncdap_test/t_dap3a.c
@@ -113,7 +113,6 @@ int main()
     int ncstat = NC_NOERR;
     char url[8102];
     const char* topsrcdir;
-    size_t len;
 #ifndef USE_NETCDF4
     int i,j;
 #endif

--- a/ncdump/indent.h
+++ b/ncdump/indent.h
@@ -1,8 +1,10 @@
 /*********************************************************************
  *   Copyright 2007, UCAR/Unidata
  *   See netcdf/COPYRIGHT file for copying and redistribution conditions.
- *   $Header: /upc/share/CVS/netcdf-3/ncdump/indent.h,v 1.1 2007/05/20 20:42:30 russ Exp $
+ *   Russ Rew
  *********************************************************************/
+#ifndef _INDENT_H
+#define _INDENT_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -18,3 +20,5 @@ extern int  indent_get();	/* return current indent */
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* _INDENT_H */

--- a/ncdump/isnan.h
+++ b/ncdump/isnan.h
@@ -1,8 +1,10 @@
 /*********************************************************************
  *   Copyright 2008, University Corporation for Atmospheric Research
  *   See netcdf/README file for copying and redistribution conditions.
- *   $Id: isnan.h,v 1.3 2008/04/23 22:05:00 russ Exp $
+ *   Russ Rew
  *********************************************************************/
+#ifndef _ISNAN_H
+#define _ISNAN_H
 
 #include "config.h"
 
@@ -20,3 +22,5 @@
 #if ! (defined(isfinite) || HAVE_DECL_ISFINITE)
 #define isfinite(x) (!(isinf(x)||isnan(x)))
 #endif /* !HAVE_DECL_ISFINITE */
+
+#endif /* _ISNAN_H */

--- a/ncdump/ncdump.c
+++ b/ncdump/ncdump.c
@@ -273,7 +273,7 @@ kind_string(int kind)
     case NC_FORMAT_NETCDF4_CLASSIC:
 	return "netCDF-4 classic model";
     default:
-	error("unrecognized file format: %d");
+       error("unrecognized file format: %d", kind);
 	return "unrecognized";
     }
 }

--- a/ncdump/nctime0.h
+++ b/ncdump/nctime0.h
@@ -1,8 +1,10 @@
 /*********************************************************************
  *   Copyright 2008, University Corporation for Atmospheric Research
  *   See netcdf/COPYRIGHT file for copying and redistribution conditions.
- *   $Id: nctime.h,v 1.6 2010/03/18 19:24:26 russ Exp $
+ *   Russ Rew
  *********************************************************************/
+#ifndef _NCTIME0_H
+#define _NCTIME0_H
 
 #include "nctime.h"
 
@@ -12,3 +14,6 @@ extern int is_valid_time_unit(const char *units);
 extern int is_bounds_att(ncatt_t *attp);
 extern void get_timeinfo(int ncid, int varid, ncvar_t *vp);
 extern void print_att_times(int ncid, int varid, const ncatt_t *att);
+
+#endif /* _NCTIME0_H */
+

--- a/ncdump/utils.h
+++ b/ncdump/utils.h
@@ -5,6 +5,8 @@
  *   Stuff that's common to both ncdump and nccopy
  *
  *********************************************************************/
+#ifndef _UTILS_H
+#define _UTILS_H
 
 #include "config.h"
 
@@ -157,3 +159,6 @@ extern int getrootid(int grpid);
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* _UTILS_H */
+

--- a/ncdump/vardata.h
+++ b/ncdump/vardata.h
@@ -1,8 +1,10 @@
 /*********************************************************************
  *   Copyright 1993, University Corporation for Atmospheric Research
  *   See netcdf/COPYRIGHT file for copying and redistribution conditions.
- *   $Header: /upc/share/CVS/netcdf-3/ncdump/vardata.h,v 1.7 2007/10/08 02:47:57 russ Exp $
+ *   Russ Rew
  *********************************************************************/
+#ifndef _VARDATA_H
+#define _VARDATA_H
 
 extern char *progname;		/* for error messages */
 
@@ -43,3 +45,5 @@ extern void pr_any_att_vals( const ncatt_t *attp, const void *vals );
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* _VARDATA_H */

--- a/ncgen/nc_iter.h
+++ b/ncgen/nc_iter.h
@@ -4,8 +4,8 @@
  *   "$Id $"
  *********************************************************************/
 
-#ifndef _NCITER_
-#define _NCITER_
+#ifndef _NC_ITER_
+#define _NC_ITER_
 
 #include <netcdf.h>
 
@@ -49,4 +49,4 @@ nc_next_iter(nciter_t *iterp, size_t *start, size_t *count);
 }
 #endif
 
-#endif /* _NCITER_ */
+#endif /* _NC_ITER_ */

--- a/ncgen/nc_iter.h
+++ b/ncgen/nc_iter.h
@@ -4,8 +4,8 @@
  *   "$Id $"
  *********************************************************************/
 
-#ifndef _NC_ITER_
-#define _NC_ITER_
+#ifndef _NC_ITER_H
+#define _NC_ITER_H
 
 #include <netcdf.h>
 
@@ -49,4 +49,4 @@ nc_next_iter(nciter_t *iterp, size_t *start, size_t *count);
 }
 #endif
 
-#endif /* _NC_ITER_ */
+#endif /* _NC_ITER_H */


### PR DESCRIPTION
This PR contains more changes from PR #755, which was not merged. I am breaking it into smaller pieces.

In this PR I add guards to all the header files that need them, and remove some unneeded HDF4 checking code in nc4_dev_var() and nc4_def_var_extar(). (Recall that HDF4 is read-only, so these functions can't be called for HDF4 anyway.)

Also added necessary parameter checks for nc4_def_var_extra() and nc4_rename().

Also added some test code in support of checking HDF4 changes. I have much more test code on branch ejh_fill_values but I think I need to see all the existing PRs merged, then I can do a compare with master and see what is left on ejh_fill_values. There are certainly some important string fill value fixes there, so I hope this can happen soon.

Fixes #759.
Fixes #757.
Fixes #750.
Fixes #743.
Fixes #739.
Fixes #772.
Fixes #758.
Fixes #741.
Part of #710.
Part of #721.
Part of #748.
