### PR TITLE
Increased testing of nc4grp.c, fixed nc_rename_grp() duplicate name, NULL name bugs

### DIFF
--- a/libsrc4/nc4grp.c
+++ b/libsrc4/nc4grp.c
@@ -1,3 +1,6 @@
+/* Copyright 2005-2018, University Corporation for Atmospheric
+ * Research. See COPYRIGHT file for copying and redistribution
+ * conditions. */
 /**
  * @file 
  * @internal This file is part of netcdf-4, a netCDF-like interface
@@ -5,10 +8,6 @@
  * view.
  *
  * This file handles the nc4 groups.
- *
- * Copyright 2005, University Corporation for Atmospheric Research. See
- * netcdf-4/docs/COPYRIGHT file for copying and redistribution
- * conditions.
  * 
  * @author Ed Hartnett
 */
@@ -108,15 +107,16 @@ NC4_rename_grp(int grpid, const char *name)
       return NC_EPERM; /* attempt to write to a read-only file */
 
    /* Do not allow renaming the root group */
-   if(grp->parent == NULL)
+   if (grp->parent == NULL)
 	return NC_EBADGRPID;
 
    /* Check and normalize the name. */
    if ((retval = nc4_check_name(name, norm_name)))
       return retval;
 
-   /* Check that this name is not in use as a var, grp, or type. */
-   if ((retval = nc4_check_dup_name(grp, norm_name)))
+   /* Check that this name is not in use as a var, grp, or type in the
+    * parent group (i.e. the group that grp is in). */
+   if ((retval = nc4_check_dup_name(grp->parent, norm_name)))
       return retval;
 
    /* If it's not in define mode, switch to define mode. */

--- a/libsrc4/nc4grp.c
+++ b/libsrc4/nc4grp.c
@@ -15,7 +15,7 @@
 #include "nc4dispatch.h"
 
 /**
- * @internal Create a group. It's ncid is returned in the new_ncid
+ * @internal Create a group. Its ncid is returned in the new_ncid
  * pointer. 
  *
  * @param parent_ncid Parent group.

--- a/libsrc4/nc4grp.c
+++ b/libsrc4/nc4grp.c
@@ -7,7 +7,7 @@
  * for HDF5, or a HDF5 backend for netCDF, depending on your point of
  * view.
  *
- * This file handles the nc4 groups.
+ * This file handles groups.
  * 
  * @author Ed Hartnett
 */

--- a/libsrc4/nc4internal.c
+++ b/libsrc4/nc4internal.c
@@ -93,6 +93,7 @@ nc4_hdf5_initialize(void)
  *
  * @return ::NC_NOERR No error.
  * @return ::NC_EMAXNAME Name too long.
+ * @return ::NC_EINVAL Invalid parameter.
  * @author Dennis Heimbigner
  */
 int
@@ -100,6 +101,10 @@ nc4_check_name(const char *name, char *norm_name)
 {
    char *temp;
    int retval;
+   
+   /* Check for NULL. */
+   if (!name)
+      return NC_EINVAL;
 
    /* Check the length. */
    if (strlen(name) > NC_MAX_NAME)

--- a/nc_test4/Makefile.am
+++ b/nc_test4/Makefile.am
@@ -97,6 +97,7 @@ check_PROGRAMS += tst_interops2 tst_chunk_hdf4 tst_h4_lendian
 if BUILD_UTILITIES
 # This test script depends on ncdump.
 TESTS += tst_interops2 tst_formatx_hdf4.sh
+tst_formatx_hdf4.log: tst_interops2.log
 endif # BUILD_UTILITIES
 
 TESTS += run_chunk_hdf4.sh tst_h4_lendian

--- a/nc_test4/tst_grps.c
+++ b/nc_test4/tst_grps.c
@@ -89,10 +89,8 @@ main(int argc, char **argv)
       if (strcmp(name_in, HENRY_VII)) ERR;
       if (nc_inq_varids(grpid_in[0], &nvars_in, varids_in)) ERR;
       if (nvars_in != 0) ERR;
-      if (nc_inq_varids(grpid_in[0], &ndims_in, dimids_in)) ERR;
-      if (ndims_in != 0) ERR;
-      if (nc_inq_varids(grpid_in[0], NULL, dimids_in)) ERR;
-      if (nc_inq_varids(grpid_in[0], &ndims_in, NULL)) ERR;
+      if (nc_inq_varids(grpid_in[0], NULL, varids_in)) ERR;
+      if (nc_inq_varids(grpid_in[0], &nvars_in, NULL)) ERR;
       if (nc_inq_varids(grpid_in[0], NULL, NULL)) ERR;
       
       if (nc_inq_ncid(ncid, HENRY_VII, &ncid_in)) ERR;

--- a/nc_test4/tst_grps.c
+++ b/nc_test4/tst_grps.c
@@ -3,7 +3,8 @@
    See COPYRIGHT file for conditions of use.
 
    Test netcdf-4 group code.
-   $Id: tst_grps.c,v 1.37 2010/04/07 15:21:28 ed Exp $
+
+   Ed Hartnett
 */
 
 #include <nc_tests.h>


### PR DESCRIPTION
I took a look at the test coverage of nc4grp.c this morning, which was %75. This PR takes it up to a more respectable 90%.

While testing I found and fixed some bugs with nc_rename_grp() and names. 

Fixes #785.
Fixes #784.
Fixes #783.
Fixes #782 
