### PR TITLE
Eliminate nested comment

### DIFF
--- a/include/nc_provenance.h
+++ b/include/nc_provenance.h
@@ -1,12 +1,13 @@
 /* Copyright 2005-2018 University Corporation for Atmospheric
    Research/Unidata. */
-/**
+
 /**
  * @file
  * @internal Contains information for creating provenance
  * info and/or displaying provenance info.
  *
  * @author Dennis Heimbigner, Ward Fisher
+ */
 
 /**************************************************/
 /**


### PR DESCRIPTION
Looks like extra comment begin and a missing comment end resulted in nested comments.  Results in warning on at least the ibm compiler:
```
In file included from /g/g16/TPL/netcdf/netcdf-c/include/nc4internal.h:24:0,
                 from /g/g16/TPL/netcdf/netcdf-c/ncgen/includes.h:50,
                 from /g/g16/TPL/netcdf/netcdf-c/ncgen/genc.c:7:
/g/g16/TPL/netcdf/netcdf-c/include/nc_provenance.h:4:1: warning: "/*" within comment [-Wcomment]
 /**
 ^
```