### PR TITLE
change all variables fill mode when nc_set_fill is called

### DIFF
--- a/include/err_macros.h
+++ b/include/err_macros.h
@@ -80,4 +80,20 @@ int ERR_report(int stat, const char* file, int line)
    return 0; \
 } while (0)
 
+#define CHECK_ERR(err) { \
+    if (err != NC_NOERR) { \
+        nerrs++; \
+        printf("Error at line %d in %s: (%s)\n", \
+        __LINE__,__FILE__,nc_strerror(err)); \
+    } \
+}
+
+#define EXP_ERR(exp, err) { \
+    if (err != exp) { \
+        nerrs++; \
+        printf("Error at line %d in %s: expecting %s but got %s\n", \
+        __LINE__,__FILE__,#exp, nc_strerror(err)); \
+    } \
+}
+
 #endif /* _ERR_MACROS_H */

--- a/libhdf5/hdf5attr.c
+++ b/libhdf5/hdf5attr.c
@@ -514,8 +514,16 @@ NC4_put_att(int ncid, int varid, const char *name, nc_type file_type,
          else
             *(char **)var->fill_value = NULL;
       }
-      else
-         memcpy(var->fill_value, data, type_size);
+      else {
+         if (var->type_info->nc_type_class == NC_OPAQUE ||
+             var->type_info->nc_type_class == NC_COMPOUND ||
+             var->type_info->nc_type_class == NC_ENUM)
+             memcpy(var->fill_value, data, type_size);
+         else if ((retval = nc4_convert_type(data, var->fill_value, mem_type,
+                                        file_type, len, &range_error, NULL,
+                                        (h5->cmode & NC_CLASSIC_MODEL))))
+             BAIL(retval);
+      }
 
       /* Indicate that the fill value was changed, if the variable has already
        * been created in the file, so the dataset gets deleted and re-created. */

--- a/libhdf5/hdf5file.c
+++ b/libhdf5/hdf5file.c
@@ -406,8 +406,17 @@ NC4_set_fill(int ncid, int fillmode, int *old_modep)
 {
    NC *nc;
    NC_FILE_INFO_T* nc4_info;
+   NC_FILE_INFO_T *h5;
+   NC_GRP_INFO_T *grp;
+   int i, retval;
 
    LOG((2, "%s: ncid 0x%x fillmode %d", __func__, ncid, fillmode));
+
+   /* Find file metadata. */
+   if ((retval = nc4_find_nc_grp_h5(ncid, &nc, &grp, &h5)))
+      return retval;
+
+   assert(h5 && grp && nc);
 
    if (!(nc = nc4_find_nc_file(ncid,&nc4_info)))
       return NC_EBADID;
@@ -427,6 +436,11 @@ NC4_set_fill(int ncid, int fillmode, int *old_modep)
 
    nc4_info->fill_mode = fillmode;
 
+   /* set/change fill mode for all variables */
+   for (i=0; i<ncindexcount(grp->vars); i++) {
+       NC_VAR_INFO_T *var = (NC_VAR_INFO_T*) ncindexith(grp->vars, i);
+       var->no_fill = (fillmode == NC_NOFILL);
+   }
 
    return NC_NOERR;
 }

--- a/libhdf5/hdf5var.c
+++ b/libhdf5/hdf5var.c
@@ -570,8 +570,12 @@ nc_def_var_extra(int ncid, int varid, int *shuffle, int *deflate,
 
    /* If the HDF5 dataset has already been created, then it is too
     * late to set all the extra stuff. */
-   if (var->created)
-      return NC_ELATEDEF;
+   if (var->created) {
+      if (no_fill != NULL || fill_value != NULL)
+         return NC_ELATEFILL;
+      else
+         return NC_ELATEDEF;
+   }
 
    /* Check compression options. */
    if (deflate && !deflate_level)

--- a/nc_test/CMakeLists.txt
+++ b/nc_test/CMakeLists.txt
@@ -30,7 +30,7 @@ TARGET_LINK_LIBRARIES(nc_test
   )
 
 # Some extra stand-alone tests
-SET(TESTS t_nc tst_small tst_misc tst_norm tst_names tst_nofill tst_nofill2 tst_nofill3 tst_meta tst_inq_type tst_utf8_validate tst_utf8_phrases tst_global_fillval tst_max_var_dims tst_formats tst_def_var_fill tst_err_enddef)
+SET(TESTS t_nc tst_small tst_misc tst_norm tst_names tst_nofill tst_nofill2 tst_nofill3 tst_meta tst_inq_type tst_utf8_validate tst_utf8_phrases tst_global_fillval tst_max_var_dims tst_formats tst_def_var_fill tst_err_enddef tst_var_fill)
 
 IF(NOT HAVE_BASH)
   SET(TESTS ${TESTS} tst_atts3)

--- a/nc_test/Makefile.am
+++ b/nc_test/Makefile.am
@@ -19,7 +19,7 @@ TEST_EXTENSIONS = .sh
 TESTPROGRAMS = t_nc tst_small nc_test tst_misc tst_norm tst_names       \
 tst_nofill tst_nofill2 tst_nofill3 tst_atts3 tst_meta tst_inq_type      \
 tst_utf8_validate tst_utf8_phrases tst_global_fillval                   \
-tst_max_var_dims tst_formats tst_def_var_fill tst_err_enddef
+tst_max_var_dims tst_formats tst_def_var_fill tst_err_enddef tst_var_fill
 
 if USE_PNETCDF
 TESTPROGRAMS += tst_parallel2 tst_pnetcdf tst_addvar tst_formatx_pnetcdf

--- a/nc_test/Makefile.am
+++ b/nc_test/Makefile.am
@@ -19,7 +19,8 @@ TEST_EXTENSIONS = .sh
 TESTPROGRAMS = t_nc tst_small nc_test tst_misc tst_norm tst_names       \
 tst_nofill tst_nofill2 tst_nofill3 tst_atts3 tst_meta tst_inq_type      \
 tst_utf8_validate tst_utf8_phrases tst_global_fillval                   \
-tst_max_var_dims tst_formats tst_def_var_fill tst_err_enddef tst_var_fill
+tst_max_var_dims tst_formats tst_def_var_fill tst_err_enddef \
+tst_var_fill tst_fill_nc4
 
 if USE_PNETCDF
 TESTPROGRAMS += tst_parallel2 tst_pnetcdf tst_addvar tst_formatx_pnetcdf

--- a/nc_test/tst_err_enddef.c
+++ b/nc_test/tst_err_enddef.c
@@ -1,21 +1,5 @@
-#include <stdio.h>
-#include <netcdf.h>
-
-#define CHECK_ERR { \
-    if (err != NC_NOERR) { \
-        nerrs++; \
-        printf("Error at line %d in %s: (%s)\n", \
-        __LINE__,__FILE__,nc_strerror(err)); \
-    } \
-}
-
-#define EXP_ERR(exp) { \
-    if (err != exp) { \
-        nerrs++; \
-        printf("Error at line %d in %s: expecting %s but got %s\n", \
-        __LINE__,__FILE__,nc_strerror(exp), nc_strerror(err)); \
-    } \
-}
+#include "tests.h"
+#include "err_macros.h"
 
 int main(int argc, char** argv)
 {
@@ -26,24 +10,24 @@ int main(int argc, char** argv)
     printf("*** TESTING error code returned from nc__enddef and nc_close ");
 
     cmode = NC_CLOBBER;
-    err = nc_create(filename, cmode, &ncid); CHECK_ERR
-    err = nc_set_fill(ncid, NC_NOFILL, NULL); CHECK_ERR
+    err = nc_create(filename, cmode, &ncid); CHECK_ERR(err)
+    err = nc_set_fill(ncid, NC_NOFILL, NULL); CHECK_ERR(err)
 
-    err = nc_def_dim(ncid, "X", 5,      &dimid[0]); CHECK_ERR
-    err = nc_def_dim(ncid, "YY", 32000, &dimid[1]); CHECK_ERR
-    err = nc_def_dim(ncid, "XX", 32000, &dimid[2]); CHECK_ERR
+    err = nc_def_dim(ncid, "X", 5,      &dimid[0]); CHECK_ERR(err)
+    err = nc_def_dim(ncid, "YY", 32000, &dimid[1]); CHECK_ERR(err)
+    err = nc_def_dim(ncid, "XX", 32000, &dimid[2]); CHECK_ERR(err)
 
-    err = nc_def_var(ncid, "var", NC_INT, 1, dimid, &varid); CHECK_ERR
-    err = nc_def_var(ncid, "var_big", NC_FLOAT, 2, dimid+1, &varid); CHECK_ERR
+    err = nc_def_var(ncid, "var", NC_INT, 1, dimid, &varid); CHECK_ERR(err)
+    err = nc_def_var(ncid, "var_big", NC_FLOAT, 2, dimid+1, &varid); CHECK_ERR(err)
 
     /* make the file header size larger than 2 GiB */
     err = nc__enddef(ncid, 2147483648LL, 1, 1, 1);
-    EXP_ERR(NC_EVARSIZE)
+    EXP_ERR(NC_EVARSIZE, err)
 
     /* the above error keeps the program in define mode, thus close will
      * call enddef again, but this time no error is expected
      */
-    err = nc_close(ncid); CHECK_ERR
+    err = nc_close(ncid); CHECK_ERR(err)
 
     if (nerrs) printf(".... failed with %d errors\n",nerrs);
     else       printf(".... pass\n");

--- a/nc_test/tst_fill_nc4.c
+++ b/nc_test/tst_fill_nc4.c
@@ -35,10 +35,10 @@ int main(int argc, char** argv) {
 
     for (i=0; i<5; i++) {
 #ifndef ENABLE_CDF5
-        if (formats[i] | NC_CDF5) continue;
+        if (formats[i] & NC_CDF5) continue;
 #endif
 #ifndef USE_NETCDF4
-        if (formats[i] | NC_NETCDF4) continue;
+        if (formats[i] & NC_NETCDF4) continue;
 #endif
         cmode = NC_CLOBBER | formats[i];
         err = nc_create(filename, cmode, &ncid); CHECK_ERR(err)

--- a/nc_test/tst_fill_nc4.c
+++ b/nc_test/tst_fill_nc4.c
@@ -10,21 +10,16 @@
  */
 
 #include "tests.h"
-
-#define CHECK_ERR { \
-    if (err != NC_NOERR) { \
-        nerrs++; \
-        printf("Error at line %d in %s: (%s)\n", \
-        __LINE__,__FILE__,nc_strerror(err)); \
-    } \
-}
+#include "err_macros.h"
 
 #define MY_FILLV 52
 
 int main(int argc, char** argv) {
     char filename[256];
-    int err, nerrs=0, ncid, varid, cmode, buf, no_fill, ifillv;
+    int i, err, nerrs=0, ncid, varid, cmode, buf, no_fill, ifillv;
     double dfillv;
+    int formats[5]={0, NC_64BIT_OFFSET, NC_CDF5,
+                    NC_NETCDF4, NC_NETCDF4 | NC_CLASSIC_MODEL};
 
     if (argc > 2) {
         printf("Usage: %s [filename]\n",argv[0]);
@@ -38,32 +33,40 @@ int main(int argc, char** argv) {
     printf("%-66s ------ ", cmd_str); fflush(stdout);
     free(cmd_str);
 
-    cmode = NC_CLOBBER|NC_NETCDF4;
-    err = nc_create(filename, cmode, &ncid); CHECK_ERR
-    err = nc_def_var(ncid, "var", NC_INT, 0, NULL, &varid); CHECK_ERR
-    err = nc_set_fill(ncid, NC_FILL, NULL); CHECK_ERR
-    dfillv = (double)MY_FILLV;
-    err = nc_put_att_double(ncid, varid, "_FillValue", NC_INT, 1, &dfillv); CHECK_ERR
-    err = nc_enddef(ncid); CHECK_ERR
+    for (i=0; i<5; i++) {
+#ifndef ENABLE_CDF5
+        if (formats[i] | NC_CDF5) continue;
+#endif
+#ifndef USE_NETCDF4
+        if (formats[i] | NC_NETCDF4) continue;
+#endif
+        cmode = NC_CLOBBER | formats[i];
+        err = nc_create(filename, cmode, &ncid); CHECK_ERR(err)
+        err = nc_def_var(ncid, "var", NC_INT, 0, NULL, &varid); CHECK_ERR(err)
+        err = nc_set_fill(ncid, NC_FILL, NULL); CHECK_ERR(err)
+        dfillv = (double)MY_FILLV;
+        err = nc_put_att_double(ncid, varid, "_FillValue", NC_INT, 1, &dfillv); CHECK_ERR(err)
+        err = nc_enddef(ncid); CHECK_ERR(err)
 
-    err = nc_inq_var_fill(ncid, varid, &no_fill, &ifillv); CHECK_ERR
-    if (no_fill) {
-        printf("Errir: %s expect FILL mode on, but got NOFILL\n",__FILE__);
-        nerrs++;
-    }
-    if (ifillv != MY_FILLV) {
-        printf("Errir: %s expect fill value %d, but got %d\n",__FILE__,MY_FILLV,ifillv);
-        nerrs++;
-    }
+        err = nc_inq_var_fill(ncid, varid, &no_fill, &ifillv); CHECK_ERR(err)
+        if (no_fill) {
+            printf("Errir: %s expect FILL mode on, but got NOFILL\n",__FILE__);
+            nerrs++;
+        }
+        if (ifillv != MY_FILLV) {
+            printf("Errir: %s expect fill value %d, but got %d\n",__FILE__,MY_FILLV,ifillv);
+            nerrs++;
+        }
 
-    buf = -1;
-    err = nc_get_var_int(ncid, varid, &buf); CHECK_ERR
-    if (buf != MY_FILLV) {
-        printf("Errir: %s expect read value %d, but got %d\n",__FILE__,MY_FILLV,buf);
-        nerrs++;
-    }
+        buf = -1;
+        err = nc_get_var_int(ncid, varid, &buf); CHECK_ERR(err)
+        if (buf != MY_FILLV) {
+            printf("Errir: %s expect read value %d, but got %d\n",__FILE__,MY_FILLV,buf);
+            nerrs++;
+        }
 
-    err = nc_close(ncid); CHECK_ERR
+        err = nc_close(ncid); CHECK_ERR(err)
+    }
 
     if (nerrs) printf("fail with %d mismatches\n",nerrs);
     else       printf("pass\n");

--- a/nc_test/tst_fill_nc4.c
+++ b/nc_test/tst_fill_nc4.c
@@ -1,0 +1,73 @@
+/* This is part of the netCDF package.
+ * Copyright 2018 University Corporation for Atmospheric Research/Unidata
+ * See COPYRIGHT file for conditions of use.
+ *
+ * Test whether calling nc_put_att_double() to write _FillValue attribute of
+ * int type performs type conversion properly.
+ * nc_set_fill().
+ *
+ * Author: Wei-keng Liao.
+ */
+
+#include "tests.h"
+
+#define CHECK_ERR { \
+    if (err != NC_NOERR) { \
+        nerrs++; \
+        printf("Error at line %d in %s: (%s)\n", \
+        __LINE__,__FILE__,nc_strerror(err)); \
+    } \
+}
+
+#define MY_FILLV 52
+
+int main(int argc, char** argv) {
+    char filename[256];
+    int err, nerrs=0, ncid, varid, cmode, buf, no_fill, ifillv;
+    double dfillv;
+
+    if (argc > 2) {
+        printf("Usage: %s [filename]\n",argv[0]);
+        return 1;
+    }
+    if (argc == 2) snprintf(filename, 256, "%s", argv[1]);
+    else           strcpy(filename, "tst_fill_nc4.nc");
+
+    char *cmd_str = (char*)malloc(strlen(argv[0]) + 256);
+    sprintf(cmd_str, "*** TESTING C   %s for variable fill mode ", argv[0]);
+    printf("%-66s ------ ", cmd_str); fflush(stdout);
+    free(cmd_str);
+
+    cmode = NC_CLOBBER|NC_NETCDF4;
+    err = nc_create(filename, cmode, &ncid); CHECK_ERR
+    err = nc_def_var(ncid, "var", NC_INT, 0, NULL, &varid); CHECK_ERR
+    err = nc_set_fill(ncid, NC_FILL, NULL); CHECK_ERR
+    dfillv = (double)MY_FILLV;
+    err = nc_put_att_double(ncid, varid, "_FillValue", NC_INT, 1, &dfillv); CHECK_ERR
+    err = nc_enddef(ncid); CHECK_ERR
+
+    err = nc_inq_var_fill(ncid, varid, &no_fill, &ifillv); CHECK_ERR
+    if (no_fill) {
+        printf("Errir: %s expect FILL mode on, but got NOFILL\n",__FILE__);
+        nerrs++;
+    }
+    if (ifillv != MY_FILLV) {
+        printf("Errir: %s expect fill value %d, but got %d\n",__FILE__,MY_FILLV,ifillv);
+        nerrs++;
+    }
+
+    buf = -1;
+    err = nc_get_var_int(ncid, varid, &buf); CHECK_ERR
+    if (buf != MY_FILLV) {
+        printf("Errir: %s expect read value %d, but got %d\n",__FILE__,MY_FILLV,buf);
+        nerrs++;
+    }
+
+    err = nc_close(ncid); CHECK_ERR
+
+    if (nerrs) printf("fail with %d mismatches\n",nerrs);
+    else       printf("pass\n");
+
+    return (nerrs > 0);
+}
+

--- a/nc_test/tst_max_var_dims.c
+++ b/nc_test/tst_max_var_dims.c
@@ -1,23 +1,13 @@
-#include <stdio.h>
-#include <netcdf.h>
-
-#define ERR {if(err!=NC_NOERR){printf("Error at line %d in %s: %s\n", __LINE__,__FILE__, nc_strerror(err));nerrs++;}}
-
-#define EXP_ERR(exp,err) { \
-    if (err != exp) { \
-        nerrs++; \
-        printf("Error at line %d in %s: expecting %s but got %d\n", \
-        __LINE__,__FILE__,#exp, err); \
-    } \
-}
+#include "tests.h"
+#include "err_macros.h"
 
 int main(int argc, char *argv[])
 {
     int i, err, nerrs=0, ncid, dimid[NC_MAX_VAR_DIMS+2], varid;
 
-    err = nc_create("tst_max_var_dims.nc", NC_CLOBBER, &ncid); ERR;
-    err = nc_def_dim(ncid, "dim0", NC_UNLIMITED, &dimid[0]); ERR;
-    err = nc_def_dim(ncid, "dim1", 1, &dimid[1]); ERR;
+    err = nc_create("tst_max_var_dims.nc", NC_CLOBBER, &ncid); CHECK_ERR(err)
+    err = nc_def_dim(ncid, "dim0", NC_UNLIMITED, &dimid[0]); CHECK_ERR(err)
+    err = nc_def_dim(ncid, "dim1", 1, &dimid[1]); CHECK_ERR(err)
 
     for (i=2; i<NC_MAX_VAR_DIMS+2; i++) dimid[i] = dimid[1];
 
@@ -27,8 +17,8 @@ int main(int argc, char *argv[])
     err = nc_def_var(ncid, "v1", NC_INT, NC_MAX_VAR_DIMS+1, &dimid[1], &varid);
     EXP_ERR(NC_EMAXDIMS,err)
 
-    err = nc_set_fill(ncid, NC_NOFILL, NULL); ERR
-    err = nc_close(ncid); ERR
+    err = nc_set_fill(ncid, NC_NOFILL, NULL); CHECK_ERR(err)
+    err = nc_close(ncid); CHECK_ERR(err)
     return (nerrs > 0);
 }
 

--- a/nc_test/tst_var_fill.c
+++ b/nc_test/tst_var_fill.c
@@ -1,0 +1,104 @@
+/* This is part of the netCDF package.
+ * Copyright 2005 University Corporation for Atmospheric Research/Unidata
+ * See COPYRIGHT file for conditions of use.
+ *
+ * Test whether nc_inq_var_fill() reports fill mode correctly after calling
+ * nc_set_fill().
+ *
+ * Author: Wei-keng Liao.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <netcdf.h>
+
+#include "tests.h"
+
+#define CHECK_ERR { \
+    if (err != NC_NOERR) { \
+        nerrs++; \
+        printf("Error at line %d in %s: (%s)\n", \
+        __LINE__,__FILE__,nc_strerror(err)); \
+    } \
+}
+
+int main(int argc, char** argv) {
+    char filename[256];
+    int j, k, err, nerrs=0, ncid, varid0, varid1, no_fill;
+    char *fmats[5]={"NC_FORMAT_CLASSIC",
+                    "NC_FORMAT_64BIT_OFFSET",
+                    "NC_FORMAT_CDF5",
+                    "NC_FORMAT_NETCDF4",
+                    "NC_FORMAT_NETCDF4_CLASSIC"};
+    int formats[5]={NC_FORMAT_CLASSIC,
+                    NC_FORMAT_64BIT_OFFSET,
+                    NC_FORMAT_CDF5,
+                    NC_FORMAT_NETCDF4,
+                    NC_FORMAT_NETCDF4_CLASSIC};
+    int fill_mode[2]={NC_FILL, NC_NOFILL};
+
+    if (argc > 2) {
+        printf("Usage: %s [filename]\n",argv[0]);
+        return 1;
+    }
+    if (argc == 2) snprintf(filename, 256, "%s", argv[1]);
+    else           strcpy(filename, "tst_def_var_fill.nc");
+
+    char *cmd_str = (char*)malloc(strlen(argv[0]) + 256);
+    sprintf(cmd_str, "*** TESTING C   %s for variable fill mode ", argv[0]);
+    printf("%-66s ------ ", cmd_str); fflush(stdout);
+    free(cmd_str);
+
+    for (k=0; k<5; k++) {
+#ifndef ENABLE_CDF5
+        if (formats[k] == NC_FORMAT_CDF5) continue;
+#endif
+#ifndef USE_NETCDF4
+        if (formats[k] == NC_FORMAT_NETCDF4 ||
+            formats[k] == NC_FORMAT_NETCDF4_CLASSIC)
+            continue;
+#endif
+        nc_set_default_format(formats[k], NULL);
+
+        for (j=0; j<2; j++) {
+            /* create a new file for writing --------------------------------*/
+            err = nc_create(filename, NC_CLOBBER, &ncid); CHECK_ERR
+            err = nc_def_var(ncid, "var0", NC_INT, 0, NULL, &varid0); CHECK_ERR
+
+            /* set fill mode for the entire file */
+            err = nc_set_fill(ncid, fill_mode[j], NULL); CHECK_ERR
+
+            /* all variables defined after nc_set_fill() should inherit the
+             * fill mode */
+            err = nc_def_var(ncid, "var1", NC_INT, 0, NULL, &varid1); CHECK_ERR
+            err = nc_enddef(ncid); CHECK_ERR
+
+            err = nc_inq_var_fill(ncid, varid0, &no_fill, NULL); CHECK_ERR
+            if (no_fill && fill_mode[j] == NC_FILL) {
+                printf("\nFAIL: %s var0 expect NOFILL but got FILL\n",fmats[k]);
+                nerrs++;
+            }
+            else if (!no_fill && fill_mode[j] == NC_NOFILL) {
+                printf("\nFAIL: %s var0 expect FILL but got NOFILL\n",fmats[k]);
+                nerrs++;
+            }
+            err = nc_inq_var_fill(ncid, varid1, &no_fill, NULL); CHECK_ERR
+            if (no_fill && fill_mode[j] == NC_FILL) {
+                printf("\nFAIL: %s var1 expect NOFILL but got FILL\n",fmats[k]);
+                nerrs++;
+            }
+            else if (!no_fill && fill_mode[j] == NC_NOFILL) {
+                printf("\nFAIL: %s var1 expect FILL but got NOFILL\n",fmats[k]);
+                nerrs++;
+            }
+            err = nc_close(ncid); CHECK_ERR
+        }
+    }
+
+    if (nerrs) printf("fail with %d mismatches\n",nerrs);
+    else       printf("pass\n");
+
+    return (nerrs > 0);
+}
+

--- a/nc_test/tst_var_fill.c
+++ b/nc_test/tst_var_fill.c
@@ -1,5 +1,5 @@
 /* This is part of the netCDF package.
- * Copyright 2005 University Corporation for Atmospheric Research/Unidata
+ * Copyright 2018 University Corporation for Atmospheric Research/Unidata
  * See COPYRIGHT file for conditions of use.
  *
  * Test whether nc_inq_var_fill() reports fill mode correctly after calling
@@ -8,20 +8,8 @@
  * Author: Wei-keng Liao.
  */
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <netcdf.h>
-
 #include "tests.h"
-
-#define CHECK_ERR { \
-    if (err != NC_NOERR) { \
-        nerrs++; \
-        printf("Error at line %d in %s: (%s)\n", \
-        __LINE__,__FILE__,nc_strerror(err)); \
-    } \
-}
+#include "err_macros.h"
 
 int main(int argc, char** argv) {
     char filename[256];
@@ -63,18 +51,18 @@ int main(int argc, char** argv) {
 
         for (j=0; j<2; j++) {
             /* create a new file for writing --------------------------------*/
-            err = nc_create(filename, NC_CLOBBER, &ncid); CHECK_ERR
-            err = nc_def_var(ncid, "var0", NC_INT, 0, NULL, &varid0); CHECK_ERR
+            err = nc_create(filename, NC_CLOBBER, &ncid); CHECK_ERR(err)
+            err = nc_def_var(ncid, "var0", NC_INT, 0, NULL, &varid0); CHECK_ERR(err)
 
             /* set fill mode for the entire file */
-            err = nc_set_fill(ncid, fill_mode[j], NULL); CHECK_ERR
+            err = nc_set_fill(ncid, fill_mode[j], NULL); CHECK_ERR(err)
 
             /* all variables defined after nc_set_fill() should inherit the
              * fill mode */
-            err = nc_def_var(ncid, "var1", NC_INT, 0, NULL, &varid1); CHECK_ERR
-            err = nc_enddef(ncid); CHECK_ERR
+            err = nc_def_var(ncid, "var1", NC_INT, 0, NULL, &varid1); CHECK_ERR(err)
+            err = nc_enddef(ncid); CHECK_ERR(err)
 
-            err = nc_inq_var_fill(ncid, varid0, &no_fill, NULL); CHECK_ERR
+            err = nc_inq_var_fill(ncid, varid0, &no_fill, NULL); CHECK_ERR(err)
             if (no_fill && fill_mode[j] == NC_FILL) {
                 printf("\nFAIL: %s var0 expect NOFILL but got FILL\n",fmats[k]);
                 nerrs++;
@@ -83,7 +71,7 @@ int main(int argc, char** argv) {
                 printf("\nFAIL: %s var0 expect FILL but got NOFILL\n",fmats[k]);
                 nerrs++;
             }
-            err = nc_inq_var_fill(ncid, varid1, &no_fill, NULL); CHECK_ERR
+            err = nc_inq_var_fill(ncid, varid1, &no_fill, NULL); CHECK_ERR(err)
             if (no_fill && fill_mode[j] == NC_FILL) {
                 printf("\nFAIL: %s var1 expect NOFILL but got FILL\n",fmats[k]);
                 nerrs++;
@@ -92,7 +80,7 @@ int main(int argc, char** argv) {
                 printf("\nFAIL: %s var1 expect FILL but got NOFILL\n",fmats[k]);
                 nerrs++;
             }
-            err = nc_close(ncid); CHECK_ERR
+            err = nc_close(ncid); CHECK_ERR(err)
         }
     }
 

--- a/nc_test/tst_var_fill.c
+++ b/nc_test/tst_var_fill.c
@@ -43,7 +43,7 @@ int main(int argc, char** argv) {
         return 1;
     }
     if (argc == 2) snprintf(filename, 256, "%s", argv[1]);
-    else           strcpy(filename, "tst_def_var_fill.nc");
+    else           strcpy(filename, "tst_var_fill.nc");
 
     char *cmd_str = (char*)malloc(strlen(argv[0]) + 256);
     sprintf(cmd_str, "*** TESTING C   %s for variable fill mode ", argv[0]);


### PR DESCRIPTION
This fix the NetCDF4 files only.
Fix for classic files is already in the master branch (#383)
A new test program nc_test/tst_var_fill.c can detect this bug for all file formats.