### PR TITLE
Recent refactoring removed uses of variables

### DIFF
--- a/libsrc4/nc4var.c
+++ b/libsrc4/nc4var.c
@@ -965,10 +965,8 @@ nc_def_var_extra(int ncid, int varid, int *shuffle, int *deflate,
    NC_GRP_INFO_T *grp;
    NC_HDF5_FILE_INFO_T *h5;
    NC_VAR_INFO_T *var;
-   NC_DIM_INFO_T *dim;
    int d;
    int retval;
-   nc_bool_t ishdf4 = NC_FALSE; /* Use this to avoid so many ifdefs */
 
    /* All or none of these will be provided. */
    assert((deflate && deflate_level && shuffle) ||


### PR DESCRIPTION
Recent refactorings removed the use of these variable, but they were still defined.  Removing to eliminate unused variable warnings.