### PR TITLE
Eliminate compiler warnings (and code error)

### DIFF
--- a/libhdf5/nc4info.c
+++ b/libhdf5/nc4info.c
@@ -493,7 +493,7 @@ int
 NC4_free_provenance(struct NCPROVENANCE* prov)
 {
     if(prov == NULL) return NC_NOERR;
-    if(prov->propattr.properties != NULL);
+    if(prov->propattr.properties != NULL)
 	nclistfreeall(prov->propattr.properties);
     prov->propattr.properties = NULL;
     free(prov);

--- a/ncdump/dumplib.c
+++ b/ncdump/dumplib.c
@@ -920,7 +920,7 @@ int ncstring_typ_tostring(const nctype_t *typ, safebuf_t *sfbf, const void *valp
 int
 ncenum_typ_tostring(const nctype_t *typ, safebuf_t *sfbf, const void *valp) {
     char symbol[NC_MAX_NAME + 1];
-    long long val;
+    long long val = 0;
 
     switch (typ->base_tid) {
     case NC_BYTE:
@@ -1215,7 +1215,7 @@ ncdouble_val_tostring(const ncvar_t *varp, safebuf_t *sfbf, const void *valp) {
  * lose precision for values of type NC_INT64 or NC_UINT64 */
 static
 double to_double(const ncvar_t *varp, const void *valp) {
-    double dd;
+    double dd = 0.0;
     switch (varp->type) {
     case NC_BYTE:
 	dd = *(signed char *)valp;

--- a/ncdump/ncdump.c
+++ b/ncdump/ncdump.c
@@ -836,7 +836,7 @@ pr_att(
        size_t type_size, nfields;
        nc_type base_nc_type;
        int class, i;
-       void *data;
+       void *data = NULL;
 
        NC_CHECK( nc_inq_user_type(ncid, att.type,  type_name, &type_size,
 				  &base_nc_type, &nfields, &class));

--- a/ncgen/data.c
+++ b/ncgen/data.c
@@ -553,10 +553,10 @@ retry:	    switch ((c=*p++)) {
 	    case 'u':
 		if(hcount == 2) {
    	            snprintf(tmp,sizeof(tmp),"%hhu",
-			(unsigned int)va_arg(argv,unsigned int));
+			(unsigned char)va_arg(argv,unsigned int));
 		} else if(hcount == 1) {
    	            snprintf(tmp,sizeof(tmp),"%hu",
-			(unsigned int)va_arg(argv,unsigned int));
+			(unsigned short)va_arg(argv,unsigned int));
 		} else if(lcount == 2) {
    	            snprintf(tmp,sizeof(tmp),"%llu",
 			(unsigned long long)va_arg(argv,unsigned long long));
@@ -572,10 +572,10 @@ retry:	    switch ((c=*p++)) {
 	    case 'd':
 		if(hcount == 2) {
    	            snprintf(tmp,sizeof(tmp),"%hhd",
-			(signed int)va_arg(argv,signed int));
+			(signed char)va_arg(argv,signed int));
 		} else if(hcount == 1) {
    	            snprintf(tmp,sizeof(tmp),"%hd",
-			(signed int)va_arg(argv,signed int));
+			(signed short)va_arg(argv,signed int));
 		} else if(lcount == 2) {
    	            snprintf(tmp,sizeof(tmp),"%lld",
 			(signed long long)va_arg(argv,signed long long));


### PR DESCRIPTION
Fixed a few compiler warnings.  One of these is actually a code error where the statement following the `if` is always executed due to the semicolon at the end of the if statement:
``` 
if(prov->propattr.properties != NULL);
 	nclistfreeall(prov->propattr.properties);
```
