### PR TITLE
Revert "fix cdf5 configure option"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,19 +12,19 @@ services:
 env:
     matrix:
 # Ubuntu
-        - DOCKIMG=unidata/nctests:serial   USECMAKE=TRUE USEAC=TRUE DISTCHECK=TRUE USE_CC=gcc   AC_COPTS='CFLAGS=-fsigned-char --disable-netcdf-4 --disable-dap-remote-tests --enable-cdf5' COPTS='-DENABLE_NETCDF_4=OFF -DCMAKE_C_FLAGS=-fsigned-char -DENABLE_DAP_REMOTE_TESTS=OFF -DENABLE_CDF5=ON' USECP=FALSE CURHOST=docker-gcc-x64-signed
+        - DOCKIMG=unidata/nctests:serial   USECMAKE=TRUE USEAC=TRUE DISTCHECK=TRUE USE_CC=gcc   AC_COPTS='CFLAGS=-fsigned-char --disable-netcdf-4 --disable-dap-remote-tests --enable-cdf5' COPTS='-DENABLE_NETCDF_4=OFF -DCMAKE_C_FLAGS=-fsigned-char -DENABLE_DAP_REMOTE_TESTS=OFF -DENABLE_CDF5=TRUE' USECP=FALSE CURHOST=docker-gcc-x64-signed
 
         - DOCKIMG=unidata/nctests:serial32 USECMAKE=TRUE USEAC=TRUE DISTCHECK=TRUE USE_CC=gcc   AC_COPTS='CFLAGS=-fsigned-char --disable-netcdf-4 --disable-dap-remote-tests' COPTS='-DENABLE_NETCDF_4=OFF -DCMAKE_C_FLAGS=-fsigned-char -DENABLE_DAP_REMOTE_TESTS=OFF -DENABLE_CDF5=OFF' USECP=FALSE CURHOST=docker-gcc-x86-signed
 
-        - DOCKIMG=unidata/nctests:serial   USECMAKE=TRUE USEAC=TRUE DISTCHECK=TRUE USE_CC=gcc   AC_COPTS='CFLAGS=-funsigned-char --disable-netcdf-4 --disable-dap-remote-tests --enable-cdf5' COPTS='-DENABLE_NETCDF_4=OFF -DCMAKE_C_FLAGS=-funsigned-char -DENABLE_DAP_REMOTE_TESTS=OFF -DENABLE_CDF5=ON' USECP=FALSE CURHOST=docker-gcc-x64-unsigned
+        - DOCKIMG=unidata/nctests:serial   USECMAKE=TRUE USEAC=TRUE DISTCHECK=TRUE USE_CC=gcc   AC_COPTS='CFLAGS=-funsigned-char --disable-netcdf-4 --disable-dap-remote-tests --enable-cdf5' COPTS='-DENABLE_NETCDF_4=OFF -DCMAKE_C_FLAGS=-funsigned-char -DENABLE_DAP_REMOTE_TESTS=OFF -DENABLE_CDF5=TRUE' USECP=FALSE CURHOST=docker-gcc-x64-unsigned
 
         - DOCKIMG=unidata/nctests:serial32 USECMAKE=TRUE USEAC=TRUE DISTCHECK=TRUE USE_CC=gcc   AC_COPTS='CFLAGS=-funsigned-char --disable-netcdf-4 --disable-dap-remote-tests' COPTS='-DENABLE_NETCDF_4=OFF -DCMAKE_C_FLAGS=-funsigned-char -DENABLE_DAP_REMOTE_TESTS=OFF -DENABLE_CDF5=OFF' USECP=FALSE CURHOST=docker-gcc-x86-unsigned
 
-        - DOCKIMG=unidata/nctests:serial   USECMAKE=TRUE USEAC=TRUE DISTCHECK=TRUE USE_CC=gcc   AC_COPTS='CFLAGS=-fsigned-char --disable-dap-remote-tests --enable-cdf5' COPTS='-DCMAKE_C_FLAGS=-fsigned-char -DENABLE_DAP_REMOTE_TESTS=OFF -DENABLE_CDF5=ON' USECP=FALSE CURHOST=docker-gcc-x64-signed
+        - DOCKIMG=unidata/nctests:serial   USECMAKE=TRUE USEAC=TRUE DISTCHECK=TRUE USE_CC=gcc   AC_COPTS='CFLAGS=-fsigned-char --disable-dap-remote-tests --enable-cdf5' COPTS='-DCMAKE_C_FLAGS=-fsigned-char -DENABLE_DAP_REMOTE_TESTS=OFF -DENABLE_CDF5=TRUE' USECP=FALSE CURHOST=docker-gcc-x64-signed
 
         - DOCKIMG=unidata/nctests:serial32 USECMAKE=TRUE USEAC=TRUE DISTCHECK=TRUE USE_CC=gcc   AC_COPTS='CFLAGS=-fsigned-char --disable-dap-remote-tests' COPTS='-DCMAKE_C_FLAGS=-fsigned-char -DENABLE_DAP_REMOTE_TESTS=OFF -DENABLE_CDF5=OFF' USECP=FALSE CURHOST=docker-gcc-x86-signed
 
-        - DOCKIMG=unidata/nctests:serial   USECMAKE=TRUE USEAC=TRUE DISTCHECK=TRUE USE_CC=gcc   AC_COPTS='CFLAGS=-funsigned-char --disable-dap-remote-tests --enable-cdf5' COPTS='-DCMAKE_C_FLAGS=-funsigned-char -DENABLE_DAP_REMOTE_TESTS=OFF -DENABLE_CDF5=ON' USECP=FALSE CURHOST=docker-gcc-x64-unsigned
+        - DOCKIMG=unidata/nctests:serial   USECMAKE=TRUE USEAC=TRUE DISTCHECK=TRUE USE_CC=gcc   AC_COPTS='CFLAGS=-funsigned-char --disable-dap-remote-tests --enable-cdf5' COPTS='-DCMAKE_C_FLAGS=-funsigned-char -DENABLE_DAP_REMOTE_TESTS=OFF -DENABLE_CDF5=TRUE' USECP=FALSE CURHOST=docker-gcc-x64-unsigned
 
         - DOCKIMG=unidata/nctests:serial32 USECMAKE=TRUE USEAC=TRUE DISTCHECK=TRUE USE_CC=gcc   AC_COPTS='CFLAGS=-funsigned-char --disable-dap-remote-tests' COPTS='-DCMAKE_C_FLAGS=-funsigned-char -DENABLE_DAP_REMOTE_TESTS=OFF -DENABLE_CDF5=OFF' USECP=FALSE CURHOST=docker-gcc-x86-unsigned
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -306,12 +306,6 @@ ENDIF()
 # Option checks
 ################################
 
-set(ENABLE_CDF5 AUTO CACHE STRING "Enable CDF5 support")
-set_property(CACHE ENABLE_CDF5 PROPERTY STRINGS AUTO ON OFF)
-IF(NOT ENABLE_CDF5 STREQUAL "AUTO" AND NOT ENABLE_CDF5 STREQUAL "ON" AND NOT ENABLE_CDF5 STREQUAL "OFF")
-   MESSAGE(FATAL_ERROR "Invalid value (\"${ENABLE_CDF5}\") used in setting ENABLE_CDF5")
-ENDIF(NOT ENABLE_CDF5 STREQUAL "AUTO" AND NOT ENABLE_CDF5 STREQUAL "ON" AND NOT ENABLE_CDF5 STREQUAL "OFF")
-
 # HDF5 cache variables.
 SET(DEFAULT_CHUNK_SIZE 4194304 CACHE STRING "Default Chunk Cache Size.")
 SET(DEFAULT_CHUNKS_IN_CACHE 10 CACHE STRING "Default number of chunks in cache.")
@@ -772,6 +766,12 @@ IF(USE_HDF5 OR ENABLE_NETCDF_4)
 
 
 ENDIF(USE_HDF5 OR ENABLE_NETCDF_4)
+
+# Option to turn on CDF5 support.
+OPTION(ENABLE_CDF5 "Enable CDF5 Support." ON)
+IF(ENABLE_CDF5)
+    SET(USE_CDF5 ON CACHE BOOL "")
+ENDIF(ENABLE_CDF5)
 
 # Option to Build DAP2+DAP4 Clients
 OPTION(ENABLE_DAP "Enable DAP2 and DAP4 Client." ON)
@@ -1292,20 +1292,6 @@ ENDIF(SIZEOF_USHORT)
 CHECK_TYPE_SIZE("_Bool"     SIZEOF__BOOL)
 
 CHECK_TYPE_SIZE("size_t"    SIZEOF_SIZE_T)
-
-# Check whether to turn on or off CDF5 support.
-IF(SIZEOF_SIZE_T EQUAL 4)
-   IF(ENABLE_CDF5 STREQUAL "ON") # error out if explicitly enabled by user
-      MESSAGE(FATAL_ERROR "Unable to support CDF5 feature because size_t is less than 8 bytes")
-   ENDIF(ENABLE_CDF5 STREQUAL "ON")
-   SET(USE_CDF5 OFF CACHE BOOL "") # cannot support CDF5
-ELSE(SIZEOF_SIZE_T EQUAL 4)
-   IF(ENABLE_CDF5 STREQUAL "OFF") # explicitly disabled by user
-      SET(USE_CDF5 OFF CACHE BOOL "")
-   ELSE(ENABLE_CDF5 STREQUAL "OFF") # explicitly set by user or not set
-      SET(USE_CDF5 ON CACHE BOOL "")
-   ENDIF(ENABLE_CDF5 STREQUAL "OFF")
-ENDIF(SIZEOF_SIZE_T EQUAL 4)
 
 CHECK_TYPE_SIZE("ssize_t"   SIZEOF_SSIZE_T)
 IF(SIZEOF_SSIZE_T)

--- a/configure.ac
+++ b/configure.ac
@@ -886,22 +886,20 @@ $SLEEPCMD
 AC_CHECK_SIZEOF(unsigned long long)
 
 # Check whether we want to enable CDF5 support.
-AC_MSG_CHECKING([whether CDF5 support should be disabled])
+AC_MSG_CHECKING([whether CDF5 support should be enabled])
 AC_ARG_ENABLE([cdf5],
-              [AS_HELP_STRING([--disable-cdf5],
+              [AS_HELP_STRING([--enable-cdf5],
                               [build without CDF5 support.])],
               [enable_cdf5=${enableval}], [enable_cdf5=auto]
 )
+if test "x${enable_cdf5}" = xyes && test "$ac_cv_sizeof_size_t" -lt "8" ; then
+   dnl unable to support CDF5, but --enable-cdf5 is explicitly set
+   AC_MSG_ERROR([Unable to support CDF5 feature because size_t is less than 4 bytes])
+fi
 if test "$ac_cv_sizeof_size_t" -lt "8" ; then
-   if test "x${enable_cdf5}" = xyes ; then
-      dnl unable to support CDF5, but --enable-cdf5 is explicitly set
-      AC_MSG_ERROR([Unable to support CDF5 feature because size_t is less than 8 bytes])
-   fi
    enable_cdf5=no
 else
-   if test "x${enable_cdf5}" != xno ; then
-      enable_cdf5=yes
-   fi
+   enable_cdf5=yes
 fi
 AC_MSG_RESULT($enable_cdf5)
 


### PR DESCRIPTION
Reverts Unidata/netcdf-c#1033 due to failures observed after the merge.  We can fix these and re-apply this merge.

Failure details can be seen here:

* http://cdash.unidata.ucar.edu/viewTest.php?onlyfailed&buildid=3790