### PR TITLE
Fix test run_diskless2.sh with LARGE_FILE_TESTS

### DIFF
--- a/nc_test/CMakeLists.txt
+++ b/nc_test/CMakeLists.txt
@@ -78,14 +78,11 @@ IF(BUILD_UTILITIES)
       add_sh_test(nc_test run_mmap)
       SET_TESTS_PROPERTIES(nc_test_run_mmap PROPERTIES RUN_SERIAL TRUE)
     ENDIF(BUILD_MMAP)
-    if(USE_NETCDF4)
-      IF(LARGE_FILE_TESTS)
-        add_sh_test(nc_test run_diskless2)
-      ENDIF(LARGE_FILE_TESTS)
-    ENDIF(USE_NETCDF4)
     add_sh_test(nc_test run_diskless5)
     add_sh_test(nc_test run_inmemory)
-
+    IF(LARGE_FILE_TESTS)
+      add_sh_test(nc_test run_diskless2)
+    ENDIF()
 ENDIF(BUILD_UTILITIES)
 
 # Copy some test files from current source dir to out-of-tree build dir.

--- a/nc_test/Makefile.am
+++ b/nc_test/Makefile.am
@@ -60,7 +60,7 @@ endif
 check_PROGRAMS = $(TESTPROGRAMS)
 
 # Build Diskless test helpers
-check_PROGRAMS += tst_diskless tst_diskless3 tst_diskless4	\
+check_PROGRAMS += tst_diskless tst_diskless3 tst_diskless4 \
 tst_diskless5 tst_inmemory tst_open_mem
 if USE_NETCDF4
 check_PROGRAMS += tst_diskless2
@@ -70,10 +70,8 @@ TESTS = $(TESTPROGRAMS)
 
 if BUILD_UTILITIES
 TESTS += run_diskless.sh run_diskless5.sh run_inmemory.sh
-if USE_NETCDF4
 if LARGE_FILE_TESTS
 TESTS += run_diskless2.sh
-endif
 endif
 endif
 
@@ -92,7 +90,7 @@ CMakeLists.txt
 # These files are created by the tests.
 CLEANFILES = nc_test_*.nc tst_*.nc t_nc.nc large_files.nc		\
 quick_large_files.nc tst_diskless3_file.cdl tst_diskless3_memory.cdl	\
-tst_diskless4.cdl benchmark.nc
+tst_diskless4.cdl ref_tst_diskless4.cdl benchmark.nc
 
 EXTRA_DIST += bad_cdf5_begin.nc run_cdf5.sh
 if ENABLE_CDF5

--- a/nc_test/run_diskless2.sh
+++ b/nc_test/run_diskless2.sh
@@ -12,48 +12,46 @@ if test "x$srcdir" = x ; then srcdir=`pwd`; fi
 CPU=`uname -p`
 OS=`uname`
 
-#Constants
+# Test diskless on a reasonably large file size
+
+# Try a large in-memory file
+SIZE=1000000000
+
 FILE4=tst_diskless4.nc
 
-# Compute the file size for tst_diskless4
-SIZE=0
-case $CPU in
-*_64*) SIZE=3000000000;;
-*)     SIZE=1000000000;;
-esac
+# Uncomment to get timing
+#TIME=time
 
 # Create the reference ncdump output for tst_diskless4
-rm -fr tst_diskless4.cdl
-echo "netcdf tst_diskless4 {" >>tst_diskless4.cdl
-echo "dimensions:" >>tst_diskless4.cdl
-echo "	dim = 1000000000 ;" >>tst_diskless4.cdl
-echo "variables:" >>tst_diskless4.cdl
-echo "	byte var0(dim) ;" >>tst_diskless4.cdl
-if test $SIZE = 3000000000 ; then
-echo "	byte var1(dim) ;" >>tst_diskless4.cdl
-echo "	byte var2(dim) ;" >>tst_diskless4.cdl
-fi
-echo "}" >>tst_diskless4.cdl
+rm -fr ref_tst_diskless4.cdl
+cat >ref_tst_diskless4.cdl <<EOF
+netcdf tst_diskless4 {
+dimensions:
+	dim = 1000000000 ;
+variables:
+	byte var0(dim) ;
+}
+EOF
 
 echo ""
 rm -f $FILE4
-time ./tst_diskless4 $SIZE create
+$TIME ./tst_diskless4 $SIZE create
 # Validate it
-${NCDUMP} -h $FILE4 |diff -w - tst_diskless4.cdl
+${NCDUMP} -h $FILE4 |diff -w - ref_tst_diskless4.cdl
 
 echo ""
 rm -f $FILE4
-time ./tst_diskless4 $SIZE creatediskless
+$TIME ./tst_diskless4 $SIZE creatediskless
 # Validate it
-${NCDUMP} -h $FILE4 |diff -w - tst_diskless4.cdl
+${NCDUMP} -h $FILE4 |diff -w - ref_tst_diskless4.cdl
 
 echo ""
-time ./tst_diskless4 $SIZE open
+$TIME ./tst_diskless4 $SIZE open
 
 echo ""
-time ./tst_diskless4 $SIZE opendiskless
+$TIME ./tst_diskless4 $SIZE opendiskless
 
 # cleanup
-rm -f $FILE4 tst_diskless4.cdl
+rm -f $FILE4 tst_diskless4.cdl ref_tst_diskless4.cdl
 
 exit

--- a/nc_test/tst_diskless4.c
+++ b/nc_test/tst_diskless4.c
@@ -20,7 +20,7 @@
 #define FILE_NAME "tst_diskless4.nc"
 #define CHUNKSIZE 4096
 #define DATASIZE (CHUNKSIZE/sizeof(int))
-#define DIMMAX 1000000000
+#define DIMMAX 1000000000L
 
 typedef enum Tag {Create,CreateDiskless,Open,OpenDiskless} Tag;
 
@@ -58,16 +58,8 @@ main(int argc, char **argv)
     /* Get the specified var/file size */
     if(argc > 1) {
 	filesize = atol(argv[1]);
-    } else {
-	if(sizeof(size_t) == 4)
-	    filesize = 1000000000L;
-	else if(sizeof(size_t) == 8)
-	    filesize = 3000000000L;
-	else {
-	    fprintf(stderr,"Cannot compute filesize\n");
-	    exit(1);
-	}
-    }
+    } else
+	filesize = 1000000000L;
 
     /* Test that we can malloc that much space */
     memory = malloc(filesize);
@@ -99,7 +91,7 @@ main(int argc, char **argv)
 
     switch (tag) {
     case Create:	  cmode = NC_CLOBBER; break;
-    case CreateDiskless:  cmode = NC_CLOBBER|NC_DISKLESS|NC_WRITE; break;
+    case CreateDiskless:  cmode = NC_CLOBBER|NC_DISKLESS|NC_PERSIST|NC_WRITE; break;
     case Open:		  cmode = 0; break;
     case OpenDiskless:	  cmode = NC_DISKLESS; break;
     }


### PR DESCRIPTION
ret: https://github.com/Unidata/netcdf-c/issues/1162

The test nc_test/run_diskless2.sh fails
when LARGE_FILE_TESTS is enabled.
Since the goal of the test was to test out
diskless+persist on a reasonably large file,
I fixed by just limiting the file size to
1000000000L bytes.