### PR TITLE
Fix failings of nc_test/run_inmemory.sh

### DIFF
--- a/debug/README.txt
+++ b/debug/README.txt
@@ -1,5 +1,6 @@
 This directory contains various scripts for debugging by Dennis
 Heimbigner @ Unidata.
+DO NOT DELETE.
 USE AT YOUR OWN PERIL.
 
 

--- a/debug/cf.cmake
+++ b/debug/cf.cmake
@@ -97,7 +97,7 @@ NCLIB="${NCLIB}/build/liblib"
 #G="-GUnix Makefiles"
 #T="--trace-expand"
 cmake "${G}" $FLAGS ..
-if test "x$NOBUILD" == x ; then
+if test "x$NOBUILD" = x ; then
 make all
 make test
 fi

--- a/include/nc_provenance.h
+++ b/include/nc_provenance.h
@@ -1,13 +1,12 @@
 /* Copyright 2005-2018 University Corporation for Atmospheric
    Research/Unidata. */
 /**
-/**
  * @file
  * @internal Contains information for creating provenance
  * info and/or displaying provenance info.
  *
  * @author Dennis Heimbigner, Ward Fisher
-
+*/
 /**************************************************/
 /**
 

--- a/nc_test/run_inmemory.sh
+++ b/nc_test/run_inmemory.sh
@@ -16,7 +16,7 @@ CREATE3=tst_inmemory3_create
 FILE4=tst_inmemory4
 CREATE4=tst_inmemory4_create
 
-# For tst_open_mem
+# For tst_open_mem NETCDF4 only
 OMEMFILE=f03tst_open_mem.nc
 
 echo ""
@@ -26,8 +26,9 @@ HASNC4=`${top_builddir}/nc-config --has-nc4`
 
 # Execute the core of the inmemory tests
 ${execdir}/tst_inmemory
-exit
+if test "x$HASNC4" = xyes ; then
 ${execdir}/tst_open_mem ${srcdir}/${OMEMFILE}
+fi
 
 echo "**** Test ncdump of the resulting inmemory data"
 ${NCDUMP} -n "${FILE3}" ${FILE3}.nc > ${FILE3}.cdl
@@ -36,8 +37,9 @@ diff -wb ${FILE3}.cdl ${CREATE3}.cdl
 
 if test "x$HASNC4" = "xyes" ; then
 ${NCDUMP} ${FILE4}.nc > ${FILE4}.cdl
-${NCDUMP} ${CREATE4}.nc > ${CREATE4}.cdl
+${NCDUMP} -n ${FILE4} ${CREATE4}.nc > ${CREATE4}.cdl
 diff -wb ${FILE4}.cdl ${CREATE4}.cdl
+fi
 
 # cleanup
 rm -f ${FILE3}.nc ${FILE4}.nc ${CREATE3}.nc ${CREATE4}.nc

--- a/nc_test/tst_open_mem.c
+++ b/nc_test/tst_open_mem.c
@@ -31,8 +31,12 @@ readfile(const char* path, NC_memio* memio)
 #else
     f = fopen(path,"r");
 #endif
-    if(f == NULL)
-	{status = errno; goto done;}
+    if(f == NULL) {
+	fprintf(stderr,"cannot open file: %s\n",path);
+	fflush(stderr);
+	status = errno;
+	goto done;
+    }
     /* get current filesize */
     if(fseek(f,0,SEEK_END) < 0)
 	{status = errno; goto done;}
@@ -56,6 +60,7 @@ readfile(const char* path, NC_memio* memio)
     if(memio) {
 	memio->size = (size_t)filesize;
 	memio->memory = memory;
+	memory = NULL;
     }    
 done:
     if(status != NC_NOERR && memory != NULL)
@@ -82,6 +87,8 @@ main(int argc, char** argv)
 	goto exit;
     if((retval = nc_close(ncid)))
 	goto exit;
+    if(mem.memory)
+        free(mem.memory);
     return 0;
 exit:
     fprintf(stderr,"retval=%d\n",retval);

--- a/ncgen/bindata.c
+++ b/ncgen/bindata.c
@@ -431,13 +431,15 @@ Internal equivalent of ncaux_reclaim_data.
 /* It is helpful to have a structure that contains memory and an offset */
 typedef struct Reclaim {char* memory; ptrdiff_t offset;} Reclaim;
 
-static ptrdiff_t read_alignment(ptrdiff_t offset, unsigned long alignment);
 static int bin_reclaim_datar(Symbol* tsym, Reclaim* reclaim);
+#ifdef USE_NETCDF4
+static ptrdiff_t read_alignment(ptrdiff_t offset, unsigned long alignment);
 static int bin_reclaim_usertype(Symbol* tsym, Reclaim* reclaim);
 static int bin_reclaim_compound(Symbol* tsym, Reclaim* reclaim);
 static int bin_reclaim_vlen(Symbol* tsym, Reclaim* reclaim);
 static int bin_reclaim_enum(Symbol* tsym, Reclaim* reclaim);
 static int bin_reclaim_opaque(Symbol* tsym, Reclaim* reclaim);
+#endif
 
 int
 binary_reclaim_data(Symbol* tsym, void* memory, size_t count)
@@ -493,6 +495,7 @@ bin_reclaim_datar(Symbol* tsym, Reclaim* reclaimer)
     return stat;
 }
 	
+#ifdef USE_NETCDF4
 static int
 bin_reclaim_usertype(Symbol* tsym, Reclaim* reclaimer)
 {
@@ -587,6 +590,7 @@ bin_reclaim_compound(Symbol* tsym, Reclaim* reclaimer)
 done:
     return stat;
 }
+#endif /*USE_NETCDF4*/
 
 #endif /*ENABLE_BINARY*/
 

--- a/ncgen/ncgenl.c
+++ b/ncgen/ncgenl.c
@@ -1,5 +1,5 @@
 
-#line 2 "ncgenl.c"
+#line 3 "ncgenl.c"
 
 #define  YY_INT_ALIGNED short int
 
@@ -7,17 +7,11 @@
 
 #define yy_create_buffer ncg_create_buffer
 #define yy_delete_buffer ncg_delete_buffer
-#define yy_scan_buffer ncg_scan_buffer
-#define yy_scan_string ncg_scan_string
-#define yy_scan_bytes ncg_scan_bytes
+#define yy_flex_debug ncg_flex_debug
 #define yy_init_buffer ncg_init_buffer
 #define yy_flush_buffer ncg_flush_buffer
 #define yy_load_buffer_state ncg_load_buffer_state
 #define yy_switch_to_buffer ncg_switch_to_buffer
-#define yypush_buffer_state ncgpush_buffer_state
-#define yypop_buffer_state ncgpop_buffer_state
-#define yyensure_buffer_stack ncgensure_buffer_stack
-#define yy_flex_debug ncg_flex_debug
 #define yyin ncgin
 #define yyleng ncgleng
 #define yylex ncglex
@@ -33,243 +27,9 @@
 #define FLEX_SCANNER
 #define YY_FLEX_MAJOR_VERSION 2
 #define YY_FLEX_MINOR_VERSION 6
-#define YY_FLEX_SUBMINOR_VERSION 4
+#define YY_FLEX_SUBMINOR_VERSION 0
 #if YY_FLEX_SUBMINOR_VERSION > 0
 #define FLEX_BETA
-#endif
-
-#ifdef yy_create_buffer
-#define ncg_create_buffer_ALREADY_DEFINED
-#else
-#define yy_create_buffer ncg_create_buffer
-#endif
-
-#ifdef yy_delete_buffer
-#define ncg_delete_buffer_ALREADY_DEFINED
-#else
-#define yy_delete_buffer ncg_delete_buffer
-#endif
-
-#ifdef yy_scan_buffer
-#define ncg_scan_buffer_ALREADY_DEFINED
-#else
-#define yy_scan_buffer ncg_scan_buffer
-#endif
-
-#ifdef yy_scan_string
-#define ncg_scan_string_ALREADY_DEFINED
-#else
-#define yy_scan_string ncg_scan_string
-#endif
-
-#ifdef yy_scan_bytes
-#define ncg_scan_bytes_ALREADY_DEFINED
-#else
-#define yy_scan_bytes ncg_scan_bytes
-#endif
-
-#ifdef yy_init_buffer
-#define ncg_init_buffer_ALREADY_DEFINED
-#else
-#define yy_init_buffer ncg_init_buffer
-#endif
-
-#ifdef yy_flush_buffer
-#define ncg_flush_buffer_ALREADY_DEFINED
-#else
-#define yy_flush_buffer ncg_flush_buffer
-#endif
-
-#ifdef yy_load_buffer_state
-#define ncg_load_buffer_state_ALREADY_DEFINED
-#else
-#define yy_load_buffer_state ncg_load_buffer_state
-#endif
-
-#ifdef yy_switch_to_buffer
-#define ncg_switch_to_buffer_ALREADY_DEFINED
-#else
-#define yy_switch_to_buffer ncg_switch_to_buffer
-#endif
-
-#ifdef yypush_buffer_state
-#define ncgpush_buffer_state_ALREADY_DEFINED
-#else
-#define yypush_buffer_state ncgpush_buffer_state
-#endif
-
-#ifdef yypop_buffer_state
-#define ncgpop_buffer_state_ALREADY_DEFINED
-#else
-#define yypop_buffer_state ncgpop_buffer_state
-#endif
-
-#ifdef yyensure_buffer_stack
-#define ncgensure_buffer_stack_ALREADY_DEFINED
-#else
-#define yyensure_buffer_stack ncgensure_buffer_stack
-#endif
-
-#ifdef yylex
-#define ncglex_ALREADY_DEFINED
-#else
-#define yylex ncglex
-#endif
-
-#ifdef yyrestart
-#define ncgrestart_ALREADY_DEFINED
-#else
-#define yyrestart ncgrestart
-#endif
-
-#ifdef yylex_init
-#define ncglex_init_ALREADY_DEFINED
-#else
-#define yylex_init ncglex_init
-#endif
-
-#ifdef yylex_init_extra
-#define ncglex_init_extra_ALREADY_DEFINED
-#else
-#define yylex_init_extra ncglex_init_extra
-#endif
-
-#ifdef yylex_destroy
-#define ncglex_destroy_ALREADY_DEFINED
-#else
-#define yylex_destroy ncglex_destroy
-#endif
-
-#ifdef yyget_debug
-#define ncgget_debug_ALREADY_DEFINED
-#else
-#define yyget_debug ncgget_debug
-#endif
-
-#ifdef yyset_debug
-#define ncgset_debug_ALREADY_DEFINED
-#else
-#define yyset_debug ncgset_debug
-#endif
-
-#ifdef yyget_extra
-#define ncgget_extra_ALREADY_DEFINED
-#else
-#define yyget_extra ncgget_extra
-#endif
-
-#ifdef yyset_extra
-#define ncgset_extra_ALREADY_DEFINED
-#else
-#define yyset_extra ncgset_extra
-#endif
-
-#ifdef yyget_in
-#define ncgget_in_ALREADY_DEFINED
-#else
-#define yyget_in ncgget_in
-#endif
-
-#ifdef yyset_in
-#define ncgset_in_ALREADY_DEFINED
-#else
-#define yyset_in ncgset_in
-#endif
-
-#ifdef yyget_out
-#define ncgget_out_ALREADY_DEFINED
-#else
-#define yyget_out ncgget_out
-#endif
-
-#ifdef yyset_out
-#define ncgset_out_ALREADY_DEFINED
-#else
-#define yyset_out ncgset_out
-#endif
-
-#ifdef yyget_leng
-#define ncgget_leng_ALREADY_DEFINED
-#else
-#define yyget_leng ncgget_leng
-#endif
-
-#ifdef yyget_text
-#define ncgget_text_ALREADY_DEFINED
-#else
-#define yyget_text ncgget_text
-#endif
-
-#ifdef yyget_lineno
-#define ncgget_lineno_ALREADY_DEFINED
-#else
-#define yyget_lineno ncgget_lineno
-#endif
-
-#ifdef yyset_lineno
-#define ncgset_lineno_ALREADY_DEFINED
-#else
-#define yyset_lineno ncgset_lineno
-#endif
-
-#ifdef yywrap
-#define ncgwrap_ALREADY_DEFINED
-#else
-#define yywrap ncgwrap
-#endif
-
-#ifdef yyalloc
-#define ncgalloc_ALREADY_DEFINED
-#else
-#define yyalloc ncgalloc
-#endif
-
-#ifdef yyrealloc
-#define ncgrealloc_ALREADY_DEFINED
-#else
-#define yyrealloc ncgrealloc
-#endif
-
-#ifdef yyfree
-#define ncgfree_ALREADY_DEFINED
-#else
-#define yyfree ncgfree
-#endif
-
-#ifdef yytext
-#define ncgtext_ALREADY_DEFINED
-#else
-#define yytext ncgtext
-#endif
-
-#ifdef yyleng
-#define ncgleng_ALREADY_DEFINED
-#else
-#define yyleng ncgleng
-#endif
-
-#ifdef yyin
-#define ncgin_ALREADY_DEFINED
-#else
-#define yyin ncgin
-#endif
-
-#ifdef yyout
-#define ncgout_ALREADY_DEFINED
-#else
-#define yyout ncgout
-#endif
-
-#ifdef yy_flex_debug
-#define ncg_flex_debug_ALREADY_DEFINED
-#else
-#define yy_flex_debug ncg_flex_debug
-#endif
-
-#ifdef yylineno
-#define ncglineno_ALREADY_DEFINED
-#else
-#define yylineno ncglineno
 #endif
 
 /* First, we deal with  platform-specific or compiler-specific issues. */
@@ -342,48 +102,60 @@ typedef unsigned int flex_uint32_t;
 #define UINT32_MAX             (4294967295U)
 #endif
 
-#ifndef SIZE_MAX
-#define SIZE_MAX               (~(size_t)0)
-#endif
-
 #endif /* ! C99 */
 
 #endif /* ! FLEXINT_H */
 
-/* begin standard C++ headers. */
+#ifdef __cplusplus
 
-/* TODO: this is always defined, so inline it */
+/* The "const" storage-class-modifier is valid. */
+#define YY_USE_CONST
+
+#else	/* ! __cplusplus */
+
+/* C99 requires __STDC__ to be defined as 1. */
+#if defined (__STDC__)
+
+#define YY_USE_CONST
+
+#endif	/* defined (__STDC__) */
+#endif	/* ! __cplusplus */
+
+#ifdef YY_USE_CONST
 #define yyconst const
-
-#if defined(__GNUC__) && __GNUC__ >= 3
-#define yynoreturn __attribute__((__noreturn__))
 #else
-#define yynoreturn
+#define yyconst
 #endif
 
 /* Returned upon end-of-file. */
 #define YY_NULL 0
 
-/* Promotes a possibly negative, possibly signed char to an
- *   integer in range [0..255] for use as an array index.
+/* Promotes a possibly negative, possibly signed char to an unsigned
+ * integer for use as an array index.  If the signed char is negative,
+ * we want to instead treat it as an 8-bit unsigned char, hence the
+ * double cast.
  */
-#define YY_SC_TO_UI(c) ((YY_CHAR) (c))
+#define YY_SC_TO_UI(c) ((unsigned int) (unsigned char) c)
 
 /* Enter a start condition.  This macro really ought to take a parameter,
  * but we do it the disgusting crufty way forced on us by the ()-less
  * definition of BEGIN.
  */
 #define BEGIN (yy_start) = 1 + 2 *
+
 /* Translate the current start state into a value that can be later handed
  * to BEGIN to return to the state.  The YYSTATE alias is for lex
  * compatibility.
  */
 #define YY_START (((yy_start) - 1) / 2)
 #define YYSTATE YY_START
+
 /* Action number for EOF rule of a given start state. */
 #define YY_STATE_EOF(state) (YY_END_OF_BUFFER + state + 1)
+
 /* Special action meaning "start processing a new file". */
-#define YY_NEW_FILE yyrestart( yyin  )
+#define YY_NEW_FILE ncgrestart(ncgin  )
+
 #define YY_END_OF_BUFFER_CHAR 0
 
 /* Size of default input buffer. */
@@ -413,14 +185,14 @@ typedef struct yy_buffer_state *YY_BUFFER_STATE;
 typedef size_t yy_size_t;
 #endif
 
-extern int yyleng;
+extern yy_size_t ncgleng;
 
-extern FILE *yyin, *yyout;
+extern FILE *ncgin, *ncgout;
 
 #define EOB_ACT_CONTINUE_SCAN 0
 #define EOB_ACT_END_OF_FILE 1
 #define EOB_ACT_LAST_MATCH 2
-    
+
     #define YY_LESS_LINENO(n)
     #define YY_LINENO_REWIND_TO(ptr)
     
@@ -428,15 +200,16 @@ extern FILE *yyin, *yyout;
 #define yyless(n) \
 	do \
 		{ \
-		/* Undo effects of setting up yytext. */ \
+		/* Undo effects of setting up ncgtext. */ \
         int yyless_macro_arg = (n); \
         YY_LESS_LINENO(yyless_macro_arg);\
 		*yy_cp = (yy_hold_char); \
 		YY_RESTORE_YY_MORE_OFFSET \
 		(yy_c_buf_p) = yy_cp = yy_bp + yyless_macro_arg - YY_MORE_ADJ; \
-		YY_DO_BEFORE_ACTION; /* set up yytext again */ \
+		YY_DO_BEFORE_ACTION; /* set up ncgtext again */ \
 		} \
 	while ( 0 )
+
 #define unput(c) yyunput( c, (yytext_ptr)  )
 
 #ifndef YY_STRUCT_YY_BUFFER_STATE
@@ -451,7 +224,7 @@ struct yy_buffer_state
 	/* Size of input buffer in bytes, not including room for EOB
 	 * characters.
 	 */
-	int yy_buf_size;
+	yy_size_t yy_buf_size;
 
 	/* Number of characters read into yy_ch_buf, not including EOB
 	 * characters.
@@ -479,7 +252,7 @@ struct yy_buffer_state
 
     int yy_bs_lineno; /**< The line count. */
     int yy_bs_column; /**< The column count. */
-
+    
 	/* Whether to try to fill the input buffer when we reach the
 	 * end of it.
 	 */
@@ -496,8 +269,8 @@ struct yy_buffer_state
 	 * possible backing-up.
 	 *
 	 * When we actually see the EOF, we change the status to "new"
-	 * (via yyrestart()), so that the user can continue scanning by
-	 * just pointing yyin at a new input file.
+	 * (via ncgrestart()), so that the user can continue scanning by
+	 * just pointing ncgin at a new input file.
 	 */
 #define YY_BUFFER_EOF_PENDING 2
 
@@ -507,7 +280,7 @@ struct yy_buffer_state
 /* Stack of input buffers. */
 static size_t yy_buffer_stack_top = 0; /**< index of top of stack. */
 static size_t yy_buffer_stack_max = 0; /**< capacity of stack. */
-static YY_BUFFER_STATE * yy_buffer_stack = NULL; /**< Stack as an array. */
+static YY_BUFFER_STATE * yy_buffer_stack = 0; /**< Stack as an array. */
 
 /* We provide macros for accessing buffer states in case in the
  * future we want to put the buffer states in a more general
@@ -518,98 +291,109 @@ static YY_BUFFER_STATE * yy_buffer_stack = NULL; /**< Stack as an array. */
 #define YY_CURRENT_BUFFER ( (yy_buffer_stack) \
                           ? (yy_buffer_stack)[(yy_buffer_stack_top)] \
                           : NULL)
+
 /* Same as previous macro, but useful when we know that the buffer stack is not
  * NULL or when we need an lvalue. For internal use only.
  */
 #define YY_CURRENT_BUFFER_LVALUE (yy_buffer_stack)[(yy_buffer_stack_top)]
 
-/* yy_hold_char holds the character lost when yytext is formed. */
+/* yy_hold_char holds the character lost when ncgtext is formed. */
 static char yy_hold_char;
 static int yy_n_chars;		/* number of characters read into yy_ch_buf */
-int yyleng;
+yy_size_t ncgleng;
 
 /* Points to current character in buffer. */
-static char *yy_c_buf_p = NULL;
+static char *yy_c_buf_p = (char *) 0;
 static int yy_init = 0;		/* whether we need to initialize */
 static int yy_start = 0;	/* start state number */
 
-/* Flag which is used to allow yywrap()'s to do buffer switches
- * instead of setting up a fresh yyin.  A bit of a hack ...
+/* Flag which is used to allow ncgwrap()'s to do buffer switches
+ * instead of setting up a fresh ncgin.  A bit of a hack ...
  */
 static int yy_did_buffer_switch_on_eof;
 
-void yyrestart ( FILE *input_file  );
-void yy_switch_to_buffer ( YY_BUFFER_STATE new_buffer  );
-YY_BUFFER_STATE yy_create_buffer ( FILE *file, int size  );
-void yy_delete_buffer ( YY_BUFFER_STATE b  );
-void yy_flush_buffer ( YY_BUFFER_STATE b  );
-void yypush_buffer_state ( YY_BUFFER_STATE new_buffer  );
-void yypop_buffer_state ( void );
+void ncgrestart (FILE *input_file  );
+void ncg_switch_to_buffer (YY_BUFFER_STATE new_buffer  );
+YY_BUFFER_STATE ncg_create_buffer (FILE *file,int size  );
+void ncg_delete_buffer (YY_BUFFER_STATE b  );
+void ncg_flush_buffer (YY_BUFFER_STATE b  );
+void ncgpush_buffer_state (YY_BUFFER_STATE new_buffer  );
+void ncgpop_buffer_state (void );
 
-static void yyensure_buffer_stack ( void );
-static void yy_load_buffer_state ( void );
-static void yy_init_buffer ( YY_BUFFER_STATE b, FILE *file  );
-#define YY_FLUSH_BUFFER yy_flush_buffer( YY_CURRENT_BUFFER )
+static void ncgensure_buffer_stack (void );
+static void ncg_load_buffer_state (void );
+static void ncg_init_buffer (YY_BUFFER_STATE b,FILE *file  );
 
-YY_BUFFER_STATE yy_scan_buffer ( char *base, yy_size_t size  );
-YY_BUFFER_STATE yy_scan_string ( const char *yy_str  );
-YY_BUFFER_STATE yy_scan_bytes ( const char *bytes, int len  );
+#define YY_FLUSH_BUFFER ncg_flush_buffer(YY_CURRENT_BUFFER )
 
-void *yyalloc ( yy_size_t  );
-void *yyrealloc ( void *, yy_size_t  );
-void yyfree ( void *  );
+YY_BUFFER_STATE ncg_scan_buffer (char *base,yy_size_t size  );
+YY_BUFFER_STATE ncg_scan_string (yyconst char *yy_str  );
+YY_BUFFER_STATE ncg_scan_bytes (yyconst char *bytes,yy_size_t len  );
 
-#define yy_new_buffer yy_create_buffer
+void *ncgalloc (yy_size_t  );
+void *ncgrealloc (void *,yy_size_t  );
+void ncgfree (void *  );
+
+#define yy_new_buffer ncg_create_buffer
+
 #define yy_set_interactive(is_interactive) \
 	{ \
 	if ( ! YY_CURRENT_BUFFER ){ \
-        yyensure_buffer_stack (); \
+        ncgensure_buffer_stack (); \
 		YY_CURRENT_BUFFER_LVALUE =    \
-            yy_create_buffer( yyin, YY_BUF_SIZE ); \
+            ncg_create_buffer(ncgin,YY_BUF_SIZE ); \
 	} \
 	YY_CURRENT_BUFFER_LVALUE->yy_is_interactive = is_interactive; \
 	}
+
 #define yy_set_bol(at_bol) \
 	{ \
 	if ( ! YY_CURRENT_BUFFER ){\
-        yyensure_buffer_stack (); \
+        ncgensure_buffer_stack (); \
 		YY_CURRENT_BUFFER_LVALUE =    \
-            yy_create_buffer( yyin, YY_BUF_SIZE ); \
+            ncg_create_buffer(ncgin,YY_BUF_SIZE ); \
 	} \
 	YY_CURRENT_BUFFER_LVALUE->yy_at_bol = at_bol; \
 	}
+
 #define YY_AT_BOL() (YY_CURRENT_BUFFER_LVALUE->yy_at_bol)
 
 /* Begin user sect3 */
-typedef flex_uint8_t YY_CHAR;
 
-FILE *yyin = NULL, *yyout = NULL;
+typedef unsigned char YY_CHAR;
+
+FILE *ncgin = (FILE *) 0, *ncgout = (FILE *) 0;
 
 typedef int yy_state_type;
 
-extern int yylineno;
-int yylineno = 1;
+extern int ncglineno;
 
-extern char *yytext;
+int ncglineno = 1;
+
+extern char *ncgtext;
 #ifdef yytext_ptr
 #undef yytext_ptr
 #endif
-#define yytext_ptr yytext
+#define yytext_ptr ncgtext
 
-static yy_state_type yy_get_previous_state ( void );
-static yy_state_type yy_try_NUL_trans ( yy_state_type current_state  );
-static int yy_get_next_buffer ( void );
-static void yynoreturn yy_fatal_error ( const char* msg  );
+static yy_state_type yy_get_previous_state (void );
+static yy_state_type yy_try_NUL_trans (yy_state_type current_state  );
+static int yy_get_next_buffer (void );
+#if defined(__GNUC__) && __GNUC__ >= 3
+__attribute__((__noreturn__))
+#endif
+static void yy_fatal_error (yyconst char msg[]  );
 
 /* Done after the current pattern has been matched and before the
- * corresponding action - sets up yytext.
+ * corresponding action - sets up ncgtext.
  */
 #define YY_DO_BEFORE_ACTION \
 	(yytext_ptr) = yy_bp; \
-	yyleng = (int) (yy_cp - yy_bp); \
+	ncgleng = (size_t) (yy_cp - yy_bp); \
 	(yy_hold_char) = *yy_cp; \
 	*yy_cp = '\0'; \
 	(yy_c_buf_p) = yy_cp;
+
 #define YY_NUM_RULES 49
 #define YY_END_OF_BUFFER 50
 /* This struct is not used in this scanner,
@@ -619,7 +403,7 @@ struct yy_trans_info
 	flex_int32_t yy_verify;
 	flex_int32_t yy_nxt;
 	};
-static const flex_int16_t yy_accept[422] =
+static yyconst flex_int16_t yy_accept[422] =
     {   0,
         0,    0,   46,   46,    0,    0,   50,   48,    1,   44,
        48,   48,   48,   48,   38,   32,   36,   36,   35,   35,
@@ -670,7 +454,7 @@ static const flex_int16_t yy_accept[422] =
         0
     } ;
 
-static const YY_CHAR yy_ec[256] =
+static yyconst YY_CHAR yy_ec[256] =
     {   0,
         1,    1,    1,    1,    1,    1,    1,    1,    2,    3,
         1,    2,    2,    1,    1,    1,    1,    1,    1,    1,
@@ -702,7 +486,7 @@ static const YY_CHAR yy_ec[256] =
         1,    1,    1,    1,    1
     } ;
 
-static const YY_CHAR yy_meta[69] =
+static yyconst YY_CHAR yy_meta[69] =
     {   0,
         1,    1,    2,    1,    1,    1,    3,    4,    5,    5,
         6,    7,    8,    8,    8,    8,    8,    8,    8,    1,
@@ -713,7 +497,7 @@ static const YY_CHAR yy_meta[69] =
        11,   11,   11,   14,    1,   11,   11,   11
     } ;
 
-static const flex_int16_t yy_base[440] =
+static yyconst flex_uint16_t yy_base[440] =
     {   0,
         0,    0,  325,  321,  264,  255,  318, 2387,   67, 2387,
        64,  269,   61,   62,   95,   77,  136,  259,   51,   61,
@@ -765,7 +549,7 @@ static const flex_int16_t yy_base[440] =
      2315, 2329, 2339, 2345, 2353, 2355, 2361, 2367, 2373
     } ;
 
-static const flex_int16_t yy_def[440] =
+static yyconst flex_int16_t yy_def[440] =
     {   0,
       421,    1,  422,  422,  423,  423,  421,  421,  421,  421,
       424,  425,  421,  426,  421,  427,  421,   17,  428,  428,
@@ -817,7 +601,7 @@ static const flex_int16_t yy_def[440] =
       421,  421,  421,  421,  421,  421,  421,  421,  421
     } ;
 
-static const flex_int16_t yy_nxt[2456] =
+static yyconst flex_uint16_t yy_nxt[2456] =
     {   0,
         8,    9,   10,    9,    8,   11,   12,    8,   13,   14,
        15,   16,   17,   18,   18,   18,   18,   18,   18,    8,
@@ -1091,7 +875,7 @@ static const flex_int16_t yy_nxt[2456] =
       421,  421,  421,  421,  421
     } ;
 
-static const flex_int16_t yy_chk[2456] =
+static yyconst flex_int16_t yy_chk[2456] =
     {   0,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
@@ -1368,8 +1152,8 @@ static const flex_int16_t yy_chk[2456] =
 static yy_state_type yy_last_accepting_state;
 static char *yy_last_accepting_cpos;
 
-extern int yy_flex_debug;
-int yy_flex_debug = 0;
+extern int ncg_flex_debug;
+int ncg_flex_debug = 0;
 
 /* The intent behind this definition is that it'll catch
  * any uses of REJECT which flex missed.
@@ -1378,7 +1162,7 @@ int yy_flex_debug = 0;
 #define yymore() yymore_used_but_not_detected
 #define YY_MORE_ADJ 0
 #define YY_RESTORE_YY_MORE_OFFSET
-char *yytext;
+char *ncgtext;
 #line 1 "ncgen.l"
 #line 2 "ncgen.l"
 /*********************************************************************
@@ -1518,7 +1302,7 @@ struct Specialtoken specials[] = {
 {NULL,0} /* null terminate */
 };
 
-#line 1521 "ncgenl.c"
+
 
 /* The most correct (validating) version of UTF8 character set
    (Taken from: http://www.w3.org/2005/03/23-lex-U)
@@ -1561,7 +1345,7 @@ ID ([A-Za-z_]|{UTF8})([A-Z.@#\[\]a-z_0-9+-]|{UTF8})*
 /* Note: this definition of string will work for utf8 as well,
    although it is a very relaxed definition
 */
-#line 1564 "ncgenl.c"
+#line 1349 "ncgenl.c"
 
 #define INITIAL 0
 #define ST_C_COMMENT 1
@@ -1579,36 +1363,36 @@ ID ([A-Za-z_]|{UTF8})([A-Z.@#\[\]a-z_0-9+-]|{UTF8})*
 #define YY_EXTRA_TYPE void *
 #endif
 
-static int yy_init_globals ( void );
+static int yy_init_globals (void );
 
 /* Accessor methods to globals.
    These are made visible to non-reentrant scanners for convenience. */
 
-int yylex_destroy ( void );
+int ncglex_destroy (void );
 
-int yyget_debug ( void );
+int ncgget_debug (void );
 
-void yyset_debug ( int debug_flag  );
+void ncgset_debug (int debug_flag  );
 
-YY_EXTRA_TYPE yyget_extra ( void );
+YY_EXTRA_TYPE ncgget_extra (void );
 
-void yyset_extra ( YY_EXTRA_TYPE user_defined  );
+void ncgset_extra (YY_EXTRA_TYPE user_defined  );
 
-FILE *yyget_in ( void );
+FILE *ncgget_in (void );
 
-void yyset_in  ( FILE * _in_str  );
+void ncgset_in  (FILE * _in_str  );
 
-FILE *yyget_out ( void );
+FILE *ncgget_out (void );
 
-void yyset_out  ( FILE * _out_str  );
+void ncgset_out  (FILE * _out_str  );
 
-			int yyget_leng ( void );
+yy_size_t ncgget_leng (void );
 
-char *yyget_text ( void );
+char *ncgget_text (void );
 
-int yyget_lineno ( void );
+int ncgget_lineno (void );
 
-void yyset_lineno ( int _line_number  );
+void ncgset_lineno (int _line_number  );
 
 /* Macros after this point can all be overridden by user definitions in
  * section 1.
@@ -1616,31 +1400,32 @@ void yyset_lineno ( int _line_number  );
 
 #ifndef YY_SKIP_YYWRAP
 #ifdef __cplusplus
-extern "C" int yywrap ( void );
+extern "C" int ncgwrap (void );
 #else
-extern int yywrap ( void );
+extern int ncgwrap (void );
 #endif
 #endif
 
 #ifndef YY_NO_UNPUT
     
-    static void yyunput ( int c, char *buf_ptr  );
+    static void yyunput (int c,char *buf_ptr  );
     
 #endif
 
 #ifndef yytext_ptr
-static void yy_flex_strncpy ( char *, const char *, int );
+static void yy_flex_strncpy (char *,yyconst char *,int );
 #endif
 
 #ifdef YY_NEED_STRLEN
-static int yy_flex_strlen ( const char * );
+static int yy_flex_strlen (yyconst char * );
 #endif
 
 #ifndef YY_NO_INPUT
+
 #ifdef __cplusplus
-static int yyinput ( void );
+static int yyinput (void );
 #else
-static int input ( void );
+static int input (void );
 #endif
 
 #endif
@@ -1660,7 +1445,7 @@ static int input ( void );
 /* This used to be an fputs(), but since the string might contain NUL's,
  * we now use fwrite().
  */
-#define ECHO do { if (fwrite( yytext, (size_t) yyleng, 1, yyout )) {} } while (0)
+#define ECHO do { if (fwrite( ncgtext, ncgleng, 1, ncgout )) {} } while (0)
 #endif
 
 /* Gets input and stuffs it into "buf".  number of characters read, or YY_NULL,
@@ -1671,20 +1456,20 @@ static int input ( void );
 	if ( YY_CURRENT_BUFFER_LVALUE->yy_is_interactive ) \
 		{ \
 		int c = '*'; \
-		int n; \
+		size_t n; \
 		for ( n = 0; n < max_size && \
-			     (c = getc( yyin )) != EOF && c != '\n'; ++n ) \
+			     (c = getc( ncgin )) != EOF && c != '\n'; ++n ) \
 			buf[n] = (char) c; \
 		if ( c == '\n' ) \
 			buf[n++] = (char) c; \
-		if ( c == EOF && ferror( yyin ) ) \
+		if ( c == EOF && ferror( ncgin ) ) \
 			YY_FATAL_ERROR( "input in flex scanner failed" ); \
 		result = n; \
 		} \
 	else \
 		{ \
 		errno=0; \
-		while ( (result = (int) fread(buf, 1, (yy_size_t) max_size, yyin)) == 0 && ferror(yyin)) \
+		while ( (result = fread(buf, 1, max_size, ncgin))==0 && ferror(ncgin)) \
 			{ \
 			if( errno != EINTR) \
 				{ \
@@ -1692,7 +1477,7 @@ static int input ( void );
 				break; \
 				} \
 			errno=0; \
-			clearerr(yyin); \
+			clearerr(ncgin); \
 			} \
 		}\
 \
@@ -1725,12 +1510,12 @@ static int input ( void );
 #ifndef YY_DECL
 #define YY_DECL_IS_OURS 1
 
-extern int yylex (void);
+extern int ncglex (void);
 
-#define YY_DECL int yylex (void)
+#define YY_DECL int ncglex (void)
 #endif /* !YY_DECL */
 
-/* Code executed at the beginning of each rule, after yytext and yyleng
+/* Code executed at the beginning of each rule, after ncgtext and ncgleng
  * have been set up.
  */
 #ifndef YY_USER_ACTION
@@ -1764,31 +1549,31 @@ YY_DECL
 		if ( ! (yy_start) )
 			(yy_start) = 1;	/* first start state */
 
-		if ( ! yyin )
-			yyin = stdin;
+		if ( ! ncgin )
+			ncgin = stdin;
 
-		if ( ! yyout )
-			yyout = stdout;
+		if ( ! ncgout )
+			ncgout = stdout;
 
 		if ( ! YY_CURRENT_BUFFER ) {
-			yyensure_buffer_stack ();
+			ncgensure_buffer_stack ();
 			YY_CURRENT_BUFFER_LVALUE =
-				yy_create_buffer( yyin, YY_BUF_SIZE );
+				ncg_create_buffer(ncgin,YY_BUF_SIZE );
 		}
 
-		yy_load_buffer_state(  );
+		ncg_load_buffer_state( );
 		}
 
 	{
 #line 218 "ncgen.l"
 
-#line 1785 "ncgenl.c"
+#line 1571 "ncgenl.c"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
 		yy_cp = (yy_c_buf_p);
 
-		/* Support of yytext. */
+		/* Support of ncgtext. */
 		*yy_cp = (yy_hold_char);
 
 		/* yy_bp points to the position in yy_ch_buf of the start of
@@ -1810,9 +1595,9 @@ yy_match:
 				{
 				yy_current_state = (int) yy_def[yy_current_state];
 				if ( yy_current_state >= 422 )
-					yy_c = yy_meta[yy_c];
+					yy_c = yy_meta[(unsigned int) yy_c];
 				}
-			yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
+			yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
 			++yy_cp;
 			}
 		while ( yy_base[yy_current_state] != 2387 );
@@ -1861,14 +1646,14 @@ YY_RULE_SETUP
 			 /* In netcdf4, this will be used in a variety
                             of places, so only remove escapes */
 /*
-if(yyleng > MAXTRST) {
+if(ncgleng > MAXTRST) {
 yyerror("string too long, truncated\n");
-yytext[MAXTRST-1] = '\0';
+ncgtext[MAXTRST-1] = '\0';
 }
 */
-			len = unescape((char *)yytext+1,yyleng-2,!ISIDENT,&s);
+			len = unescape((char *)ncgtext+1,ncgleng-2,!ISIDENT,&s);
 			if(len < 0) {
-			    sprintf(errstr,"Illegal character: %s",yytext);
+			    sprintf(errstr,"Illegal character: %s",ncgtext);
 			    yyerror(errstr);
 			}
 			bbClear(lextext);
@@ -1882,8 +1667,8 @@ case 4:
 YY_RULE_SETUP
 #line 248 "ncgen.l"
 { /* drop leading 0x; pad to even number of chars */
-		char* p = yytext+2;
-		int len = yyleng - 2;
+		char* p = ncgtext+2;
+		int len = ncgleng - 2;
 		bbClear(lextext);
 	        bbAppendn(lextext,p,len);
 	        if((len % 2) == 1) bbAppend(lextext,'0');
@@ -2008,7 +1793,7 @@ case 27:
 YY_RULE_SETUP
 #line 288 "ncgen.l"
 { /* missing value (pre-2.4 backward compatibility) */
-                if (yytext[0] == '-') {
+                if (ncgtext[0] == '-') {
 		    double_val = NEGNC_INFINITE;
                 } else {
 		    double_val = NC_INFINITE;
@@ -2030,7 +1815,7 @@ case 29:
 YY_RULE_SETUP
 #line 303 "ncgen.l"
 {/* missing value (pre-2.4 backward compatibility)*/
-                if (yytext[0] == '-') {
+                if (ncgtext[0] == '-') {
 		    float_val = NEGNC_INFINITEF;
                 } else {
 		    float_val = NC_INFINITEF;
@@ -2066,7 +1851,7 @@ YY_RULE_SETUP
 #line 328 "ncgen.l"
 {
 		bbClear(lextext);
-		bbAppendn(lextext,(char*)yytext,yyleng+1); /* include null */
+		bbAppendn(lextext,(char*)ncgtext,ncgleng+1); /* include null */
 	        bbNull(lextext);
 		yylval.sym = makepath(bbContents(lextext));
 		return lexdebug(PATH);
@@ -2077,7 +1862,7 @@ YY_RULE_SETUP
 #line 337 "ncgen.l"
 {struct Specialtoken* st;
 		bbClear(lextext);
-		bbAppendn(lextext,(char*)yytext,yyleng+1); /* include null */
+		bbAppendn(lextext,(char*)ncgtext,ncgleng+1); /* include null */
 		bbNull(lextext);
 		for(st=specials;st->name;st++) {
 		    if(strcmp(bbContents(lextext),st->name)==0) {return lexdebug(st->token);}
@@ -2094,7 +1879,7 @@ YY_RULE_SETUP
 		    char* p; char* q;
 		    /* copy the trimmed name */
 		    bbClear(lextext);
-		    bbAppendn(lextext,(char*)yytext,yyleng+1); /* include null */
+		    bbAppendn(lextext,(char*)ncgtext,ncgleng+1); /* include null */
 		    bbNull(lextext);
 		    p = bbContents(lextext);
 		    q = p;
@@ -2110,8 +1895,8 @@ case 35:
 YY_RULE_SETUP
 #line 364 "ncgen.l"
 { char* id = NULL; int len;
-		    len = strlen(yytext);
-		    len = unescape(yytext,len,ISIDENT,&id);
+		    len = strlen(ncgtext);
+		    len = unescape(ncgtext,len,ISIDENT,&id);
 		    if(NCSTREQ(id, FILL_STRING)) {
 			efree(id);
 		        return lexdebug(FILLMARKER);
@@ -2195,21 +1980,21 @@ YY_RULE_SETUP
 {
 		int c;
 		int token = 0;
-		int slen = strlen(yytext);
+		int slen = strlen(ncgtext);
 		char* stag = NULL;
 	        int tag = NC_NAT;
-		char* hex = yytext+2; /* point to first true hex digit */
+		char* hex = ncgtext+2; /* point to first true hex digit */
 		int xlen = (slen - 3);  /* true hex length */
 
-		yytext[slen-1] = '\0';
+		ncgtext[slen-1] = '\0';
 	        /* capture the tag string */
-		tag = collecttag(yytext,&stag);
+		tag = collecttag(ncgtext,&stag);
 		if(tag == NC_NAT) {
 		    sprintf(errstr,"Illegal integer suffix: %s",stag);
 		    yyerror(errstr);
 		    goto done;
 		}
-		yytext[slen - strlen(stag)] = '\0';
+		ncgtext[slen - strlen(stag)] = '\0';
 	        if(xlen > 16) { /* truncate hi order digits */
 		    hex += (xlen - 16);
 		}
@@ -2231,8 +2016,8 @@ YY_RULE_SETUP
 		    token = UINT64_CONST;
 		    break;
 		default: /* should never happen */
-		    if (sscanf((char*)yytext, "%i", &uint32_val) != 1) {
-		        sprintf(errstr,"bad unsigned int constant: %s",(char*)yytext);
+		    if (sscanf((char*)ncgtext, "%i", &uint32_val) != 1) {
+		        sprintf(errstr,"bad unsigned int constant: %s",(char*)ncgtext);
 		        yyerror(errstr);
 		    }
 		    token = UINT_CONST;
@@ -2244,8 +2029,8 @@ case 38:
 YY_RULE_SETUP
 #line 488 "ncgen.l"
 {
-		if (sscanf((char*)yytext, "%le", &double_val) != 1) {
-		    sprintf(errstr,"bad long or double constant: %s",(char*)yytext);
+		if (sscanf((char*)ncgtext, "%le", &double_val) != 1) {
+		    sprintf(errstr,"bad long or double constant: %s",(char*)ncgtext);
 		    yyerror(errstr);
 		}
                 return lexdebug(DOUBLE_CONST);
@@ -2255,8 +2040,8 @@ case 39:
 YY_RULE_SETUP
 #line 495 "ncgen.l"
 {
-		if (sscanf((char*)yytext, "%e", &float_val) != 1) {
-		    sprintf(errstr,"bad float constant: %s",(char*)yytext);
+		if (sscanf((char*)ncgtext, "%e", &float_val) != 1) {
+		    sprintf(errstr,"bad float constant: %s",(char*)ncgtext);
 		    yyerror(errstr);
 		}
                 return lexdebug(FLOAT_CONST);
@@ -2267,7 +2052,7 @@ case 40:
 YY_RULE_SETUP
 #line 502 "ncgen.l"
 {
-	        (void) sscanf((char*)&yytext[1],"%c",&byte_val);
+	        (void) sscanf((char*)&ncgtext[1],"%c",&byte_val);
 		return lexdebug(BYTE_CONST);
                 }
 	YY_BREAK
@@ -2275,9 +2060,9 @@ case 41:
 YY_RULE_SETUP
 #line 506 "ncgen.l"
 {
-		int oct = unescapeoct(&yytext[2]);
+		int oct = unescapeoct(&ncgtext[2]);
 		if(oct < 0) {
-		    sprintf(errstr,"bad octal character constant: %s",(char*)yytext);
+		    sprintf(errstr,"bad octal character constant: %s",(char*)ncgtext);
 		    yyerror(errstr);
 		}
 	        byte_val = (unsigned int)oct;
@@ -2288,9 +2073,9 @@ case 42:
 YY_RULE_SETUP
 #line 515 "ncgen.l"
 {
-		int hex = unescapehex(&yytext[3]);
+		int hex = unescapehex(&ncgtext[3]);
 		if(byte_val < 0) {
-		    sprintf(errstr,"bad hex character constant: %s",(char*)yytext);
+		    sprintf(errstr,"bad hex character constant: %s",(char*)ncgtext);
 		    yyerror(errstr);
 		}
 		byte_val = (unsigned int)hex;
@@ -2301,7 +2086,7 @@ case 43:
 YY_RULE_SETUP
 #line 524 "ncgen.l"
 {
-	       switch ((char)yytext[2]) {
+	       switch ((char)ncgtext[2]) {
 	          case 'a': byte_val = '\007'; break; /* not everyone under-
 						       * stands '\a' yet */
      	          case 'b': byte_val = '\b'; break;
@@ -2313,7 +2098,7 @@ YY_RULE_SETUP
 		  case '\\': byte_val = '\\'; break;
 		  case '?': byte_val = '\177'; break;
 		  case '\'': byte_val = '\''; break;
-		  default: byte_val = (char)yytext[2];
+		  default: byte_val = (char)ncgtext[2];
 	           }
 		return lexdebug(BYTE_CONST);
                 }
@@ -2363,7 +2148,7 @@ case 48:
 YY_RULE_SETUP
 #line 567 "ncgen.l"
 {/* Note: this next rule will not work for UTF8 characters */
-		return lexdebug(yytext[0]) ;
+		return lexdebug(ncgtext[0]) ;
 		}
 	YY_BREAK
 case 49:
@@ -2371,7 +2156,7 @@ YY_RULE_SETUP
 #line 570 "ncgen.l"
 ECHO;
 	YY_BREAK
-#line 2374 "ncgenl.c"
+#line 2160 "ncgenl.c"
 case YY_STATE_EOF(INITIAL):
 case YY_STATE_EOF(TEXT):
 	yyterminate();
@@ -2389,15 +2174,15 @@ case YY_STATE_EOF(TEXT):
 			{
 			/* We're scanning a new file or input source.  It's
 			 * possible that this happened because the user
-			 * just pointed yyin at a new source and called
-			 * yylex().  If so, then we have to assure
+			 * just pointed ncgin at a new source and called
+			 * ncglex().  If so, then we have to assure
 			 * consistency between YY_CURRENT_BUFFER and our
 			 * globals.  Here is the right place to do so, because
 			 * this is the first action (other than possibly a
 			 * back-up) that will match for the new input source.
 			 */
 			(yy_n_chars) = YY_CURRENT_BUFFER_LVALUE->yy_n_chars;
-			YY_CURRENT_BUFFER_LVALUE->yy_input_file = yyin;
+			YY_CURRENT_BUFFER_LVALUE->yy_input_file = ncgin;
 			YY_CURRENT_BUFFER_LVALUE->yy_buffer_status = YY_BUFFER_NORMAL;
 			}
 
@@ -2450,11 +2235,11 @@ case YY_STATE_EOF(TEXT):
 				{
 				(yy_did_buffer_switch_on_eof) = 0;
 
-				if ( yywrap(  ) )
+				if ( ncgwrap( ) )
 					{
 					/* Note: because we've taken care in
 					 * yy_get_next_buffer() to have set up
-					 * yytext, we can now set up
+					 * ncgtext, we can now set up
 					 * yy_c_buf_p so that if some total
 					 * hoser (like flex itself) wants to
 					 * call the scanner after we return the
@@ -2504,7 +2289,7 @@ case YY_STATE_EOF(TEXT):
 	} /* end of action switch */
 		} /* end of scanning one token */
 	} /* end of user's declarations */
-} /* end of yylex */
+} /* end of ncglex */
 
 /* yy_get_next_buffer - try to read in a new buffer
  *
@@ -2517,7 +2302,7 @@ static int yy_get_next_buffer (void)
 {
     	char *dest = YY_CURRENT_BUFFER_LVALUE->yy_ch_buf;
 	char *source = (yytext_ptr);
-	int number_to_move, i;
+	yy_size_t number_to_move, i;
 	int ret_val;
 
 	if ( (yy_c_buf_p) > &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[(yy_n_chars) + 1] )
@@ -2546,7 +2331,7 @@ static int yy_get_next_buffer (void)
 	/* Try to read more data. */
 
 	/* First move last chars to start of buffer. */
-	number_to_move = (int) ((yy_c_buf_p) - (yytext_ptr) - 1);
+	number_to_move = (yy_size_t) ((yy_c_buf_p) - (yytext_ptr)) - 1;
 
 	for ( i = 0; i < number_to_move; ++i )
 		*(dest++) = *(source++);
@@ -2559,7 +2344,7 @@ static int yy_get_next_buffer (void)
 
 	else
 		{
-			int num_to_read =
+			yy_size_t num_to_read =
 			YY_CURRENT_BUFFER_LVALUE->yy_buf_size - number_to_move - 1;
 
 		while ( num_to_read <= 0 )
@@ -2573,7 +2358,7 @@ static int yy_get_next_buffer (void)
 
 			if ( b->yy_is_our_buffer )
 				{
-				int new_size = b->yy_buf_size * 2;
+				yy_size_t new_size = b->yy_buf_size * 2;
 
 				if ( new_size <= 0 )
 					b->yy_buf_size += b->yy_buf_size / 8;
@@ -2582,12 +2367,11 @@ static int yy_get_next_buffer (void)
 
 				b->yy_ch_buf = (char *)
 					/* Include room in for 2 EOB chars. */
-					yyrealloc( (void *) b->yy_ch_buf,
-							 (yy_size_t) (b->yy_buf_size + 2)  );
+					ncgrealloc((void *) b->yy_ch_buf,b->yy_buf_size + 2  );
 				}
 			else
 				/* Can't grow it, we don't own it. */
-				b->yy_ch_buf = NULL;
+				b->yy_ch_buf = 0;
 
 			if ( ! b->yy_ch_buf )
 				YY_FATAL_ERROR(
@@ -2615,7 +2399,7 @@ static int yy_get_next_buffer (void)
 		if ( number_to_move == YY_MORE_ADJ )
 			{
 			ret_val = EOB_ACT_END_OF_FILE;
-			yyrestart( yyin  );
+			ncgrestart(ncgin  );
 			}
 
 		else
@@ -2629,15 +2413,12 @@ static int yy_get_next_buffer (void)
 	else
 		ret_val = EOB_ACT_CONTINUE_SCAN;
 
-	if (((yy_n_chars) + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
+	if ((int) ((yy_n_chars) + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
 		/* Extend the array by 50%, plus the number we really need. */
 		int new_size = (yy_n_chars) + number_to_move + ((yy_n_chars) >> 1);
-		YY_CURRENT_BUFFER_LVALUE->yy_ch_buf = (char *) yyrealloc(
-			(void *) YY_CURRENT_BUFFER_LVALUE->yy_ch_buf, (yy_size_t) new_size  );
+		YY_CURRENT_BUFFER_LVALUE->yy_ch_buf = (char *) ncgrealloc((void *) YY_CURRENT_BUFFER_LVALUE->yy_ch_buf,new_size  );
 		if ( ! YY_CURRENT_BUFFER_LVALUE->yy_ch_buf )
 			YY_FATAL_ERROR( "out of dynamic memory in yy_get_next_buffer()" );
-		/* "- 2" to take care of EOB's */
-		YY_CURRENT_BUFFER_LVALUE->yy_buf_size = (int) (new_size - 2);
 	}
 
 	(yy_n_chars) += number_to_move;
@@ -2670,9 +2451,9 @@ static int yy_get_next_buffer (void)
 			{
 			yy_current_state = (int) yy_def[yy_current_state];
 			if ( yy_current_state >= 422 )
-				yy_c = yy_meta[yy_c];
+				yy_c = yy_meta[(unsigned int) yy_c];
 			}
-		yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
+		yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
 		}
 
 	return yy_current_state;
@@ -2698,9 +2479,9 @@ static int yy_get_next_buffer (void)
 		{
 		yy_current_state = (int) yy_def[yy_current_state];
 		if ( yy_current_state >= 422 )
-			yy_c = yy_meta[yy_c];
+			yy_c = yy_meta[(unsigned int) yy_c];
 		}
-	yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
+	yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
 	yy_is_jam = (yy_current_state == 421);
 
 		return yy_is_jam ? 0 : yy_current_state;
@@ -2714,13 +2495,13 @@ static int yy_get_next_buffer (void)
     
     yy_cp = (yy_c_buf_p);
 
-	/* undo effects of setting up yytext */
+	/* undo effects of setting up ncgtext */
 	*yy_cp = (yy_hold_char);
 
 	if ( yy_cp < YY_CURRENT_BUFFER_LVALUE->yy_ch_buf + 2 )
 		{ /* need to shift things up to make room */
 		/* +2 for EOB chars. */
-		int number_to_move = (yy_n_chars) + 2;
+		yy_size_t number_to_move = (yy_n_chars) + 2;
 		char *dest = &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[
 					YY_CURRENT_BUFFER_LVALUE->yy_buf_size + 2];
 		char *source =
@@ -2732,7 +2513,7 @@ static int yy_get_next_buffer (void)
 		yy_cp += (int) (dest - source);
 		yy_bp += (int) (dest - source);
 		YY_CURRENT_BUFFER_LVALUE->yy_n_chars =
-			(yy_n_chars) = (int) YY_CURRENT_BUFFER_LVALUE->yy_buf_size;
+			(yy_n_chars) = YY_CURRENT_BUFFER_LVALUE->yy_buf_size;
 
 		if ( yy_cp < YY_CURRENT_BUFFER_LVALUE->yy_ch_buf + 2 )
 			YY_FATAL_ERROR( "flex scanner push-back overflow" );
@@ -2771,7 +2552,7 @@ static int yy_get_next_buffer (void)
 
 		else
 			{ /* need more input */
-			int offset = (int) ((yy_c_buf_p) - (yytext_ptr));
+			yy_size_t offset = (yy_c_buf_p) - (yytext_ptr);
 			++(yy_c_buf_p);
 
 			switch ( yy_get_next_buffer(  ) )
@@ -2788,14 +2569,14 @@ static int yy_get_next_buffer (void)
 					 */
 
 					/* Reset buffer status. */
-					yyrestart( yyin );
+					ncgrestart(ncgin );
 
 					/*FALLTHROUGH*/
 
 				case EOB_ACT_END_OF_FILE:
 					{
-					if ( yywrap(  ) )
-						return 0;
+					if ( ncgwrap( ) )
+						return EOF;
 
 					if ( ! (yy_did_buffer_switch_on_eof) )
 						YY_NEW_FILE;
@@ -2814,7 +2595,7 @@ static int yy_get_next_buffer (void)
 		}
 
 	c = *(unsigned char *) (yy_c_buf_p);	/* cast for 8-bit char's */
-	*(yy_c_buf_p) = '\0';	/* preserve yytext */
+	*(yy_c_buf_p) = '\0';	/* preserve ncgtext */
 	(yy_hold_char) = *++(yy_c_buf_p);
 
 	return c;
@@ -2826,32 +2607,32 @@ static int yy_get_next_buffer (void)
  * 
  * @note This function does not reset the start condition to @c INITIAL .
  */
-    void yyrestart  (FILE * input_file )
+    void ncgrestart  (FILE * input_file )
 {
     
 	if ( ! YY_CURRENT_BUFFER ){
-        yyensure_buffer_stack ();
+        ncgensure_buffer_stack ();
 		YY_CURRENT_BUFFER_LVALUE =
-            yy_create_buffer( yyin, YY_BUF_SIZE );
+            ncg_create_buffer(ncgin,YY_BUF_SIZE );
 	}
 
-	yy_init_buffer( YY_CURRENT_BUFFER, input_file );
-	yy_load_buffer_state(  );
+	ncg_init_buffer(YY_CURRENT_BUFFER,input_file );
+	ncg_load_buffer_state( );
 }
 
 /** Switch to a different input buffer.
  * @param new_buffer The new input buffer.
  * 
  */
-    void yy_switch_to_buffer  (YY_BUFFER_STATE  new_buffer )
+    void ncg_switch_to_buffer  (YY_BUFFER_STATE  new_buffer )
 {
     
 	/* TODO. We should be able to replace this entire function body
 	 * with
-	 *		yypop_buffer_state();
-	 *		yypush_buffer_state(new_buffer);
+	 *		ncgpop_buffer_state();
+	 *		ncgpush_buffer_state(new_buffer);
      */
-	yyensure_buffer_stack ();
+	ncgensure_buffer_stack ();
 	if ( YY_CURRENT_BUFFER == new_buffer )
 		return;
 
@@ -2864,21 +2645,21 @@ static int yy_get_next_buffer (void)
 		}
 
 	YY_CURRENT_BUFFER_LVALUE = new_buffer;
-	yy_load_buffer_state(  );
+	ncg_load_buffer_state( );
 
 	/* We don't actually know whether we did this switch during
-	 * EOF (yywrap()) processing, but the only time this flag
-	 * is looked at is after yywrap() is called, so it's safe
+	 * EOF (ncgwrap()) processing, but the only time this flag
+	 * is looked at is after ncgwrap() is called, so it's safe
 	 * to go ahead and always set it.
 	 */
 	(yy_did_buffer_switch_on_eof) = 1;
 }
 
-static void yy_load_buffer_state  (void)
+static void ncg_load_buffer_state  (void)
 {
     	(yy_n_chars) = YY_CURRENT_BUFFER_LVALUE->yy_n_chars;
 	(yytext_ptr) = (yy_c_buf_p) = YY_CURRENT_BUFFER_LVALUE->yy_buf_pos;
-	yyin = YY_CURRENT_BUFFER_LVALUE->yy_input_file;
+	ncgin = YY_CURRENT_BUFFER_LVALUE->yy_input_file;
 	(yy_hold_char) = *(yy_c_buf_p);
 }
 
@@ -2888,35 +2669,35 @@ static void yy_load_buffer_state  (void)
  * 
  * @return the allocated buffer state.
  */
-    YY_BUFFER_STATE yy_create_buffer  (FILE * file, int  size )
+    YY_BUFFER_STATE ncg_create_buffer  (FILE * file, int  size )
 {
 	YY_BUFFER_STATE b;
     
-	b = (YY_BUFFER_STATE) yyalloc( sizeof( struct yy_buffer_state )  );
+	b = (YY_BUFFER_STATE) ncgalloc(sizeof( struct yy_buffer_state )  );
 	if ( ! b )
-		YY_FATAL_ERROR( "out of dynamic memory in yy_create_buffer()" );
+		YY_FATAL_ERROR( "out of dynamic memory in ncg_create_buffer()" );
 
-	b->yy_buf_size = size;
+	b->yy_buf_size = (yy_size_t)size;
 
 	/* yy_ch_buf has to be 2 characters longer than the size given because
 	 * we need to put in 2 end-of-buffer characters.
 	 */
-	b->yy_ch_buf = (char *) yyalloc( (yy_size_t) (b->yy_buf_size + 2)  );
+	b->yy_ch_buf = (char *) ncgalloc(b->yy_buf_size + 2  );
 	if ( ! b->yy_ch_buf )
-		YY_FATAL_ERROR( "out of dynamic memory in yy_create_buffer()" );
+		YY_FATAL_ERROR( "out of dynamic memory in ncg_create_buffer()" );
 
 	b->yy_is_our_buffer = 1;
 
-	yy_init_buffer( b, file );
+	ncg_init_buffer(b,file );
 
 	return b;
 }
 
 /** Destroy the buffer.
- * @param b a buffer created with yy_create_buffer()
+ * @param b a buffer created with ncg_create_buffer()
  * 
  */
-    void yy_delete_buffer (YY_BUFFER_STATE  b )
+    void ncg_delete_buffer (YY_BUFFER_STATE  b )
 {
     
 	if ( ! b )
@@ -2926,27 +2707,27 @@ static void yy_load_buffer_state  (void)
 		YY_CURRENT_BUFFER_LVALUE = (YY_BUFFER_STATE) 0;
 
 	if ( b->yy_is_our_buffer )
-		yyfree( (void *) b->yy_ch_buf  );
+		ncgfree((void *) b->yy_ch_buf  );
 
-	yyfree( (void *) b  );
+	ncgfree((void *) b  );
 }
 
 /* Initializes or reinitializes a buffer.
  * This function is sometimes called more than once on the same buffer,
- * such as during a yyrestart() or at EOF.
+ * such as during a ncgrestart() or at EOF.
  */
-    static void yy_init_buffer  (YY_BUFFER_STATE  b, FILE * file )
+    static void ncg_init_buffer  (YY_BUFFER_STATE  b, FILE * file )
 
 {
 	int oerrno = errno;
     
-	yy_flush_buffer( b );
+	ncg_flush_buffer(b );
 
 	b->yy_input_file = file;
 	b->yy_fill_buffer = 1;
 
-    /* If b is the current buffer, then yy_init_buffer was _probably_
-     * called from yyrestart() or through yy_get_next_buffer.
+    /* If b is the current buffer, then ncg_init_buffer was _probably_
+     * called from ncgrestart() or through yy_get_next_buffer.
      * In that case, we don't want to reset the lineno or column.
      */
     if (b != YY_CURRENT_BUFFER){
@@ -2963,7 +2744,7 @@ static void yy_load_buffer_state  (void)
  * @param b the buffer state to be flushed, usually @c YY_CURRENT_BUFFER.
  * 
  */
-    void yy_flush_buffer (YY_BUFFER_STATE  b )
+    void ncg_flush_buffer (YY_BUFFER_STATE  b )
 {
     	if ( ! b )
 		return;
@@ -2983,7 +2764,7 @@ static void yy_load_buffer_state  (void)
 	b->yy_buffer_status = YY_BUFFER_NEW;
 
 	if ( b == YY_CURRENT_BUFFER )
-		yy_load_buffer_state(  );
+		ncg_load_buffer_state( );
 }
 
 /** Pushes the new state onto the stack. The new state becomes
@@ -2992,14 +2773,14 @@ static void yy_load_buffer_state  (void)
  *  @param new_buffer The new state.
  *  
  */
-void yypush_buffer_state (YY_BUFFER_STATE new_buffer )
+void ncgpush_buffer_state (YY_BUFFER_STATE new_buffer )
 {
     	if (new_buffer == NULL)
 		return;
 
-	yyensure_buffer_stack();
+	ncgensure_buffer_stack();
 
-	/* This block is copied from yy_switch_to_buffer. */
+	/* This block is copied from ncg_switch_to_buffer. */
 	if ( YY_CURRENT_BUFFER )
 		{
 		/* Flush out information for old buffer. */
@@ -3013,8 +2794,8 @@ void yypush_buffer_state (YY_BUFFER_STATE new_buffer )
 		(yy_buffer_stack_top)++;
 	YY_CURRENT_BUFFER_LVALUE = new_buffer;
 
-	/* copied from yy_switch_to_buffer. */
-	yy_load_buffer_state(  );
+	/* copied from ncg_switch_to_buffer. */
+	ncg_load_buffer_state( );
 	(yy_did_buffer_switch_on_eof) = 1;
 }
 
@@ -3022,18 +2803,18 @@ void yypush_buffer_state (YY_BUFFER_STATE new_buffer )
  *  The next element becomes the new top.
  *  
  */
-void yypop_buffer_state (void)
+void ncgpop_buffer_state (void)
 {
     	if (!YY_CURRENT_BUFFER)
 		return;
 
-	yy_delete_buffer(YY_CURRENT_BUFFER );
+	ncg_delete_buffer(YY_CURRENT_BUFFER );
 	YY_CURRENT_BUFFER_LVALUE = NULL;
 	if ((yy_buffer_stack_top) > 0)
 		--(yy_buffer_stack_top);
 
 	if (YY_CURRENT_BUFFER) {
-		yy_load_buffer_state(  );
+		ncg_load_buffer_state( );
 		(yy_did_buffer_switch_on_eof) = 1;
 	}
 }
@@ -3041,7 +2822,7 @@ void yypop_buffer_state (void)
 /* Allocates the stack if it does not exist.
  *  Guarantees space for at least one push.
  */
-static void yyensure_buffer_stack (void)
+static void ncgensure_buffer_stack (void)
 {
 	yy_size_t num_to_alloc;
     
@@ -3051,15 +2832,15 @@ static void yyensure_buffer_stack (void)
 		 * scanner will even need a stack. We use 2 instead of 1 to avoid an
 		 * immediate realloc on the next call.
          */
-      num_to_alloc = 1; /* After all that talk, this was set to 1 anyways... */
-		(yy_buffer_stack) = (struct yy_buffer_state**)yyalloc
+		num_to_alloc = 1; /* After all that talk, this was set to 1 anyways... */
+		(yy_buffer_stack) = (struct yy_buffer_state**)ncgalloc
 								(num_to_alloc * sizeof(struct yy_buffer_state*)
 								);
 		if ( ! (yy_buffer_stack) )
-			YY_FATAL_ERROR( "out of dynamic memory in yyensure_buffer_stack()" );
-
+			YY_FATAL_ERROR( "out of dynamic memory in ncgensure_buffer_stack()" );
+								  
 		memset((yy_buffer_stack), 0, num_to_alloc * sizeof(struct yy_buffer_state*));
-
+				
 		(yy_buffer_stack_max) = num_to_alloc;
 		(yy_buffer_stack_top) = 0;
 		return;
@@ -3071,12 +2852,12 @@ static void yyensure_buffer_stack (void)
 		yy_size_t grow_size = 8 /* arbitrary grow size */;
 
 		num_to_alloc = (yy_buffer_stack_max) + grow_size;
-		(yy_buffer_stack) = (struct yy_buffer_state**)yyrealloc
+		(yy_buffer_stack) = (struct yy_buffer_state**)ncgrealloc
 								((yy_buffer_stack),
 								num_to_alloc * sizeof(struct yy_buffer_state*)
 								);
 		if ( ! (yy_buffer_stack) )
-			YY_FATAL_ERROR( "out of dynamic memory in yyensure_buffer_stack()" );
+			YY_FATAL_ERROR( "out of dynamic memory in ncgensure_buffer_stack()" );
 
 		/* zero only the new slots.*/
 		memset((yy_buffer_stack) + (yy_buffer_stack_max), 0, grow_size * sizeof(struct yy_buffer_state*));
@@ -3088,9 +2869,9 @@ static void yyensure_buffer_stack (void)
  * @param base the character buffer
  * @param size the size in bytes of the character buffer
  * 
- * @return the newly allocated buffer state object.
+ * @return the newly allocated buffer state object. 
  */
-YY_BUFFER_STATE yy_scan_buffer  (char * base, yy_size_t  size )
+YY_BUFFER_STATE ncg_scan_buffer  (char * base, yy_size_t  size )
 {
 	YY_BUFFER_STATE b;
     
@@ -3098,69 +2879,69 @@ YY_BUFFER_STATE yy_scan_buffer  (char * base, yy_size_t  size )
 	     base[size-2] != YY_END_OF_BUFFER_CHAR ||
 	     base[size-1] != YY_END_OF_BUFFER_CHAR )
 		/* They forgot to leave room for the EOB's. */
-		return NULL;
+		return 0;
 
-	b = (YY_BUFFER_STATE) yyalloc( sizeof( struct yy_buffer_state )  );
+	b = (YY_BUFFER_STATE) ncgalloc(sizeof( struct yy_buffer_state )  );
 	if ( ! b )
-		YY_FATAL_ERROR( "out of dynamic memory in yy_scan_buffer()" );
+		YY_FATAL_ERROR( "out of dynamic memory in ncg_scan_buffer()" );
 
-	b->yy_buf_size = (int) (size - 2);	/* "- 2" to take care of EOB's */
+	b->yy_buf_size = size - 2;	/* "- 2" to take care of EOB's */
 	b->yy_buf_pos = b->yy_ch_buf = base;
 	b->yy_is_our_buffer = 0;
-	b->yy_input_file = NULL;
+	b->yy_input_file = 0;
 	b->yy_n_chars = b->yy_buf_size;
 	b->yy_is_interactive = 0;
 	b->yy_at_bol = 1;
 	b->yy_fill_buffer = 0;
 	b->yy_buffer_status = YY_BUFFER_NEW;
 
-	yy_switch_to_buffer( b  );
+	ncg_switch_to_buffer(b  );
 
 	return b;
 }
 
-/** Setup the input buffer state to scan a string. The next call to yylex() will
+/** Setup the input buffer state to scan a string. The next call to ncglex() will
  * scan from a @e copy of @a str.
  * @param yystr a NUL-terminated string to scan
  * 
  * @return the newly allocated buffer state object.
  * @note If you want to scan bytes that may contain NUL values, then use
- *       yy_scan_bytes() instead.
+ *       ncg_scan_bytes() instead.
  */
-YY_BUFFER_STATE yy_scan_string (const char * yystr )
+YY_BUFFER_STATE ncg_scan_string (yyconst char * yystr )
 {
     
-	return yy_scan_bytes( yystr, (int) strlen(yystr) );
+	return ncg_scan_bytes(yystr,strlen(yystr) );
 }
 
-/** Setup the input buffer state to scan the given bytes. The next call to yylex() will
+/** Setup the input buffer state to scan the given bytes. The next call to ncglex() will
  * scan from a @e copy of @a bytes.
  * @param yybytes the byte buffer to scan
  * @param _yybytes_len the number of bytes in the buffer pointed to by @a bytes.
  * 
  * @return the newly allocated buffer state object.
  */
-YY_BUFFER_STATE yy_scan_bytes  (const char * yybytes, int  _yybytes_len )
+YY_BUFFER_STATE ncg_scan_bytes  (yyconst char * yybytes, yy_size_t  _yybytes_len )
 {
 	YY_BUFFER_STATE b;
 	char *buf;
 	yy_size_t n;
-	int i;
+	yy_size_t i;
     
 	/* Get memory for full buffer, including space for trailing EOB's. */
-	n = (yy_size_t) (_yybytes_len + 2);
-	buf = (char *) yyalloc( n  );
+	n = _yybytes_len + 2;
+	buf = (char *) ncgalloc(n  );
 	if ( ! buf )
-		YY_FATAL_ERROR( "out of dynamic memory in yy_scan_bytes()" );
+		YY_FATAL_ERROR( "out of dynamic memory in ncg_scan_bytes()" );
 
 	for ( i = 0; i < _yybytes_len; ++i )
 		buf[i] = yybytes[i];
 
 	buf[_yybytes_len] = buf[_yybytes_len+1] = YY_END_OF_BUFFER_CHAR;
 
-	b = yy_scan_buffer( buf, n );
+	b = ncg_scan_buffer(buf,n );
 	if ( ! b )
-		YY_FATAL_ERROR( "bad buffer in yy_scan_bytes()" );
+		YY_FATAL_ERROR( "bad buffer in ncg_scan_bytes()" );
 
 	/* It's okay to grow etc. this buffer, and we should throw it
 	 * away when we're done.
@@ -3174,9 +2955,9 @@ YY_BUFFER_STATE yy_scan_bytes  (const char * yybytes, int  _yybytes_len )
 #define YY_EXIT_FAILURE 2
 #endif
 
-static void yynoreturn yy_fatal_error (const char* msg )
+static void yy_fatal_error (yyconst char* msg )
 {
-			fprintf( stderr, "%s\n", msg );
+			(void) fprintf( stderr, "%s\n", msg );
 	exit( YY_EXIT_FAILURE );
 }
 
@@ -3186,14 +2967,14 @@ static void yynoreturn yy_fatal_error (const char* msg )
 #define yyless(n) \
 	do \
 		{ \
-		/* Undo effects of setting up yytext. */ \
+		/* Undo effects of setting up ncgtext. */ \
         int yyless_macro_arg = (n); \
         YY_LESS_LINENO(yyless_macro_arg);\
-		yytext[yyleng] = (yy_hold_char); \
-		(yy_c_buf_p) = yytext + yyless_macro_arg; \
+		ncgtext[ncgleng] = (yy_hold_char); \
+		(yy_c_buf_p) = ncgtext + yyless_macro_arg; \
 		(yy_hold_char) = *(yy_c_buf_p); \
 		*(yy_c_buf_p) = '\0'; \
-		yyleng = yyless_macro_arg; \
+		ncgleng = yyless_macro_arg; \
 		} \
 	while ( 0 )
 
@@ -3202,126 +2983,126 @@ static void yynoreturn yy_fatal_error (const char* msg )
 /** Get the current line number.
  * 
  */
-int yyget_lineno  (void)
+int ncgget_lineno  (void)
 {
-    
-    return yylineno;
+        
+    return ncglineno;
 }
 
 /** Get the input stream.
  * 
  */
-FILE *yyget_in  (void)
+FILE *ncgget_in  (void)
 {
-        return yyin;
+        return ncgin;
 }
 
 /** Get the output stream.
  * 
  */
-FILE *yyget_out  (void)
+FILE *ncgget_out  (void)
 {
-        return yyout;
+        return ncgout;
 }
 
 /** Get the length of the current token.
  * 
  */
-int yyget_leng  (void)
+yy_size_t ncgget_leng  (void)
 {
-        return yyleng;
+        return ncgleng;
 }
 
 /** Get the current token.
  * 
  */
 
-char *yyget_text  (void)
+char *ncgget_text  (void)
 {
-        return yytext;
+        return ncgtext;
 }
 
 /** Set the current line number.
  * @param _line_number line number
  * 
  */
-void yyset_lineno (int  _line_number )
+void ncgset_lineno (int  _line_number )
 {
     
-    yylineno = _line_number;
+    ncglineno = _line_number;
 }
 
 /** Set the input stream. This does not discard the current
  * input buffer.
  * @param _in_str A readable stream.
  * 
- * @see yy_switch_to_buffer
+ * @see ncg_switch_to_buffer
  */
-void yyset_in (FILE *  _in_str )
+void ncgset_in (FILE *  _in_str )
 {
-        yyin = _in_str ;
+        ncgin = _in_str ;
 }
 
-void yyset_out (FILE *  _out_str )
+void ncgset_out (FILE *  _out_str )
 {
-        yyout = _out_str ;
+        ncgout = _out_str ;
 }
 
-int yyget_debug  (void)
+int ncgget_debug  (void)
 {
-        return yy_flex_debug;
+        return ncg_flex_debug;
 }
 
-void yyset_debug (int  _bdebug )
+void ncgset_debug (int  _bdebug )
 {
-        yy_flex_debug = _bdebug ;
+        ncg_flex_debug = _bdebug ;
 }
 
 static int yy_init_globals (void)
 {
         /* Initialization is the same as for the non-reentrant scanner.
-     * This function is called from yylex_destroy(), so don't allocate here.
+     * This function is called from ncglex_destroy(), so don't allocate here.
      */
 
-    (yy_buffer_stack) = NULL;
+    (yy_buffer_stack) = 0;
     (yy_buffer_stack_top) = 0;
     (yy_buffer_stack_max) = 0;
-    (yy_c_buf_p) = NULL;
+    (yy_c_buf_p) = (char *) 0;
     (yy_init) = 0;
     (yy_start) = 0;
 
 /* Defined in main.c */
 #ifdef YY_STDINIT
-    yyin = stdin;
-    yyout = stdout;
+    ncgin = stdin;
+    ncgout = stdout;
 #else
-    yyin = NULL;
-    yyout = NULL;
+    ncgin = (FILE *) 0;
+    ncgout = (FILE *) 0;
 #endif
 
     /* For future reference: Set errno on error, since we are called by
-     * yylex_init()
+     * ncglex_init()
      */
     return 0;
 }
 
-/* yylex_destroy is for both reentrant and non-reentrant scanners. */
-int yylex_destroy  (void)
+/* ncglex_destroy is for both reentrant and non-reentrant scanners. */
+int ncglex_destroy  (void)
 {
     
     /* Pop the buffer stack, destroying each element. */
 	while(YY_CURRENT_BUFFER){
-		yy_delete_buffer( YY_CURRENT_BUFFER  );
+		ncg_delete_buffer(YY_CURRENT_BUFFER  );
 		YY_CURRENT_BUFFER_LVALUE = NULL;
-		yypop_buffer_state();
+		ncgpop_buffer_state();
 	}
 
 	/* Destroy the stack itself. */
-	yyfree((yy_buffer_stack) );
+	ncgfree((yy_buffer_stack) );
 	(yy_buffer_stack) = NULL;
 
     /* Reset the globals. This is important in a non-reentrant scanner so the next time
-     * yylex() is called, initialization will occur. */
+     * ncglex() is called, initialization will occur. */
     yy_init_globals( );
 
     return 0;
@@ -3332,7 +3113,7 @@ int yylex_destroy  (void)
  */
 
 #ifndef yytext_ptr
-static void yy_flex_strncpy (char* s1, const char * s2, int n )
+static void yy_flex_strncpy (char* s1, yyconst char * s2, int n )
 {
 		
 	int i;
@@ -3342,7 +3123,7 @@ static void yy_flex_strncpy (char* s1, const char * s2, int n )
 #endif
 
 #ifdef YY_NEED_STRLEN
-static int yy_flex_strlen (const char * s )
+static int yy_flex_strlen (yyconst char * s )
 {
 	int n;
 	for ( n = 0; s[n]; ++n )
@@ -3352,12 +3133,12 @@ static int yy_flex_strlen (const char * s )
 }
 #endif
 
-void *yyalloc (yy_size_t  size )
+void *ncgalloc (yy_size_t  size )
 {
-			return malloc(size);
+			return (void *) malloc( size );
 }
 
-void *yyrealloc  (void * ptr, yy_size_t  size )
+void *ncgrealloc  (void * ptr, yy_size_t  size )
 {
 		
 	/* The cast to (char *) in the following accommodates both
@@ -3367,25 +3148,26 @@ void *yyrealloc  (void * ptr, yy_size_t  size )
 	 * any pointer type to void*, and deal with argument conversions
 	 * as though doing an assignment.
 	 */
-	return realloc(ptr, size);
+	return (void *) realloc( (char *) ptr, size );
 }
 
-void yyfree (void * ptr )
+void ncgfree (void * ptr )
 {
-			free( (char *) ptr );	/* see yyrealloc() for (char *) cast */
+			free( (char *) ptr );	/* see ncgrealloc() for (char *) cast */
 }
 
 #define YYTABLES_NAME "yytables"
 
 #line 570 "ncgen.l"
 
+
 static int
 lexdebug(int token)
 {
     if(debug >= 2)
     {
-	char* text = yytext;
-	text[yyleng] = 0;
+	char* text = ncgtext;
+	text[ncgleng] = 0;
         fprintf(stderr,"Token=%d |%s| line=%d\n",token,text,lineno);
     }
     return token;


### PR DESCRIPTION
* Fixes #1233 

re: issue https://github.com/Unidata/netcdf-c/issues/1233

Changes:

1. remove exit that was there for testing.
2. the program tst_open_mem must be netcdf-4 only.
3. fix some diff problems
   - Change dataset name for tst_inmemory4_create to tst_inmemory4
   - Modify tst_inmemory.c to reorder the variables (somewhat major rewrite)

Minor Unrelated Fixes:
1. fix comment problem in nc_provenance.h
2. Fix memory leak in tst_open_mem.c
3. fix ncdump/bindata.c to properly compile if netcdf4 is disabled.
4. minor changes to ncgen.l