### PR TITLE
Use hdf5-1.8 compatible output format if possible

### DIFF
--- a/libsrc4/nc4file.c
+++ b/libsrc4/nc4file.c
@@ -997,7 +997,11 @@ nc4_create_file(const char *path, int cmode, MPI_Comm comm, MPI_Info info,
 #endif /* USE_PARALLEL4 */
 
 #ifdef HDF5_HAS_LIBVER_BOUNDS
+#if H5_VERSION_GE(1,10,2)
+   if (H5Pset_libver_bounds(fapl_id, H5F_LIBVER_EARLIEST, H5F_LIBVER_V18) < 0)
+#else
    if (H5Pset_libver_bounds(fapl_id, H5F_LIBVER_EARLIEST, H5F_LIBVER_LATEST) < 0)
+#endif
       BAIL(NC_EHDFERR);
 #endif
 


### PR DESCRIPTION
In hdf5-1.10.2, THG added a new enumeration for use in the `H5Pset_libver_bounds` function which makes it easier to maintain compatibility with hdf5-1.8.X clients.   

An explanation is provided at https://www.hdfgroup.org/2018/04/why-should-i-care-about-the-hdf5-1-10-2-release/ 

In particular, the section "What does this change mean to an HDF5 application?" discusses its use with NetCDF