### PR TITLE
Update nc_test/tst_inmemory to cover more cases

### DIFF
--- a/libsrc/memio.c
+++ b/libsrc/memio.c
@@ -483,8 +483,6 @@ fprintf(stderr,"realloc: %lu/%lu -> %lu/%lu\n",
 (unsigned long)memio->memory,(unsigned long)memio->alloc,
 (unsigned long)newmem,(unsigned long)newsize);
 #endif
-	if(memio->memory != NULL && (!memio->locked || memio->modified))
-	    free(memio->memory);
 	memio->memory = newmem;
 	memio->alloc = newsize;
 	memio->modified = 1;

--- a/plugins/H5Zbzip2.c
+++ b/plugins/H5Zbzip2.c
@@ -123,7 +123,7 @@ size_t H5Z_filter_bzip2(unsigned int flags, size_t cd_nelmts,
       if (ret != BZ_STREAM_END && stream.avail_out == 0) {
         /* Grow the output buffer. */
         newbuflen = outbuflen * 2;
-        newbuf = realloc(outbuf, newbuflen);
+        newbuf = H5resize_memory(outbuf, newbuflen);
         if (newbuf == NULL) {
           fprintf(stderr, "memory allocation failed for bzip2 decompression\n");
           goto cleanupAndFail;


### PR DESCRIPTION
re: pull request https://github.com/Unidata/netcdf-c/pull/1219

This pr should go in after or at the same time as 1219.
It updates nc_test/tst_inmemory to add a test to cover
the case fixed in 1219. It also disables a couple of tests
that no longer are relevant.