### PR TITLE
introduce error code NC_EPNETCDF for errors at PnetCDF level

### DIFF
--- a/docs/all-error-codes.md
+++ b/docs/all-error-codes.md
@@ -71,6 +71,7 @@ may occur.
 #define NC_ENOTFOUND     (-90)  // No such file
 #define NC_ECANTREMOVE   (-91)  // Cannot remove file
 #define NC_EINTERNAL     (-92)  // NetCDF Library Internal Error
+#define NC_EPNETCDF      (-93)  // Error at PnetCDF layer
 ~~~~
 
 # NetCDF-4 Error Codes {#nc4-error-codes}

--- a/include/netcdf.h
+++ b/include/netcdf.h
@@ -426,6 +426,7 @@ by the desired type. */
 #define NC_ENOTFOUND     (-90)      /**< No such file */
 #define NC_ECANTREMOVE   (-91)      /**< Can't remove file */
 #define NC_EINTERNAL     (-92)      /**< NetCDF Library Internal Error */
+#define NC_EPNETCDF      (-93)      /**< Error at PnetCDF layer */
 
 /* The following was added in support of netcdf-4. Make all netcdf-4
    error codes < -100 so that errors can be added to netcdf-3 if

--- a/libdispatch/derror.c
+++ b/libdispatch/derror.c
@@ -196,6 +196,8 @@ const char *nc_strerror(int ncerr1)
 	 return "NetCDF: cannot delete file";
       case NC_EINTERNAL:
 	 return "NetCDF: internal library error; Please contact Unidata support";
+      case NC_EPNETCDF:
+	 return "NetCDF: PnetCDF error";
       case NC_EHDFERR:
 	 return "NetCDF: HDF error";
       case NC_ECANTREAD:

--- a/libsrcp/ncpdispatch.c
+++ b/libsrcp/ncpdispatch.c
@@ -15,14 +15,9 @@
 
 typedef struct NCP_INFO
 {
-   /* pnetcdf_file will be true if the file is created/opened with the
-    * parallel-netcdf library. pnetcdf_access_mode keeps track of
-    * whether independpent or collective mode is
-    * desired. pnetcdf_ndims keeps track of how many dims each var
-    * has, which I need to know to convert start, count, and stride
-    * arrays from size_t to MPI_Offset. (I can't use an inq function
-    * to find out the number of dims, because these are collective in
-    * pnetcdf.) */
+   /* pnetcdf_access_mode keeps track of whether independpent or collective
+    * mode is set currently.
+    */
    int pnetcdf_access_mode;
 } NCP_INFO;
 
@@ -46,8 +41,8 @@ NCP_create(const char *path, int cmode,
 {
     int res, default_format;
     NCP_INFO* nc5;
-    MPI_Comm comm = MPI_COMM_WORLD;
-    MPI_Info info = MPI_INFO_NULL;
+    MPI_Comm comm;
+    MPI_Info info;
 
     /* Check the cmode for only valid flags*/
     if(cmode & ~LEGAL_CREATE_FLAGS)
@@ -88,23 +83,9 @@ NCP_create(const char *path, int cmode,
     /* Link nc5 and nc */
     NCP_DATA_SET(nc,nc5);
 
-    /* Fix up the cmode by keeping only essential flags;
-       these are the flags that are the same in netcf.h and pnetcdf.h
-    */
-    /* It turns out that pnetcdf.h defines a flag called
-       NC_64BIT_DATA (not to be confused with NC_64BIT_OFFSET).
-       This flag is essential to getting ncmpi_create to create
-       a proper pnetcdf format file.
-       We have set the value of NC_64BIT_DATA to be the same as in pnetcdf.h
-       (as of pnetcdf version 1.6.0) to avoid conflicts.
-       In any case, this flag must be set.
-    */
-    /* PnetCDF recognizes the flags below for create and ignores NC_LOCK and  NC_SHARE */
-    cmode &= (NC_WRITE | NC_NOCLOBBER | NC_SHARE | NC_64BIT_OFFSET | NC_64BIT_DATA);
-
     res = ncmpi_create(comm, path, cmode, info, &(nc->int_ncid));
 
-    if(res && nc5 != NULL) free(nc5); /* reclaim allocated space */
+    if (res != NC_NOERR) free(nc5); /* reclaim allocated space */
 done:
     return res;
 }
@@ -117,36 +98,19 @@ NCP_open(const char *path, int cmode,
 {
     int res;
     NCP_INFO* nc5;
-    MPI_Comm comm = MPI_COMM_WORLD;
-    MPI_Info info = MPI_INFO_NULL;
+    MPI_Comm comm;
+    MPI_Info info;
 
     /* Check the cmode for only valid flags*/
     if(cmode & ~LEGAL_OPEN_FLAGS)
 	{res = NC_EINVAL; goto done;}
 
-    /* Cannot have both MPIO flags */
-    if((cmode & (NC_MPIIO|NC_MPIPOSIX)) == (NC_MPIIO|NC_MPIPOSIX))
-	{res = NC_EINVAL; goto done;}
+    /* No MPI environment initialized */
+    if (mpidata == NULL)
+	{res = NC_ENOPAR; goto done;}
 
-    /* Appears that this comment is wrong; allow 64 bit offset*/
-    /* Cannot have 64 bit offset flag */
-    /* if(cmode & (NC_64BIT_OFFSET)) {res = NC_EINVAL; goto done;} */
-    if(mpidata != NULL) {
-        comm = ((NC_MPI_INFO *)mpidata)->comm;
-        info = ((NC_MPI_INFO *)mpidata)->info;
-    } else {
-	comm = MPI_COMM_WORLD;
-	info = MPI_INFO_NULL;
-    }
-
-   /* PnetCDF recognizes the flags NC_WRITE and NC_NOCLOBBER for file open
-     * and ignores NC_LOCK, NC_SHARE, NC_64BIT_OFFSET, and NC_64BIT_DATA.
-     * Ignoring the NC_64BIT_OFFSET and NC_64BIT_DATA flags is because the
-     * file is already in one of the CDF-formats, and setting these 2 flags
-     * will not change the format of that file.
-     */
-
-    cmode &= (NC_WRITE | NC_NOCLOBBER);
+    comm = ((NC_MPI_INFO *)mpidata)->comm;
+    info = ((NC_MPI_INFO *)mpidata)->info;
 
     /* Create our specific NCP_INFO instance */
     nc5 = (NCP_INFO*)calloc(1,sizeof(NCP_INFO));
@@ -158,7 +122,7 @@ NCP_open(const char *path, int cmode,
     res = ncmpi_open(comm, path, cmode, info, &(nc->int_ncid));
 
     /* Default to independent access, like netCDF-4/HDF5 files. */
-    if(!res) {
+    if (res == NC_NOERR) {
 	res = ncmpi_begin_indep_data(nc->int_ncid);
 	nc5->pnetcdf_access_mode = NC_INDEPENDENT;
     }
@@ -193,9 +157,8 @@ NCP__enddef(int ncid, size_t h_minfree, size_t v_align, size_t v_minfree, size_t
     nc5 = NCP_DATA(nc);
     assert(nc5);
 
-    /* causes implicitly defined warning; may be because of old installed pnetcdf? */
-#if 1
-    /* In PnetCDF ncmpi__enddef() is only implemented in v1.5.0 and later */
+#if (PNETCDF_VERSION_MAJOR*10000 + PNETCDF_VERSION_MINOR*100 + PNETCDF_VERSION_SUB >= 10500)
+    /* ncmpi__enddef() was first implemented in PnetCDF v1.5.0 */
     status = ncmpi__enddef(nc->int_ncid, mpi_h_minfree, mpi_v_align,
                            mpi_v_minfree, mpi_r_align);
 #else
@@ -257,7 +220,12 @@ NCP_set_fill(int ncid, int fillmode, int *old_mode_ptr)
     NC* nc;
     int status = NC_check_id(ncid, &nc);
     if(status != NC_NOERR) return status;
+#if (PNETCDF_VERSION_MAJOR*10000 + PNETCDF_VERSION_MINOR*100 + PNETCDF_VERSION_SUB >= 10601)
+    /* ncmpi_set_fill was first implemented in PnetCDF 1.6.1 */
     return ncmpi_set_fill(nc->int_ncid,fillmode,old_mode_ptr);
+#else
+    return NC_EPNETCDF;
+#endif
 }
 
 static int
@@ -314,7 +282,7 @@ NCP_inq_type(int ncid, nc_type typeid, char* name, size_t* size)
 {
     /* Assert mode & NC_FORMAT_CDF5 */
     if (typeid < NC_BYTE || typeid >= NC_STRING)
-           return NC_EBADTYPE;
+        return NC_EBADTYPE;
     if(name)
 	strcpy(name, NC_atomictypename(typeid));
     if(size)
@@ -440,15 +408,14 @@ NCP_get_att(
 {
     NC* nc;
     int status;
-    nc_type xtype;
 
     status = NC_check_id(ncid, &nc);
     if(status != NC_NOERR) return status;
 
-    status = NCP_inq_att(ncid,varid,name,&xtype,NULL);
-    if(status != NC_NOERR) return status;
-
-    if(memtype == NC_NAT) memtype = xtype;
+    if (memtype == NC_NAT) {
+        status = NCP_inq_att(ncid,varid,name,&memtype,NULL);
+        if (status != NC_NOERR) return status;
+    }
 
     switch (memtype) {
     case NC_CHAR:
@@ -1171,7 +1138,13 @@ NCP_inq_var_all(int ncid, int varid, char *name, nc_type *xtypep,
     if(deflatep) *deflatep = 0;
     if(fletcher32p) *fletcher32p = 0;
     if(contiguousp) *contiguousp = NC_CONTIGUOUS;
+#if (PNETCDF_VERSION_MAJOR*10000 + PNETCDF_VERSION_MINOR*100 + PNETCDF_VERSION_SUB >= 10601)
+    /* ncmpi_inq_var_fill was first implemented in PnetCDF 1.6.1 */
     if(no_fill) ncmpi_inq_var_fill(nc->int_ncid, varid, no_fill, fill_valuep);
+#else
+    /* PnetCDF 1.6.0 and priors support NC_NOFILL only */
+    if(no_fill) *no_fill = 1;
+#endif
     if(endiannessp) return NC_ENOTNC4;
     if(idp) return NC_ENOTNC4;
     if(nparamsp) return NC_ENOTNC4;
@@ -1185,7 +1158,12 @@ NCP_def_var_fill(int ncid, int varid, int no_fill, const void *fill_value)
     NC* nc;
     int status = NC_check_id(ncid, &nc);
     if(status != NC_NOERR) return status;
+#if (PNETCDF_VERSION_MAJOR*10000 + PNETCDF_VERSION_MINOR*100 + PNETCDF_VERSION_SUB >= 10601)
+    /* ncmpi_def_var_fill was first implemented in PnetCDF 1.6.1 */
     return ncmpi_def_var_fill(nc->int_ncid, varid, no_fill, fill_value);
+#else
+    return NC_EPNETCDF;
+#endif
 }
 
 static int

--- a/nc_test/util.c
+++ b/nc_test/util.c
@@ -1284,6 +1284,8 @@ char* nc_err_code_name(int err)
         case (NC_EAUTH):			return "NC_EAUTH";
         case (NC_ENOTFOUND):			return "NC_ENOTFOUND";
         case (NC_ECANTREMOVE):			return "NC_ECANTREMOVE";
+        case (NC_EINTERNAL):			return "NC_EINTERNAL";
+        case (NC_EPNETCDF):			return "NC_EPNETCDF";
         case (NC_EHDFERR):			return "NC_EHDFERR";
         case (NC_ECANTREAD):			return "NC_ECANTREAD";
         case (NC_ECANTWRITE):			return "NC_ECANTWRITE";
@@ -1315,8 +1317,9 @@ char* nc_err_code_name(int err)
         case (NC_EDISKLESS):			return "NC_EDISKLESS";
         case (NC_ECANTEXTEND):			return "NC_ECANTEXTEND";
         case (NC_EMPI):				return "NC_EMPI";
-    case (NC_ENULLPAD):             return "NC_NULLPAD";
-          // case (NC_EURL):				return "NC_EURL";
+        case (NC_ENULLPAD):			return "NC_NULLPAD";
+        case (NC_EINMEMORY):			return "NC_EINMEMORY";
+        // case (NC_EURL):				return "NC_EURL";
         // case (NC_ECONSTRAINT):			return "NC_ECONSTRAINT";
 #ifdef USE_PNETCDF
         case (NC_ESMALL):			return "NC_ESMALL";


### PR DESCRIPTION
In addition to introducing `NC_EPNETCDF`, this PR also updates comments in `libsrcp/ncpdispatch.c` to match PnetCDF implementation. It also changes some APIs to return `NC_EPNETCDF` when certain features are not available from the (earlier versions of) PnetCDF library used underneath.