### PR TITLE
RPATH handling is not needed for archive library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -273,7 +273,7 @@ SET(CMAKE_REQUIRED_INCLUDES ${CMAKE_SOURCE_DIR}/libsrc)
 # Configuration for post-install RPath
 # Adapted from http://www.cmake.org/Wiki/CMake_RPATH_handling
 ##
-IF(NOT MSVC)
+IF(NOT MSVC AND BUILD_SHARED_LIBS)
   # use, i.e. don't skip the full RPATH for the build tree
   SET(CMAKE_SKIP_BUILD_RPATH  FALSE)
 


### PR DESCRIPTION
If not building shared libraries, then the RPATH handling should not be specified.  Although ignored on some compilers, the CRAY / Intel compiler will error out when installing the NetCDF executables if the RPATH settings are enabled.

Not sure if this is the best fix, but it does work on our internal CRAY systems.