### PR TITLE
Fix failure in the nccopy -c option

### DIFF
--- a/ncdump/chunkspec.c
+++ b/ncdump/chunkspec.c
@@ -242,10 +242,19 @@ varchunkspec_parse(int igrp, const char *spec0)
     if(p == NULL)
 	{ret = NC_EINVAL; goto done;}
     *p++ = '\0';
+
     /* Lookup the variable by name */
     ret = nc_inq_varid2(igrp, spec, &chunkspec->ivarid, &chunkspec->igrpid);
     if(ret != NC_NOERR) goto done;
     
+    if(*p == '\0') {/* we have -c var: => do not chunk var */
+	chunkspec->omit = 1;
+        /* add the chunkspec to our list */
+        listpush(varchunkspecs,chunkspec);
+        chunkspec = NULL;
+	goto done;
+    }
+
     /* Iterate over dimension sizes */
     while(*p) {
 	unsigned long dimsize;

--- a/ncdump/nccopy.1
+++ b/ncdump/nccopy.1
@@ -179,7 +179,8 @@ syntax: \fI var:n1,n2,...,nn \fP. This assumes that the variable named
 variable is specified by the values of n1 through nn. This second
 form of chunking specification can be repeated multiple times to specify
 the exact chunking for different variables.
-If the variable is specified but no chunk sizes are specified (i.e. \fI -d var: \fP)
+If the variable is specified but no chunk sizes are specified
+(i.e. \fI -c var: \fP)
 then chunking is disabled for that variable.
 If the same variable is specified
 more than once, the second and later specifications are ignored.


### PR DESCRIPTION
re: https://github.com/Unidata/netcdf-c/issues/1183

* Fixes #1183 

Changes:
1. fix typo in nccopy.1 man page
2. fix chunkspec parsing for -c so that "-c var:"
   (with no chunkspec arguments) disables chunking
   on the specified variable
3. Add test case to ncdump/tst_nccopy5.sh