### PR TITLE
Next step in HDF5 separation - moving att HDF5 info to libhdf5

### DIFF
--- a/include/hdf5internal.h
+++ b/include/hdf5internal.h
@@ -56,6 +56,12 @@ typedef struct  NC_HDF5_FILE_INFO
    hid_t hdfid;
 } NC_HDF5_FILE_INFO_T;
 
+/** Strut to hold HDF5-specific info for attributes. */
+typedef struct  NC_HDF5_ATT_INFO
+{
+   hid_t native_hdf_typeid;     /* Native HDF5 datatype for attribute's data */
+} NC_HDF5_ATT_INFO_T;
+
 /* These functions do HDF5 things. */
 int rec_detach_scales(NC_GRP_INFO_T *grp, int dimid, hid_t dimscaleid);
 int rec_reattach_scales(NC_GRP_INFO_T *grp, int dimid, hid_t dimscaleid);

--- a/include/nc4internal.h
+++ b/include/nc4internal.h
@@ -131,6 +131,7 @@ typedef struct NC_ATT_INFO
    nc_bool_t created;           /* True if attribute already created */
    nc_type nc_typeid;           /* netCDF type of attribute's data */
    hid_t native_hdf_typeid;     /* Native HDF5 datatype for attribute's data */
+   void *format_dim_info;
    void *data;
    nc_vlen_t *vldata; /* only used for vlen */
    char **stdata; /* only for string type. */

--- a/include/nc4internal.h
+++ b/include/nc4internal.h
@@ -130,7 +130,7 @@ typedef struct NC_ATT_INFO
    nc_bool_t dirty;             /* True if attribute modified */
    nc_bool_t created;           /* True if attribute already created */
    nc_type nc_typeid;           /* netCDF type of attribute's data */
-   hid_t native_hdf_typeid;     /* Native HDF5 datatype for attribute's data */
+   /* hid_t native_hdf_typeid;     /\* Native HDF5 datatype for attribute's data *\/ */
    void *format_att_info;
    void *data;
    nc_vlen_t *vldata; /* only used for vlen */

--- a/include/nc4internal.h
+++ b/include/nc4internal.h
@@ -131,7 +131,7 @@ typedef struct NC_ATT_INFO
    nc_bool_t created;           /* True if attribute already created */
    nc_type nc_typeid;           /* netCDF type of attribute's data */
    hid_t native_hdf_typeid;     /* Native HDF5 datatype for attribute's data */
-   void *format_dim_info;
+   void *format_att_info;
    void *data;
    nc_vlen_t *vldata; /* only used for vlen */
    char **stdata; /* only for string type. */

--- a/include/nc4internal.h
+++ b/include/nc4internal.h
@@ -130,7 +130,6 @@ typedef struct NC_ATT_INFO
    nc_bool_t dirty;             /* True if attribute modified */
    nc_bool_t created;           /* True if attribute already created */
    nc_type nc_typeid;           /* netCDF type of attribute's data */
-   /* hid_t native_hdf_typeid;     /\* Native HDF5 datatype for attribute's data *\/ */
    void *format_att_info;
    void *data;
    nc_vlen_t *vldata; /* only used for vlen */

--- a/libhdf5/hdf5attr.c
+++ b/libhdf5/hdf5attr.c
@@ -451,7 +451,11 @@ nc4_put_att(NC_GRP_INFO_T* grp, int varid, const char *name, nc_type file_type,
    {
       LOG((3, "adding attribute %s to the list...", norm_name));
       if ((ret = nc4_att_list_add(attlist, norm_name, &att)))
-         BAIL (ret);
+         BAIL(ret);
+
+      /* Allocate storage for the HDF5 specific att info. */
+      if (!(att->format_att_info = calloc(1, sizeof(NC_HDF5_ATT_INFO_T))))
+         BAIL(NC_ENOMEM);
    }
 
    /* Now fill in the metadata. */

--- a/libhdf5/hdf5file.c
+++ b/libhdf5/hdf5file.c
@@ -258,14 +258,10 @@ nc4_close_netcdf4_file(NC_FILE_INFO_T *h5, int abort, NC_memio *memio)
 int
 nc4_close_hdf5_file(NC_FILE_INFO_T *h5, int abort,  NC_memio *memio)
 {
-   /* NC_HDF5_FILE_INFO_T *hdf5_info; */
    int retval;
 
    assert(h5 && h5->root_grp && h5->format_file_info);
    LOG((3, "%s: h5->path %s abort %d", __func__, h5->controller->path, abort));
-
-   /* /\* Get HDF5 specific info. *\/ */
-   /* hdf5_info = (NC_HDF5_FILE_INFO_T *)h5->format_file_info; */
 
    /* According to the docs, always end define mode on close. */
    if (h5->flags & NC_INDEF)

--- a/libhdf5/hdf5file.c
+++ b/libhdf5/hdf5file.c
@@ -258,14 +258,14 @@ nc4_close_netcdf4_file(NC_FILE_INFO_T *h5, int abort, NC_memio *memio)
 int
 nc4_close_hdf5_file(NC_FILE_INFO_T *h5, int abort,  NC_memio *memio)
 {
-   NC_HDF5_FILE_INFO_T *hdf5_info;
+   /* NC_HDF5_FILE_INFO_T *hdf5_info; */
    int retval;
 
    assert(h5 && h5->root_grp && h5->format_file_info);
    LOG((3, "%s: h5->path %s abort %d", __func__, h5->controller->path, abort));
 
-   /* Get HDF5 specific info. */
-   hdf5_info = (NC_HDF5_FILE_INFO_T *)h5->format_file_info;
+   /* /\* Get HDF5 specific info. *\/ */
+   /* hdf5_info = (NC_HDF5_FILE_INFO_T *)h5->format_file_info; */
 
    /* According to the docs, always end define mode on close. */
    if (h5->flags & NC_INDEF)

--- a/libhdf5/hdf5internal.c
+++ b/libhdf5/hdf5internal.c
@@ -510,13 +510,15 @@ nc4_rec_grp_HDF5_del(NC_GRP_INFO_T *grp)
    /* Close HDF5 resources associated with global attributes. */
    for (a = 0; a < ncindexsize(grp->att); a++)
    {
-      NC_HDF5_ATT_INFO_T hdf5_att;
+      NC_HDF5_ATT_INFO_T *hdf5_att;
 
       att = (NC_ATT_INFO_T *)ncindexith(grp->att, a);
-      assert(att);
+      assert(att && att->format_att_info);
+      hdf5_att = (NC_HDF5_ATT_INFO_T *)att->format_att_info;
 
       /* Close the HDF5 typeid. */
-      if (att->native_hdf_typeid && H5Tclose(att->native_hdf_typeid) < 0)
+      if (hdf5_att->native_hdf_typeid &&
+          H5Tclose(hdf5_att->native_hdf_typeid) < 0)
          return NC_EHDFERR;
    }
 
@@ -536,11 +538,14 @@ nc4_rec_grp_HDF5_del(NC_GRP_INFO_T *grp)
 
       for (a = 0; a < ncindexsize(var->att); a++)
       {
+         NC_HDF5_ATT_INFO_T *hdf5_att;
          att = (NC_ATT_INFO_T *)ncindexith(var->att, a);
-         assert(att);
+         assert(att && att->format_att_info);
+         hdf5_att = (NC_HDF5_ATT_INFO_T *)att->format_att_info;
 
          /* Close the HDF5 typeid if one is open. */
-         if (att->native_hdf_typeid && H5Tclose(att->native_hdf_typeid) < 0)
+         if (hdf5_att->native_hdf_typeid &&
+             H5Tclose(hdf5_att->native_hdf_typeid) < 0)
             return NC_EHDFERR;
       }
    }

--- a/libhdf5/hdf5internal.c
+++ b/libhdf5/hdf5internal.c
@@ -507,9 +507,11 @@ nc4_rec_grp_HDF5_del(NC_GRP_INFO_T *grp)
                                                                      i))))
          return retval;
 
-   /* Close HDF5 resources associated with attributes. */
+   /* Close HDF5 resources associated with global attributes. */
    for (a = 0; a < ncindexsize(grp->att); a++)
    {
+      NC_HDF5_ATT_INFO_T hdf5_att;
+
       att = (NC_ATT_INFO_T *)ncindexith(grp->att, a);
       assert(att);
 

--- a/libhdf5/hdf5open.c
+++ b/libhdf5/hdf5open.c
@@ -1593,6 +1593,10 @@ att_read_callbk(hid_t loc_id, const char *att_name, const H5A_info_t *ainfo,
    if ((retval = nc4_att_list_add(list, att_name, &att)))
       BAIL(-1);
 
+   /* Allocate storage for the HDF5 specific att info. */
+   if (!(att->format_att_info = calloc(1, sizeof(NC_HDF5_ATT_INFO_T))))
+      BAIL(-1);
+
    /* Open the att by name. */
    if ((attid = H5Aopen(loc_id, att_name, H5P_DEFAULT)) < 0)
       BAIL(-1);

--- a/libsrc4/nc4internal.c
+++ b/libsrc4/nc4internal.c
@@ -1143,7 +1143,8 @@ att_free(NC_ATT_INFO_T *att)
       free(att->vldata);
    }
 
-   /* Free any format-sepecific info. */
+   /* Free any format-sepecific info. Some formats use this (ex. HDF5)
+    * and some don't (ex. HDF4). So it may be NULL. */
    if (att->format_att_info)
       free(att->format_att_info);
 

--- a/libsrc4/nc4internal.c
+++ b/libsrc4/nc4internal.c
@@ -1143,6 +1143,10 @@ att_free(NC_ATT_INFO_T *att)
       free(att->vldata);
    }
 
+   /* Free any format-sepecific info. */
+   if (att->format_att_info)
+      free(att->format_att_info);
+
    free(att);
    return NC_NOERR;
 }


### PR DESCRIPTION
Part of #856.

Starting to move hid_t elements from nc4internal.h to hdf5internal.h. In this PR I do the attributes.

No effect on library operation, just moving these pointers to libhdf5 so that they are not in libsrc4.

