### PR TITLE
Remove compiler warning

### DIFF
--- a/include/netcdf.h
+++ b/include/netcdf.h
@@ -1741,10 +1741,12 @@ EXTERNL int
 nc_get_var_ubyte(int ncid, int varid, unsigned char *ip);
 /* End Deprecated */
 
+#ifndef ENABLE_SET_LOG_LEVEL
 /* Set the log level. 0 shows only errors, 1 only major messages,
  * etc., to 5, which shows way too much information. */
 EXTERNL int
 nc_set_log_level(int new_level);
+#endif
 
 /* Use this to turn off logging by calling
    nc_log_level(NC_TURN_OFF_LOGGING) */


### PR DESCRIPTION
If `ENABLE_SET_LOG_LEVEL` is not defined, then `nc_set_log_level()` is removed via a macro such that `nc_set_log_level(val)` will be replaced by the C preprocessor to be nothing.  This works fine in the code, but in the `netcdf.h` include file, it results in an empty declaration of `EXTERNL int;` which causes the compiler warning: `TPL/netcdf/netcdf-c/include/netcdf.h:1751: warning: useless type name in empty declaration`.

This change removes the declaration of `nc_set_log_level()` if `ENABLE_SET_LOG_LEVEL` is not defined.