### PR TITLE
Fix some bad parameter bugs in type functions, add documentation and testing

### DIFF
--- a/libdispatch/dtype.c
+++ b/libdispatch/dtype.c
@@ -41,7 +41,12 @@ type). Read attributes of the new type with nc_get_att (see
 
 /** 
 \ingroup user_types
-Learn if two types are equal
+Learn if two types are equal.
+
+\note User-defined types in netCDF-4/HDF5 files must be committed to
+the file before nc_inq_type_equal() will work on the type. For
+uncommitted user-defined types, nc_inq_type_equal() will return
+::NC_EHDFERR. Commit types to the file with a call to nc_enddef().
 
 \param ncid1 \ref ncid of first typeid.
 \param typeid1 First typeid.
@@ -54,8 +59,11 @@ the two types are equal, a zero if they are not equal.
 \returns ::NC_EBADID Bad \ref ncid.
 \returns ::NC_EBADTYPE Bad type id.
 \returns ::NC_ENOTNC4 Not an netCDF-4 file, or classic model enabled.
-\returns ::NC_EHDFERR An error was reported by the HDF5 layer.
-\author Dennis Heimbigner, Ward Fisher
+\returns ::NC_EHDFERR An error was reported by the HDF5 layer. This
+will occur if either of the types have not been committed to the file
+(with an nc_enddef()).
+
+\author Dennis Heimbigner, Ward Fisher, Ed Hartnett
  */
 int
 nc_inq_type_equal(int ncid1, nc_type typeid1, int ncid2,

--- a/libsrc4/nc4internal.c
+++ b/libsrc4/nc4internal.c
@@ -93,6 +93,7 @@ nc4_hdf5_initialize(void)
  *
  * @return ::NC_NOERR No error.
  * @return ::NC_EMAXNAME Name too long.
+ * @return ::NC_EINVAL NULL given for name.
  * @author Dennis Heimbigner
  */
 int
@@ -100,6 +101,12 @@ nc4_check_name(const char *name, char *norm_name)
 {
    char *temp;
    int retval;
+
+   assert(norm_name);
+   
+   /* Check for NULL. */
+   if (!name)
+      return NC_EINVAL;
 
    /* Check the length. */
    if (strlen(name) > NC_MAX_NAME)

--- a/libsrc4/nc4type.c
+++ b/libsrc4/nc4type.c
@@ -217,9 +217,10 @@ NC4_inq_typeids(int ncid, int *ntypes, int *typeids)
    /* Find info for this file and group, and set pointer to each. */
    if ((retval = nc4_find_grp_h5(ncid, &grp, &h5)))
       return retval;
+   assert(h5 && grp);
 
-   /* If this is a netCDF-4 file, count types. */
-   if (h5 && grp->type)
+   /* Count types. */
+   if (grp->type)
       for (type = grp->type; type; type = type->l.next)
       {
 	 if (typeids)
@@ -631,8 +632,9 @@ find_nc4_file(int ncid, NC **nc)
    NC_HDF5_FILE_INFO_T* h5;
    
    /* Find file metadata. */
-   if (!((*nc) = nc4_find_nc_file(ncid,&h5)))
+   if (!((*nc) = nc4_find_nc_file(ncid, &h5)))
       return NC_EBADID;
+   assert(h5);
       
    if (h5->cmode & NC_CLASSIC_MODEL)
       return NC_ESTRICTNC3;

--- a/libsrc4/nc4type.c
+++ b/libsrc4/nc4type.c
@@ -104,7 +104,11 @@ NC4_inq_type_equal(int ncid1, nc_type typeid1, int ncid2,
 
    /* Are the two types equal? */
    if (equalp)
-      *equalp = (int)H5Tequal(type1->native_hdf_typeid, type2->native_hdf_typeid);
+   {
+      if ((retval = H5Tequal(type1->native_hdf_typeid, type2->native_hdf_typeid)) < 0)
+         return NC_EHDFERR;
+      *equalp = 1 ? retval : 0;
+   }
    
    return NC_NOERR;
 }

--- a/libsrc4/nc4type.c
+++ b/libsrc4/nc4type.c
@@ -137,6 +137,7 @@ NC4_inq_typeid(int ncid, const char *name, nc_type *typeidp)
    char *norm_name;
    int i, retval;
 
+   /* Handle atomic types. */
    for (i = 0; i < NUM_ATOMIC_TYPES; i++)
       if (!strcmp(name, atomic_name[i]))
       {
@@ -148,10 +149,7 @@ NC4_inq_typeid(int ncid, const char *name, nc_type *typeidp)
    /* Find info for this file and group, and set pointer to each. */
    if ((retval = nc4_find_grp_h5(ncid, &grp, &h5)))
       return retval;
-
-   /* Must be a netCDF-4 file. */
-   if (!h5)
-      return NC_ENOTNC4;
+   assert(h5 && grp);
 
    /* If the first char is a /, this is a fully-qualified
     * name. Otherwise, this had better be a local name (i.e. no / in
@@ -275,10 +273,7 @@ add_user_type(int ncid, size_t size, const char *name, nc_type base_typeid,
    /* Find group metadata. */
    if ((retval = nc4_find_grp_h5(ncid, &grp, &h5)))
       return retval;
-
-   /* Only netcdf-4 files! */
-   if (!h5)
-      return NC_ENOTNC4;
+   assert(h5 && grp);
 
    /* Turn on define mode if it is not on. */
    if (!(h5->cmode & NC_INDEF))

--- a/nc_test4/CMakeLists.txt
+++ b/nc_test4/CMakeLists.txt
@@ -9,7 +9,8 @@ SET(NC4_TESTS tst_dims tst_dims2 tst_dims3 tst_files tst_files4
   cdm_sea_soundings tst_vl tst_atts1 tst_atts2 tst_vars2 tst_files5
   tst_files6 tst_sync tst_h_strbug tst_h_refs tst_h_scalar tst_rename
   tst_h5_endians tst_atts_string_rewrite tst_put_vars_two_unlim_dim
-  tst_hdf5_file_compat tst_fill_attr_vanish tst_rehash tst_filterparser)
+  tst_hdf5_file_compat tst_fill_attr_vanish tst_rehash tst_filterparser
+  tst_types)
 
 
 # Note, renamegroup needs to be compiled before run_grp_rename

--- a/nc_test4/Makefile.am
+++ b/nc_test4/Makefile.am
@@ -25,7 +25,7 @@ tst_fillbug tst_xplatform tst_xplatform2 tst_endian_fill tst_atts	\
 t_type cdm_sea_soundings tst_camrun tst_vl tst_atts1 tst_atts2		\
 tst_vars2 tst_files5 tst_files6 tst_sync tst_h_scalar tst_rename	\
 tst_h5_endians tst_atts_string_rewrite tst_hdf5_file_compat		\
-tst_fill_attr_vanish tst_rehash tst_filterparser tst_bug324
+tst_fill_attr_vanish tst_rehash tst_filterparser tst_bug324 tst_types
 
 # Temporary I hope
 if !ISCYGWIN

--- a/nc_test4/tst_types.c
+++ b/nc_test4/tst_types.c
@@ -1,333 +1,228 @@
-/* Test program for types. */
-#include <config.h>
-#include <netcdf.h>
+/* This is part of the netCDF package.
+   Copyright 2005 University Corporation for Atmospheric Research/Unidata
+   See COPYRIGHT file for conditions of use.
 
-/* This macro prints an error message and exits. */
-#define BAIL(e) do { \
-fprintf(stderr, "Error in file %s, line %d.\n%s\n", \
-__FILE__, __LINE__, nc_strerror(e)); \
-return 2; \
-} while (0)
+   Test netcdf-4 types.
 
-/* This macro keep track of the number of errors and prints an error
- * message. */
-#define ERR do { \
-fprintf(stderr, "Error in file %s, line %d.\n", __FILE__, __LINE__); \
-errors++; \
-} while (0)
- 
+   Ed Hartnett
+*/
+
+#include "config.h"
+#include "nc_tests.h"
+#include "err_macros.h"
+
 #define MAX_VARNAME 20
 #define NUM_TYPES 6
 #define NUM_DIMS 1
 #define SIZE 5
 #define STRIDE_SIZE 2
-#define FILENAME "test.nc"
+#define FILENAME "tst_types.nc"
 
-#define CLEAN_INPUT_BUFFERS  \
-   for (i=0; i<SIZE; i++) { \
-      ubyte_data_out[i] = 0; \
-      ushort_data_out[i] = 0; \
-      uint_data_out[i] = 0; \
-      int64_data_out[i] = 0; \
-      uint64_data_out[i] = 0; \
-      bool_data_out[i] = 0; \
+#define CLEAN_INPUT_BUFFERS                     \
+   for (i=0; i<SIZE; i++) {                     \
+      ubyte_data_out[i] = 0;                    \
+      ushort_data_out[i] = 0;                   \
+      uint_data_out[i] = 0;                     \
+      int64_data_out[i] = 0;                    \
+      uint64_data_out[i] = 0;                   \
    }
 
 int main(int argc, char *argv[])
 {
    /* IDs, names, and parameters for the var[asm1] functions. */
-   int ncid, varid[NUM_TYPES], attid, dimid;
+   int ncid, varid[NUM_TYPES], dimid;
    char varname[MAX_VARNAME];
-   size_t index1[NUM_DIMS], start[NUM_DIMS], offset[NUM_DIMS];
-   size_t count[NUM_DIMS], imap[NUM_DIMS];
+   size_t index1[NUM_DIMS], start[NUM_DIMS];
+   size_t count[NUM_DIMS];
+   ptrdiff_t imap[NUM_DIMS];
    ptrdiff_t stride[NUM_DIMS];
 
    /* Phoney data we will write. */
    unsigned char ubyte_data_out[] = {0,1,2,3,4};
-   unsigned short ushort_data_out[] = {0,11,22,33,44}; 
-   unsigned int uint_data_out[] = {0,111,222,333,3000000000u;};
-   nc_int64 int64_data_out[] = {0,-111111111,2222222222,-3333333333,444444444};
-   nc_uint64 uint64_data_out[] = {0,111111111,2222222222,33333333,44444444};
-   unsigned char bool_data_out[] = {0,1,0,1,0};
+   unsigned short ushort_data_out[] = {0,11,22,33,44};
+   unsigned int uint_data_out[] = {0,111,222,333,3000000000u};
+   long long int int64_data_out[] = {0,-111111111,2222222222,-3333333333,444444444};
+   unsigned long long int uint64_data_out[] = {0,111111111,2222222222,33333333,44444444};
 
    /* We will read back in the phoney data with these. */
    unsigned char ubyte_data_in[SIZE];
    unsigned short ushort_data_in[SIZE];
    unsigned int uint_data_in[SIZE];
-   nc_int64 int64_data_in[SIZE];
-   nc_uint64 uint64_data_in[SIZE];
-   unsigned char bool_data_in[SIZE];
+   long long int int64_data_in[SIZE];
+   unsigned long long int uint64_data_in[SIZE];
 
    int i;
-   int type, num_errors = 0, res = NC_NOERR;
-   int errors = 0, total_errors = 0;
+   int type;
 
-   /* Uncomment the following line to get verbose feedback. */
-   /*nc_set_log_level(2);*/
-   printf("\n\n*** Testing netCDF-4 new atomic types...\n");
-
-   /* Open a netcdf-4 file, and one dimension. */
-   if ((res = nc_create(FILENAME, NC_NETCDF4, &ncid)))
-      BAIL(res);
-   if ((res = nc_def_dim(ncid, "dim1", SIZE, &dimid)))
-      BAIL(res);
-
-   /* Create vars of the new types. Take advantage of the fact that
-    * new types are numbered from NC_UBYTE (7) through NC_BOOL (12).*/
-   for(type = 0; type < NUM_TYPES; type++)
+   printf("\n*** Testing netCDF-4 new atomic types...");
    {
-      /* Create a var... */
-      sprintf(varname, "var_%d", type);
-      printf("*** creating var %s, type: %d...\t\t", varname, type+NC_UBYTE);
-      if ((res = nc_def_var(ncid, varname, type+NC_UBYTE, 1, &dimid, &varid[type])))
-	 BAIL(res);
-      printf("ok!\n");
+      /* Open a netcdf-4 file, and one dimension. */
+      if (nc_create(FILENAME, NC_NETCDF4, &ncid)) ERR;
+      if (nc_def_dim(ncid, "dim1", SIZE, &dimid)) ERR;
+
+      /* Create vars of the new types. Take advantage of the fact that
+       * new types are numbered from NC_UBYTE (7) through NC_STRING
+       * (12). */
+      for(type = 0; type < NUM_TYPES; type++)
+      {
+         /* Create a var... */
+         sprintf(varname, "var_%d", type);
+         if (nc_def_var(ncid, varname, type+NC_UBYTE, 1, &dimid, &varid[type])) ERR;
+      }
    }
-   
+   SUMMARIZE_ERR;
+
    /* Test the varm functions. */
-   printf("*** testing varm functions...\t\t\t");
-/*   CLEAN_INPUT_BUFFERS;
-   errors = 0;
-   start[0] = 0;
-   count[0] = 1;
-   stride[0] = 1;
-   imap[0] = 0;
+   printf("*** testing varm functions...");
+   {
+      CLEAN_INPUT_BUFFERS;
+      start[0] = 0;
+      count[0] = 1;
+      stride[0] = 1;
+      imap[0] = 0;
 
-   if ((res = nc_put_varm_ubyte(ncid, varid[0], start, count, 
-				stride, imap, ubyte_data_out)))
-      BAIL(res);
-   if ((res = nc_get_varm_ubyte(ncid, varid[0], start, count, 
-				stride, imap, ubyte_data_in)))
-      BAIL(res);
-   for (i=0; i<STRIDE_SIZE; i++)
-      if (ubyte_data_in[i] != ubyte_data_out[i]) ERR;
+      if (nc_put_varm_ubyte(ncid, varid[0], start, count,
+                            stride, imap, ubyte_data_out)) ERR;
+      if (nc_get_varm_ubyte(ncid, varid[0], start, count,
+                            stride, imap, ubyte_data_in)) ERR;
+      for (i=0; i<STRIDE_SIZE; i++)
+         if (ubyte_data_in[i] != ubyte_data_out[i]) ERR;
 
-   if ((res = nc_put_varm_ushort(ncid, varid[1], start, count, 
-				 stride, imap, ushort_data_out)))
-      BAIL(res);
-   if ((res = nc_get_varm_ushort(ncid, varid[1], start, count,
-				 stride, imap, ushort_data_in)))
-      BAIL(res);
-   for (i=0; i<STRIDE_SIZE; i++)
-      if (ubyte_data_in[i] != ubyte_data_out[i]) ERR;
+      if (nc_put_varm_ushort(ncid, varid[1], start, count,
+                             stride, imap, ushort_data_out)) ERR;
+      if (nc_get_varm_ushort(ncid, varid[1], start, count,
+                             stride, imap, ushort_data_in)) ERR;
+      for (i=0; i<STRIDE_SIZE; i++)
+         if (ubyte_data_in[i] != ubyte_data_out[i]) ERR;
 
-   if ((res = nc_put_varm_uint(ncid, varid[2], start, 
-			       count, stride, imap, uint_data_out)))
-      BAIL(res);
-   if ((res = nc_get_varm_uint(ncid, varid[2], start, count, 
-			       stride, imap, uint_data_in)))
-      BAIL(res);
-   for (i=0; i<STRIDE_SIZE; i++)
-      if (ubyte_data_in[i] != ubyte_data_out[i]) ERR;
+      if (nc_put_varm_uint(ncid, varid[2], start,
+                           count, stride, imap, uint_data_out)) ERR;
+      if (nc_get_varm_uint(ncid, varid[2], start, count,
+                           stride, imap, uint_data_in)) ERR;
+      for (i=0; i<STRIDE_SIZE; i++)
+         if (ubyte_data_in[i] != ubyte_data_out[i]) ERR;
 
-   if ((res = nc_put_varm_int64(ncid, varid[3], start, count, 
-				stride, imap, int64_data_out)))
-      BAIL(res);
-   if ((res = nc_get_varm_int64(ncid, varid[3], start, count, 
-				stride, imap, int64_data_in)))
-      BAIL(res);
-   for (i=0; i<STRIDE_SIZE; i++)
-      if (ubyte_data_in[i] != ubyte_data_out[i]) ERR;
+      if (nc_put_varm_longlong(ncid, varid[3], start, count,
+                               stride, imap, int64_data_out)) ERR;
+      if (nc_get_varm_longlong(ncid, varid[3], start, count,
+                               stride, imap, int64_data_in)) ERR;
+      for (i=0; i<STRIDE_SIZE; i++)
+         if (ubyte_data_in[i] != ubyte_data_out[i]) ERR;
 
-   if ((res = nc_put_varm_uint64(ncid, varid[4], start, count, 
-				 stride, imap, uint64_data_out)))
-      BAIL(res);
-   if ((res = nc_get_varm_uint64(ncid, varid[4], start, count,
-				 stride, imap, uint64_data_in)))
-      BAIL(res);
-   for (i=0; i<STRIDE_SIZE; i++)
-      if (ubyte_data_in[i] != ubyte_data_out[i]) ERR;
+      if (nc_put_varm_ulonglong(ncid, varid[4], start, count,
+                                stride, imap, uint64_data_out)) ERR;
+      if (nc_get_varm_ulonglong(ncid, varid[4], start, count,
+                                stride, imap, uint64_data_in)) ERR;
+      for (i=0; i<STRIDE_SIZE; i++)
+         if (ubyte_data_in[i] != ubyte_data_out[i]) ERR;
+   }
+   SUMMARIZE_ERR;
 
-   if ((res = nc_put_varm_bool(ncid, varid[5], start, count, 
-			       stride, imap, bool_data_out)))
-      BAIL(res);
-   if ((res = nc_get_varm_bool(ncid, varid[5], start, 
-			       count, stride, imap, bool_data_in)))
-      BAIL(res);
-   for (i=0; i<STRIDE_SIZE; i++)
-      if (ubyte_data_in[i] != ubyte_data_out[i]) ERR;
-
-   total_errors += errors;
-   if (errors)
-      printf("*** ERROR!! - %d errors. Sorry!\n");
-   else
-      printf("ok!\n");
-*/
    /* Test the vars functions. */
-   printf("*** testing vars functions...\t\t\t");
-   CLEAN_INPUT_BUFFERS;
-   errors = 0;
-   start[0] = 0;
-   count[0] = 2;
-   stride[0] = STRIDE_SIZE;
+   printf("*** testing vars functions...");
+   {
+      CLEAN_INPUT_BUFFERS;
+      start[0] = 0;
+      count[0] = 2;
+      stride[0] = STRIDE_SIZE;
 
-   if ((res = nc_put_vars_uchar(ncid, varid[0], start, count, 
-				stride, ubyte_data_out)))
-      BAIL(res);
-   if ((res = nc_get_vars_uchar(ncid, varid[0], start, count, 
-				stride, ubyte_data_in)))
-      BAIL(res);
-   if (ubyte_data_in[0] != ubyte_data_out[0]) ERR;
-   if (ubyte_data_in[1] != ubyte_data_out[STRIDE_SIZE]) ERR;
+      if (nc_put_vars_uchar(ncid, varid[0], start, count,
+                            stride, ubyte_data_out)) ERR;
+      if (nc_get_vars_uchar(ncid, varid[0], start, count,
+                            stride, ubyte_data_in)) ERR;
+      if (ubyte_data_in[0] != ubyte_data_out[0]) ERR;
+      if (ubyte_data_in[1] != ubyte_data_out[STRIDE_SIZE]) ERR;
 
-   if ((res = nc_put_vars_ushort(ncid, varid[1], start, count, 
-				 stride, ushort_data_out)))
-      BAIL(res);
-   if ((res = nc_get_vars_ushort(ncid, varid[1], start, count,
-				 stride, ushort_data_in)))
-      BAIL(res);
-   for (i=0; i<2; i++)
-      if (ubyte_data_in[i] != ubyte_data_out[i]) ERR;
+      if (nc_put_vars_ushort(ncid, varid[1], start, count,
+                             stride, ushort_data_out)) ERR;
+      if (nc_get_vars_ushort(ncid, varid[1], start, count,
+                             stride, ushort_data_in)) ERR;
+      for (i=0; i<2; i++)
+         if (ubyte_data_in[i] != ubyte_data_out[i]) ERR;
 
-   if ((res = nc_put_vars_uint(ncid, varid[2], start, 
-			       count, stride, uint_data_out)))
-      BAIL(res);
-   if ((res = nc_get_vars_uint(ncid, varid[2], start, count, 
-			       stride, uint_data_in)))
-      BAIL(res);
-   for (i=0; i<2; i++)
-      if (ubyte_data_in[i] != ubyte_data_out[i]) ERR;
+      if (nc_put_vars_uint(ncid, varid[2], start,
+                           count, stride, uint_data_out)) ERR;
+      if (nc_get_vars_uint(ncid, varid[2], start, count,
+                           stride, uint_data_in)) ERR;
+      for (i=0; i<2; i++)
+         if (ubyte_data_in[i] != ubyte_data_out[i]) ERR;
 
-   if ((res = nc_put_vars_int64(ncid, varid[3], start, count, 
-				stride, int64_data_out)))
-      BAIL(res);
-   if ((res = nc_get_vars_int64(ncid, varid[3], start, count, 
-				stride, int64_data_in)))
-      BAIL(res);
-   for (i=0; i<2; i++)
-      if (ubyte_data_in[i] != ubyte_data_out[i]) ERR;
+      if (nc_put_vars_longlong(ncid, varid[3], start, count,
+                               stride, int64_data_out)) ERR;
+      if (nc_get_vars_longlong(ncid, varid[3], start, count,
+                               stride, int64_data_in)) ERR;
+      for (i=0; i<2; i++)
+         if (ubyte_data_in[i] != ubyte_data_out[i]) ERR;
 
-   if ((res = nc_put_vars_uint64(ncid, varid[4], start, count, 
-				 stride, uint64_data_out)))
-      BAIL(res);
-   if ((res = nc_get_vars_uint64(ncid, varid[4], start, count,
-				 stride, uint64_data_in)))
-      BAIL(res);
-   for (i=0; i<2; i++)
-      if (ubyte_data_in[i] != ubyte_data_out[i]) ERR;
-
-   if ((res = nc_put_vars_bool(ncid, varid[5], start, count, 
-			       stride, bool_data_out)))
-      BAIL(res);
-   if ((res = nc_get_vars_bool(ncid, varid[5], start, 
-			       count, stride, bool_data_in)))
-      BAIL(res);
-   for (i=0; i<2; i++)
-      if (ubyte_data_in[i] != ubyte_data_out[i]) ERR;
-
-   total_errors += errors;
-   if (errors)
-      printf("*** ERROR!! - %d errors. Sorry!\n");
-   else
-      printf("ok!\n");
+      if (nc_put_vars_ulonglong(ncid, varid[4], start, count,
+                                stride, uint64_data_out)) ERR;
+      if (nc_get_vars_ulonglong(ncid, varid[4], start, count,
+                                stride, uint64_data_in)) ERR;
+      for (i=0; i<2; i++)
+         if (ubyte_data_in[i] != ubyte_data_out[i]) ERR;
+   }
+   SUMMARIZE_ERR;
 
    /* Test the vara functions. */
-   printf("*** testing vara functions...\t\t\t");
-   CLEAN_INPUT_BUFFERS;
-   errors = 0;
-   start[0] = 0;
-   count[0] = SIZE;
+   printf("*** testing vara functions...");
+   {
+      CLEAN_INPUT_BUFFERS;
+      start[0] = 0;
+      count[0] = SIZE;
 
-   if ((res = nc_put_vara_uchar(ncid, varid[0], start, count, ubyte_data_out)))
-      BAIL(res);
-   if ((res = nc_get_vara_uchar(ncid, varid[0], start, count, ubyte_data_in)))
-      BAIL(res);
-   for (i=0; i<SIZE; i++)
-      if (ubyte_data_in[i] != ubyte_data_out[i]) ERR;
+      if (nc_put_vara_uchar(ncid, varid[0], start, count, ubyte_data_out)) ERR;
+      if (nc_get_vara_uchar(ncid, varid[0], start, count, ubyte_data_in)) ERR;
+      for (i=0; i<SIZE; i++)
+         if (ubyte_data_in[i] != ubyte_data_out[i]) ERR;
 
-   if ((res = nc_put_vara_ushort(ncid, varid[1], start, count, ushort_data_out)))
-      BAIL(res);
-   if ((res = nc_get_vara_ushort(ncid, varid[1], start, count, ushort_data_in)))
-      BAIL(res);
-   for (i=0; i<SIZE; i++)
-      if (ubyte_data_in[i] != ubyte_data_out[i]) ERR;
+      if (nc_put_vara_ushort(ncid, varid[1], start, count, ushort_data_out)) ERR;
+      if (nc_get_vara_ushort(ncid, varid[1], start, count, ushort_data_in)) ERR;
+      for (i=0; i<SIZE; i++)
+         if (ubyte_data_in[i] != ubyte_data_out[i]) ERR;
 
-   if ((res = nc_put_vara_uint(ncid, varid[2], start, count, uint_data_out)))
-      BAIL(res);
-   if ((res = nc_get_vara_uint(ncid, varid[2], start, count, uint_data_in)))
-      BAIL(res);
-   for (i=0; i<SIZE; i++)
-      if (ubyte_data_in[i] != ubyte_data_out[i]) ERR;
+      if (nc_put_vara_uint(ncid, varid[2], start, count, uint_data_out)) ERR;
+      if (nc_get_vara_uint(ncid, varid[2], start, count, uint_data_in)) ERR;
+      for (i=0; i<SIZE; i++)
+         if (ubyte_data_in[i] != ubyte_data_out[i]) ERR;
 
-   if ((res = nc_put_vara_int64(ncid, varid[3], start, count, int64_data_out)))
-      BAIL(res);
-   if ((res = nc_get_vara_int64(ncid, varid[3], start, count, int64_data_in)))
-      BAIL(res);
-   for (i=0; i<SIZE; i++)
-      if (ubyte_data_in[i] != ubyte_data_out[i]) ERR;
+      if (nc_put_vara_longlong(ncid, varid[3], start, count, int64_data_out)) ERR;
+      if (nc_get_vara_longlong(ncid, varid[3], start, count, int64_data_in)) ERR;
+      for (i=0; i<SIZE; i++)
+         if (ubyte_data_in[i] != ubyte_data_out[i]) ERR;
 
-   if ((res = nc_put_vara_uint64(ncid, varid[4], start, count, uint64_data_out)))
-      BAIL(res);
-   if ((res = nc_get_vara_uint64(ncid, varid[4], start, count, uint64_data_in)))
-      BAIL(res);
-   for (i=0; i<SIZE; i++)
-      if (ubyte_data_in[i] != ubyte_data_out[i]) ERR;
-
-   if ((res = nc_put_vara_bool(ncid, varid[5], start, count, bool_data_out)))
-      BAIL(res);
-   if ((res = nc_get_vara_bool(ncid, varid[5], start, count, bool_data_in)))
-      BAIL(res);
-   for (i=0; i<SIZE; i++)
-      if (ubyte_data_in[i] != ubyte_data_out[i]) ERR;
-
-   total_errors += errors;
-   if (errors)
-      printf("*** ERROR!! - %d errors. Sorry!\n");
-   else
-      printf("ok!\n");
+      if (nc_put_vara_ulonglong(ncid, varid[4], start, count, uint64_data_out)) ERR;
+      if (nc_get_vara_ulonglong(ncid, varid[4], start, count, uint64_data_in)) ERR;
+      for (i=0; i<SIZE; i++)
+         if (ubyte_data_in[i] != ubyte_data_out[i]) ERR;
+   }
+   SUMMARIZE_ERR;
 
    /* Test the var1 functions. */
-   printf("*** testing var1 functions...\t\t\t");
-   CLEAN_INPUT_BUFFERS;
-   errors = 0;
-   index1[0] = 0;
+   printf("*** testing var1 functions...");
+   {
+      CLEAN_INPUT_BUFFERS;
+      index1[0] = 0;
 
-   if ((res = nc_put_var1_uchar(ncid, varid[0], index1, uchar_data_out)))
-      BAIL(res);
-   if ((res = nc_get_var1_uchar(ncid, varid[0], index1, uchar_data_in)))
-      BAIL(res);
-   if (uchar_data_in[0] != uchar_data_out[0]) ERR;
+      if (nc_put_var1_uchar(ncid, varid[0], index1, ubyte_data_out)) ERR;
+      if (nc_get_var1_uchar(ncid, varid[0], index1, ubyte_data_in)) ERR;
+      if (ubyte_data_in[0] != ubyte_data_out[0]) ERR;
 
-   if ((res = nc_put_var1_ushort(ncid, varid[1], index1, ushort_data_out)))
-      BAIL(res);
-   if ((res = nc_get_var1_ushort(ncid, varid[1], index1, ushort_data_in)))
-      BAIL(res);
-   if (ushort_data_in[0] != ushort_data_out[0]) ERR;
+      if (nc_put_var1_ushort(ncid, varid[1], index1, ushort_data_out)) ERR;
+      if (nc_get_var1_ushort(ncid, varid[1], index1, ushort_data_in)) ERR;
+      if (ushort_data_in[0] != ushort_data_out[0]) ERR;
 
-   if ((res = nc_put_var1_uint(ncid, varid[2], index1, uint_data_out)))
-      BAIL(res);
-   if ((res = nc_get_var1_uint(ncid, varid[2], index1, uint_data_in)))
-      BAIL(res);
-   if (uint_data_in[0] != uint_data_out[0]) ERR;
+      if (nc_put_var1_uint(ncid, varid[2], index1, uint_data_out)) ERR;
+      if (nc_get_var1_uint(ncid, varid[2], index1, uint_data_in)) ERR;
+      if (uint_data_in[0] != uint_data_out[0]) ERR;
 
-   if ((res = nc_put_var1_int64(ncid, varid[3], index1, int64_data_out)))
-      BAIL(res);
-   if ((res = nc_get_var1_int64(ncid, varid[3], index1, int64_data_in)))
-      BAIL(res);
-   if (int64_data_in[0] != int64_data_out[0]) ERR;
+      if (nc_put_var1_longlong(ncid, varid[3], index1, int64_data_out)) ERR;
+      if (nc_get_var1_longlong(ncid, varid[3], index1, int64_data_in)) ERR;
+      if (int64_data_in[0] != int64_data_out[0]) ERR;
 
-   if ((res = nc_put_var1_uint64(ncid, varid[4], index1, uint64_data_out)))
-      BAIL(res);
-   if ((res = nc_get_var1_uint64(ncid, varid[4], index1, uint64_data_in)))
-      BAIL(res);
-   if (uint64_data_in[0] != uint64_data_out[0]) ERR;
-
-   if ((res = nc_put_var1_bool(ncid, varid[5], index1, bool_data_out)))
-      BAIL(res);
-   if ((res = nc_get_var1_bool(ncid, varid[5], index1, bool_data_in)))
-      BAIL(res);
-   if (bool_data_in[0] != bool_data_out[0]) ERR;
-
-   total_errors += errors;
-   if (errors)
-      printf("*** ERROR!! - %d errors. Sorry!\n");
-   else
-      printf("ok!\n");
-
-   if (total_errors)
-      printf(" *** %d total errors\n", errors);
-   else
-      printf(" *** success!\n");
-
-   return 2 ? errors : 0;
+      if (nc_put_var1_ulonglong(ncid, varid[4], index1, uint64_data_out)) ERR;
+      if (nc_get_var1_ulonglong(ncid, varid[4], index1, uint64_data_in)) ERR;
+      if (uint64_data_in[0] != uint64_data_out[0]) ERR;
+   }
+   SUMMARIZE_ERR;
+   FINAL_RESULTS;
 }


### PR DESCRIPTION
While waiting for other PRs to be merged, I took a stab at improving the testing of nc4type.c, currently the lowest tested file in libsrc4 with 65% test coverage.

While adding tests I found and fixed a few problems, including SEGFAULT if NULL is passed for name parameter when adding a user-defined type.

Also fixed bug in nc_inq_type_equal() relating to uncommitted types. Documented the tricky behavior of this function with uncommitted user-defined types.

Also also added a bunch of extra tests. ;-)

Part of #701.
Fixes #779.
Fixes #777.
Fixes #776.
Fixes #775.
Fixes #774.
