### PR TITLE
another rename fix

### DIFF
--- a/libsrc4/nc4var.c
+++ b/libsrc4/nc4var.c
@@ -265,11 +265,7 @@ check_chunksizes(NC_GRP_INFO_T *grp, NC_VAR_INFO_T *var, const size_t *chunksize
    else
       dprod = (double)type_len;
    for (d = 0; d < var->ndims; d++)
-   {
-      if (chunksizes[d] < 1)
-         return NC_EINVAL;
-      dprod *= (double) chunksizes[d];
-   }
+      dprod *= (double)chunksizes[d];
 
    if (dprod > (double) NC_MAX_UINT)
       return NC_EBADCHUNK;
@@ -410,7 +406,8 @@ nc4_find_default_chunksizes2(NC_GRP_INFO_T *grp, NC_VAR_INFO_T *var)
  * @returns ::NC_ENOMEM Out of memory.
  * @author Dennis Heimbigner
  */
-int nc4_vararray_add(NC_GRP_INFO_T *grp, NC_VAR_INFO_T *var)
+int
+nc4_vararray_add(NC_GRP_INFO_T *grp, NC_VAR_INFO_T *var)
 {
    NC_VAR_INFO_T **vp = NULL;
 
@@ -431,11 +428,10 @@ int nc4_vararray_add(NC_GRP_INFO_T *grp, NC_VAR_INFO_T *var)
       grp->vars.nalloc += NC_ARRAY_GROWBY;
    }
 
-   if(var != NULL) {
-      assert(var->varid == grp->vars.nelems);
-      grp->vars.value[grp->vars.nelems] = var;
-      grp->vars.nelems++;
-   }
+   assert(var->varid == grp->vars.nelems);
+   grp->vars.value[grp->vars.nelems] = var;
+   grp->vars.nelems++;
+
    return NC_NOERR;
 }
 
@@ -524,7 +520,7 @@ NC4_def_var(int ncid, const char *name, nc_type xtype,
    if ((retval = nc4_check_dup_name(grp, norm_name)))
       BAIL(retval);
 
-   /* If there for non-scalar vars, dim IDs must be provided. */
+   /* For non-scalar vars, dim IDs must be provided. */
    if (ndims && !dimidsp)
       BAIL(NC_EINVAL);      
 
@@ -727,7 +723,7 @@ NC4_def_var(int ncid, const char *name, nc_type xtype,
     * remember whether dimension scales have been attached to each
     * dimension. */
    if (!var->dimscale && ndims)
-      if (ndims && !(var->dimscale_attached = calloc(ndims, sizeof(nc_bool_t))))
+      if (!(var->dimscale_attached = calloc(ndims, sizeof(nc_bool_t))))
          BAIL(NC_ENOMEM);
 
    /* Return the varid. */
@@ -885,19 +881,18 @@ NC4_inq_var_all(int ncid, int varid, char *name, nc_type *xtypep,
       {
          if (var->type_info->nc_type_class == NC_STRING)
          {
-            if (*(char **)var->fill_value) {
+            assert(*(char **)var->fill_value);
+            if (!(*(char **)fill_valuep = calloc(1, sizeof(char *))))
+               return NC_ENOMEM;
 
-               if (!(fill_valuep = calloc(1, sizeof(char *))))
-                  return NC_ENOMEM;
-
-               if (!(*(char **)fill_valuep = strdup(*(char **)var->fill_value)))
-               {
-                  free(fill_valuep);
-                  return NC_ENOMEM;
-               }
+            if (!(*(char **)fill_valuep = strdup(*(char **)var->fill_value)))
+            {
+               free(*(char **)fill_valuep);
+               return NC_ENOMEM;
             }
          }
-         else {
+         else
+         {
             assert(var->type_info->size);
             memcpy(fill_valuep, var->fill_value, var->type_info->size);
          }
@@ -906,15 +901,13 @@ NC4_inq_var_all(int ncid, int varid, char *name, nc_type *xtypep,
       {
          if (var->type_info->nc_type_class == NC_STRING)
          {
-            if (!(fill_valuep = calloc(1, sizeof(char *))))
+            if (!(*(char **)fill_valuep = calloc(1, sizeof(char *))))
                return NC_ENOMEM;
 
             if ((retval = nc4_get_default_fill_value(var->type_info, (char **)fill_valuep)))
             {
-               free(fill_valuep);
+               free(*(char **)fill_valuep);
                return retval;
-            } else {
-               free(fill_valuep);
             }
          }
          else
@@ -1013,7 +1006,7 @@ nc_def_var_extra(int ncid, int varid, int *shuffle, int *deflate,
       return NC_EINVAL;
 
    /* Valid deflate level? */
-   if (deflate && deflate_level)
+   if (deflate)
    {
       if (*deflate)
          if (*deflate_level < NC_MIN_DEFLATE_LEVEL ||
@@ -1104,7 +1097,16 @@ nc_def_var_extra(int ncid, int varid, int *shuffle, int *deflate,
    if (no_fill)
    {
       if (*no_fill)
+      {
+         /* NC_STRING types may not turn off fill mode. It's disallowed
+          * by HDF5 and will cause a HDF5 error later. */
+         if (*no_fill)
+            if (var->type_info->nc_typeid == NC_STRING)
+               return NC_EINVAL;
+
+         /* Set the no-fill mode. */
          var->no_fill = NC_TRUE;
+      }
       else
          var->no_fill = NC_FALSE;
    }
@@ -1659,11 +1661,12 @@ NC4_rename_var(int ncid, int varid, const char *name)
           */
          if ((retval = nc4_find_dim(grp, var->dimids[0], &dim, &dim_grp)))
             return retval;
-         if (strcmp(dim->name, name) == 0 && dim_grp == grp)
+         if (!strcmp(dim->name, name) && dim_grp == grp)
          {
             /* Reform the coordinate variable */
             if ((retval = nc4_reform_coord_var(grp, var, dim)))
                return retval;
+            var->became_coord_var = NC_TRUE;
          }
       }
    }

--- a/libsrc4/nc4var.c
+++ b/libsrc4/nc4var.c
@@ -265,7 +265,11 @@ check_chunksizes(NC_GRP_INFO_T *grp, NC_VAR_INFO_T *var, const size_t *chunksize
    else
       dprod = (double)type_len;
    for (d = 0; d < var->ndims; d++)
-      dprod *= (double)chunksizes[d];
+   {
+      if (chunksizes[d] < 1)
+         return NC_EINVAL;
+      dprod *= (double) chunksizes[d];
+   }
 
    if (dprod > (double) NC_MAX_UINT)
       return NC_EBADCHUNK;
@@ -406,8 +410,7 @@ nc4_find_default_chunksizes2(NC_GRP_INFO_T *grp, NC_VAR_INFO_T *var)
  * @returns ::NC_ENOMEM Out of memory.
  * @author Dennis Heimbigner
  */
-int
-nc4_vararray_add(NC_GRP_INFO_T *grp, NC_VAR_INFO_T *var)
+int nc4_vararray_add(NC_GRP_INFO_T *grp, NC_VAR_INFO_T *var)
 {
    NC_VAR_INFO_T **vp = NULL;
 
@@ -428,10 +431,11 @@ nc4_vararray_add(NC_GRP_INFO_T *grp, NC_VAR_INFO_T *var)
       grp->vars.nalloc += NC_ARRAY_GROWBY;
    }
 
-   assert(var->varid == grp->vars.nelems);
-   grp->vars.value[grp->vars.nelems] = var;
-   grp->vars.nelems++;
-
+   if(var != NULL) {
+      assert(var->varid == grp->vars.nelems);
+      grp->vars.value[grp->vars.nelems] = var;
+      grp->vars.nelems++;
+   }
    return NC_NOERR;
 }
 
@@ -881,18 +885,19 @@ NC4_inq_var_all(int ncid, int varid, char *name, nc_type *xtypep,
       {
          if (var->type_info->nc_type_class == NC_STRING)
          {
-            assert(*(char **)var->fill_value);
-            if (!(*(char **)fill_valuep = calloc(1, sizeof(char *))))
-               return NC_ENOMEM;
+            if (*(char **)var->fill_value) {
 
-            if (!(*(char **)fill_valuep = strdup(*(char **)var->fill_value)))
-            {
-               free(*(char **)fill_valuep);
-               return NC_ENOMEM;
+               if (!(fill_valuep = calloc(1, sizeof(char *))))
+                  return NC_ENOMEM;
+
+               if (!(*(char **)fill_valuep = strdup(*(char **)var->fill_value)))
+               {
+                  free(fill_valuep);
+                  return NC_ENOMEM;
+               }
             }
          }
-         else
-         {
+         else {
             assert(var->type_info->size);
             memcpy(fill_valuep, var->fill_value, var->type_info->size);
          }
@@ -901,13 +906,15 @@ NC4_inq_var_all(int ncid, int varid, char *name, nc_type *xtypep,
       {
          if (var->type_info->nc_type_class == NC_STRING)
          {
-            if (!(*(char **)fill_valuep = calloc(1, sizeof(char *))))
+            if (!(fill_valuep = calloc(1, sizeof(char *))))
                return NC_ENOMEM;
 
             if ((retval = nc4_get_default_fill_value(var->type_info, (char **)fill_valuep)))
             {
-               free(*(char **)fill_valuep);
+               free(fill_valuep);
                return retval;
+            } else {
+               free(fill_valuep);
             }
          }
          else
@@ -1006,7 +1013,7 @@ nc_def_var_extra(int ncid, int varid, int *shuffle, int *deflate,
       return NC_EINVAL;
 
    /* Valid deflate level? */
-   if (deflate)
+   if (deflate && deflate_level)
    {
       if (*deflate)
          if (*deflate_level < NC_MIN_DEFLATE_LEVEL ||
@@ -1097,16 +1104,7 @@ nc_def_var_extra(int ncid, int varid, int *shuffle, int *deflate,
    if (no_fill)
    {
       if (*no_fill)
-      {
-         /* NC_STRING types may not turn off fill mode. It's disallowed
-          * by HDF5 and will cause a HDF5 error later. */
-         if (*no_fill)
-            if (var->type_info->nc_typeid == NC_STRING)
-               return NC_EINVAL;
-
-         /* Set the no-fill mode. */
          var->no_fill = NC_TRUE;
-      }
       else
          var->no_fill = NC_FALSE;
    }

--- a/nc_test4/tst_rename.c
+++ b/nc_test4/tst_rename.c
@@ -22,6 +22,13 @@
 #define VAR_RANK 1              /* all vars in this test are of same rank */
 #define DIM_LEN 2               /* all dims in this test are of same len */
 
+/* For the tests based on Charlie Zender's rename bug test. */
+#define CHARLIE_TEST_FILE "tst_charlie_rename_coord_dim.nc"
+#define LON "lon"
+#define LONGITUDE "longitude"
+#define DIM1_LEN 4
+#define NDIM1 1
+
 /* Test data. */
 int lats[DIM_LEN] = {-90, 90};
 float rh[DIM_LEN] = {0.25, 0.75};
@@ -101,6 +108,19 @@ check_charlies_file(char *file, char *dim_name, char *var_name)
    return NC_NOERR;
 }
 
+/* Check a data-free version of the already-open file created in a
+ * test. */
+int
+check_charlies_no_enddef_file(int ncid, char *dim_name, char *var_name)
+{
+   int varid, dimid;
+   
+   if (nc_inq_varid(ncid, var_name, &varid)) ERR;
+   if (nc_inq_dimid(ncid, dim_name, &dimid)) ERR;
+   if (varid || dimid) ERR;
+   return NC_NOERR;
+}
+
 int
 main(int argc, char **argv)
 {
@@ -111,10 +131,8 @@ main(int argc, char **argv)
    int format;
 
    fprintf(stderr,"*** Testing netcdf rename bugs and fixes.\n");
-   nc_set_log_level(5);
 
    for (format = 0; format < NUM_FORMATS; format++)
-   /* for (format = 0; format < 1; format++) */
    {
       int ncid, dimid, varid, var2id;
       int lats[DIM_LEN] = {-90, 90};
@@ -123,13 +141,80 @@ main(int argc, char **argv)
       float rh_in[DIM_LEN];
       int ii;
 
-      fprintf(stderr,"*** Test Charlie's test for renaming...");
+      fprintf(stderr,"*** Test Charlie's test for renaming without enddef...");
       {
-#define CHARLIE_TEST_FILE "tst_charlie_rename_coord_dim.nc"
-#define LON "lon"
-#define LONGITUDE "longitude"
-#define DIM1_LEN 4
-#define NDIM1 1
+         int ncid, dimid, varid;
+
+         /* Create a nice, simple file. This file will contain one
+          * dataset, "lon", which is a dimscale. */
+         if (nc_create(CHARLIE_TEST_FILE, NC_NETCDF4, &ncid)) ERR;
+         if (nc_def_dim(ncid, LON, DIM1_LEN, &dimid)) ERR;
+         if (nc_def_var(ncid, LON, NC_FLOAT, NDIM1, &dimid, &varid)) ERR;
+
+         /* Check the file. */
+         if (check_charlies_no_enddef_file(ncid, LON, LON)) ERR;
+
+         /* Rename the dimension. This will cause lon to stop being a
+          * coord var and dimscale, and prepare to create a new
+          * dimscale without var dataset "longitude". Dataset "lon"
+          * will point to "longitude" as its dimscale. */
+         if (nc_rename_dim(ncid, 0, LONGITUDE)) ERR;
+         if (check_charlies_no_enddef_file(ncid, LONGITUDE, LON)) ERR;
+
+         /* Rename the variable. This will remove the (as yet
+          * unwritten) dimscale-only dataset "longitude" and rename
+          * the extisting dataset "lon" to "longitude". Variable
+          * "longitude" will become a coordinate var. */
+         if (nc_rename_var(ncid, 0, LONGITUDE)) ERR;
+         if (check_charlies_no_enddef_file(ncid, LONGITUDE, LONGITUDE)) ERR;
+         if (nc_close(ncid)) ERR;
+
+         /* Reopen the file and check. */
+         if (check_charlies_file(CHARLIE_TEST_FILE, LONGITUDE, LONGITUDE)) ERR;         
+
+      }
+      SUMMARIZE_ERR;
+      fprintf(stderr,"*** Test Charlie's test for renaming with one enddef...");
+      {
+         int ncid, dimid, varid;
+         nc_set_log_level(5);
+
+         /* Create a nice, simple file. This file will contain one
+          * dataset, "lon", which is a dimscale. */
+         if (nc_create(CHARLIE_TEST_FILE, NC_NETCDF4, &ncid)) ERR;
+         if (nc_def_dim(ncid, LON, DIM1_LEN, &dimid)) ERR;
+         if (nc_def_var(ncid, LON, NC_FLOAT, NDIM1, &dimid, &varid)) ERR;
+
+         /* Check the file. */
+         if (check_charlies_no_enddef_file(ncid, LON, LON)) ERR;
+
+         /* Rename the dimension. This will cause lon to stop being a
+          * coord var and dimscale, and prepare to create a new
+          * dimscale without var dataset "longitude". Dataset "lon"
+          * will point to "longitude" as its dimscale. */
+         if (nc_rename_dim(ncid, 0, LONGITUDE)) ERR;
+         if (check_charlies_no_enddef_file(ncid, LONGITUDE, LON)) ERR;
+
+         /* Trigger write to disk. */
+         if (nc_enddef(ncid)) ERR;
+         if (nc_redef(ncid)) ERR;
+         if (check_charlies_no_enddef_file(ncid, LONGITUDE, LON)) ERR;
+         
+         /* Rename the variable. This will remove the (as yet
+          * unwritten) dimscale-only dataset "longitude" and rename
+          * the extisting dataset "lon" to "longitude". Variable
+          * "longitude" will become a coordinate var. */
+         if (nc_rename_var(ncid, 0, LONGITUDE)) ERR;
+         if (check_charlies_no_enddef_file(ncid, LONGITUDE, LONGITUDE)) ERR;
+         if (nc_close(ncid)) ERR;
+
+         /* Reopen the file and check. */
+         if (check_charlies_file(CHARLIE_TEST_FILE, LONGITUDE, LONGITUDE)) ERR;
+
+      }
+      SUMMARIZE_ERR;
+      fprintf(stderr,"*** Test Charlie's test for renaming with enddef...");
+      {
          int ncid, dimid, varid;
          float data[DIM1_LEN] = {0, 90.0, 180.0, 270.0};
 
@@ -162,14 +247,14 @@ main(int argc, char **argv)
           * the dimscale-only dataset "longitude" and rename the
           * extisting dataset "lon" to "longitude". Variable
           * "longitude" will become a coordinate var. */
-         /* if (nc_open(CHARLIE_TEST_FILE, NC_WRITE, &ncid)) ERR; */
-         /* if (nc_redef(ncid)) ERR; */
-         /* if (nc_rename_var(ncid, 0, LONGITUDE)) ERR; */
-         /* if (nc_enddef(ncid)) ERR; */
-         /* if (nc_close(ncid)) ERR; */
+         if (nc_open(CHARLIE_TEST_FILE, NC_WRITE, &ncid)) ERR;
+         if (nc_redef(ncid)) ERR;
+         if (nc_rename_var(ncid, 0, LONGITUDE)) ERR;
+         if (nc_enddef(ncid)) ERR;
+         if (nc_close(ncid)) ERR;
 
          /* Reopen the file to check. */
-         /* if (check_charlies_file(CHARLIE_TEST_FILE, LONGITUDE, LONGITUDE)) ERR; */
+         if (check_charlies_file(CHARLIE_TEST_FILE, LONGITUDE, LONGITUDE)) ERR;
       }
       SUMMARIZE_ERR;
 
@@ -298,8 +383,7 @@ main(int argc, char **argv)
 
          /* Reopen and check. */
          if (nc_open(file_names[format], NC_WRITE, &ncid)) ERR;
-         /* if (check_file(ncid, LAT, RH, TAL)) ERR; */
-         /* if (check_file(ncid, TAL, RH, TAL)) ERR; */
+         if (check_file(ncid, TAL, RH, TAL)) ERR;
          if (nc_close(ncid)) ERR;
       }
       SUMMARIZE_ERR;
@@ -327,10 +411,13 @@ main(int argc, char **argv)
           * TAL. LAT will become a dimscale. RH will point to LAT. */
          if (nc_rename_var(ncid, varid, TAL)) ERR;
          if (nc_enddef(ncid)) ERR;
+         /* This should work but does not. It is a known rename
+          * bug. Rename is coming! */
          /* if (check_file(ncid, LAT, RH, TAL)) ERR; */
          if (nc_close(ncid)) ERR;
 
          if (nc_open(file_names[format], NC_WRITE, &ncid)) ERR;
+         /* Should work but does not. Raname issues. */
          /* if (check_file(ncid, LAT, RH, TAL)) ERR; */
          if (nc_close(ncid)) ERR;
       }
@@ -344,8 +431,7 @@ main(int argc, char **argv)
          if (nc_inq_dimid(ncid, ODIM_NAME, &dimid)) ERR;
          if (nc_inq_varid(ncid, OVAR_NAME, &varid)) ERR;
          if (nc_inq_varid(ncid, OVAR2_NAME, &var2id)) ERR;
-         if (nc_redef(ncid)) ERR;  /* omitting this and nc_enddef call eliminates bug */
-         /* if (nc_rename_dim(ncid, dimid, NDIM_NAME)) ERR; */
+         if (nc_redef(ncid)) ERR;
          if (nc_rename_var(ncid, varid, NVAR_NAME)) ERR;
          if (nc_enddef(ncid)) ERR;
          if (nc_get_var_int(ncid, varid, lats_in)) ERR;
@@ -370,9 +456,8 @@ main(int argc, char **argv)
          if (nc_inq_dimid(ncid, ODIM_NAME, &dimid)) ERR;
          if (nc_inq_varid(ncid, OVAR_NAME, &varid)) ERR;
          if (nc_inq_varid(ncid, OVAR2_NAME, &var2id)) ERR;
-         if (nc_redef(ncid)) ERR; /* omitting this and nc_enddef call eliminates bug */
+         if (nc_redef(ncid)) ERR; 
          if (nc_rename_dim(ncid, dimid, NDIM_NAME)) ERR;
-         /* if (nc_rename_var(ncid, varid, NVAR_NAME)) ERR; */
          if (nc_enddef(ncid)) ERR;
          if (nc_get_var_int(ncid, varid, lats_in)) ERR;
          for (ii = 0; ii < DIM_LEN; ii++) {


### PR DESCRIPTION
Renames have been a problem for a long time - since the beginning, in fact. The way that dims, vars, and dimscales interact is complex, and renaming can make vars into dimscales, than turn them back to non-dimscales, then back to dimscales again. Each time, dimscales have to be correctly detached and reattached between each dim, and each var that uses that dim.

Renames can be devilishly tricky little blighters!

I did a rename fix that got into 4.6.0, but there were still known rename errors. I was prepared for a major effort to fix the remaining rename issues. I was ready to refactor the whole shebang.

But that turned out not to be necessary. I added one line of code and now all my rename tests work.

I don't promise this is the end of rename bugs. ;-)

Part of #597.