### PR TITLE
removed dead code associated with old handling of NC_LONG

### DIFF
--- a/include/nc4internal.h
+++ b/include/nc4internal.h
@@ -348,8 +348,7 @@ int nc4_get_typelen_mem(NC_HDF5_FILE_INFO_T *h5, nc_type xtype, size_t *len);
 int nc4_convert_type(const void *src, void *dest,
 		     const nc_type src_type, const nc_type dest_type,
 		     const size_t len, int *range_error,
-		     const void *fill_value, int strict_nc3, int src_long,
-		     int dest_long);
+		     const void *fill_value, int strict_nc3);
 
 /* These functions do HDF5 things. */
 int rec_detach_scales(NC_GRP_INFO_T *grp, int dimid, hid_t dimscaleid);
@@ -357,9 +356,9 @@ int rec_reattach_scales(NC_GRP_INFO_T *grp, int dimid, hid_t dimscaleid);
 int delete_existing_dimscale_dataset(NC_GRP_INFO_T *grp, int dimid, NC_DIM_INFO_T *dim);
 int nc4_open_var_grp2(NC_GRP_INFO_T *grp, int varid, hid_t *dataset);
 int nc4_put_vara(NC *nc, int ncid, int varid, const size_t *startp,
-		 const size_t *countp, nc_type xtype, int is_long, void *op);
+		 const size_t *countp, nc_type xtype, void *op);
 int nc4_get_vara(NC *nc, int ncid, int varid, const size_t *startp,
-		 const size_t *countp, nc_type xtype, int is_long, void *op);
+		 const size_t *countp, nc_type xtype, void *op);
 int nc4_rec_match_dimscales(NC_GRP_INFO_T *grp);
 int nc4_rec_detect_need_to_preserve_dimids(NC_GRP_INFO_T *grp, nc_bool_t *bad_coord_orderp);
 int nc4_rec_write_metadata(NC_GRP_INFO_T *grp, nc_bool_t bad_coord_order);

--- a/libhdf4/hdf4var.c
+++ b/libhdf4/hdf4var.c
@@ -96,7 +96,7 @@ NC_HDF4_get_vara(int ncid, int varid, const size_t *startp,
    if (var->type_info->hdr.id != memtype)
    {
       if ((retval = nc4_convert_type(data, ip, var->type_info->hdr.id, memtype, nelem,
-                                     &range_error, NULL, 0, 0, 0)))
+                                     &range_error, NULL, 0)))
          return retval;
       free(data);
       if (range_error)

--- a/libhdf5/nc4hdf.c
+++ b/libhdf5/nc4hdf.c
@@ -650,7 +650,6 @@ set_par_access(NC_HDF5_FILE_INFO_T *h5, NC_VAR_INFO_T *var, hid_t xfer_plistid)
  * @param startp Array of start indices.
  * @param countp Array of counts.
  * @param mem_nc_type The type of the data in memory.
- * @param is_long True only if NC_LONG is the memory type.
  * @param data The data to be written.
  *
  * @returns ::NC_NOERR No error.
@@ -667,7 +666,7 @@ set_par_access(NC_HDF5_FILE_INFO_T *h5, NC_VAR_INFO_T *var, hid_t xfer_plistid)
  */
 int
 nc4_put_vara(NC *nc, int ncid, int varid, const size_t *startp,
-             const size_t *countp, nc_type mem_nc_type, int is_long, void *data)
+             const size_t *countp, nc_type mem_nc_type, void *data)
 {
    NC_GRP_INFO_T *grp;
    NC_HDF5_FILE_INFO_T *h5;
@@ -699,8 +698,8 @@ nc4_put_vara(NC *nc, int ncid, int varid, const size_t *startp,
    h5 = NC4_DATA(nc);
    assert(grp && h5 && var && var->hdr.name);
 
-   LOG((3, "%s: var->hdr.name %s mem_nc_type %d is_long %d",
-        __func__, var->hdr.name, mem_nc_type, is_long));
+   LOG((3, "%s: var->hdr.name %s mem_nc_type %d",
+        __func__, var->hdr.name, mem_nc_type));
 
    /* Check some stuff about the type and the file. If the file must
     * be switched from define mode, it happens here. */
@@ -785,8 +784,7 @@ nc4_put_vara(NC *nc, int ncid, int varid, const size_t *startp,
 #ifndef HDF5_CONVERT
    /* Are we going to convert any data? (No converting of compound or
     * opaque types.) */
-   if ((mem_nc_type != var->type_info->hdr.id || (var->type_info->hdr.id == NC_INT && is_long)) &&
-       mem_nc_type != NC_COMPOUND && mem_nc_type != NC_OPAQUE)
+   if (mem_nc_type != var->type_info->hdr.id)
    {
       size_t file_type_size;
 
@@ -924,7 +922,7 @@ nc4_put_vara(NC *nc, int ncid, int varid, const size_t *startp,
    {
       if ((retval = nc4_convert_type(data, bufr, mem_nc_type, var->type_info->hdr.id,
                                      len, &range_error, var->fill_value,
-                                     (h5->cmode & NC_CLASSIC_MODEL), is_long, 0)))
+                                     (h5->cmode & NC_CLASSIC_MODEL))))
          BAIL(retval);
    }
 #endif
@@ -983,7 +981,6 @@ exit:
  * @param countp Array of counts.
  * @param mem_nc_type The type of the data in memory. (Convert to this
  * type from file type.)
- * @param is_long True only if NC_LONG is the memory type.
  * @param data The data to be written.
  *
  * @returns ::NC_NOERR No error.
@@ -1000,7 +997,7 @@ exit:
  */
 int
 nc4_get_vara(NC *nc, int ncid, int varid, const size_t *startp,
-             const size_t *countp, nc_type mem_nc_type, int is_long, void *data)
+             const size_t *countp, nc_type mem_nc_type, void *data)
 {
    NC_GRP_INFO_T *grp;
    NC_HDF5_FILE_INFO_T *h5;
@@ -1033,8 +1030,8 @@ nc4_get_vara(NC *nc, int ncid, int varid, const size_t *startp,
    h5 = NC4_DATA(nc);
    assert(grp && h5 && var && var->hdr.name);
 
-   LOG((3, "%s: var->hdr.name %s mem_nc_type %d is_long %d",
-        __func__, var->hdr.name, mem_nc_type, is_long));
+   LOG((3, "%s: var->hdr.name %s mem_nc_type %d",
+        __func__, var->hdr.name, mem_nc_type));
 
    /* Check some stuff about the type and the file. */
    if ((retval = check_for_vara(&mem_nc_type, var, h5)))
@@ -1187,8 +1184,7 @@ nc4_get_vara(NC *nc, int ncid, int varid, const size_t *startp,
 #ifndef HDF5_CONVERT
       /* Are we going to convert any data? (No converting of compound or
        * opaque types.) */
-      if ((mem_nc_type != var->type_info->hdr.id || (var->type_info->hdr.id == NC_INT && is_long)) &&
-          mem_nc_type != NC_COMPOUND && mem_nc_type != NC_OPAQUE)
+      if (mem_nc_type != var->type_info->hdr.id)
       {
          /* We must convert - allocate a buffer. */
          need_to_convert++;
@@ -1251,7 +1247,7 @@ nc4_get_vara(NC *nc, int ncid, int varid, const size_t *startp,
       {
          if ((retval = nc4_convert_type(bufr, data, var->type_info->hdr.id, mem_nc_type,
                                         len, &range_error, var->fill_value,
-                                        (h5->cmode & NC_CLASSIC_MODEL), 0, is_long)))
+                                        (h5->cmode & NC_CLASSIC_MODEL))))
             BAIL(retval);
 
          /* For strict netcdf-3 rules, ignore erange errors between UBYTE
@@ -2915,25 +2911,20 @@ nc4_rec_write_groups_types(NC_GRP_INFO_T *grp)
  * @param range_error Pointer that gets 1 if there was a range error.
  * @param fill_value The fill value.
  * @param strict_nc3 Non-zero if strict model in effect.
- * @param src_long Is the source NC_LONG?
- * @param dest_long Is the destination NC_LONG?
  *
  * @returns NC_NOERR No error.
  * @returns NC_EBADTYPE Type not found.
  * @author Ed Hartnett
 */
 int
-nc4_convert_type(const void *src, void *dest,
-                 const nc_type src_type, const nc_type dest_type,
-                 const size_t len, int *range_error,
-                 const void *fill_value, int strict_nc3, int src_long,
-                 int dest_long)
+nc4_convert_type(const void *src, void *dest, const nc_type src_type,
+                 const nc_type dest_type, const size_t len, int *range_error,
+                 const void *fill_value, int strict_nc3)
 {
    char *cp, *cp1;
    float *fp, *fp1;
    double *dp, *dp1;
    int *ip, *ip1;
-   signed long *lp, *lp1;
    short *sp, *sp1;
    signed char *bp, *bp1;
    unsigned char *ubp, *ubp1;
@@ -2944,8 +2935,8 @@ nc4_convert_type(const void *src, void *dest,
    size_t count = 0;
 
    *range_error = 0;
-   LOG((3, "%s: len %d src_type %d dest_type %d src_long %d dest_long %d",
-        __func__, len, src_type, dest_type, src_long, dest_long));
+   LOG((3, "%s: len %d src_type %d dest_type %d",
+        __func__, len, src_type, dest_type));
 
    /* OK, this is ugly. If you can think of anything better, I'm open
       to suggestions!
@@ -2997,18 +2988,9 @@ nc4_convert_type(const void *src, void *dest,
          }
          break;
       case NC_INT:
-         if (dest_long)
-         {
-            for (bp = (signed char *)src, lp = dest; count < len; count++)
-               *lp++ = *bp++;
-            break;
-         }
-         else
-         {
-            for (bp = (signed char *)src, ip = dest; count < len; count++)
-               *ip++ = *bp++;
-            break;
-         }
+         for (bp = (signed char *)src, ip = dest; count < len; count++)
+            *ip++ = *bp++;
+         break;
       case NC_UINT:
          for (bp = (signed char *)src, uip = dest; count < len; count++)
          {
@@ -3068,18 +3050,9 @@ nc4_convert_type(const void *src, void *dest,
             *usp++ = *ubp++;
          break;
       case NC_INT:
-         if (dest_long)
-         {
-            for (ubp = (unsigned char *)src, lp = dest; count < len; count++)
-               *lp++ = *ubp++;
-            break;
-         }
-         else
-         {
-            for (ubp = (unsigned char *)src, ip = dest; count < len; count++)
-               *ip++ = *ubp++;
-            break;
-         }
+         for (ubp = (unsigned char *)src, ip = dest; count < len; count++)
+            *ip++ = *ubp++;
+         break;
       case NC_UINT:
          for (ubp = (unsigned char *)src, uip = dest; count < len; count++)
             *uip++ = *ubp++;
@@ -3139,12 +3112,8 @@ nc4_convert_type(const void *src, void *dest,
          }
          break;
       case NC_INT:
-         if (dest_long)
-            for (sp = (short *)src, lp = dest; count < len; count++)
-               *lp++ = *sp++;
-         else
-            for (sp = (short *)src, ip = dest; count < len; count++)
-               *ip++ = *sp++;
+         for (sp = (short *)src, ip = dest; count < len; count++)
+            *ip++ = *sp++;
          break;
       case NC_UINT:
          for (sp = (short *)src, uip = dest; count < len; count++)
@@ -3213,12 +3182,8 @@ nc4_convert_type(const void *src, void *dest,
             *usp1++ = *usp++;
          break;
       case NC_INT:
-         if (dest_long)
-            for (usp = (unsigned short *)src, lp = dest; count < len; count++)
-               *lp++ = *usp++;
-         else
-            for (usp = (unsigned short *)src, ip = dest; count < len; count++)
-               *ip++ = *usp++;
+         for (usp = (unsigned short *)src, ip = dest; count < len; count++)
+            *ip++ = *usp++;
          break;
       case NC_UINT:
          for (usp = (unsigned short *)src, uip = dest; count < len; count++)
@@ -3248,185 +3213,80 @@ nc4_convert_type(const void *src, void *dest,
       break;
 
    case NC_INT:
-      if (src_long)
+      switch (dest_type)
       {
-         switch (dest_type)
+      case NC_UBYTE:
+         for (ip = (int *)src, ubp = dest; count < len; count++)
          {
-         case NC_UBYTE:
-            for (lp = (long *)src, ubp = dest; count < len; count++)
-            {
-               if (*lp > X_UCHAR_MAX || *lp < 0)
-                  (*range_error)++;
-               *ubp++ = *lp++;
-            }
-            break;
-         case NC_BYTE:
-            for (lp = (long *)src, bp = dest; count < len; count++)
-            {
-               if (*lp > X_SCHAR_MAX || *lp < X_SCHAR_MIN)
-                  (*range_error)++;
-               *bp++ = *lp++;
-            }
-            break;
-         case NC_SHORT:
-            for (lp = (long *)src, sp = dest; count < len; count++)
-            {
-               if (*lp > X_SHORT_MAX || *lp < X_SHORT_MIN)
-                  (*range_error)++;
-               *sp++ = *lp++;
-            }
-            break;
-         case NC_USHORT:
-            for (lp = (long *)src, usp = dest; count < len; count++)
-            {
-               if (*lp > X_USHORT_MAX || *lp < 0)
-                  (*range_error)++;
-               *usp++ = *lp++;
-            }
-            break;
-         case NC_INT: /* src is long */
-            if (dest_long)
-            {
-               for (lp = (long *)src, lp1 = dest; count < len; count++)
-               {
-                  if (*lp > X_LONG_MAX || *lp < X_LONG_MIN)
-                     (*range_error)++;
-                  *lp1++ = *lp++;
-               }
-            }
-            else /* dest is int */
-            {
-               for (lp = (long *)src, ip = dest; count < len; count++)
-               {
-                  if (*lp > X_INT_MAX || *lp < X_INT_MIN)
-                     (*range_error)++;
-                  *ip++ = *lp++;
-               }
-            }
-            break;
-         case NC_UINT:
-            for (lp = (long *)src, uip = dest; count < len; count++)
-            {
-               if (*lp > X_UINT_MAX || *lp < 0)
-                  (*range_error)++;
-               *uip++ = *lp++;
-            }
-            break;
-         case NC_INT64:
-            for (lp = (long *)src, lip = dest; count < len; count++)
-               *lip++ = *lp++;
-            break;
-         case NC_UINT64:
-            for (lp = (long *)src, ulip = dest; count < len; count++)
-            {
-               if (*lp < 0)
-                  (*range_error)++;
-               *ulip++ = *lp++;
-            }
-            break;
-         case NC_FLOAT:
-            for (lp = (long *)src, fp = dest; count < len; count++)
-               *fp++ = *lp++;
-            break;
-         case NC_DOUBLE:
-            for (lp = (long *)src, dp = dest; count < len; count++)
-               *dp++ = *lp++;
-            break;
-         default:
-            LOG((0, "%s: unexpected dest type. src_type %d, dest_type %d",
-                 __func__, src_type, dest_type));
-            return NC_EBADTYPE;
+            if (*ip > X_UCHAR_MAX || *ip < 0)
+               (*range_error)++;
+            *ubp++ = *ip++;
          }
-      }
-      else
-      {
-         switch (dest_type)
+         break;
+      case NC_BYTE:
+         for (ip = (int *)src, bp = dest; count < len; count++)
          {
-         case NC_UBYTE:
-            for (ip = (int *)src, ubp = dest; count < len; count++)
-            {
-               if (*ip > X_UCHAR_MAX || *ip < 0)
-                  (*range_error)++;
-               *ubp++ = *ip++;
-            }
-            break;
-         case NC_BYTE:
-            for (ip = (int *)src, bp = dest; count < len; count++)
-            {
-               if (*ip > X_SCHAR_MAX || *ip < X_SCHAR_MIN)
-                  (*range_error)++;
-               *bp++ = *ip++;
-            }
-            break;
-         case NC_SHORT:
-            for (ip = (int *)src, sp = dest; count < len; count++)
-            {
-               if (*ip > X_SHORT_MAX || *ip < X_SHORT_MIN)
-                  (*range_error)++;
-               *sp++ = *ip++;
-            }
-            break;
-         case NC_USHORT:
-            for (ip = (int *)src, usp = dest; count < len; count++)
-            {
-               if (*ip > X_USHORT_MAX || *ip < 0)
-                  (*range_error)++;
-               *usp++ = *ip++;
-            }
-            break;
-         case NC_INT: /* src is int */
-            if (dest_long)
-            {
-               for (ip = (int *)src, lp1 = dest; count < len; count++)
-               {
-                  if (*ip > X_LONG_MAX || *ip < X_LONG_MIN)
-                     (*range_error)++;
-                  *lp1++ = *ip++;
-               }
-            }
-            else /* dest is int */
-            {
-               for (ip = (int *)src, ip1 = dest; count < len; count++)
-               {
-                  if (*ip > X_INT_MAX || *ip < X_INT_MIN)
-                     (*range_error)++;
-                  *ip1++ = *ip++;
-               }
-            }
-            break;
-         case NC_UINT:
-            for (ip = (int *)src, uip = dest; count < len; count++)
-            {
-               if (*ip > X_UINT_MAX || *ip < 0)
-                  (*range_error)++;
-               *uip++ = *ip++;
-            }
-            break;
-         case NC_INT64:
-            for (ip = (int *)src, lip = dest; count < len; count++)
-               *lip++ = *ip++;
-            break;
-         case NC_UINT64:
-            for (ip = (int *)src, ulip = dest; count < len; count++)
-            {
-               if (*ip < 0)
-                  (*range_error)++;
-               *ulip++ = *ip++;
-            }
-            break;
-         case NC_FLOAT:
-            for (ip = (int *)src, fp = dest; count < len; count++)
-               *fp++ = *ip++;
-            break;
-         case NC_DOUBLE:
-            for (ip = (int *)src, dp = dest; count < len; count++)
-               *dp++ = *ip++;
-            break;
-         default:
-            LOG((0, "%s: unexpected dest type. src_type %d, dest_type %d",
-                 __func__, src_type, dest_type));
-            return NC_EBADTYPE;
+            if (*ip > X_SCHAR_MAX || *ip < X_SCHAR_MIN)
+               (*range_error)++;
+            *bp++ = *ip++;
          }
+         break;
+      case NC_SHORT:
+         for (ip = (int *)src, sp = dest; count < len; count++)
+         {
+            if (*ip > X_SHORT_MAX || *ip < X_SHORT_MIN)
+               (*range_error)++;
+            *sp++ = *ip++;
+         }
+         break;
+      case NC_USHORT:
+         for (ip = (int *)src, usp = dest; count < len; count++)
+         {
+            if (*ip > X_USHORT_MAX || *ip < 0)
+               (*range_error)++;
+            *usp++ = *ip++;
+         }
+         break;
+      case NC_INT: /* src is int */
+         for (ip = (int *)src, ip1 = dest; count < len; count++)
+         {
+            if (*ip > X_INT_MAX || *ip < X_INT_MIN)
+               (*range_error)++;
+            *ip1++ = *ip++;
+         }
+         break;
+      case NC_UINT:
+         for (ip = (int *)src, uip = dest; count < len; count++)
+         {
+            if (*ip > X_UINT_MAX || *ip < 0)
+               (*range_error)++;
+            *uip++ = *ip++;
+         }
+         break;
+      case NC_INT64:
+         for (ip = (int *)src, lip = dest; count < len; count++)
+            *lip++ = *ip++;
+         break;
+      case NC_UINT64:
+         for (ip = (int *)src, ulip = dest; count < len; count++)
+         {
+            if (*ip < 0)
+               (*range_error)++;
+            *ulip++ = *ip++;
+         }
+         break;
+      case NC_FLOAT:
+         for (ip = (int *)src, fp = dest; count < len; count++)
+            *fp++ = *ip++;
+         break;
+      case NC_DOUBLE:
+         for (ip = (int *)src, dp = dest; count < len; count++)
+            *dp++ = *ip++;
+         break;
+      default:
+         LOG((0, "%s: unexpected dest type. src_type %d, dest_type %d",
+              __func__, src_type, dest_type));
+         return NC_EBADTYPE;
       }
       break;
 
@@ -3466,20 +3326,12 @@ nc4_convert_type(const void *src, void *dest,
          }
          break;
       case NC_INT:
-         if (dest_long)
-            for (uip = (unsigned int *)src, lp = dest; count < len; count++)
-            {
-               if (*uip > X_LONG_MAX)
-                  (*range_error)++;
-               *lp++ = *uip++;
-            }
-         else
-            for (uip = (unsigned int *)src, ip = dest; count < len; count++)
-            {
-               if (*uip > X_INT_MAX)
-                  (*range_error)++;
-               *ip++ = *uip++;
-            }
+         for (uip = (unsigned int *)src, ip = dest; count < len; count++)
+         {
+            if (*uip > X_INT_MAX)
+               (*range_error)++;
+            *ip++ = *uip++;
+         }
          break;
       case NC_UINT:
          for (uip = (unsigned int *)src, uip1 = dest; count < len; count++)
@@ -3556,20 +3408,12 @@ nc4_convert_type(const void *src, void *dest,
          }
          break;
       case NC_INT:
-         if (dest_long)
-            for (lip = (long long *)src, lp = dest; count < len; count++)
-            {
-               if (*lip > X_LONG_MAX || *lip < X_LONG_MIN)
-                  (*range_error)++;
-               *lp++ = *lip++;
-            }
-         else
-            for (lip = (long long *)src, ip = dest; count < len; count++)
-            {
-               if (*lip > X_INT_MAX || *lip < X_INT_MIN)
-                  (*range_error)++;
-               *ip++ = *lip++;
-            }
+         for (lip = (long long *)src, ip = dest; count < len; count++)
+         {
+            if (*lip > X_INT_MAX || *lip < X_INT_MIN)
+               (*range_error)++;
+            *ip++ = *lip++;
+         }
          break;
       case NC_INT64:
          for (lip = (long long *)src, lip1 = dest; count < len; count++)
@@ -3642,20 +3486,12 @@ nc4_convert_type(const void *src, void *dest,
          }
          break;
       case NC_INT:
-         if (dest_long)
-            for (ulip = (unsigned long long *)src, lp = dest; count < len; count++)
-            {
-               if (*ulip > X_LONG_MAX)
-                  (*range_error)++;
-               *lp++ = *ulip++;
-            }
-         else
-            for (ulip = (unsigned long long *)src, ip = dest; count < len; count++)
-            {
-               if (*ulip > X_INT_MAX)
-                  (*range_error)++;
-               *ip++ = *ulip++;
-            }
+         for (ulip = (unsigned long long *)src, ip = dest; count < len; count++)
+         {
+            if (*ulip > X_INT_MAX)
+               (*range_error)++;
+            *ip++ = *ulip++;
+         }
          break;
       case NC_INT64:
          for (ulip = (unsigned long long *)src, lip = dest; count < len; count++)
@@ -3728,20 +3564,12 @@ nc4_convert_type(const void *src, void *dest,
          }
          break;
       case NC_INT:
-         if (dest_long)
-            for (fp = (float *)src, lp = dest; count < len; count++)
-            {
-               if (*fp > (double)X_LONG_MAX || *fp < (double)X_LONG_MIN)
-                  (*range_error)++;
-               *lp++ = *fp++;
-            }
-         else
-            for (fp = (float *)src, ip = dest; count < len; count++)
-            {
-               if (*fp > (double)X_INT_MAX || *fp < (double)X_INT_MIN)
-                  (*range_error)++;
-               *ip++ = *fp++;
-            }
+         for (fp = (float *)src, ip = dest; count < len; count++)
+         {
+            if (*fp > (double)X_INT_MAX || *fp < (double)X_INT_MIN)
+               (*range_error)++;
+            *ip++ = *fp++;
+         }
          break;
       case NC_INT64:
          for (fp = (float *)src, lip = dest; count < len; count++)
@@ -3822,20 +3650,12 @@ nc4_convert_type(const void *src, void *dest,
          }
          break;
       case NC_INT:
-         if (dest_long)
-            for (dp = (double *)src, lp = dest; count < len; count++)
-            {
-               if (*dp > X_LONG_MAX || *dp < X_LONG_MIN)
-                  (*range_error)++;
-               *lp++ = *dp++;
-            }
-         else
-            for (dp = (double *)src, ip = dest; count < len; count++)
-            {
-               if (*dp > X_INT_MAX || *dp < X_INT_MIN)
-                  (*range_error)++;
-               *ip++ = *dp++;
-            }
+         for (dp = (double *)src, ip = dest; count < len; count++)
+         {
+            if (*dp > X_INT_MAX || *dp < X_INT_MIN)
+               (*range_error)++;
+            *ip++ = *dp++;
+         }
          break;
       case NC_INT64:
          for (dp = (double *)src, lip = dest; count < len; count++)

--- a/libsrc4/nc4attr.c
+++ b/libsrc4/nc4attr.c
@@ -206,7 +206,7 @@ nc4_get_att(int ncid, int varid, const char *name, nc_type *xtype,
       need_to_convert++;
       if ((retval = nc4_convert_type(att->data, bufr, att->nc_typeid,
                                      mem_type, (size_t)att->len, &range_error,
-                                     NULL, (h5->cmode & NC_CLASSIC_MODEL), 0, 0)))
+                                     NULL, (h5->cmode & NC_CLASSIC_MODEL))))
          BAIL(retval);
 
       /* For strict netcdf-3 rules, ignore erange errors between UBYTE
@@ -924,7 +924,7 @@ NC4_put_att(int ncid, int varid, const char *name, nc_type file_type,
             /* Data types are like religions, in that one can convert.  */
             if ((retval = nc4_convert_type(data, att->data, mem_type, file_type,
                                            len, &range_error, NULL,
-                                           (h5->cmode & NC_CLASSIC_MODEL), 0, 0)))
+                                           (h5->cmode & NC_CLASSIC_MODEL))))
                BAIL(retval);
          }
       }

--- a/libsrc4/nc4var.c
+++ b/libsrc4/nc4var.c
@@ -1673,7 +1673,7 @@ NC4_put_vara(int ncid, int varid, const size_t *startp,
    if (!(nc = nc4_find_nc_file(ncid, NULL)))
       return NC_EBADID;
 
-   return nc4_put_vara(nc, ncid, varid, startp, countp, memtype, 0, (void *)op);
+   return nc4_put_vara(nc, ncid, varid, startp, countp, memtype, (void *)op);
 }
 
 /**
@@ -1705,6 +1705,5 @@ NC4_get_vara(int ncid, int varid, const size_t *startp,
       return NC_EBADID;
 
    /* Get the data. */
-   return nc4_get_vara(nc, ncid, varid, startp, countp, memtype,
-                       0, (void *)ip);
+   return nc4_get_vara(nc, ncid, varid, startp, countp, memtype, (void *)ip);
 }


### PR DESCRIPTION
Fixes #997.

The new way of handling long vs. int is much simpler. There was a lot of code associated with the old way of handling long vs. int which this PR removes.

