### PR TITLE
Eliminate double printing of nccopy program name in usage output

### DIFF
--- a/ncdump/nccopy.c
+++ b/ncdump/nccopy.c
@@ -1984,8 +1984,8 @@ usage(void)
     /* Don't document this flaky option until it works better */
     /* [-x]      use experimental computed estimates for variable-specific chunk caches\n\ */
 
-    error("%s [-k kind] [-[3|4|6|7]] [-d n] [-s] [-c chunkspec] [-u] [-w] [-[v|V] varlist] [-[g|G] grplist] [-m n] [-h n] [-e n] [-r] infile outfile\n%s\nnetCDF library version %s",
-	  progname, USAGE, nc_inq_libvers());
+    error("[-k kind] [-[3|4|6|7]] [-d n] [-s] [-c chunkspec] [-u] [-w] [-[v|V] varlist] [-[g|G] grplist] [-m n] [-h n] [-e n] [-r] infile outfile\n%s\nnetCDF library version %s",
+	  USAGE, nc_inq_libvers());
 }
 
 int


### PR DESCRIPTION
The `error` macro used to output the usage information already outputs `progname`, so the `progname` argument is not needed and results in double printing of the `progname` as shown below:

```
ceerws2703a:build(master)> ../bin/nccopy
../bin/nccopy: ../bin/nccopy [-k kind] [-[3|4|6|7]] [-d n] [-s] [-c chunkspec] [-u] [-w] [-[v|V] varlist] [-[g|G] grplist] [-m n] [-h n] [-e n] [-r] infile outfile
  [-k kind] specify kind of netCDF format for output file, default same as input
            kind strings: 'classic', '64-bit offset', 'cdf5',
                          'netCDF-4', 'netCDF-4 classic model'
```