### PR TITLE
Remove V2 code if V2 API not being built

### DIFF
--- a/nc_test4/tst_vars2.c
+++ b/nc_test4/tst_vars2.c
@@ -559,6 +559,7 @@ main(int argc, char **argv)
    }
    SUMMARIZE_ERR;
 
+#ifndef NO_NETCDF_2
 #define VAR_DIMS2 2
    printf("*** testing 2D array of NC_FLOAT with v2 API...");
    {
@@ -584,6 +585,7 @@ main(int argc, char **argv)
       ncclose(ncid);
    }
    SUMMARIZE_ERR;
+#endif
 
 #define NDIMS 3
 #define NNAMES 4


### PR DESCRIPTION
Remove test code that uses the version 2 API if the version 2 API code is not being activated in the build.

This was originally proposed in #656 with a better fix in #755 which was removed.