### PR TITLE
change rm in test script to use specific file names so parallel builds continue to work

### DIFF
--- a/ncdump/Makefile.am
+++ b/ncdump/Makefile.am
@@ -143,9 +143,9 @@ EXTRA_DIST += L512.bin
 SUBDIRS = cdl expected
 
 CLEANFILES = tst_*.nc tmp*.nc test*.nc iter.* tmp*.cdl			\
-tst_output_*.cdl tst_output_*.c tst_utf8_*.cdl tst_tst8.cdl		\
-tst_netcdf4_*.cdl test1_ncdump.cdl test2_ncdump.cdl test1.cdl		\
-ctest1.cdl test1_cdf5.cdl test2_cdf5.cdl test1_offset.cdl		\
+tst_output_*.cdl tst_output_*.c tst_utf8_*.cdl *.tmp
+tst_tst8.cdl tst_netcdf4_*.cdl test1_ncdump.cdl test2_ncdump.cdl	\
+test1.cdl ctest1.cdl test1_cdf5.cdl test2_cdf5.cdl test1_offset.cdl	\
 test2_offset.cdl ctest0.nc ctest0_64.nc c1.cdl c1_4.cdl ctest1_64.cdl	\
 c0.nc c0_4.nc small.nc small2.nc c0tmp.nc c1.ncml utf8.cdl		\
 utf8_64.cdl utf8.nc utf8_64.nc nc4_utf8.cdl nc4_utf8.nc			\
@@ -163,4 +163,4 @@ compound_datasize_test.nc compound_datasize_test2.nc ncf199.nc		\
 tst_c0.cdl tst_c0_4.cdl tst_c0_4c.cdl tst_c0_64.cdl			\
 tst_compound_datasize_test.cdl tst_compound_datasize_test2.cdl		\
 tst_ncf199.cdl tst_tst_gattenum.cdl tst_tst_usuffix.cdl ctest.c		\
-ctest64.c nccopy3_subset_out.nc camrun.c
+ctest64.c nccopy3_subset_out.nc camrun.c tst_ncf213.cdl tst_ncf213.nc

--- a/ncdump/Makefile.am
+++ b/ncdump/Makefile.am
@@ -143,9 +143,9 @@ EXTRA_DIST += L512.bin
 SUBDIRS = cdl expected
 
 CLEANFILES = tst_*.nc tmp*.nc test*.nc iter.* tmp*.cdl			\
-tst_output_*.cdl tst_output_*.c tst_utf8_*.cdl *.tmp
-tst_tst8.cdl tst_netcdf4_*.cdl test1_ncdump.cdl test2_ncdump.cdl	\
-test1.cdl ctest1.cdl test1_cdf5.cdl test2_cdf5.cdl test1_offset.cdl	\
+tst_output_*.cdl tst_output_*.c tst_utf8_*.cdl *.tmp tst_tst8.cdl	\
+tst_netcdf4_*.cdl test1_ncdump.cdl test2_ncdump.cdl test1.cdl		\
+ctest1.cdl test1_cdf5.cdl test2_cdf5.cdl test1_offset.cdl		\
 test2_offset.cdl ctest0.nc ctest0_64.nc c1.cdl c1_4.cdl ctest1_64.cdl	\
 c0.nc c0_4.nc small.nc small2.nc c0tmp.nc c1.ncml utf8.cdl		\
 utf8_64.cdl utf8.nc utf8_64.nc nc4_utf8.cdl nc4_utf8.nc			\

--- a/ncdump/tst_netcdf4_4.sh
+++ b/ncdump/tst_netcdf4_4.sh
@@ -75,8 +75,7 @@ ok=1;
 if diff -b tst_ncf213.tmp ref_tst_ncf213.tmp ; then ok=1; else ok=0; fi
 
 # cleanup
-#rm -f tst_ncf213.cdl tst_ncf213.nc
-rm -f *.tmp
+rm -f tst_ncf213.cdl tst_ncf213.nc tst_ncf213.tmp ref_tst_ncf213.tmp
 
 if test $ok = 0 ; then
   echo "*** FAIL: NCF-213 Bug Fix test"

--- a/ncdump/tst_netcdf4_4.sh
+++ b/ncdump/tst_netcdf4_4.sh
@@ -74,9 +74,6 @@ cleanncprops ${srcdir}/ref_tst_ncf213.cdl ref_tst_ncf213.tmp
 ok=1;
 if diff -b tst_ncf213.tmp ref_tst_ncf213.tmp ; then ok=1; else ok=0; fi
 
-# cleanup
-rm -f tst_ncf213.cdl tst_ncf213.nc tst_ncf213.tmp ref_tst_ncf213.tmp
-
 if test $ok = 0 ; then
   echo "*** FAIL: NCF-213 Bug Fix test"
   exit 1


### PR DESCRIPTION
Fixes #1205.
