### PR TITLE
add NC_HAS_PARALLEL4 to netcdf_meta.h.in

### DIFF
--- a/include/netcdf_meta.h.in
+++ b/include/netcdf_meta.h.in
@@ -48,8 +48,8 @@
 #define NC_HAS_MMAP      @NC_HAS_MMAP@ /*!< mmap support. */
 #define NC_HAS_JNA       @NC_HAS_JNA@ /*!< jna support. */
 #define NC_HAS_PNETCDF   @NC_HAS_PNETCDF@ /*!< pnetcdf support. */
-#define NC_HAS_PARALLEL  @NC_HAS_PARALLEL@ /*!< parallel IO support via hdf5 and
-/or pnetcdf. */
+#define NC_HAS_PARALLEL4 @NC_HAS_PARALLEL4@ /*!< parallel IO support via hdf5 */
+#define NC_HAS_PARALLEL  @NC_HAS_PARALLEL@ /*!< parallel IO support via hdf5 and/or pnetcdf. */
 
 #define NC_HAS_CDF5      @NC_HAS_CDF5@  /*!< CDF5 support. */
 #define NC_HAS_ERANGE_FILL @NC_HAS_ERANGE_FILL@ /*!< ERANGE_FILL Support */


### PR DESCRIPTION
NC_HAS_PARALLEL4, NC_HAS_PARALLEL, and NC_HAS_PNETCDF can be used by netcdf-fortran, netcdf-cxx, and others.