### PR TITLE
fix tst_converts.c when enable-erange-fill is set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1921,6 +1921,7 @@ is_enabled(USE_MMAP HAS_MMAP)
 is_enabled(JNA HAS_JNA)
 is_enabled(STATUS_RELAX_COORD_BOUND RELAX_COORD_BOUND)
 is_enabled(USE_CDF5 HAS_CDF5)
+is_enabled(ENABLE_ERANGE_FILL ENABLE_ERANGE_FILL)
 
 # Generate file from template.
 CONFIGURE_FILE("${CMAKE_CURRENT_SOURCE_DIR}/libnetcdf.settings.in"

--- a/configure.ac
+++ b/configure.ac
@@ -1368,6 +1368,7 @@ AC_SUBST(HAS_DISKLESS,[$enable_diskless])
 AC_SUBST(HAS_MMAP,[$enable_mmap])
 AC_SUBST(HAS_JNA,[$enable_jna])
 AC_SUBST(RELAX_COORD_BOUND,[$enable_relax_coord_bound])
+AC_SUBST(ENABLE_ERANGE_FILL,[$enable_erange_fill])
 
 # Include some specifics for netcdf on windows.
 #AH_VERBATIM([_WIN32_STRICMP],

--- a/libnetcdf.settings.in
+++ b/libnetcdf.settings.in
@@ -35,3 +35,4 @@ Diskless Support:	@HAS_DISKLESS@
 MMap Support:		@HAS_MMAP@
 JNA Support:		@HAS_JNA@
 CDF5 Support:		@HAS_CDF5@
+ERANGE fill Support:	@ENABLE_ERANGE_FILL@

--- a/nc_test4/tst_converts.c
+++ b/nc_test4/tst_converts.c
@@ -149,19 +149,35 @@ check_file(int format, unsigned char *uchar_out)
    else if (res) ERR;
 
    for (i=0; i<DIM1_LEN; i++)
+#ifdef ERANGE_FILL
+      if (uchar_in[i] != uchar_out[i] && uchar_in[i] != NC_FILL_UBYTE) ERR;
+#else
       if (uchar_in[i] != uchar_out[i]) ERR;
+#endif
 
    if (nc_get_var_schar(ncid, 0, char_in)) ERR;
    for (i=0; i<DIM1_LEN; i++)
+#ifdef ERANGE_FILL
+      if (char_in[i] != (signed char)uchar_out[i] && char_in[i] != NC_FILL_BYTE) ERR;
+#else
       if (char_in[i] != (signed char)uchar_out[i]) ERR;
+#endif
 
    if (nc_get_var_short(ncid, 0, short_in)) ERR;
    for (i=0; i<DIM1_LEN; i++)
+#ifdef ERANGE_FILL
+      if (short_in[i] != (signed char)uchar_out[i] && short_in[i] != NC_FILL_BYTE) ERR;
+#else
       if (short_in[i] != (signed char)uchar_out[i]) ERR;
+#endif
 
    if (nc_get_var_int(ncid, 0, int_in)) ERR;
    for (i=0; i<DIM1_LEN; i++)
+#ifdef ERANGE_FILL
+      if (int_in[i] != (signed char)uchar_out[i] && int_in[i] != NC_FILL_BYTE) ERR;
+#else
       if (int_in[i] != (signed char)uchar_out[i]) ERR;
+#endif
 
    if (format == NC_FORMAT_NETCDF4 || format == NC_FORMAT_NETCDF4_CLASSIC)
    {


### PR DESCRIPTION
When erange-fill is enabled, nc_test4/tst_converts.c fails with the following error message.
This is also reported in #424
```
*** Testing conversion in netCDF CDF5 files... Sorry! Unexpected result,
netcdf-c/nc_test4/tst_converts.c, line: 152
1 failures
1 errors detected! Sorry!
```
No such error would occur when erange-fill is disabled (NetCDF default mode).

This PR also add an item in libnetcdf.settings.in to report whether erange-fill is enabled or not. 
