### PR TITLE
Fix error report coming out of nc4info.c

### DIFF
--- a/include/hdf5internal.h
+++ b/include/hdf5internal.h
@@ -94,4 +94,33 @@ int nc4_detect_preserve_dimids(NC_GRP_INFO_T *grp, nc_bool_t *bad_coord_orderp);
 int hdf5_set_log_level();
 int nc4_get_fill_value(NC_FILE_INFO_T *h5, NC_VAR_INFO_T *var, void **fillp);
 
+/* Provenance Management (moved from nc4internal.h) */
+/* Initialize the fileinfo global state */
+extern int NC4_provenance_init();
+
+/* Finalize the fileinfo global state */
+extern int NC4_provenance_finalize();
+
+/* Extract the provenance from a file, using dfalt as default */
+extern int NC4_get_provenance(NC_FILE_INFO_T* file, const char* propstring, const struct NCPROPINFO* dfalt);
+
+/* Set the provenance for a created file using dfalt as default */
+extern int NC4_set_provenance(NC_FILE_INFO_T* file, const struct NCPROPINFO* dfalt);
+
+/* Recover memory of an NCPROVENANCE object */
+extern int NC4_free_provenance(struct NCPROVENANCE* prov);
+
+extern int NC4_hdf5get_libversion(unsigned*,unsigned*,unsigned*);/*libsrc4/nc4hdf.c*/
+extern int NC4_hdf5get_superblock(struct NC_FILE_INFO*, int*);/*libsrc4/nc4hdf.c*/
+extern int NC4_isnetcdf4(struct NC_FILE_INFO*); /*libsrc4/nc4hdf.c*/
+
+/* Convert a NCPROPINFO instance to a single string. */
+extern int NC4_buildpropinfo(struct NCPROPINFO* info, char** propdatap);
+
+/* Use HDF5 API to read the _NCProperties attribute */
+extern int NC4_read_ncproperties(NC_FILE_INFO_T*);
+
+/* Use HDF5 API to write the _NCProperties attribute */
+extern int NC4_write_ncproperties(NC_FILE_INFO_T*);
+
 #endif /* _HDF5INTERNAL_ */

--- a/include/nc4internal.h
+++ b/include/nc4internal.h
@@ -502,35 +502,4 @@ struct NCPROVENANCE {
 /* Provenance Initialization */
 extern struct NCPROPINFO globalpropinfo;
 
-/* Initialize the fileinfo global state */
-extern int NC4_provenance_init();
-
-/* Finalize the fileinfo global state */
-extern int NC4_provenance_finalize();
-
-/* Write the properties attribute to file. */
-extern int NC4_put_ncproperties(NC_FILE_INFO_T* file);
-
-/* Extract the provenance from a file, using dfalt as default */
-extern int NC4_get_provenance(NC_FILE_INFO_T* file, const char* propstring, const struct NCPROPINFO* dfalt);
-
-/* Set the provenance for a created file using dfalt as default */
-extern int NC4_set_provenance(NC_FILE_INFO_T* file, const struct NCPROPINFO* dfalt);
-
-/* Recover memory of an NCPROVENANCE object */
-extern int NC4_free_provenance(struct NCPROVENANCE* prov);
-
-extern int NC4_hdf5get_libversion(unsigned*,unsigned*,unsigned*);/*libsrc4/nc4hdf.c*/
-extern int NC4_hdf5get_superblock(struct NC_FILE_INFO*, int*);/*libsrc4/nc4hdf.c*/
-extern int NC4_isnetcdf4(struct NC_FILE_INFO*); /*libsrc4/nc4hdf.c*/
-
-/* Convert a NCPROPINFO instance to a single string. */
-extern int NC4_buildpropinfo(struct NCPROPINFO* info, char** propdatap);
-
-/* Use HDF5 API to read the _NCProperties attribute */
-extern int NC4_read_ncproperties(NC_FILE_INFO_T*);
-
-/* Use HDF5 API to write the _NCProperties attribute */
-extern int NC4_write_ncproperties(NC_FILE_INFO_T*);
-
 #endif /* _NC4INTERNAL_ */

--- a/liblib/nc_initialize.c
+++ b/liblib/nc_initialize.c
@@ -17,6 +17,7 @@ extern int NC3_finalize(void);
 
 #ifdef USE_NETCDF4
 #include "nc4internal.h"
+#include "hdf5internal.h"
 extern int NC4_initialize(void);
 extern int NC4_finalize(void);
 #endif


### PR DESCRIPTION
* Fixes #1207 

re: issue https://github.com/Unidata/netcdf-c/issues/1207

The NC4_get_provenance is generating a spurious error message.
This properly suppresses it.