### PR TITLE
Separate out the -ansi comment fixes.

### DIFF
--- a/hdf4_test/tst_interops3.c
+++ b/hdf4_test/tst_interops3.c
@@ -36,7 +36,7 @@ check_inq_format(int ncid, int expected_format, int expected_extended_format, in
       if (nc_inq_format_extended(ncid, NULL, &mode)) ERR;
       if (mode != expected_mode) {
          printf("expected_mode %x mode %x\n", expected_mode, mode);
-         //ERR;
+         /*ERR;*/
       }
    }
    {

--- a/libdap2/ncd2dispatch.h
+++ b/libdap2/ncd2dispatch.h
@@ -274,7 +274,7 @@ NCD2_def_var_fill(int, int, int, const void *);
 extern int
 NCD2_get_var_chunk_cache(int, int, size_t *, size_t *, float *);
 
-#endif //USE_NETCDF4
+#endif /*USE_NETCDF4*/
 
 #if defined(__cplusplus)
 }

--- a/libdap4/d4meta.c
+++ b/libdap4/d4meta.c
@@ -1038,7 +1038,7 @@ computeOffsets(NCD4meta* builder, NCD4node* cmpd)
 	field->meta.offset = offset;
 	assert(ftype->meta.memsize > 0);
 	size = ftype->meta.memsize;
-	//field->meta.memsize = size;
+	/*field->meta.memsize = size;*/
 	/* Now ultiply by the field dimproduct*/
 	if(nclistlength(field->dims) > 0) {
             d4size_t count = NCD4_dimproduct(field);

--- a/libdap4/d4meta.c
+++ b/libdap4/d4meta.c
@@ -1009,26 +1009,26 @@ computeOffsets(NCD4meta* builder, NCD4node* cmpd)
 	} else if(ftype->subsort == NC_SEQ) { /* VLEN */
 	    alignment = nctypealignment(NC_VLEN);
 	    assert(ftype->meta.memsize > 0); size=ftype->meta.memsize;
-	    //size = NCD4_computeTypeSize(builder,ftype);
+	    /*size = NCD4_computeTypeSize(builder,ftype);*/
 	} else if(ftype->subsort == NC_OPAQUE) {
 	    /* Either fixed or a vlen */
 	    assert(ftype->meta.memsize > 0); size=ftype->meta.memsize;
 	    if(ftype->opaque.size == 0) {/* treat like vlen */
 	        alignment = nctypealignment(NC_VLEN);
-	        //size = NCD4_computeTypeSize(builder,ftype);
+	        /*size = NCD4_computeTypeSize(builder,ftype);*/
 	    } else { /* fixed size */
 	        alignment = nctypealignment(NC_OPAQUE);
-	        //size = NCD4_computeTypeSize(builder,ftype);
+	        /*size = NCD4_computeTypeSize(builder,ftype);*/
 	    }
 	} else if(ftype->subsort == NC_ENUM) {
 	    NCD4node* truetype = ftype->basetype;
 	    alignment = nctypealignment(truetype->meta.id);
 	    assert(ftype->meta.memsize > 0); size=ftype->meta.memsize;
-	    //size = NCD4_computeTypeSize(builder,truetype);
+	    /*size = NCD4_computeTypeSize(builder,truetype);*/
 	} else { /* Basically a primitive */
 	    alignment = nctypealignment(ftype->meta.id);
 	    assert(ftype->meta.memsize > 0); size=ftype->meta.memsize;
-	    //size = NCD4_computeTypeSize(builder,ftype);
+	    /*size = NCD4_computeTypeSize(builder,ftype);*/
 	}
 #endif
         if(alignment > largestalign)

--- a/libdap4/ncd4dispatch.c
+++ b/libdap4/ncd4dispatch.c
@@ -728,7 +728,7 @@ NCD4_get_var_chunk_cache(int ncid, int p2, size_t* p3, size_t* p4, float* p5)
     return (ret);
 }
 
-#endif // USE_NETCDF4
+#endif /*USE_NETCDF4*/
 
 /**************************************************/
 /*

--- a/libdispatch/utf8proc.c
+++ b/libdispatch/utf8proc.c
@@ -128,18 +128,18 @@ nc_utf8proc_ssize_t nc_utf8proc_iterate(
     *dst = uc;
     return 1;
   }
-  // Must be between 0xc2 and 0xf4 inclusive to be valid
+  /*Must be between 0xc2 and 0xf4 inclusive to be valid */
   if ((uc - 0xc2) > (0xf4-0xc2)) return UTF8PROC_ERROR_INVALIDUTF8;
-  if (uc < 0xe0) {         // 2-byte sequence
-     // Must have valid continuation character
+  if (uc < 0xe0) {         /* 2-byte sequence */
+     /* Must have valid continuation character */
      if (str >= end || !utf_cont(*str)) return UTF8PROC_ERROR_INVALIDUTF8;
      *dst = ((uc & 0x1f)<<6) | (*str & 0x3f);
      return 2;
   }
-  if (uc < 0xf0) {        // 3-byte sequence
+  if (uc < 0xf0) {        /* 3-byte sequence */
      if ((str + 1 >= end) || !utf_cont(*str) || !utf_cont(str[1]))
         return UTF8PROC_ERROR_INVALIDUTF8;
-     // Check for surrogate chars
+     /* Check for surrogate chars */
      if (uc == 0xed && *str > 0x9f)
          return UTF8PROC_ERROR_INVALIDUTF8;
      uc = ((uc & 0xf)<<12) | ((*str & 0x3f)<<6) | (str[1] & 0x3f);
@@ -148,11 +148,11 @@ nc_utf8proc_ssize_t nc_utf8proc_iterate(
      *dst = uc;
      return 3;
   }
-  // 4-byte sequence
-  // Must have 3 valid continuation characters
+  /* 4-byte sequence */
+  /* Must have 3 valid continuation characters */
   if ((str + 2 >= end) || !utf_cont(*str) || !utf_cont(str[1]) || !utf_cont(str[2]))
      return UTF8PROC_ERROR_INVALIDUTF8;
-  // Make sure in correct range (0x10000 - 0x10ffff)
+  /* Make sure in correct range (0x10000 - 0x10ffff) */
   if (uc == 0xf0) {
     if (*str < 0x90) return UTF8PROC_ERROR_INVALIDUTF8;
   } else if (uc == 0xf4) {
@@ -176,8 +176,8 @@ nc_utf8proc_ssize_t nc_utf8proc_iterate(
     dst[0] = (nc_utf8proc_uint8_t)(0xC0 + (uc >> 6));
     dst[1] = (nc_utf8proc_uint8_t)(0x80 + (uc & 0x3F));
     return 2;
-  // Note: we allow encoding 0xd800-0xdfff here, so as not to change
-  // the API, however, these are actually invalid in UTF-8
+  /* Note: we allow encoding 0xd800-0xdfff here, so as not to change */
+  /* the API, however, these are actually invalid in UTF-8 */
   } else if (uc < 0x10000) {
     dst[0] = (nc_utf8proc_uint8_t)(0xE0 + (uc >> 12));
     dst[1] = (nc_utf8proc_uint8_t)(0x80 + ((uc >> 6) & 0x3F));
@@ -254,36 +254,36 @@ static const nc_utf8proc_property_t *nc_unsafe_get_property(nc_utf8proc_int32_t 
 */
 static nc_utf8proc_bool nc_grapheme_break_simple(int lbc, int tbc) {
   return
-    (lbc == UTF8PROC_BOUNDCLASS_START) ? true :       // GB1
-    (lbc == UTF8PROC_BOUNDCLASS_CR &&                 // GB3
-     tbc == UTF8PROC_BOUNDCLASS_LF) ? false :         // ---
-    (lbc >= UTF8PROC_BOUNDCLASS_CR && lbc <= UTF8PROC_BOUNDCLASS_CONTROL) ? true :  // GB4
-    (tbc >= UTF8PROC_BOUNDCLASS_CR && tbc <= UTF8PROC_BOUNDCLASS_CONTROL) ? true :  // GB5
-    (lbc == UTF8PROC_BOUNDCLASS_L &&                  // GB6
-     (tbc == UTF8PROC_BOUNDCLASS_L ||                 // ---
-      tbc == UTF8PROC_BOUNDCLASS_V ||                 // ---
-      tbc == UTF8PROC_BOUNDCLASS_LV ||                // ---
-      tbc == UTF8PROC_BOUNDCLASS_LVT)) ? false :      // ---
-    ((lbc == UTF8PROC_BOUNDCLASS_LV ||                // GB7
-      lbc == UTF8PROC_BOUNDCLASS_V) &&                // ---
-     (tbc == UTF8PROC_BOUNDCLASS_V ||                 // ---
-      tbc == UTF8PROC_BOUNDCLASS_T)) ? false :        // ---
-    ((lbc == UTF8PROC_BOUNDCLASS_LVT ||               // GB8
-      lbc == UTF8PROC_BOUNDCLASS_T) &&                // ---
-     tbc == UTF8PROC_BOUNDCLASS_T) ? false :          // ---
-    (tbc == UTF8PROC_BOUNDCLASS_EXTEND ||             // GB9
-     tbc == UTF8PROC_BOUNDCLASS_ZWJ ||                // ---
-     tbc == UTF8PROC_BOUNDCLASS_SPACINGMARK ||        // GB9a
-     lbc == UTF8PROC_BOUNDCLASS_PREPEND) ? false :    // GB9b
-    ((lbc == UTF8PROC_BOUNDCLASS_E_BASE ||            // GB10 (requires additional handling below)
-      lbc == UTF8PROC_BOUNDCLASS_E_BASE_GAZ) &&       // ----
-     tbc == UTF8PROC_BOUNDCLASS_E_MODIFIER) ? false : // ----
-    (lbc == UTF8PROC_BOUNDCLASS_ZWJ &&                         // GB11
-     (tbc == UTF8PROC_BOUNDCLASS_GLUE_AFTER_ZWJ ||             // ----
-      tbc == UTF8PROC_BOUNDCLASS_E_BASE_GAZ)) ? false :        // ----
-    (lbc == UTF8PROC_BOUNDCLASS_REGIONAL_INDICATOR &&          // GB12/13 (requires additional handling below)
-     tbc == UTF8PROC_BOUNDCLASS_REGIONAL_INDICATOR) ? false :  // ----
-    true; // GB999
+    (lbc == UTF8PROC_BOUNDCLASS_START) ? true :       /* GB1 */
+    (lbc == UTF8PROC_BOUNDCLASS_CR &&                 /* GB3 */
+     tbc == UTF8PROC_BOUNDCLASS_LF) ? false :         /* --- */
+    (lbc >= UTF8PROC_BOUNDCLASS_CR && lbc <= UTF8PROC_BOUNDCLASS_CONTROL) ? true :  /* GB4 */
+    (tbc >= UTF8PROC_BOUNDCLASS_CR && tbc <= UTF8PROC_BOUNDCLASS_CONTROL) ? true :  /* GB5 */
+    (lbc == UTF8PROC_BOUNDCLASS_L &&                  /* GB6 */
+     (tbc == UTF8PROC_BOUNDCLASS_L ||                 /* --- */
+      tbc == UTF8PROC_BOUNDCLASS_V ||                 /* --- */
+      tbc == UTF8PROC_BOUNDCLASS_LV ||                /* --- */
+      tbc == UTF8PROC_BOUNDCLASS_LVT)) ? false :      /* --- */
+    ((lbc == UTF8PROC_BOUNDCLASS_LV ||                /* GB7 */
+      lbc == UTF8PROC_BOUNDCLASS_V) &&                /* --- */
+     (tbc == UTF8PROC_BOUNDCLASS_V ||                 /* --- */
+      tbc == UTF8PROC_BOUNDCLASS_T)) ? false :        /* --- */
+    ((lbc == UTF8PROC_BOUNDCLASS_LVT ||               /* GB8 */
+      lbc == UTF8PROC_BOUNDCLASS_T) &&                /* --- */
+     tbc == UTF8PROC_BOUNDCLASS_T) ? false :          /* --- */
+    (tbc == UTF8PROC_BOUNDCLASS_EXTEND ||             /* GB9 */
+     tbc == UTF8PROC_BOUNDCLASS_ZWJ ||                /* --- */
+     tbc == UTF8PROC_BOUNDCLASS_SPACINGMARK ||        /* GB9a */
+     lbc == UTF8PROC_BOUNDCLASS_PREPEND) ? false :    /* GB9b */
+    ((lbc == UTF8PROC_BOUNDCLASS_E_BASE ||            /* GB10 (requires additional handling below) */
+      lbc == UTF8PROC_BOUNDCLASS_E_BASE_GAZ) &&       /* ---- */
+     tbc == UTF8PROC_BOUNDCLASS_E_MODIFIER) ? false : /* ---- */
+    (lbc == UTF8PROC_BOUNDCLASS_ZWJ &&                         /* GB11 */
+     (tbc == UTF8PROC_BOUNDCLASS_GLUE_AFTER_ZWJ ||             /* ---- */
+      tbc == UTF8PROC_BOUNDCLASS_E_BASE_GAZ)) ? false :        /* ---- */
+    (lbc == UTF8PROC_BOUNDCLASS_REGIONAL_INDICATOR &&          /* GB12/13 (requires additional handling below) */
+     tbc == UTF8PROC_BOUNDCLASS_REGIONAL_INDICATOR) ? false :  /* ---- */
+    true; /* GB999 */
 }
 
 static nc_utf8proc_bool nc_grapheme_break_extended(int lbc, int tbc, nc_utf8proc_int32_t *state)
@@ -294,15 +294,15 @@ static nc_utf8proc_bool nc_grapheme_break_extended(int lbc, int tbc, nc_utf8proc
     lbc_override = *state;
   break_permitted = nc_grapheme_break_simple(lbc_override, tbc);
   if (state) {
-    // Special support for GB 12/13 made possible by GB999. After two RI
-    // class codepoints we want to force a break. Do this by resetting the
-    // second RI's bound class to UTF8PROC_BOUNDCLASS_OTHER, to force a break
-    // after that character according to GB999 (unless of course such a break is
-    // forbidden by a different rule such as GB9).
+    /* Special support for GB 12/13 made possible by GB999. After two RI */
+    /* class codepoints we want to force a break. Do this by resetting the */
+    /* second RI's bound class to UTF8PROC_BOUNDCLASS_OTHER, to force a break */
+    /* after that character according to GB999 (unless of course such a break is */
+    /* forbidden by a different rule such as GB9). */
     if (*state == tbc && tbc == UTF8PROC_BOUNDCLASS_REGIONAL_INDICATOR)
       *state = UTF8PROC_BOUNDCLASS_OTHER;
-    // Special support for GB10. Fold any EXTEND codepoints into the previous
-    // boundclass if we're dealing with an emoji base boundclass.
+    /* Special support for GB10. Fold any EXTEND codepoints into the previous */
+    /* boundclass if we're dealing with an emoji base boundclass. */
     else if ((*state == UTF8PROC_BOUNDCLASS_E_BASE      ||
               *state == UTF8PROC_BOUNDCLASS_E_BASE_GAZ) &&
              tbc == UTF8PROC_BOUNDCLASS_EXTEND)

--- a/libdispatch/utf8proc.h
+++ b/libdispatch/utf8proc.h
@@ -80,7 +80,7 @@
 #include "ncexternl.h"
 
 #if defined(_MSC_VER) && _MSC_VER < 1800
-// MSVC prior to 2013 lacked stdbool.h and inttypes.h
+/* MSVC prior to 2013 lacked stdbool.h and inttypes.h */
 typedef signed char nc_utf8proc_int8_t;
 typedef unsigned char nc_utf8proc_uint8_t;
 typedef short nc_utf8proc_int16_t;
@@ -95,7 +95,7 @@ typedef int nc_utf8proc_ssize_t;
 typedef unsigned int nc_utf8proc_size_t;
 #  endif
 #  ifndef __cplusplus
-// emulate C99 bool
+/* emulate C99 bool */
 typedef unsigned char nc_utf8proc_bool;
 #    ifndef __bool_true_false_are_defined
 #      define false 0
@@ -380,7 +380,7 @@ typedef nc_utf8proc_int32_t (*nc_utf8proc_custom_func)(nc_utf8proc_int32_t codep
  * Array containing the byte lengths of a UTF-8 encoded codepoint based
  * on the first byte.
  */
-//const nc_utf8proc_int8_t nc_utf8proc_utf8class[256];
+/*const nc_utf8proc_int8_t nc_utf8proc_utf8class[256]; */
 
 /**
  * Returns the utf8proc API version as a string MAJOR.MINOR.PATCH

--- a/libsrc/attr.m4
+++ b/libsrc/attr.m4
@@ -843,17 +843,17 @@ NC3_put_att(
 
        for more information. */
 
-//    if (varid != NC_GLOBAL && !strcmp(name, _FillValue)) {
-//        /* Fill value must be of the same data type */
-//        if (type != ncp->vars.value[varid]->type) return NC_EBADTYPE;
-//
-//        /* Fill value must have exactly one value */
-//        if (nelems != 1) return NC_EINVAL;
-//
-//        /* Only allow for variables defined in initial define mode */
-//        if (ncp->old != NULL && varid < ncp->old->vars.nelems)
-//            return NC_ELATEFILL; /* try put attribute for an old variable */
-//    }
+#if 0
+    if (varid != NC_GLOBAL && !strcmp(name, _FillValue)) {
+        /* Fill value must be of the same data type*/
+        if (type != ncp->vars.value[varid]->type) return NC_EBADTYPE;
+        /* Fill value must have exactly one value */
+        if (nelems != 1) return NC_EINVAL;
+        /* Only allow for variables defined in initial define mode */
+        if (ncp->old != NULL && varid < ncp->old->vars.nelems)
+            return NC_ELATEFILL; /* try put attribute for an old variable */
+    }
+#endif
 
     attrpp = NC_findattr(ncap, name);
 

--- a/nc_test/tst_formats.c
+++ b/nc_test/tst_formats.c
@@ -72,7 +72,7 @@ check_inq_format(int ncid, int expected_format, int expected_extended_format, in
       if (nc_inq_format_extended(ncid, NULL, &mode)) ERR;
       if (mode != expected_mode) {
          printf("expected_mode %x mode %x\n", expected_mode, mode);
-         //ERR;
+         /*ERR;*/
       }
    }
    {

--- a/nc_test/tst_inq_type.c
+++ b/nc_test/tst_inq_type.c
@@ -178,7 +178,7 @@ int main(int argc, char **argv) {
    }
    SUMMARIZE_ERR;
 
-#endif // USE_HDF5
+#endif /*USE_HDF5*/
 
    printf("* Finished.\n");
 

--- a/nc_test/util.c
+++ b/nc_test/util.c
@@ -1313,8 +1313,10 @@ char* nc_err_code_name(int err)
         case (NC_EMPI):				return "NC_EMPI";
         case (NC_ENULLPAD):			return "NC_NULLPAD";
         case (NC_EINMEMORY):			return "NC_EINMEMORY";
-        // case (NC_EURL):				return "NC_EURL";
-        // case (NC_ECONSTRAINT):			return "NC_ECONSTRAINT";
+#if 0
+        case (NC_EURL):				return "NC_EURL";
+        case (NC_ECONSTRAINT):			return "NC_ECONSTRAINT";
+#endif
 #ifdef USE_PNETCDF
         case (NC_ESMALL):			return "NC_ESMALL";
         case (NC_ENOTINDEP):			return "NC_ENOTINDEP";

--- a/nc_test4/tst_empty_vlen_unlim.c
+++ b/nc_test4/tst_empty_vlen_unlim.c
@@ -51,8 +51,10 @@ int main() {
     if (nc_create(FILE_NAME_UNLIM, NC_NETCDF4 | NC_CLOBBER, &ncid)) ERR;
 
     /* Set fill mode */
-    //printf("\t* Setting fill mode:\tnc_set_fill()\n");
-    //if(nc_set_fill(ncid,NC_FILL,NULL)) ERR;
+#if 0
+    printf("\t* Setting fill mode:\tnc_set_fill()\n");
+    if(nc_set_fill(ncid,NC_FILL,NULL)) ERR;
+#endif
 
     /* Create Dimension */
     printf("\t* Defining Unlimited Dimension:\tnc_def_dim()\n");
@@ -143,9 +145,10 @@ int main() {
     if (nc_create(FILE_NAME_LIM, NC_NETCDF4 | NC_CLOBBER, &ncid)) ERR;
 
     /* Set fill mode */
-    //printf("\t* Setting fill mode:\tnc_set_fill()\n");
-    //if(nc_set_fill(ncid,NC_FILL,NULL)) ERR;
-
+#if 0
+    printf("\t* Setting fill mode:\tnc_set_fill()\n");
+    if(nc_set_fill(ncid,NC_FILL,NULL)) ERR;
+#endif
     /* Create Dimension */
     printf("\t* Defining Unlimited Dimension:\tnc_def_dim()\n");
     if (nc_def_dim(ncid, DIM_NAME, DIM_LEN_LIM, &dimid)) ERR;

--- a/ncdump/nccopy.c
+++ b/ncdump/nccopy.c
@@ -2156,7 +2156,7 @@ main(int argc, char**argv)
 		    error("too many -F filterspecs\n");
 		filterspecs[nfilterspecs] = filterspec;
 		nfilterspecs++;
-		// Force output to be netcdf-4
+		/* Force output to be netcdf-4 */
 		option_kind = NC_FORMAT_NETCDF4;
 	    }
 #else

--- a/ncdump/ncdump.c
+++ b/ncdump/ncdump.c
@@ -1107,8 +1107,7 @@ pr_att_hidden(
     size_t len;
 
     /* No special variable attributes for classic or 64-bit offset data */
-    //if(kind == 1 || kind == 2)
-	//return;
+    /*if(kind == 1 || kind == 2) return; */
     /* Print out Selected hidden attributes */
     /* NCPROPS */
     stat = nc_inq_att(ncid,NC_GLOBAL,NCPROPS,NULL,&len);

--- a/ncgen/main.c
+++ b/ncgen/main.c
@@ -298,7 +298,7 @@ main(
               derror("%s: output language is null", progname);
               return(1);
             }
-            //lang_name = estrdup(optarg);
+            /*lang_name = estrdup(optarg);*/
             lang_name = (char*) emalloc(strlen(optarg)+1);
             (void)strcpy(lang_name, optarg);
 


### PR DESCRIPTION
re: pull request https://github.com/Unidata/netcdf-c/pull/1242

This pr should be applied before pr https://github.com/Unidata/netcdf-c/pull/1242.
It fixes only the -ansi '//' comment problems. There may be some
slight conflicts with that other pr when it is applied, since in some
cases I converted #if 0...#endif to /* ... */