### PR TITLE
to be NC_EINDEFINE or NC_ENOTINDEFINE

### DIFF
--- a/libhdf5/hdf5attr.c
+++ b/libhdf5/hdf5attr.c
@@ -403,7 +403,7 @@ NC4_put_att(int ncid, int varid, const char *name, nc_type file_type,
       if (!(h5->flags & NC_INDEF))
       {
          if (h5->cmode & NC_CLASSIC_MODEL)
-            return NC_EINDEFINE;
+            return NC_ENOTINDEFINE;
          if ((retval = NC4_redef(ncid)))
             BAIL(retval);
       }
@@ -417,7 +417,7 @@ NC4_put_att(int ncid, int varid, const char *name, nc_type file_type,
           len * nc4typelen(file_type) > (size_t)att->len * nc4typelen(att->nc_typeid))
       {
          if (h5->cmode & NC_CLASSIC_MODEL)
-            return NC_EINDEFINE;
+            return NC_ENOTINDEFINE;
          if ((retval = NC4_redef(ncid)))
             BAIL(retval);
       }

--- a/nc_test4/tst_atts.c
+++ b/nc_test4/tst_atts.c
@@ -178,12 +178,12 @@ main(int argc, char **argv)
 
       /* Try and write a new att. Won't work. */
       if (nc_put_att_text(ncid, NC_GLOBAL, OLD_NAME_2, strlen(CONTENTS_2),
-                          CONTENTS_2) != NC_EINDEFINE) ERR;
+                          CONTENTS_2) != NC_ENOTINDEFINE) ERR;
 
       /* This will not work. Overwriting att must be same length or
        * shorter if not in define mode. */
       if (nc_put_att_text(ncid, NC_GLOBAL, OLD_NAME, strlen(CONTENTS_2),
-                          CONTENTS_2) != NC_EINDEFINE) ERR;
+                          CONTENTS_2) != NC_ENOTINDEFINE) ERR;
 
       /* Now overwrite the att. */
       if (nc_put_att_text(ncid, NC_GLOBAL, OLD_NAME, strlen(CONTENTS_3),


### PR DESCRIPTION
The correct error code for operation not allowed in data mode is NC_ENOTINDEFINE.
The oversight only happens to NetCDF4 classic model files. Here is a test program.
```
% cat notindef.c
#include <stdio.h>
#include <netcdf.h>

#define CHECK_ERR { \
    if (err != NC_NOERR) { \
        nerrs++; \
        printf("Error at line %d in %s: (%s)\n", \
        __LINE__,__FILE__,nc_strerror(err)); \
    } \
}

int main(int argc, char **argv) {
    int i, err, nerrs=0, ncid, cmode, buf[2];
    int flags[4]={NC_CLASSIC_MODEL,NC_64BIT_OFFSET,NC_64BIT_DATA,NC_NETCDF4|NC_CLASSIC_MODEL};
    char *fmts[4]={"CDF-1","CDF-2","CDF-5","NETCDF4 classic model"};

    for (i=0; i<4; i++) {
        printf("---- Testing %s ---- ",fmts[i]);
        cmode = NC_CLOBBER | flags[i];
        err = nc_create("testfile.nc", cmode, &ncid); CHECK_ERR
        err = nc_enddef(ncid); CHECK_ERR

        err = nc_put_att_int(ncid, NC_GLOBAL, "attr", NC_INT, 1, buf);
        if (err != NC_ENOTINDEFINE) {
            printf("Failed: expecting NC_ENOTINDEFINE but got ");
            if (err == NC_EINDEFINE) printf("NC_EINDEFINE\n");
            else                     printf("%d\n",err);
            nerrs++;
        } else
            printf("Pass\n");
        err = nc_close(ncid); CHECK_ERR
    }
    return (nerrs>0);
}
```