### PR TITLE
Remove // style comments from source code.

### DIFF
--- a/include/ncdispatch.h
+++ b/include/ncdispatch.h
@@ -107,10 +107,6 @@ typedef struct NC_MPI_INFO {
 
 /* Define known dispatch tables and initializers */
 
-/*Forward*/
-// typedef struct NC_Dispatch NC_Dispatch;
-
-
 extern int NCDISPATCH_initialize(void);
 extern int NCDISPATCH_finalize(void);
 

--- a/ncgen/genbin.c
+++ b/ncgen/genbin.c
@@ -449,10 +449,12 @@ genbin_writevar(Generator* generator, Symbol* vsym, Bytebuffer* memory,
         stat = nc_put_vara(vsym->container->nc_id, vsym->nc_id, start, count, data);
     }
     check_err(stat,__LINE__,__FILE__);
-//    /* Reclaim the data */
-//    stat = ncaux_reclaim_data(vsym->container->nc_id, vsym->typ.basetype->nc_id, data, nelems);
-//    check_err(stat,__LINE__,__FILE__);
-//    bbClear(memory); /* reclaim top-level memory */
+#if 0
+    /* Reclaim the data */
+    stat = ncaux_reclaim_data(vsym->container->nc_id, vsym->typ.basetype->nc_id, data, nelems);
+    check_err(stat,__LINE__,__FILE__);
+    bbClear(memory); /* reclaim top-level memory */
+#endif
     return stat;
 }
 


### PR DESCRIPTION
We need to do this periodically because they sneek in.