### PR TITLE
Fix unused variable compiler warning

### DIFF
--- a/libsrc4/nc4hdf.c
+++ b/libsrc4/nc4hdf.c
@@ -4254,7 +4254,7 @@ reportobject(int uselog, hid_t id, unsigned int type)
    } else
 #endif
    {
-      fprintf(stderr,"Type = %s(%lld) name='%s'",typename,(long long)id,name);
+      fprintf(stderr,"Type = %s(%lld) name='%s'",typename,printid,name);
    }
    
 }


### PR DESCRIPTION
Fix unused variable warning for `printid`.   Looks like it was not substituted in all places where it should have been and was only used inside an ifdef so was unused if `LOGGING` was false.  Add use in `fprintf` line following the ifdef block.

Minor change, but compilation output is so clean that a little wart sticks out...