### PR TITLE
CMakeLists.txt: Fix compilation with default settings on debian stretch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -750,7 +750,7 @@ IF(USE_HDF5 OR ENABLE_NETCDF_4)
     SET(H5_USE_16_API 0)
   ENDIF()
 
-  FIND_PATH(HAVE_HDF5_H hdf5.h)
+  FIND_PATH(HAVE_HDF5_H hdf5.h PATHS ${HDF5_INCLUDE_DIR})
   IF(NOT HAVE_HDF5_H)
     MESSAGE(FATAL_ERROR "Compiling a test with hdf5 failed. Either hdf5.h cannot be found, or the log messages should be checked for another reason.")
   ELSE(NOT HAVE_HDF5_H)


### PR DESCRIPTION
Since 209c31d3 (Bringing config.h as generagted by cmake in line with config.h as generated by autotools., 2017-01-27)
we check that we can find the hdf5.h main include file.

But this file may reside in non-standard location so we have to search
in HDF5_INCLUDE_DIR as well.