### PR TITLE
Incorrect reference to byteswap8 in libdispatch/dfilter.c

### DIFF
--- a/cf
+++ b/cf
@@ -1,6 +1,6 @@
 #!/bin/bash
 #NB=1
-#DB=1
+DB=1
 #X=-x
 FAST=1
 

--- a/libdispatch/dfilter.c
+++ b/libdispatch/dfilter.c
@@ -156,7 +156,7 @@ NC_parsefilterspec(const char* spec, unsigned int* idp, size_t* nparamsp, unsign
 	    /* convert to network byte order */
 	    memcpy(mem,&val64u,sizeof(mem));
 #ifdef WORDS_BIGENDIAN	    
-	    byteswap8(mem);  /* convert big endian to little endian */
+	    NC_byteswap8(mem);  /* convert big endian to little endian */
 #endif
 	    vector = (unsigned int*)mem;
 	    ulist[nparams++] = vector[0];


### PR DESCRIPTION
re: GH Issue https://github.com/Unidata/netcdf-c/issues/806
Change byteswap8 -> NC_byteswap8.