### PR TITLE
more latefill tests

### DIFF
--- a/libdispatch/dvar.c
+++ b/libdispatch/dvar.c
@@ -546,42 +546,57 @@ NC_getshape(int ncid, int varid, int ndims, size_t* shape)
    return status;
 }
 
-/*! Set the fill value for a variable.
+/**
+ * @ingroup variables
+ *
+ * Set the fill value for a variable.
+ *
+ * @note For netCDF classic, 64-bit offset, and CDF5 formats, it is
+ * allowed (but not good practice) to set the fill value after data
+ * have been written to the variable. In this case, unless the
+ * variable has been completely specified (without gaps in the data),
+ * any existing filled values will not be recognized as fill values by
+ * applications reading the data. Best practice is to set the fill
+ * value after the variable has been defined, but before any data have
+ * been written to that varibale. In NetCDF-4 files, this is enforced
+ * by the HDF5 library. For netCDF-4 files, an error is returned if
+ * the user attempts to set the fill value after writing data to the
+ * variable.
 
-\ingroup variables
-
-\param ncid NetCDF ID, from a previous call to nc_open or
-nc_create.
-
-\param varid Variable ID.
-
-\param no_fill Set to NC_NOFILL to turn off fill mode for this
-variable. Set to NC_FILL (the default) to turn on fill mode for the
-variable.
-
-\param fill_value the fill value to be used for this variable. Must be
-the same type as the variable. This must point to enough free memory
-to hold one element of the data type of the variable. (For example, an
-NC_INT will require 4 bytes for it's fill value, which is also an
-NC_INT.)
-
+ * @param ncid NetCDF ID, from a previous call to nc_open or
+ * nc_create.
+ * @param varid Variable ID.
+ * @param no_fill Set to NC_NOFILL to turn off fill mode for this
+ * variable. Set to NC_FILL (the default) to turn on fill mode for the
+ * variable.
+ * @param fill_value the fill value to be used for this variable. Must
+ * be the same type as the variable. This must point to enough free
+ * memory to hold one element of the data type of the variable. (For
+ * example, an NC_INT will require 4 bytes for it's fill value, which
+ * is also an NC_INT.)
+ *
  * @returns ::NC_NOERR No error.
  * @returns ::NC_EBADID Bad ID.
- * @returns ::NC_ENOTINDEFINE Not in define mode.  This is returned for
-netCDF classic, 64-bit offset, or 64-bit data files, or for netCDF-4 files,
-when they were created with NC_STRICT_NC3 flag. See \ref nc_create.
+ * @returns ::NC_ENOTINDEFINE Not in define mode.  This is returned
+ * for netCDF classic, 64-bit offset, or 64-bit data files, or for
+ * netCDF-4 files, when they were created with NC_STRICT_NC3 flag. See
+ * @ref nc_create.
  * @returns ::NC_EPERM Attempt to create object in read-only file.
-
-\section nc_def_var_fill_example Example
-
-In this example from libsrc4/tst_vars.c, a variable is defined, and
-the fill mode turned off. Then nc_inq_fill() is used to check that the
-setting is correct. Then some data are written to the variable. Since
-the data that are written do not cover the full extent of the
-variable, the missing values will just be random. If fill value mode
-was turned on, the missing values would get the fill value.
-
-\code
+ * @returns ::NC_ELATEDEF (NetCDF-4 only). Returned when user attempts
+ * to set fill value after data are written.
+ * @returns ::NC_EGLOBAL Attempt to set fill value on NC_GLOBAL.
+ *
+ * @section nc_def_var_fill_example Example
+ *
+ * In this example from libsrc4/tst_vars.c, a variable is defined, and
+ * the fill mode turned off. Then nc_inq_fill() is used to check that
+ * the setting is correct. Then some data are written to the
+ * variable. Since the data that are written do not cover the full
+ * extent of the variable, the missing values will just be random. If
+ * fill value mode was turned on, the missing values would get the
+ * fill value.
+ *
+ @code
 #define DIM7_LEN 2
 #define DIM7_NAME "dim_7_from_Indiana"
 #define VAR7_NAME "var_7_from_Idaho"
@@ -608,7 +623,8 @@ was turned on, the missing values would get the fill value.
       if (nc_get_var1_ushort(ncid, varid, index, &ushort_data_in)) ERR;
 
       if (nc_close(ncid)) ERR;
-\endcode
+ @endcode
+ * @author Glenn Davis, Ed Hartnett, Dennis Heimbigner
 */
 int
 nc_def_var_fill(int ncid, int varid, int no_fill, const void *fill_value)
@@ -617,7 +633,7 @@ nc_def_var_fill(int ncid, int varid, int no_fill, const void *fill_value)
     int stat = NC_check_id(ncid,&ncp);
     if(stat != NC_NOERR) return stat;
 
-    /* Dennis Heimbigner: (Using NC_GLOBAL is ilegal, as this API) has no
+    /* Dennis Heimbigner: Using NC_GLOBAL is illegal, as this API has no
      * provision for specifying the type of the fillvalue, it must of necessity
      * be using the type of the variable to interpret the bytes of the
      * fill_value argument.

--- a/nc_test/Makefile.am
+++ b/nc_test/Makefile.am
@@ -79,11 +79,8 @@ if USE_PNETCDF
 TESTS += run_pnetcdf_test.sh
 endif
 
-# Distribute the .c files so that m4 isn't required on the users
-# machine.
-
-# Distribute the .c files so that m4 isn't required on the users
-# machine.
+# The .c files that are generated with m4 are already distributed, but
+# we also include the original m4 files, plus test scripts data.
 EXTRA_DIST = test_get.m4 test_put.m4 run_diskless.sh run_diskless2.sh   \
 run_diskless5.sh run_mmap.sh run_pnetcdf_test.sh test_read.m4           \
 test_write.m4 ref_tst_diskless2.cdl tst_diskless5.cdl run_inmemory.sh   \
@@ -91,13 +88,9 @@ f03tst_open_mem.nc                                                      \
 CMakeLists.txt
 
 # These files are created by the tests.
-CLEANFILES = nc_test_classic.nc nc_test_64bit.nc nc_test_netcdf4.nc	\
-tst_*.nc t_nc.nc large_files.nc quick_large_files.nc tst_diskless.nc	\
-tst_diskless2.nc tst_diskless3.nc tst_diskless3_file.cdl		\
-tst_diskless3_memory.cdl tst_diskless4.cdl tst_diskless4.nc		\
-tst_formatx.nc nc_test_cdf5.nc tst_inq_type.nc tst_elatefill.nc		\
-tst_global_fillval.nc tst_large_cdf5.nc tst_max_var_dims.nc		\
-benchmark.nc tst_def_var_fill.nc
+CLEANFILES = nc_test_*.nc tst_*.nc t_nc.nc large_files.nc		\
+quick_large_files.nc tst_diskless3_file.cdl tst_diskless3_memory.cdl	\
+tst_diskless4.cdl benchmark.nc
 
 EXTRA_DIST += bad_cdf5_begin.nc run_cdf5.sh
 if ENABLE_CDF5
@@ -108,7 +101,6 @@ if ENABLE_CDF5
    check_PROGRAMS += tst_open_cdf5
 if LARGE_FILE_TESTS
    TESTPROGRAMS   += tst_large_cdf5 tst_cdf5_begin
-   CLEANFILES     += tst_large_cdf5.nc tst_cdf5_begin.nc
 endif
 endif
 


### PR DESCRIPTION
This PR includes some extra tests and documentation for the setting of late fill values in different netcdf formats.

Fixes #1098.