### PR TITLE
Next step in libhdf5/libsrc4 separation - moving hdf5-specific dim info to libhdf5

### DIFF
--- a/include/hdf5internal.h
+++ b/include/hdf5internal.h
@@ -56,6 +56,12 @@ typedef struct  NC_HDF5_FILE_INFO
    hid_t hdfid;
 } NC_HDF5_FILE_INFO_T;
 
+/** Strut to hold HDF5-specific info for attributes. */
+typedef struct  NC_HDF5_ATT_INFO
+{
+   hid_t native_hdf_typeid;     /* Native HDF5 datatype for attribute's data */
+} NC_HDF5_ATT_INFO_T;
+
 /* These functions do HDF5 things. */
 int rec_detach_scales(NC_GRP_INFO_T *grp, int dimid, hid_t dimscaleid);
 int rec_reattach_scales(NC_GRP_INFO_T *grp, int dimid, hid_t dimscaleid);

--- a/include/hdf5internal.h
+++ b/include/hdf5internal.h
@@ -56,6 +56,13 @@ typedef struct  NC_HDF5_FILE_INFO
    hid_t hdfid;
 } NC_HDF5_FILE_INFO_T;
 
+/* This is a struct to handle the dim metadata. */
+typedef struct NC_HDF5_DIM_INFO
+{
+   hid_t hdf_dimscaleid;        /* Non-zero if a DIM_WITHOUT_VARIABLE dataset is in use (no coord var). */
+   HDF5_OBJID_T hdf5_objid;
+} NC_HDF5_DIM_INFO_T;
+
 /** Strut to hold HDF5-specific info for attributes. */
 typedef struct  NC_HDF5_ATT_INFO
 {

--- a/include/nc4internal.h
+++ b/include/nc4internal.h
@@ -118,7 +118,7 @@ typedef struct NC_DIM_INFO
    nc_bool_t extended;          /* True if the dimension needs to be extended */
    nc_bool_t too_long;          /* True if len is too big to fit in local size_t. */
    void *format_dim_info;       /* Pointer to format-specific dim info. */
-   hid_t hdf_dimscaleid;        /* Non-zero if a DIM_WITHOUT_VARIABLE dataset is in use (no coord var). */
+   /* hid_t hdf_dimscaleid;        /\* Non-zero if a DIM_WITHOUT_VARIABLE dataset is in use (no coord var). *\/ */
    HDF5_OBJID_T hdf5_objid;
    struct NC_VAR_INFO *coord_var; /* The coord var, if it exists. */
 } NC_DIM_INFO_T;

--- a/include/nc4internal.h
+++ b/include/nc4internal.h
@@ -130,7 +130,7 @@ typedef struct NC_ATT_INFO
    nc_bool_t dirty;             /* True if attribute modified */
    nc_bool_t created;           /* True if attribute already created */
    nc_type nc_typeid;           /* netCDF type of attribute's data */
-   hid_t native_hdf_typeid;     /* Native HDF5 datatype for attribute's data */
+   void *format_att_info;
    void *data;
    nc_vlen_t *vldata; /* only used for vlen */
    char **stdata; /* only for string type. */

--- a/include/nc4internal.h
+++ b/include/nc4internal.h
@@ -118,8 +118,6 @@ typedef struct NC_DIM_INFO
    nc_bool_t extended;          /* True if the dimension needs to be extended */
    nc_bool_t too_long;          /* True if len is too big to fit in local size_t. */
    void *format_dim_info;       /* Pointer to format-specific dim info. */
-   /* hid_t hdf_dimscaleid;        /\* Non-zero if a DIM_WITHOUT_VARIABLE dataset is in use (no coord var). *\/ */
-   HDF5_OBJID_T hdf5_objid;
    struct NC_VAR_INFO *coord_var; /* The coord var, if it exists. */
 } NC_DIM_INFO_T;
 

--- a/include/nc4internal.h
+++ b/include/nc4internal.h
@@ -112,11 +112,12 @@ typedef struct NC_OBJ {
 typedef struct NC_DIM_INFO
 {
    NC_OBJ hdr;
-   struct NC_GRP_INFO* container;  /* containing group */
+   struct NC_GRP_INFO *container;  /* containing group */
    size_t len;
    nc_bool_t unlimited;         /* True if the dimension is unlimited */
    nc_bool_t extended;          /* True if the dimension needs to be extended */
    nc_bool_t too_long;          /* True if len is too big to fit in local size_t. */
+   void *format_dim_info;       /* Pointer to format-specific dim info. */
    hid_t hdf_dimscaleid;        /* Non-zero if a DIM_WITHOUT_VARIABLE dataset is in use (no coord var). */
    HDF5_OBJID_T hdf5_objid;
    struct NC_VAR_INFO *coord_var; /* The coord var, if it exists. */
@@ -125,7 +126,7 @@ typedef struct NC_DIM_INFO
 typedef struct NC_ATT_INFO
 {
    NC_OBJ hdr;
-   struct NC_OBJ* container;    /* containing group|var */
+   struct NC_OBJ *container;    /* containing group|var */
    int len;
    nc_bool_t dirty;             /* True if attribute modified */
    nc_bool_t created;           /* True if attribute already created */

--- a/libhdf5/hdf5attr.c
+++ b/libhdf5/hdf5attr.c
@@ -451,7 +451,11 @@ nc4_put_att(NC_GRP_INFO_T* grp, int varid, const char *name, nc_type file_type,
    {
       LOG((3, "adding attribute %s to the list...", norm_name));
       if ((ret = nc4_att_list_add(attlist, norm_name, &att)))
-         BAIL (ret);
+         BAIL(ret);
+
+      /* Allocate storage for the HDF5 specific att info. */
+      if (!(att->format_att_info = calloc(1, sizeof(NC_HDF5_ATT_INFO_T))))
+         BAIL(NC_ENOMEM);
    }
 
    /* Now fill in the metadata. */

--- a/libhdf5/hdf5dim.c
+++ b/libhdf5/hdf5dim.c
@@ -208,7 +208,8 @@ NC4_rename_dim(int ncid, int dimid, const char *name)
 {
    NC *nc;
    NC_GRP_INFO_T *grp;
-   NC_DIM_INFO_T *dim, *tmpdim;
+   NC_DIM_INFO_T *dim;
+   NC_HDF5_DIM_INFO_T *hdf5_dim;
    NC_FILE_INFO_T *h5;
    char norm_name[NC_MAX_NAME + 1];
    int retval;
@@ -234,15 +235,14 @@ NC4_rename_dim(int ncid, int dimid, const char *name)
       return retval;
 
    /* Get the original dim */
-   if((retval=nc4_find_dim(grp,dimid,&dim,NULL)) != NC_NOERR)
-	return retval;
-   if(dim == NULL) /* No such dim */
-	return NC_EBADDIM;
+   if ((retval = nc4_find_dim(grp, dimid, &dim, NULL)))
+      return retval;
+   if (!dim) /* No such dim */
+      return NC_EBADDIM;
 
    /* Check if new name is in use */
-   tmpdim = (NC_DIM_INFO_T*)ncindexlookup(grp->dim,norm_name);
-   if(tmpdim != NULL)
-	return NC_ENAMEINUSE;
+   if (ncindexlookup(grp->dim, norm_name))
+      return NC_ENAMEINUSE;
 
    /* Check for renaming dimension w/o variable */
    if (dim->hdf_dimscaleid)

--- a/libhdf5/hdf5dim.c
+++ b/libhdf5/hdf5dim.c
@@ -104,6 +104,10 @@ NC4_def_dim(int ncid, const char *name, size_t len, int *idp)
    if ((retval = nc4_dim_list_add(grp, norm_name, len, -1, &dim)))
       return retval;
 
+   /* Create struct for HDF5-specific dim info. */
+   if (!(dim->format_dim_info = calloc(1, sizeof(NC_HDF5_DIM_INFO_T))))
+      return NC_ENOMEM;
+
    /* Pass back the dimid. */
    if (idp)
       *idp = dim->hdr.id;

--- a/libhdf5/hdf5file.c
+++ b/libhdf5/hdf5file.c
@@ -258,14 +258,10 @@ nc4_close_netcdf4_file(NC_FILE_INFO_T *h5, int abort, NC_memio *memio)
 int
 nc4_close_hdf5_file(NC_FILE_INFO_T *h5, int abort,  NC_memio *memio)
 {
-   NC_HDF5_FILE_INFO_T *hdf5_info;
    int retval;
 
    assert(h5 && h5->root_grp && h5->format_file_info);
    LOG((3, "%s: h5->path %s abort %d", __func__, h5->controller->path, abort));
-
-   /* Get HDF5 specific info. */
-   hdf5_info = (NC_HDF5_FILE_INFO_T *)h5->format_file_info;
 
    /* According to the docs, always end define mode on close. */
    if (h5->flags & NC_INDEF)

--- a/libhdf5/hdf5internal.c
+++ b/libhdf5/hdf5internal.c
@@ -458,6 +458,7 @@ nc4_reform_coord_var(NC_GRP_INFO_T *grp, NC_VAR_INFO_T *var, NC_DIM_INFO_T *dim)
       if (H5Dclose(dim->hdf_dimscaleid) < 0)
          BAIL(NC_EHDFERR);
       dim->hdf_dimscaleid = 0;
+      hdf5_dim->hdf_dimscaleid = 0;
 
       /* Now delete the dimscale's dataset
          (it will be recreated later, if necessary) */

--- a/libhdf5/hdf5internal.c
+++ b/libhdf5/hdf5internal.c
@@ -356,6 +356,7 @@ delete_existing_dimscale_dataset(NC_GRP_INFO_T *grp, int dimid, NC_DIM_INFO_T *d
    /* Close the HDF5 dataset */
    if (H5Dclose(dim->hdf_dimscaleid) < 0)
       return NC_EHDFERR;
+   hdf5_dim->hdf_dimscaleid = 0;
    dim->hdf_dimscaleid = 0;
 
    /* Now delete the dataset. */
@@ -404,9 +405,10 @@ nc4_reform_coord_var(NC_GRP_INFO_T *grp, NC_VAR_INFO_T *var, NC_DIM_INFO_T *dim)
             for (g = grp; g && !finished; g = g->parent)
             {
                NC_DIM_INFO_T *dim1;
-               for(k=0;k<ncindexsize(g->dim);k++)
+               for (k = 0; k < ncindexsize(g->dim); k++)
                {
-                  if((dim1 = (NC_DIM_INFO_T*)ncindexith(g->dim,k)) == NULL) continue;
+                  dim1 = (NC_DIM_INFO_T *)ncindexith(g->dim, k);
+                  assert(dim1);
                   if (var->dimids[d] == dim1->hdr.id)
                   {
                      hid_t dim_datasetid;  /* Dataset ID for dimension */

--- a/libhdf5/hdf5internal.c
+++ b/libhdf5/hdf5internal.c
@@ -341,11 +341,13 @@ nc4_break_coord_var(NC_GRP_INFO_T *grp, NC_VAR_INFO_T *coord_var, NC_DIM_INFO_T 
 int
 delete_existing_dimscale_dataset(NC_GRP_INFO_T *grp, int dimid, NC_DIM_INFO_T *dim)
 {
+   NC_HDF5_DIM_INFO_T *hdf5_dim;
    int retval;
 
-   assert(grp && dim);
+   assert(grp && dim && dim->format_dim_info);
    LOG((2, "%s: deleting dimscale dataset %s dimid %d", __func__, dim->hdr.name,
         dimid));
+   hdf5_dim = (NC_HDF5_DIM_INFO_T *)dim->format_dim_info;
 
    /* Detach dimscale from any variables using it */
    if ((retval = rec_detach_scales(grp, dimid, dim->hdf_dimscaleid)) < 0)
@@ -553,8 +555,11 @@ nc4_rec_grp_HDF5_del(NC_GRP_INFO_T *grp)
    /* Close HDF5 resources associated with dims. */
    for (i = 0; i < ncindexsize(grp->dim); i++)
    {
+      NC_HDF5_DIM_INFO_T *hdf5_dim;
+
       dim = (NC_DIM_INFO_T *)ncindexith(grp->dim, i);
-      assert(dim);
+      assert(dim && dim->format_dim_info);
+      hdf5_dim = (NC_HDF5_DIM_INFO_T *)dim->format_dim_info;
 
       /* If this is a dim without a coordinate variable, then close
        * the HDF5 DIM_WITHOUT_VARIABLE dataset associated with this

--- a/libhdf5/hdf5internal.c
+++ b/libhdf5/hdf5internal.c
@@ -507,14 +507,18 @@ nc4_rec_grp_HDF5_del(NC_GRP_INFO_T *grp)
                                                                      i))))
          return retval;
 
-   /* Close HDF5 resources associated with attributes. */
+   /* Close HDF5 resources associated with global attributes. */
    for (a = 0; a < ncindexsize(grp->att); a++)
    {
+      NC_HDF5_ATT_INFO_T *hdf5_att;
+
       att = (NC_ATT_INFO_T *)ncindexith(grp->att, a);
-      assert(att);
+      assert(att && att->format_att_info);
+      hdf5_att = (NC_HDF5_ATT_INFO_T *)att->format_att_info;
 
       /* Close the HDF5 typeid. */
-      if (att->native_hdf_typeid && H5Tclose(att->native_hdf_typeid) < 0)
+      if (hdf5_att->native_hdf_typeid &&
+          H5Tclose(hdf5_att->native_hdf_typeid) < 0)
          return NC_EHDFERR;
    }
 
@@ -534,11 +538,14 @@ nc4_rec_grp_HDF5_del(NC_GRP_INFO_T *grp)
 
       for (a = 0; a < ncindexsize(var->att); a++)
       {
+         NC_HDF5_ATT_INFO_T *hdf5_att;
          att = (NC_ATT_INFO_T *)ncindexith(var->att, a);
-         assert(att);
+         assert(att && att->format_att_info);
+         hdf5_att = (NC_HDF5_ATT_INFO_T *)att->format_att_info;
 
          /* Close the HDF5 typeid if one is open. */
-         if (att->native_hdf_typeid && H5Tclose(att->native_hdf_typeid) < 0)
+         if (hdf5_att->native_hdf_typeid &&
+             H5Tclose(hdf5_att->native_hdf_typeid) < 0)
             return NC_EHDFERR;
       }
    }

--- a/libhdf5/hdf5open.c
+++ b/libhdf5/hdf5open.c
@@ -1748,6 +1748,10 @@ read_scale(NC_GRP_INFO_T *grp, hid_t datasetid, const char *obj_name,
 
    dimscale_created++;
 
+   new_hdf5_dim->hdf5_objid.fileno[0] = statbuf->fileno[0];
+   new_hdf5_dim->hdf5_objid.fileno[1] = statbuf->fileno[1];
+   new_hdf5_dim->hdf5_objid.objno[0] = statbuf->objno[0];
+   new_hdf5_dim->hdf5_objid.objno[1] = statbuf->objno[1];
    new_dim->hdf5_objid.fileno[0] = statbuf->fileno[0];
    new_dim->hdf5_objid.fileno[1] = statbuf->fileno[1];
    new_dim->hdf5_objid.objno[0] = statbuf->objno[0];

--- a/libhdf5/hdf5open.c
+++ b/libhdf5/hdf5open.c
@@ -1752,10 +1752,6 @@ read_scale(NC_GRP_INFO_T *grp, hid_t datasetid, const char *obj_name,
    new_hdf5_dim->hdf5_objid.fileno[1] = statbuf->fileno[1];
    new_hdf5_dim->hdf5_objid.objno[0] = statbuf->objno[0];
    new_hdf5_dim->hdf5_objid.objno[1] = statbuf->objno[1];
-   new_dim->hdf5_objid.fileno[0] = statbuf->fileno[0];
-   new_dim->hdf5_objid.fileno[1] = statbuf->fileno[1];
-   new_dim->hdf5_objid.objno[0] = statbuf->objno[0];
-   new_dim->hdf5_objid.objno[1] = statbuf->objno[1];
 
    /* If the dimscale has an unlimited dimension, then this dimension
     * is unlimited. */

--- a/libhdf5/hdf5open.c
+++ b/libhdf5/hdf5open.c
@@ -1738,6 +1738,10 @@ read_scale(NC_GRP_INFO_T *grp, hid_t datasetid, const char *obj_name,
    if ((retval = nc4_dim_list_add(grp, obj_name, len, assigned_id, &new_dim)))
       BAIL(retval);
 
+   /* Create struct for HDF5-specific dim info. */
+   if (!(new_dim->format_dim_info = calloc(1, sizeof(NC_HDF5_DIM_INFO_T))))
+      BAIL(NC_ENOMEM);
+
    new_dim->too_long = too_long;
 
    dimscale_created++;

--- a/libhdf5/hdf5open.c
+++ b/libhdf5/hdf5open.c
@@ -1778,7 +1778,6 @@ read_scale(NC_GRP_INFO_T *grp, hid_t datasetid, const char *obj_name,
          /* Hold open the dataset, since the dimension doesn't have a
           * coordinate variable */
          new_hdf5_dim->hdf_dimscaleid = datasetid;
-         new_dim->hdf_dimscaleid = datasetid;
          H5Iinc_ref(new_hdf5_dim->hdf_dimscaleid);        /* Increment number of objects using ID */
       }
    }

--- a/libhdf5/hdf5open.c
+++ b/libhdf5/hdf5open.c
@@ -1825,6 +1825,7 @@ read_dataset(NC_GRP_INFO_T *grp, hid_t datasetid, const char *obj_name,
              const H5G_stat_t *statbuf)
 {
    NC_DIM_INFO_T *dim = NULL;   /* Dimension created for scales */
+   NC_HDF5_DIM_INFO_T *hdf5_dim;
    hid_t spaceid = 0;
    int ndims;
    htri_t is_scale;
@@ -1852,12 +1853,13 @@ read_dataset(NC_GRP_INFO_T *grp, hid_t datasetid, const char *obj_name,
       if ((retval = read_scale(grp, datasetid, obj_name, statbuf, dims[0],
                                max_dims[0], &dim)))
          BAIL(retval);
+      hdf5_dim = (NC_HDF5_DIM_INFO_T *)dim->format_dim_info;
    }
 
    /* Add a var to the linked list, and get its metadata,
     * unless this is one of those funny dimscales that are a
     * dimension in netCDF but not a variable. (Spooky!) */
-   if (!dim || (dim && !dim->hdf_dimscaleid))
+   if (!dim || (dim && !hdf5_dim->hdf_dimscaleid))
       if ((retval = read_var(grp, datasetid, obj_name, ndims, dim)))
          BAIL(retval);
 

--- a/libhdf5/hdf5open.c
+++ b/libhdf5/hdf5open.c
@@ -1033,36 +1033,40 @@ get_netcdf_type(NC_FILE_INFO_T *h5, hid_t native_typeid,
 static int
 read_hdf5_att(NC_GRP_INFO_T *grp, hid_t attid, NC_ATT_INFO_T *att)
 {
+   NC_HDF5_ATT_INFO_T *hdf5_att;
    hid_t spaceid = 0, file_typeid = 0;
    hsize_t dims[1] = {0}; /* netcdf attributes always 1-D. */
-   int retval = NC_NOERR;
    size_t type_size;
    int att_ndims;
    hssize_t att_npoints;
    H5T_class_t att_class;
    int fixed_len_string = 0;
    size_t fixed_size = 0;
+   int retval = NC_NOERR;
 
-   assert(att->hdr.name);
+   assert(att && att->hdr.name && att->format_att_info);
    LOG((5, "%s: att->hdr.id %d att->hdr.name %s att->nc_typeid %d att->len %d",
         __func__, att->hdr.id, att->hdr.name, (int)att->nc_typeid, att->len));
+
+   /* Get HDF5-sepecific info stuct for this attribute. */
+   hdf5_att = (NC_HDF5_ATT_INFO_T *)att->format_att_info;
 
    /* Get type of attribute in file. */
    if ((file_typeid = H5Aget_type(attid)) < 0)
       return NC_EATTMETA;
-   if ((att->native_hdf_typeid = H5Tget_native_type(file_typeid,
+   if ((hdf5_att->native_hdf_typeid = H5Tget_native_type(file_typeid,
                                                     H5T_DIR_DEFAULT)) < 0)
       BAIL(NC_EHDFERR);
-   if ((att_class = H5Tget_class(att->native_hdf_typeid)) < 0)
+   if ((att_class = H5Tget_class(hdf5_att->native_hdf_typeid)) < 0)
       BAIL(NC_EATTMETA);
    if (att_class == H5T_STRING &&
-       !H5Tis_variable_str(att->native_hdf_typeid))
+       !H5Tis_variable_str(hdf5_att->native_hdf_typeid))
    {
       fixed_len_string++;
-      if (!(fixed_size = H5Tget_size(att->native_hdf_typeid)))
+      if (!(fixed_size = H5Tget_size(hdf5_att->native_hdf_typeid)))
          BAIL(NC_EATTMETA);
    }
-   if ((retval = get_netcdf_type(grp->nc4_info, att->native_hdf_typeid,
+   if ((retval = get_netcdf_type(grp->nc4_info, hdf5_att->native_hdf_typeid,
                                  &(att->nc_typeid))))
       BAIL(retval);
 
@@ -1139,7 +1143,7 @@ read_hdf5_att(NC_GRP_INFO_T *grp, hid_t attid, NC_ATT_INFO_T *att)
       {
          if (!(att->vldata = malloc((unsigned int)(att->len * sizeof(hvl_t)))))
             BAIL(NC_ENOMEM);
-         if (H5Aread(attid, att->native_hdf_typeid, att->vldata) < 0)
+         if (H5Aread(attid, hdf5_att->native_hdf_typeid, att->vldata) < 0)
             BAIL(NC_EATTMETA);
       }
       else if (att->nc_typeid == NC_STRING)
@@ -1167,7 +1171,7 @@ read_hdf5_att(NC_GRP_INFO_T *grp, hid_t attid, NC_ATT_INFO_T *att)
                BAIL(NC_ENOMEM);
 
             /* Read the fixed-len strings as one big block. */
-            if (H5Aread(attid, att->native_hdf_typeid, contig_buf) < 0) {
+            if (H5Aread(attid, hdf5_att->native_hdf_typeid, contig_buf) < 0) {
                free(contig_buf);
                BAIL(NC_EATTMETA);
             }
@@ -1192,7 +1196,7 @@ read_hdf5_att(NC_GRP_INFO_T *grp, hid_t attid, NC_ATT_INFO_T *att)
          else
          {
             /* Read variable-length string atts. */
-            if (H5Aread(attid, att->native_hdf_typeid, att->stdata) < 0)
+            if (H5Aread(attid, hdf5_att->native_hdf_typeid, att->stdata) < 0)
                BAIL(NC_EATTMETA);
          }
       }
@@ -1200,7 +1204,7 @@ read_hdf5_att(NC_GRP_INFO_T *grp, hid_t attid, NC_ATT_INFO_T *att)
       {
          if (!(att->data = malloc((unsigned int)(att->len * type_size))))
             BAIL(NC_ENOMEM);
-         if (H5Aread(attid, att->native_hdf_typeid, att->data) < 0)
+         if (H5Aread(attid, hdf5_att->native_hdf_typeid, att->data) < 0)
             BAIL(NC_EATTMETA);
       }
    }
@@ -1591,6 +1595,10 @@ att_read_callbk(hid_t loc_id, const char *att_name, const H5A_info_t *ainfo,
 
    /* Add to the end of the list of atts for this var. */
    if ((retval = nc4_att_list_add(list, att_name, &att)))
+      BAIL(-1);
+
+   /* Allocate storage for the HDF5 specific att info. */
+   if (!(att->format_att_info = calloc(1, sizeof(NC_HDF5_ATT_INFO_T))))
       BAIL(-1);
 
    /* Open the att by name. */

--- a/libhdf5/hdf5var.c
+++ b/libhdf5/hdf5var.c
@@ -431,6 +431,7 @@ NC4_def_var(int ncid, const char *name, nc_type xtype,
             if (H5Dclose(dim->hdf_dimscaleid) < 0)
                BAIL(NC_EHDFERR);
             dim->hdf_dimscaleid = 0;
+            hdf5_dim->hdf_dimscaleid = 0;
 
             /* Now delete the DIM_WITHOUT_VARIABLE dataset (it will be
              * recreated later, if necessary). */

--- a/libhdf5/hdf5var.c
+++ b/libhdf5/hdf5var.c
@@ -431,7 +431,6 @@ NC4_def_var(int ncid, const char *name, nc_type xtype,
             /* Close the HDF5 DIM_WITHOUT_VARIABLE dataset. */
             if (H5Dclose(hdf5_dim->hdf_dimscaleid) < 0)
                BAIL(NC_EHDFERR);
-            dim->hdf_dimscaleid = 0;
             hdf5_dim->hdf_dimscaleid = 0;
 
             /* Now delete the DIM_WITHOUT_VARIABLE dataset (it will be

--- a/libhdf5/hdf5var.c
+++ b/libhdf5/hdf5var.c
@@ -421,14 +421,15 @@ NC4_def_var(int ncid, const char *name, nc_type xtype,
          /* Use variable's dataset ID for the dimscale ID. So delete
           * the HDF5 DIM_WITHOUT_VARIABLE dataset that was created for
           * this dim. */
-         if (dim->hdf_dimscaleid)
+         if (hdf5_dim->hdf_dimscaleid)
          {
             /* Detach dimscale from any variables using it */
-            if ((retval = rec_detach_scales(grp, dimidsp[d], dim->hdf_dimscaleid)) < 0)
+            if ((retval = rec_detach_scales(grp, dimidsp[d],
+                                            hdf5_dim->hdf_dimscaleid)) < 0)
                BAIL(retval);
 
             /* Close the HDF5 DIM_WITHOUT_VARIABLE dataset. */
-            if (H5Dclose(dim->hdf_dimscaleid) < 0)
+            if (H5Dclose(hdf5_dim->hdf_dimscaleid) < 0)
                BAIL(NC_EHDFERR);
             dim->hdf_dimscaleid = 0;
             hdf5_dim->hdf_dimscaleid = 0;
@@ -1067,7 +1068,7 @@ NC4_rename_var(int ncid, int varid, const char *name)
 
          /* Is there an existing dimscale-only dataset of this name? If
           * so, it must be deleted. */
-         if (var->dim[0]->hdf_dimscaleid)
+         if (hdf5_d0->hdf_dimscaleid)
          {
             if ((retval = delete_existing_dimscale_dataset(grp, var->dim[0]->hdr.id,
                                                            var->dim[0])))

--- a/libhdf5/nc4hdf.c
+++ b/libhdf5/nc4hdf.c
@@ -1823,7 +1823,7 @@ write_dim(NC_DIM_INFO_T *dim, NC_GRP_INFO_T *grp, nc_bool_t write_dimid)
        * be shown to the user as a variable. It is hidden. It is
        * a DIM WITHOUT A VARIABLE! */
       sprintf(dimscale_wo_var, "%s%10d", DIM_WITHOUT_VARIABLE, (int)dim->len);
-      if (H5DSset_scale(dim->hdf_dimscaleid, dimscale_wo_var) < 0)
+      if (H5DSset_scale(hdf5_dim->hdf_dimscaleid, dimscale_wo_var) < 0)
          BAIL(NC_EHDFERR);
    }
 
@@ -1864,7 +1864,7 @@ write_dim(NC_DIM_INFO_T *dim, NC_GRP_INFO_T *grp, nc_bool_t write_dimid)
     * creation order. This can be necessary when dims and their
     * coordinate variables were created in different order. */
    if (write_dimid && dim->hdf_dimscaleid)
-      if ((retval = write_netcdf4_dimid(dim->hdf_dimscaleid, dim->hdr.id)))
+      if ((retval = write_netcdf4_dimid(hdf5_dim->hdf_dimscaleid, dim->hdr.id)))
          BAIL(retval);
 
    return NC_NOERR;

--- a/libhdf5/nc4hdf.c
+++ b/libhdf5/nc4hdf.c
@@ -1669,7 +1669,7 @@ write_var(NC_VAR_INFO_T *var, NC_GRP_INFO_T *grp, nc_bool_t write_dimid)
                if (dim1->coord_var)
                   dim_datasetid = dim1->coord_var->hdf_datasetid;
                else
-                  dim_datasetid = dim1->hdf_dimscaleid;
+                  dim_datasetid = hdf5_dim1->hdf_dimscaleid;
                assert(dim_datasetid > 0);
 
                if (H5DSdetach_scale(var->hdf_datasetid, dim_datasetid, d) < 0)
@@ -1768,7 +1768,7 @@ write_dim(NC_DIM_INFO_T *dim, NC_GRP_INFO_T *grp, nc_bool_t write_dimid)
     * and mark that it should be hidden from netCDF as a
     * variable. (That is, it should appear as a dimension
     * without an associated variable.) */
-   if (!dim->hdf_dimscaleid)
+   if (!hdf5_dim->hdf_dimscaleid)
    {
       hid_t spaceid, create_propid;
       hsize_t dims[1], max_dims[1], chunk_dims[1] = {1};
@@ -1863,7 +1863,7 @@ write_dim(NC_DIM_INFO_T *dim, NC_GRP_INFO_T *grp, nc_bool_t write_dimid)
     * the dimid that the dimension would otherwise receive based on
     * creation order. This can be necessary when dims and their
     * coordinate variables were created in different order. */
-   if (write_dimid && dim->hdf_dimscaleid)
+   if (write_dimid && hdf5_dim->hdf_dimscaleid)
       if ((retval = write_netcdf4_dimid(hdf5_dim->hdf_dimscaleid, dim->hdr.id)))
          BAIL(retval);
 

--- a/libhdf5/nc4hdf.c
+++ b/libhdf5/nc4hdf.c
@@ -2978,9 +2978,15 @@ nc4_rec_match_dimscales(NC_GRP_INFO_T *grp)
                 * match. */
                for (g = grp; g && !finished; g = g->parent)
                {
-                  for(j=0;j<ncindexsize(g->dim);j++)
+                  for (j = 0; j < ncindexsize(g->dim); j++)
                   {
-                     if((dim = (NC_DIM_INFO_T*)ncindexith(g->dim,j)) == NULL) continue;
+                     NC_HDF5_DIM_INFO_T *hdf5_dim;
+                     dim = (NC_DIM_INFO_T *)ncindexith(g->dim, j);
+                     assert(dim && dim->format_dim_info);
+                     hdf5_dim = (NC_HDF5_DIM_INFO_T *)dim->format_dim_info;
+
+                     /* Check for exact match to find identical
+                      * objects in HDF5 file. */
                      if (var->dimscale_hdf5_objids[d].fileno[0] == dim->hdf5_objid.fileno[0] &&
                          var->dimscale_hdf5_objids[d].objno[0] == dim->hdf5_objid.objno[0] &&
                          var->dimscale_hdf5_objids[d].fileno[1] == dim->hdf5_objid.fileno[1] &&

--- a/libhdf5/nc4hdf.c
+++ b/libhdf5/nc4hdf.c
@@ -1808,9 +1808,10 @@ write_dim(NC_DIM_INFO_T *dim, NC_GRP_INFO_T *grp, nc_bool_t write_dimid)
 
       /* Create the dataset that will be the dimension scale. */
       LOG((4, "%s: about to H5Dcreate1 a dimscale dataset %s", __func__, dim->hdr.name));
-      if ((dim->hdf_dimscaleid = H5Dcreate1(grp->hdf_grpid, dim->hdr.name, H5T_IEEE_F32BE,
-                                            spaceid, create_propid)) < 0)
+      if ((hdf5_dim->hdf_dimscaleid = H5Dcreate1(grp->hdf_grpid, dim->hdr.name, H5T_IEEE_F32BE,
+                                                 spaceid, create_propid)) < 0)
          BAIL(NC_EHDFERR);
+      dim->hdf_dimscaleid = hdf5_dim->hdf_dimscaleid;
 
       /* Close the spaceid and create_propid. */
       if (H5Sclose(spaceid) < 0)

--- a/libhdf5/nc4hdf.c
+++ b/libhdf5/nc4hdf.c
@@ -2972,28 +2972,29 @@ nc4_rec_match_dimscales(NC_GRP_INFO_T *grp)
             for (d = 0; d < var->ndims; d++)
             {
                nc_bool_t finished = NC_FALSE;
-
                LOG((5, "%s: var %s has dimscale info...", __func__, var->hdr.name));
-               /* Look at all the dims in this group to see if they
-                * match. */
+
+               /* Check this and parent groups. */
                for (g = grp; g && !finished; g = g->parent)
                {
+                  /* Check all dims in this group. */
                   for (j = 0; j < ncindexsize(g->dim); j++)
                   {
+                     /* Get the HDF5 specific dim info. */
                      NC_HDF5_DIM_INFO_T *hdf5_dim;
                      dim = (NC_DIM_INFO_T *)ncindexith(g->dim, j);
                      assert(dim && dim->format_dim_info);
                      hdf5_dim = (NC_HDF5_DIM_INFO_T *)dim->format_dim_info;
 
-                     /* Check for exact match to find identical
-                      * objects in HDF5 file. */
-                     if (var->dimscale_hdf5_objids[d].fileno[0] == dim->hdf5_objid.fileno[0] &&
-                         var->dimscale_hdf5_objids[d].objno[0] == dim->hdf5_objid.objno[0] &&
-                         var->dimscale_hdf5_objids[d].fileno[1] == dim->hdf5_objid.fileno[1] &&
-                         var->dimscale_hdf5_objids[d].objno[1] == dim->hdf5_objid.objno[1])
+                     /* Check for exact match of fileno/objid arrays
+                      * to find identical objects in HDF5 file. */
+                     if (var->dimscale_hdf5_objids[d].fileno[0] == hdf5_dim->hdf5_objid.fileno[0] &&
+                         var->dimscale_hdf5_objids[d].objno[0] == hdf5_dim->hdf5_objid.objno[0] &&
+                         var->dimscale_hdf5_objids[d].fileno[1] == hdf5_dim->hdf5_objid.fileno[1] &&
+                         var->dimscale_hdf5_objids[d].objno[1] == hdf5_dim->hdf5_objid.objno[1])
                      {
-                        LOG((4, "%s: for dimension %d, found dim %s",
-                             __func__, d, dim->hdr.name));
+                        LOG((4, "%s: for dimension %d, found dim %s", __func__,
+                             d, dim->hdr.name));
                         var->dimids[d] = dim->hdr.id;
                         var->dim[d] = dim;
                         finished = NC_TRUE;
@@ -3001,7 +3002,8 @@ nc4_rec_match_dimscales(NC_GRP_INFO_T *grp)
                      }
                   } /* next dim */
                } /* next grp */
-               LOG((5, "%s: dimid for this dimscale is %d", __func__, var->type_info->hdr.id));
+               LOG((5, "%s: dimid for this dimscale is %d", __func__,
+                    var->type_info->hdr.id));
             } /* next var->dim */
          }
          /* No dimscales for this var! Invent phony dimensions. */

--- a/libhdf5/nc4hdf.c
+++ b/libhdf5/nc4hdf.c
@@ -1399,11 +1399,11 @@ attach_dimscales(NC_GRP_INFO_T *grp)
             {
                if (!var->dimscale_attached[d])
                {
-                  NC_HDF5_DIM_INFO_T *hdf5_dim;
+                  NC_HDF5_DIM_INFO_T *hdf5_dim1;
                   hid_t dim_datasetid;  /* Dataset ID for dimension */
                   dim1 = var->dim[d];
                   assert(dim1 && dim1->hdr.id == var->dimids[d] && dim1->format_dim_info);
-                  hdf5_dim = (NC_HDF5_DIM_INFO_T *)dim1->format_dim_info;
+                  hdf5_dim1 = (NC_HDF5_DIM_INFO_T *)dim1->format_dim_info;
 
                   LOG((2, "%s: attaching scale for dimid %d to var %s",
                        __func__, var->dimids[d], var->hdr.name));
@@ -1412,7 +1412,7 @@ attach_dimscales(NC_GRP_INFO_T *grp)
                   if (dim1->coord_var)
                      dim_datasetid = dim1->coord_var->hdf_datasetid;
                   else
-                     dim_datasetid = dim1->hdf_dimscaleid;
+                     dim_datasetid = hdf5_dim1->hdf_dimscaleid;
                   if(!(dim_datasetid > 0))
                      assert(dim_datasetid > 0);
                   if (H5DSattach_scale(var->hdf_datasetid, dim_datasetid, d) < 0)
@@ -1622,7 +1622,7 @@ write_var(NC_VAR_INFO_T *var, NC_GRP_INFO_T *grp, nc_bool_t write_dimid)
                if (d1->coord_var)
                   dim_datasetid = d1->coord_var->hdf_datasetid;
                else
-                  dim_datasetid = d1->hdf_dimscaleid;
+                  dim_datasetid = hdf5_d1->hdf_dimscaleid;
                assert(dim_datasetid > 0);
 
                /* If we're replacing an existing dimscale dataset, go to

--- a/libhdf5/nc4hdf.c
+++ b/libhdf5/nc4hdf.c
@@ -2891,6 +2891,7 @@ nc4_convert_type(const void *src, void *dest, const nc_type src_type,
  *
  * @returns NC_NOERR No error.
  * @returns NC_EHDFERR HDF5 returned an error.
+ * @returns NC_ENOMEM Out of memory.
  * @author Ed Hartnett
  */
 int
@@ -3049,11 +3050,15 @@ nc4_rec_match_dimscales(NC_GRP_INFO_T *grp)
                   char phony_dim_name[NC_MAX_NAME + 1];
                   sprintf(phony_dim_name, "phony_dim_%d", grp->nc4_info->next_dimid);
                   LOG((3, "%s: creating phony dim for var %s", __func__, var->hdr.name));
-                  if ((retval = nc4_dim_list_add(grp, phony_dim_name, h5dimlen[d], -1, &dim))) {
+                  if ((retval = nc4_dim_list_add(grp, phony_dim_name, h5dimlen[d], -1, &dim)))
+                  {
                      free(h5dimlenmax);
                      free(h5dimlen);
                      return retval;
                   }
+                  /* Create struct for HDF5-specific dim info. */
+                  if (!(dim->format_dim_info = calloc(1, sizeof(NC_HDF5_DIM_INFO_T))))
+                     return NC_ENOMEM;
                   if (h5dimlenmax[d] == H5S_UNLIMITED)
                      dim->unlimited = NC_TRUE;
                }

--- a/libhdf5/nc4hdf.c
+++ b/libhdf5/nc4hdf.c
@@ -1811,7 +1811,6 @@ write_dim(NC_DIM_INFO_T *dim, NC_GRP_INFO_T *grp, nc_bool_t write_dimid)
       if ((hdf5_dim->hdf_dimscaleid = H5Dcreate1(grp->hdf_grpid, dim->hdr.name, H5T_IEEE_F32BE,
                                                  spaceid, create_propid)) < 0)
          BAIL(NC_EHDFERR);
-      dim->hdf_dimscaleid = hdf5_dim->hdf_dimscaleid;
 
       /* Close the spaceid and create_propid. */
       if (H5Sclose(spaceid) < 0)

--- a/libsrc4/nc4internal.c
+++ b/libsrc4/nc4internal.c
@@ -1143,6 +1143,11 @@ att_free(NC_ATT_INFO_T *att)
       free(att->vldata);
    }
 
+   /* Free any format-sepecific info. Some formats use this (ex. HDF5)
+    * and some don't (ex. HDF4). So it may be NULL. */
+   if (att->format_att_info)
+      free(att->format_att_info);
+
    free(att);
    return NC_NOERR;
 }

--- a/libsrc4/nc4internal.c
+++ b/libsrc4/nc4internal.c
@@ -1277,6 +1277,10 @@ dim_free(NC_DIM_INFO_T *dim)
    if (dim->hdr.name)
       free(dim->hdr.name);
 
+   /* Release any format-specific information. */
+   if (dim->format_dim_info)
+      free(dim->format_dim_info);
+
    free(dim);
    return NC_NOERR;
 }


### PR DESCRIPTION
Part of #856.

Next step in this separation. Moving some HDF5 types from nc4internal.h to hdf5internal.h.

This is in the queue behind #1182.