### PR TITLE
Incorrect flag is set test for readonly

### DIFF
--- a/libsrc/memio.c
+++ b/libsrc/memio.c
@@ -446,7 +446,7 @@ memio_pad_length(ncio* nciop, off_t length)
     if(nciop == NULL || nciop->pvt == NULL) return NC_EINVAL;
     memio = (NCMEMIO*)nciop->pvt;
 
-    if(fIsSet(nciop->ioflags,NC_WRITE))
+    if(!fIsSet(nciop->ioflags,NC_WRITE))
         return EPERM; /* attempt to write readonly file*/
     if(memio->locked)
 	return NC_EINMEMORY;


### PR DESCRIPTION
I think that if the flag `NC_WRITE` *is* set, then the file is not readonly.  I think that the test should be negated.