### PR TITLE
Fix bug which changed varids after var rename

### DIFF
--- a/h5_test/CMakeLists.txt
+++ b/h5_test/CMakeLists.txt
@@ -5,7 +5,7 @@
 
 # See netcdf-c/COPYRIGHT file for more info.
 
-SET(H5TESTS tst_h_files tst_h_files2 tst_h_files4 tst_h_atts tst_h_atts3 tst_h_atts4 tst_h_vars tst_h_vars2 tst_h_vars3 tst_h_grps tst_h_compounds tst_h_compounds2 tst_h_wrt_cmp tst_h_vl tst_h_opaques tst_h_strings tst_h_strings1 tst_h_strings2 tst_h_ints tst_h_dimscales tst_h_dimscales1 tst_h_dimscales2 tst_h_dimscales3 tst_h_enums tst_h_dimscales4)
+SET(H5TESTS tst_h_files tst_h_files2 tst_h_files4 tst_h_atts tst_h_atts3 tst_h_atts4 tst_h_vars tst_h_vars2 tst_h_vars3 tst_h_grps tst_h_compounds tst_h_compounds2 tst_h_wrt_cmp tst_h_vl tst_h_opaques tst_h_strings tst_h_strings1 tst_h_strings2 tst_h_ints tst_h_dimscales tst_h_dimscales1 tst_h_dimscales2 tst_h_dimscales3 tst_h_enums tst_h_dimscales4 tst_h_rename)
 
 FILE(GLOB COPY_FILES ${CMAKE_CURRENT_SOURCE_DIR}/*.h5 ${CMAKE_CURRENT_SOURCE_DIR}/*.nc)
 FILE(COPY ${COPY_FILES} DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/)

--- a/h5_test/Makefile.am
+++ b/h5_test/Makefile.am
@@ -19,7 +19,7 @@ tst_h_atts3 tst_h_atts4 tst_h_vars tst_h_vars2 tst_h_vars3 tst_h_grps	\
 tst_h_compounds tst_h_compounds2 tst_h_wrt_cmp tst_h_vl tst_h_opaques	\
 tst_h_strings tst_h_strings1 tst_h_strings2 tst_h_ints			\
 tst_h_dimscales tst_h_dimscales1 tst_h_dimscales2 tst_h_dimscales3	\
-tst_h_enums tst_h_dimscales4
+tst_h_enums tst_h_dimscales4 tst_h_rename
 
 # If benchmarks were turned on, build and run a bunch more tests.
 if BUILD_BENCHMARKS

--- a/h5_test/tst_h_rename.c
+++ b/h5_test/tst_h_rename.c
@@ -23,7 +23,7 @@ int
 main()
 {
    printf("\n*** Checking HDF5 variable renaming.\n");
-   printf("*** Checking HDF5 variable ordering after renames...");
+   printf("*** Checking HDF5 variable ordering after renames...\n");
 
 #define NUM_ELEMENTS 6
 #define MAX_SYMBOL_LEN 2
@@ -80,6 +80,7 @@ main()
 
       if (H5Gget_num_objs(grpid, &num_obj) < 0) ERR;
       if (num_obj != NUM_ELEMENTS) ERR;
+      printf("Original order:\n");
       for (i = 0; i < num_obj; i++)
       {
 	 if (H5Oget_info_by_idx(grpid, ".", H5_INDEX_CRT_ORDER, H5_ITER_INC,
@@ -90,6 +91,7 @@ main()
 	 H5Lget_name_by_idx(grpid, ".", H5_INDEX_CRT_ORDER, H5_ITER_INC, i,
 				name, size+1, H5P_DEFAULT);
 	 if (strcmp(name, names[i])) ERR;
+         printf("name %s\n", name);
       }
 
       /* Rename the first dataset. */
@@ -101,30 +103,31 @@ main()
 	  H5Fclose(fileid) < 0)
 	 ERR;
 
+      /* Now reopen the file and check the order again. */
+      if ((fapl_id = H5Pcreate(H5P_FILE_ACCESS)) < 0) ERR;
+      if (H5Pset_libver_bounds(fapl_id, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0) ERR;
+      if ((fileid = H5Fopen(FILE_NAME, H5F_ACC_RDONLY, fapl_id)) < 0) ERR;
+      if ((grpid = H5Gopen(fileid, ELEMENTS_NAME)) < 0) ERR;
 
-   /*    /\* Now reopen the file and check the order again. *\/ */
-   /*    if ((fapl_id = H5Pcreate(H5P_FILE_ACCESS)) < 0) ERR; */
-   /*    if (H5Pset_libver_bounds(fapl_id, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0) ERR; */
-   /*    if ((fileid = H5Fopen(FILE_NAME, H5F_ACC_RDONLY, fapl_id)) < 0) ERR; */
-   /*    if ((grpid = H5Gopen(fileid, ELEMENTS_NAME)) < 0) ERR; */
-
-   /*    if (H5Gget_num_objs(grpid, &num_obj) < 0) ERR; */
-   /*    if (num_obj != NUM_ELEMENTS) ERR; */
-   /*    for (i = 0; i < num_obj; i++) */
-   /*    { */
-   /*       if (H5Oget_info_by_idx(grpid, ".", H5_INDEX_CRT_ORDER, H5_ITER_INC, */
-   /*      			i, &obj_info, H5P_DEFAULT) < 0) ERR; */
-   /*       if (obj_info.type != H5O_TYPE_DATASET) ERR; */
-   /*       if ((size = H5Lget_name_by_idx(grpid, ".", H5_INDEX_CRT_ORDER, H5_ITER_INC, i, */
-   /*      				NULL, 0, H5P_DEFAULT)) < 0) ERR; */
-   /*       H5Lget_name_by_idx(grpid, ".", H5_INDEX_CRT_ORDER, H5_ITER_INC, i, */
-   /*      			name, size+1, H5P_DEFAULT); */
-   /*       if (strcmp(name, names2[i])) ERR; */
-   /*    } */
-   /*    if (H5Pclose(fapl_id) < 0 || */
-   /*        H5Gclose(grpid) < 0 || */
-   /*        H5Fclose(fileid) < 0) */
-   /*       ERR; */
+      if (H5Gget_num_objs(grpid, &num_obj) < 0) ERR;
+      if (num_obj != NUM_ELEMENTS) ERR;
+      printf("New order:\n");
+      for (i = 0; i < num_obj; i++)
+      {
+         if (H5Oget_info_by_idx(grpid, ".", H5_INDEX_CRT_ORDER, H5_ITER_INC,
+        			i, &obj_info, H5P_DEFAULT) < 0) ERR;
+         if (obj_info.type != H5O_TYPE_DATASET) ERR;
+         if ((size = H5Lget_name_by_idx(grpid, ".", H5_INDEX_CRT_ORDER, H5_ITER_INC, i,
+        				NULL, 0, H5P_DEFAULT)) < 0) ERR;
+         H5Lget_name_by_idx(grpid, ".", H5_INDEX_CRT_ORDER, H5_ITER_INC, i,
+        			name, size+1, H5P_DEFAULT);
+         printf("name %s\n", name);
+         /* if (strcmp(name, names2[i])) ERR; */
+      }
+      if (H5Pclose(fapl_id) < 0 ||
+          H5Gclose(grpid) < 0 ||
+          H5Fclose(fileid) < 0)
+         ERR;
    }
    SUMMARIZE_ERR;
    FINAL_RESULTS;

--- a/h5_test/tst_h_rename.c
+++ b/h5_test/tst_h_rename.c
@@ -35,6 +35,7 @@ main()
       int i;
       H5O_info_t obj_info;
       char names[NUM_ELEMENTS][MAX_SYMBOL_LEN + 1] = {"H", "He", "Li", "Be", "B", "C"};
+      char names2[NUM_ELEMENTS][MAX_SYMBOL_LEN + 1] = {"h", "He", "Li", "Be", "B", "C"};
       char name[MAX_SYMBOL_LEN + 1];
       ssize_t size;
 
@@ -74,7 +75,7 @@ main()
       /* Now reopen the file and check the order. */
       if ((fapl_id = H5Pcreate(H5P_FILE_ACCESS)) < 0) ERR;
       if (H5Pset_libver_bounds(fapl_id, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0) ERR;
-      if ((fileid = H5Fopen(FILE_NAME, H5F_ACC_RDONLY, fapl_id)) < 0) ERR;
+      if ((fileid = H5Fopen(FILE_NAME, H5F_ACC_RDWR, fapl_id)) < 0) ERR;
       if ((grpid = H5Gopen(fileid, ELEMENTS_NAME)) < 0) ERR;
 
       if (H5Gget_num_objs(grpid, &num_obj) < 0) ERR;
@@ -90,10 +91,40 @@ main()
 				name, size+1, H5P_DEFAULT);
 	 if (strcmp(name, names[i])) ERR;
       }
+
+      /* Rename the first dataset. */
+      if (H5Lmove(grpid, names[0], grpid, names2[0], H5P_DEFAULT, H5P_DEFAULT) < 0)
+          ERR;
+
       if (H5Pclose(fapl_id) < 0 ||
 	  H5Gclose(grpid) < 0 ||
 	  H5Fclose(fileid) < 0)
 	 ERR;
+
+
+   /*    /\* Now reopen the file and check the order again. *\/ */
+   /*    if ((fapl_id = H5Pcreate(H5P_FILE_ACCESS)) < 0) ERR; */
+   /*    if (H5Pset_libver_bounds(fapl_id, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0) ERR; */
+   /*    if ((fileid = H5Fopen(FILE_NAME, H5F_ACC_RDONLY, fapl_id)) < 0) ERR; */
+   /*    if ((grpid = H5Gopen(fileid, ELEMENTS_NAME)) < 0) ERR; */
+
+   /*    if (H5Gget_num_objs(grpid, &num_obj) < 0) ERR; */
+   /*    if (num_obj != NUM_ELEMENTS) ERR; */
+   /*    for (i = 0; i < num_obj; i++) */
+   /*    { */
+   /*       if (H5Oget_info_by_idx(grpid, ".", H5_INDEX_CRT_ORDER, H5_ITER_INC, */
+   /*      			i, &obj_info, H5P_DEFAULT) < 0) ERR; */
+   /*       if (obj_info.type != H5O_TYPE_DATASET) ERR; */
+   /*       if ((size = H5Lget_name_by_idx(grpid, ".", H5_INDEX_CRT_ORDER, H5_ITER_INC, i, */
+   /*      				NULL, 0, H5P_DEFAULT)) < 0) ERR; */
+   /*       H5Lget_name_by_idx(grpid, ".", H5_INDEX_CRT_ORDER, H5_ITER_INC, i, */
+   /*      			name, size+1, H5P_DEFAULT); */
+   /*       if (strcmp(name, names2[i])) ERR; */
+   /*    } */
+   /*    if (H5Pclose(fapl_id) < 0 || */
+   /*        H5Gclose(grpid) < 0 || */
+   /*        H5Fclose(fileid) < 0) */
+   /*       ERR; */
    }
    SUMMARIZE_ERR;
    FINAL_RESULTS;

--- a/h5_test/tst_h_rename.c
+++ b/h5_test/tst_h_rename.c
@@ -1,0 +1,100 @@
+/* This is part of the netCDF package. Copyright 2018 University
+   Corporation for Atmospheric Research/Unidata See COPYRIGHT file for
+   conditions of use.
+
+   Test HDF5 dataset code, even more. These are not intended to be
+   exhaustive tests, but they use HDF5 the same way that netCDF-4
+   does, so if these tests don't work, than netCDF-4 won't work
+   either.
+
+   This test does some renames in HDF5 to see how it works.
+
+   Ed Hartnett 2/1/19
+*/
+
+#include "h5_err_macros.h"
+#include <hdf5.h>
+#include <H5DSpublic.h>
+
+#define FILE_NAME "tst_h_rename.h5"
+#define STR_LEN 255
+
+int
+main()
+{
+   printf("\n*** Checking HDF5 variable renaming.\n");
+   printf("*** Checking HDF5 variable ordering after renames...");
+
+#define NUM_ELEMENTS 6
+#define MAX_SYMBOL_LEN 2
+#define ELEMENTS_NAME "Elements"
+   {
+      hid_t did[NUM_ELEMENTS], fapl_id, fcpl_id, gcpl_id;
+      hsize_t num_obj;
+      hid_t fileid, grpid, spaceid;
+      int i;
+      H5O_info_t obj_info;
+      char names[NUM_ELEMENTS][MAX_SYMBOL_LEN + 1] = {"H", "He", "Li", "Be", "B", "C"};
+      char name[MAX_SYMBOL_LEN + 1];
+      ssize_t size;
+
+      /* Create file, setting latest_format in access propertly list
+       * and H5P_CRT_ORDER_TRACKED in the creation property list. */
+      if ((fapl_id = H5Pcreate(H5P_FILE_ACCESS)) < 0) ERR;
+      if (H5Pset_libver_bounds(fapl_id, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0) ERR;
+      if ((fcpl_id = H5Pcreate(H5P_FILE_CREATE)) < 0) ERR;
+      if (H5Pset_link_creation_order(fcpl_id, H5P_CRT_ORDER_TRACKED|H5P_CRT_ORDER_INDEXED) < 0) ERR;
+      if ((fileid = H5Fcreate(FILE_NAME, H5F_ACC_TRUNC, fcpl_id, fapl_id)) < 0) ERR;
+
+      /* Create group, with link_creation_order set in the group
+       * creation property list. */
+      if ((gcpl_id = H5Pcreate(H5P_GROUP_CREATE)) < 0) ERR;
+      if (H5Pset_link_creation_order(gcpl_id, H5P_CRT_ORDER_TRACKED|H5P_CRT_ORDER_INDEXED) < 0) ERR;
+      if ((grpid = H5Gcreate_anon(fileid, gcpl_id, H5P_DEFAULT)) < 0) ERR;
+      if ((H5Olink(grpid, fileid, ELEMENTS_NAME, H5P_DEFAULT, H5P_DEFAULT)) < 0) ERR;
+
+      /* Create a scalar space. */
+      if ((spaceid = H5Screate(H5S_SCALAR)) < 0) ERR;
+
+      /* Create the variables, one per element. */
+      for (i = 0; i < NUM_ELEMENTS; i++)
+      {
+	 if ((did[i] = H5Dcreate(grpid, names[i], H5T_NATIVE_INT,
+				 spaceid, H5P_DEFAULT)) < 0) ERR;
+	 if (H5Dclose(did[i]) < 0) ERR;
+      }
+
+      if (H5Pclose(fapl_id) < 0 ||
+	  H5Pclose(gcpl_id) < 0 ||
+	  H5Sclose(spaceid) < 0 ||
+	  H5Gclose(grpid) < 0 ||
+	  H5Fclose(fileid) < 0)
+	 ERR;
+
+      /* Now reopen the file and check the order. */
+      if ((fapl_id = H5Pcreate(H5P_FILE_ACCESS)) < 0) ERR;
+      if (H5Pset_libver_bounds(fapl_id, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0) ERR;
+      if ((fileid = H5Fopen(FILE_NAME, H5F_ACC_RDONLY, fapl_id)) < 0) ERR;
+      if ((grpid = H5Gopen(fileid, ELEMENTS_NAME)) < 0) ERR;
+
+      if (H5Gget_num_objs(grpid, &num_obj) < 0) ERR;
+      if (num_obj != NUM_ELEMENTS) ERR;
+      for (i = 0; i < num_obj; i++)
+      {
+	 if (H5Oget_info_by_idx(grpid, ".", H5_INDEX_CRT_ORDER, H5_ITER_INC,
+				i, &obj_info, H5P_DEFAULT) < 0) ERR;
+	 if (obj_info.type != H5O_TYPE_DATASET) ERR;
+	 if ((size = H5Lget_name_by_idx(grpid, ".", H5_INDEX_CRT_ORDER, H5_ITER_INC, i,
+					NULL, 0, H5P_DEFAULT)) < 0) ERR;
+	 H5Lget_name_by_idx(grpid, ".", H5_INDEX_CRT_ORDER, H5_ITER_INC, i,
+				name, size+1, H5P_DEFAULT);
+	 if (strcmp(name, names[i])) ERR;
+      }
+      if (H5Pclose(fapl_id) < 0 ||
+	  H5Gclose(grpid) < 0 ||
+	  H5Fclose(fileid) < 0)
+	 ERR;
+   }
+   SUMMARIZE_ERR;
+   FINAL_RESULTS;
+}

--- a/libhdf5/hdf5dim.c
+++ b/libhdf5/hdf5dim.c
@@ -1,4 +1,4 @@
-/* Copyright 2003-2018, University Corporation for Atmospheric
+/* Copyright 2003-2019, University Corporation for Atmospheric
  * Research. See the COPYRIGHT file for copying and redistribution
  * conditions. */
 /**

--- a/libhdf5/hdf5grp.c
+++ b/libhdf5/hdf5grp.c
@@ -147,11 +147,13 @@ NC4_rename_grp(int grpid, const char *name)
       /* Attempt to rename & re-open the group, if the parent group is open */
       if (parent_hdf5_grp->hdf_grpid)
       {
-         /* Rename the group */
-         if (H5Gmove(parent_hdf5_grp->hdf_grpid, grp->hdr.name, name) < 0)
+         /* Rename the group. */
+         if (H5Lmove(parent_hdf5_grp->hdf_grpid, grp->hdr.name,
+                     parent_hdf5_grp->hdf_grpid, name, H5P_DEFAULT,
+                     H5P_DEFAULT) < 0)
             return NC_EHDFERR;
 
-         /* Reopen the group, with the new name */
+         /* Reopen the group, with the new name. */
          if ((hdf5_grp->hdf_grpid = H5Gopen2(parent_hdf5_grp->hdf_grpid, name,
                                              H5P_DEFAULT)) < 0)
             return NC_EHDFERR;
@@ -163,8 +165,9 @@ NC4_rename_grp(int grpid, const char *name)
    free(grp->hdr.name);
    if (!(grp->hdr.name = strdup(norm_name)))
       return NC_ENOMEM;
-   grp->hdr.hashkey = NC_hashmapkey(grp->hdr.name,strlen(grp->hdr.name)); /* Fix hash key */
 
+   /* Update the hash and rebuild index. */
+   grp->hdr.hashkey = NC_hashmapkey(grp->hdr.name,strlen(grp->hdr.name));
    if(!ncindexrebuild(grp->parent->children))
       return NC_EINTERNAL;
 

--- a/libhdf5/hdf5var.c
+++ b/libhdf5/hdf5var.c
@@ -1,4 +1,4 @@
-/* Copyright 2003-2006, University Corporation for Atmospheric
+/* Copyright 2003-2019, University Corporation for Atmospheric
  * Research. See COPYRIGHT file for copying and redistribution
  * conditions.*/
 /**
@@ -10,7 +10,7 @@
 
 #include "config.h"
 #include <hdf5internal.h>
-#include <math.h>
+#include <math.h> /* For pow() used below. */
 
 /** @internal Default size for unlimited dim chunksize. */
 #define DEFAULT_1D_UNLIM_SIZE (4096)
@@ -286,8 +286,8 @@ give_var_secret_name(NC_VAR_INFO_T *var, const char *name)
  * @author Ed Hartnett, Dennis Heimbigner
  */
 int
-NC4_def_var(int ncid, const char *name, nc_type xtype,
-            int ndims, const int *dimidsp, int *varidp)
+NC4_def_var(int ncid, const char *name, nc_type xtype, int ndims,
+            const int *dimidsp, int *varidp)
 {
    NC_GRP_INFO_T *grp;
    NC_VAR_INFO_T *var;
@@ -442,6 +442,7 @@ NC4_def_var(int ncid, const char *name, nc_type xtype,
    if (!(var->format_var_info = calloc(1, sizeof(NC_HDF5_VAR_INFO_T))))
       BAIL(NC_ENOMEM);
 
+   /* Set these state flags for the var. */
    var->is_new_var = NC_TRUE;
    var->meta_read = NC_TRUE;
    var->atts_read = NC_TRUE;
@@ -451,19 +452,17 @@ NC4_def_var(int ncid, const char *name, nc_type xtype,
    var->type_info->rc++;
    type = NULL;
 
-   /* Set variables no_fill to match the database default
-    * unless the variable type is variable length (NC_STRING or NC_VLEN)
-    * or is user-defined type.
-    */
+   /* Set variables no_fill to match the database default unless the
+    * variable type is variable length (NC_STRING or NC_VLEN) or is
+    * user-defined type. */
    if (var->type_info->nc_type_class < NC_STRING)
       var->no_fill = h5->fill_mode;
 
-   /* Assign dimensions to the variable */
-   /* At the same time, check to see if this is a coordinate
-    * variable. If so, it will have the same name as one of its
-    * dimensions. If it is a coordinate var, is it a coordinate var in
-    * the same group as the dim? */
-   /* Also, check whether we should use contiguous or chunked storage */
+   /* Assign dimensions to the variable. At the same time, check to
+    * see if this is a coordinate variable. If so, it will have the
+    * same name as one of its dimensions. If it is a coordinate var,
+    * is it a coordinate var in the same group as the dim? Also, check
+    * whether we should use contiguous or chunked storage. */
    var->contiguous = NC_TRUE;
    for (d = 0; d < ndims; d++)
    {
@@ -1113,8 +1112,9 @@ NC4_rename_var(int ncid, int varid, const char *name)
    if (!(var = (NC_VAR_INFO_T *)ncindexith(grp->vars, varid)))
       return NC_ENOTVAR;
 
-   /* Check if new name is in use; note that renaming to same name is still an error
-      according to the nc_test/test_write.c code. Why?*/
+   /* Check if new name is in use; note that renaming to same name is
+      still an error according to the nc_test/test_write.c
+      code. Why?*/
    if (ncindexlookup(grp->vars, name))
       return NC_ENAMEINUSE;
 
@@ -1175,23 +1175,25 @@ NC4_rename_var(int ncid, int varid, const char *name)
                   hdf5_name, H5P_DEFAULT, H5P_DEFAULT) < 0)
           return NC_EHDFERR;
 
-      /* Now we must rename all the vars in this file with a varid
-       * greater than this var. This is because varids are assigned
-       * based on HDF5 creation time for the dataset, and we have just
-       * changed that for this var. Now we have to do the same for all
-       * vars with a > varid, so that the creation order will continue
-       * to be correct. */
+      /* Rename all the vars in this file with a varid greater than
+       * this var. Varids are assigned based on dataset creation time,
+       * and we have just changed that for this var. We must do the
+       * same for all vars with a > varid, so that the creation order
+       * will continue to be correct. */
       for (v = var->hdr.id + 1; v < ncindexsize(grp->vars); v++)
       {
          NC_VAR_INFO_T *my_var;
          my_var = (NC_VAR_INFO_T *)ncindexith(grp->vars, v);
          assert(my_var);
-         if (!my_var->created)
-            continue; /* I'm not sure this is possible. */
+
          LOG((3, "mandatory rename of %s to same name", my_var->hdr.name));
+
+         /* Rename to temp name. */
          if (H5Lmove(hdf5_grp->hdf_grpid, my_var->hdr.name, hdf5_grp->hdf_grpid,
                      NC_TEMP_NAME, H5P_DEFAULT, H5P_DEFAULT) < 0)
             return NC_EHDFERR;
+
+         /* Rename to real name. */
          if (H5Lmove(hdf5_grp->hdf_grpid, NC_TEMP_NAME, hdf5_grp->hdf_grpid,
                      my_var->hdr.name, H5P_DEFAULT, H5P_DEFAULT) < 0)
             return NC_EHDFERR;
@@ -1385,11 +1387,12 @@ set_par_access(NC_FILE_INFO_T *h5, NC_VAR_INFO_T *var, hid_t xfer_plistid)
          return NC_EPARINIT;
 
       LOG((4, "%s: %d H5FD_MPIO_COLLECTIVE: %d H5FD_MPIO_INDEPENDENT: %d",
-           __func__, (int)hdf5_xfer_mode, H5FD_MPIO_COLLECTIVE, H5FD_MPIO_INDEPENDENT));
+           __func__, (int)hdf5_xfer_mode, H5FD_MPIO_COLLECTIVE,
+           H5FD_MPIO_INDEPENDENT));
    }
    return NC_NOERR;
 }
-#endif
+#endif /* USE_PARALLEL4 */
 
 /**
  * @internal Write a strided array of data to a variable. This is
@@ -1582,10 +1585,9 @@ NC4_put_vars(int ncid, int varid, const size_t *startp, const size_t *countp,
       BAIL(retval);
 #endif
 
-   /* Read this hyperslab from  memory. */
-   /* Does the dataset have to be extended? If it's already
-      extended to the required size, it will do no harm to reextend
-      it to that size. */
+   /* Read this hyperslab from memory. Does the dataset have to be
+      extended? If it's already extended to the required size, it will
+      do no harm to reextend it to that size. */
    if (var->ndims)
    {
       for (d2 = 0; d2 < var->ndims; d2++)
@@ -1621,13 +1623,12 @@ NC4_put_vars(int ncid, int varid, const size_t *startp, const size_t *countp,
       }
 
 #ifdef USE_PARALLEL4
-      /* Check if anyone wants to extend */
+      /* Check if anyone wants to extend. */
       if (extend_possible && h5->parallel &&
           NC_COLLECTIVE == var->parallel_access)
       {
-         /* Form consensus opinion among all processes about whether to perform
-          * collective I/O
-          */
+         /* Form consensus opinion among all processes about whether
+          * to perform collective I/O.  */
          if (MPI_SUCCESS != MPI_Allreduce(MPI_IN_PLACE, &need_to_extend, 1,
                                           MPI_INT, MPI_BOR, h5->comm))
             BAIL(NC_EMPI);
@@ -1652,7 +1653,8 @@ NC4_put_vars(int ncid, int varid, const size_t *startp, const size_t *countp,
                BAIL(NC_EMPI);
          }
 #endif /* USE_PARALLEL4 */
-         /* Convert xtend_size back to hsize_t for use with H5Dset_extent */
+         /* Convert xtend_size back to hsize_t for use with
+          * H5Dset_extent. */
          for (d2 = 0; d2 < var->ndims; d2++)
             fdims[d2] = (hsize_t)xtend_size[d2];
 
@@ -1774,7 +1776,8 @@ NC4_get_vars(int ncid, int varid, const size_t *startp, const size_t *countp,
    if ((retval = nc4_hdf5_find_grp_h5_var(ncid, varid, &h5, &grp, &var)))
       return retval;
    assert(h5 && grp && var && var->hdr.id == varid && var->format_var_info &&
-          var->type_info && var->type_info->size && var->type_info->format_type_info);
+          var->type_info && var->type_info->size &&
+          var->type_info->format_type_info);
 
    /* Get the HDF5-specific var and type info. */
    hdf5_var = (NC_HDF5_VAR_INFO_T *)var->format_var_info;
@@ -1887,7 +1890,8 @@ NC4_get_vars(int ncid, int varid, const size_t *startp, const size_t *countp,
    }
 
    /* Check the type_info fields. */
-   /* assert(var->type_info && var->type_info->size && var->type_info->format_type_info); */
+   assert(var->type_info && var->type_info->size &&
+          var->type_info->format_type_info);
 
    /* Later on, we will need to know the size of this type in the
     * file. */
@@ -2025,7 +2029,7 @@ NC4_get_vars(int ncid, int varid, const size_t *startp, const size_t *countp,
                      mem_spaceid, file_spaceid, xfer_plistid, bufr) < 0)
             BAIL(NC_EHDFERR);
       }
-#endif /* End ifdef USE_PARALLEL4 */
+#endif /* USE_PARALLEL4 */
    }
    /* Now we need to fake up any further data that was asked for,
       using the fill values instead. First skip past the data we
@@ -2186,7 +2190,8 @@ NC4_HDF5_inq_var_all(int ncid, int varid, char *name, nc_type *xtypep,
  * @returns ::NC_NOERR No error.
  * @returns ::NC_EBADID Bad ncid.
  * @returns ::NC_ENOTVAR Invalid variable ID.
- * @returns ::NC_ESTRICTNC3 Attempting netcdf-4 operation on strict nc3 netcdf-4 file.
+ * @returns ::NC_ESTRICTNC3 Attempting netcdf-4 operation on strict
+ * nc3 netcdf-4 file.
  * @returns ::NC_EINVAL Invalid input.
  * @returns ::NC_EHDFERR HDF5 error.
  * @author Ed Hartnett

--- a/libhdf5/hdf5var.c
+++ b/libhdf5/hdf5var.c
@@ -12,8 +12,12 @@
 #include <hdf5internal.h>
 #include <math.h>
 
-/** @internal Default size for unlimited dim chunksize */
+/** @internal Default size for unlimited dim chunksize. */
 #define DEFAULT_1D_UNLIM_SIZE (4096)
+
+/** @internal Temp name used when renaming vars to preserve varid
+ * order. */
+#define NC_TEMP_NAME "_netcdf4_temporary_variable_name_for_rename"
 
 /**
  * @internal If the HDF5 dataset for this variable is open, then close
@@ -1184,8 +1188,13 @@ NC4_rename_var(int ncid, int varid, const char *name)
          assert(my_var);
          if (!my_var->created)
             continue; /* I'm not sure this is possible. */
-
          LOG((3, "mandatory rename of %s to same name", my_var->hdr.name));
+         if (H5Lmove(hdf5_grp->hdf_grpid, my_var->hdr.name, hdf5_grp->hdf_grpid,
+                     NC_TEMP_NAME, H5P_DEFAULT, H5P_DEFAULT) < 0)
+            return NC_EHDFERR;
+         if (H5Lmove(hdf5_grp->hdf_grpid, NC_TEMP_NAME, hdf5_grp->hdf_grpid,
+                     my_var->hdr.name, H5P_DEFAULT, H5P_DEFAULT) < 0)
+            return NC_EHDFERR;
       }
    }
 

--- a/libhdf5/hdf5var.c
+++ b/libhdf5/hdf5var.c
@@ -1151,7 +1151,8 @@ NC4_rename_var(int ncid, int varid, const char *name)
       }
 
       LOG((3, "Moving dataset %s to %s", var->hdr.name, name));
-      if (H5Gmove(hdf5_grp->hdf_grpid, var->hdr.name, hdf5_name) < 0)
+      if (H5Lmove(hdf5_grp->hdf_grpid, var->hdr.name, hdf5_grp->hdf_grpid,
+                  hdf5_name, H5P_DEFAULT, H5P_DEFAULT) < 0)
          BAIL(NC_EHDFERR);
    }
 

--- a/libhdf5/nc4hdf.c
+++ b/libhdf5/nc4hdf.c
@@ -1379,7 +1379,7 @@ attach_dimscales(NC_GRP_INFO_T *grp)
    for (v = 0; v < ncindexsize(grp->vars); v++)
    {
       /* Get pointer to var and HDF5-specific var info. */
-      var = (NC_VAR_INFO_T*)ncindexith(grp->vars, v);
+      var = (NC_VAR_INFO_T *)ncindexith(grp->vars, v);
       assert(var && var->format_var_info);
       hdf5_var = (NC_HDF5_VAR_INFO_T *)var->format_var_info;
 

--- a/libhdf5/nc4hdf.c
+++ b/libhdf5/nc4hdf.c
@@ -1785,6 +1785,12 @@ nc4_create_dim_wo_var(NC_DIM_INFO_T *dim)
    if (H5DSset_scale(hdf5_dim->hdf_dimscaleid, dimscale_wo_var) < 0)
       BAIL(NC_EHDFERR);
 
+   /* Since this dimension was created out of order, we cannot rely on
+    * it getting the correct dimid on file open. We must assign it
+    * explicitly. */
+   if ((retval = write_netcdf4_dimid(hdf5_dim->hdf_dimscaleid, dim->hdr.id)))
+       BAIL(retval);
+
 exit:
    if (spaceid > 0 && H5Sclose(spaceid) < 0)
       BAIL2(NC_EHDFERR);

--- a/nc_test4/CMakeLists.txt
+++ b/nc_test4/CMakeLists.txt
@@ -14,7 +14,7 @@ SET(NC4_TESTS tst_dims tst_dims2 tst_dims3 tst_files tst_files4
   tst_fillbug tst_xplatform2 tst_endian_fill tst_atts t_type
   cdm_sea_soundings tst_vl tst_atts1 tst_atts2 tst_vars2 tst_files5
   tst_files6 tst_sync tst_h_strbug tst_h_refs tst_h_scalar tst_rename
-  tst_rename2 tst_h5_endians tst_atts_string_rewrite tst_put_vars_two_unlim_dim
+  tst_rename2 tst_rename3 tst_h5_endians tst_atts_string_rewrite tst_put_vars_two_unlim_dim
   tst_hdf5_file_compat tst_fill_attr_vanish tst_rehash tst_types tst_bug324
   tst_filterparser tst_atts3 tst_put_vars tst_elatefill tst_udf)
 

--- a/nc_test4/Makefile.am
+++ b/nc_test4/Makefile.am
@@ -30,7 +30,7 @@ tst_vars4 tst_chunks tst_chunks2 tst_utf8 tst_fills tst_fills2		\
 tst_fillbug tst_xplatform tst_xplatform2 tst_endian_fill tst_atts	\
 t_type cdm_sea_soundings tst_camrun tst_vl tst_atts1 tst_atts2		\
 tst_vars2 tst_files5 tst_files6 tst_sync tst_h_scalar tst_rename	\
-tst_rename2 tst_h5_endians tst_atts_string_rewrite			\
+tst_rename2 tst_rename3 tst_h5_endians tst_atts_string_rewrite		\
 tst_hdf5_file_compat tst_fill_attr_vanish tst_rehash tst_filterparser	\
 tst_bug324 tst_types tst_atts3 tst_put_vars tst_elatefill tst_udf
 

--- a/nc_test4/tst_rename2.c
+++ b/nc_test4/tst_rename2.c
@@ -273,5 +273,44 @@ main(int argc, char **argv)
       if (nc_close(ncid)) ERR;
    }
    SUMMARIZE_ERR;
+   fprintf(stderr,"*** test exchanging names of two coord vars, making them non-coord vars with names same as dims...");
+   {
+      int ncid, dimid1, dimid2, varid1, varid2;
+      int dimid_in, varid_in;
+      char file_name[NC_MAX_NAME + 1];
+
+      /* Create file with dim and associated coordinate var. */
+      sprintf(file_name, "%s_non_coord_to_dim.nc", TEST_NAME);
+      if (nc_create(file_name, NC_CLOBBER|NC_NETCDF4|NC_CLASSIC_MODEL, &ncid)) ERR;
+      if (nc_def_dim(ncid, D1_NAME, DIM1_LEN, &dimid1)) ERR;
+      if (nc_def_dim(ncid, D2_NAME, DIM1_LEN, &dimid2)) ERR;
+      if (nc_def_var(ncid, D1_NAME, NC_INT, NDIM1, &dimid1, &varid1)) ERR;
+      if (nc_def_var(ncid, D2_NAME, NC_INT, NDIM1, &dimid2, &varid2)) ERR;
+      if (nc_close(ncid)) ERR;
+
+      /* Open the file and rename the vars. */
+      nc_set_log_level(4);
+      if (nc_open(file_name, NC_WRITE, &ncid)) ERR;
+      if (nc_rename_var(ncid, varid1, TMP_NAME)) ERR;
+      nc_sync(ncid);
+      /* if (nc_rename_var(ncid, varid2, D1_NAME)) ERR; */
+      /* nc_sync(ncid); */
+      /* if (nc_rename_var(ncid, varid1, D2_NAME)) ERR; */
+      if (nc_close(ncid)) ERR;
+
+      /* Reopen file and check, */
+      if (nc_open(file_name, NC_WRITE, &ncid)) ERR;
+      /* if (nc_inq_dimid(ncid, D1_NAME, &dimid_in)) ERR; */
+      /* if (dimid_in != dimid1) ERR; */
+      /* if (nc_inq_dimid(ncid, D2_NAME, &dimid_in)) ERR; */
+      /* if (dimid_in != dimid2) ERR; */
+      /* if (nc_inq_dimid(ncid, TMP_NAME, &dimid_in) != NC_EBADDIM) ERR; */
+      /* if (nc_inq_varid(ncid, TMP_NAME, &varid_in)) ERR; */
+      /* if (varid_in != varid1) ERR; */
+      /* if (nc_inq_varid(ncid, D1_NAME, &varid_in)) ERR; */
+      /* if (varid_in != varid2) ERR; */
+      if (nc_close(ncid)) ERR;
+   }
+   SUMMARIZE_ERR;
    FINAL_RESULTS;
 }

--- a/nc_test4/tst_rename2.c
+++ b/nc_test4/tst_rename2.c
@@ -41,246 +41,210 @@ See \ref copyright file for more info.
 int
 main(int argc, char **argv)
 {
-/* #define NUM_FORMATS 2 */
-/*    int formats[NUM_FORMATS] = {NC_FORMAT_NETCDF4, NC_FORMAT_NETCDF4_CLASSIC}; */
-/*    int format; */
+#define NUM_FORMATS 2
+   int formats[NUM_FORMATS] = {NC_FORMAT_NETCDF4, NC_FORMAT_NETCDF4_CLASSIC};
+   int format;
 
-/*    fprintf(stderr,"*** Testing more renames\n"); */
+   fprintf(stderr,"*** Testing more renames\n");
 
-/*    for (format = 0; format < NUM_FORMATS; format++) */
-/*    { */
-/*       fprintf(stderr,"*** test renaming 3 dimensions with format %d...", */
-/*               formats[format]); */
-/*       { */
-/*          char filename[NC_MAX_NAME + 1]; */
-/*          int ncid, dimid[NDIM3]; */
-/*          int dimid_in; */
-/*          int enddef_setting; */
+   for (format = 0; format < NUM_FORMATS; format++)
+   {
+      fprintf(stderr,"*** test renaming 3 dimensions with format %d...",
+              formats[format]);
+      {
+         char filename[NC_MAX_NAME + 1];
+         int ncid, dimid[NDIM3];
+         int dimid_in;
+         int enddef_setting;
 
-/*          if (nc_set_default_format(formats[format], NULL)) ERR; */
+         if (nc_set_default_format(formats[format], NULL)) ERR;
 
-/*          for (enddef_setting = 0; enddef_setting < NUM_ENDDEF_SETTINGS; */
-/*               enddef_setting++) */
-/*          { */
-/*             sprintf(filename, "%s_%d_%d.nc", TEST_NAME, formats[format], */
-/*                     enddef_setting); */
+         for (enddef_setting = 0; enddef_setting < NUM_ENDDEF_SETTINGS;
+              enddef_setting++)
+         {
+            sprintf(filename, "%s_%d_%d.nc", TEST_NAME, formats[format],
+                    enddef_setting);
 
-/*             /\* Create file with three dims. *\/ */
-/*             if (nc_create(filename, 0, &ncid)) ERR; */
-/*             if (nc_def_dim(ncid, LAT, DIM1_LEN, &dimid[0])) ERR; */
-/*             if (nc_def_dim(ncid, LON, DIM1_LEN, &dimid[1])) ERR; */
-/*             if (nc_def_dim(ncid, LEV, DIM1_LEN, &dimid[2])) ERR; */
+            /* Create file with three dims. */
+            if (nc_create(filename, 0, &ncid)) ERR;
+            if (nc_def_dim(ncid, LAT, DIM1_LEN, &dimid[0])) ERR;
+            if (nc_def_dim(ncid, LON, DIM1_LEN, &dimid[1])) ERR;
+            if (nc_def_dim(ncid, LEV, DIM1_LEN, &dimid[2])) ERR;
 
-/*             if (enddef_setting) */
-/*             { */
-/*                if (nc_enddef(ncid)) ERR; */
-/*                if (nc_redef(ncid)) ERR; */
-/*             } */
+            if (enddef_setting)
+            {
+               if (nc_enddef(ncid)) ERR;
+               if (nc_redef(ncid)) ERR;
+            }
 
-/*             /\* Rename the dimensions. *\/ */
-/*             if (nc_rename_dim(ncid, 0, DIM_X)) ERR; */
-/*             if (nc_rename_dim(ncid, 1, DIM_Y)) ERR; */
-/*             if (nc_rename_dim(ncid, 2, DIM_Z)) ERR; */
+            /* Rename the dimensions. */
+            if (nc_rename_dim(ncid, 0, DIM_X)) ERR;
+            if (nc_rename_dim(ncid, 1, DIM_Y)) ERR;
+            if (nc_rename_dim(ncid, 2, DIM_Z)) ERR;
 
-/*             /\* Close the file. *\/ */
-/*             if (nc_close(ncid)) ERR; */
+            /* Close the file. */
+            if (nc_close(ncid)) ERR;
 
-/*             /\* Reopen the file and check. *\/ */
-/*             if (nc_open(filename, NC_NOWRITE, &ncid)) ERR; */
-/*             if (nc_inq_dimid(ncid, DIM_X, &dimid_in)) ERR; */
-/*             if (dimid_in != 0) ERR; */
-/*             if (nc_inq_dimid(ncid, DIM_Y, &dimid_in)) ERR; */
-/*             if (dimid_in != 1) ERR; */
-/*             if (nc_inq_dimid(ncid, DIM_Z, &dimid_in)) ERR; */
-/*             if (dimid_in != 2) ERR; */
-/*             if (nc_close(ncid)) ERR; */
-/*          } /\* next enddef setting *\/ */
-/*       } */
-/*       SUMMARIZE_ERR; */
+            /* Reopen the file and check. */
+            if (nc_open(filename, NC_NOWRITE, &ncid)) ERR;
+            if (nc_inq_dimid(ncid, DIM_X, &dimid_in)) ERR;
+            if (dimid_in != 0) ERR;
+            if (nc_inq_dimid(ncid, DIM_Y, &dimid_in)) ERR;
+            if (dimid_in != 1) ERR;
+            if (nc_inq_dimid(ncid, DIM_Z, &dimid_in)) ERR;
+            if (dimid_in != 2) ERR;
+            if (nc_close(ncid)) ERR;
+         } /* next enddef setting */
+      }
+      SUMMARIZE_ERR;
 
-/*       fprintf(stderr,"*** test renaming 3 dims with coord data format %d...", */
-/*               formats[format]); */
-/*       { */
-/*          char filename[NC_MAX_NAME + 1]; */
-/*          int ncid, dimid[NDIM3], varid[NDIM3]; */
-/*          int dimid_in; */
-/*          int lat_data[DIM1_LEN] = {0, 1, 2, 3}; */
-/*          int lon_data[DIM1_LEN] = {0, 10, 20, 30}; */
-/*          int lev_data[DIM1_LEN] = {0, 100, 200, 300}; */
+      fprintf(stderr,"*** test renaming 3 dims with coord data format %d...",
+              formats[format]);
+      {
+         char filename[NC_MAX_NAME + 1];
+         int ncid, dimid[NDIM3], varid[NDIM3];
+         int dimid_in;
+         int lat_data[DIM1_LEN] = {0, 1, 2, 3};
+         int lon_data[DIM1_LEN] = {0, 10, 20, 30};
+         int lev_data[DIM1_LEN] = {0, 100, 200, 300};
 
-/*          if (nc_set_default_format(formats[format], NULL)) ERR; */
+         if (nc_set_default_format(formats[format], NULL)) ERR;
 
-/*          sprintf(filename, "%s_data_%d.nc", TEST_NAME, formats[format]); */
+         sprintf(filename, "%s_data_%d.nc", TEST_NAME, formats[format]);
 
-/*          /\* Create file with three dims. *\/ */
-/*          if (nc_create(filename, 0, &ncid)) ERR; */
-/*          if (nc_def_dim(ncid, LAT, DIM1_LEN, &dimid[0])) ERR; */
-/*          if (nc_def_dim(ncid, LON, DIM1_LEN, &dimid[1])) ERR; */
-/*          if (nc_def_dim(ncid, LEV, DIM1_LEN, &dimid[2])) ERR; */
+         /* Create file with three dims. */
+         if (nc_create(filename, 0, &ncid)) ERR;
+         if (nc_def_dim(ncid, LAT, DIM1_LEN, &dimid[0])) ERR;
+         if (nc_def_dim(ncid, LON, DIM1_LEN, &dimid[1])) ERR;
+         if (nc_def_dim(ncid, LEV, DIM1_LEN, &dimid[2])) ERR;
 
-/*          /\* Define coordinate data vars. *\/ */
-/*          if (nc_def_var(ncid, LAT, NC_INT, NDIM1, &dimid[0], &varid[0])) ERR; */
-/*          if (nc_def_var(ncid, LON, NC_INT, NDIM1, &dimid[1], &varid[1])) ERR; */
-/*          if (nc_def_var(ncid, LEV, NC_INT, NDIM1, &dimid[2], &varid[2])) ERR; */
+         /* Define coordinate data vars. */
+         if (nc_def_var(ncid, LAT, NC_INT, NDIM1, &dimid[0], &varid[0])) ERR;
+         if (nc_def_var(ncid, LON, NC_INT, NDIM1, &dimid[1], &varid[1])) ERR;
+         if (nc_def_var(ncid, LEV, NC_INT, NDIM1, &dimid[2], &varid[2])) ERR;
 
-/*          if (nc_enddef(ncid)) ERR; */
+         if (nc_enddef(ncid)) ERR;
 
-/*          if (nc_put_var(ncid, 0, lat_data)) ERR; */
-/*          if (nc_put_var(ncid, 1, lon_data)) ERR; */
-/*          if (nc_put_var(ncid, 2, lev_data)) ERR; */
+         if (nc_put_var(ncid, 0, lat_data)) ERR;
+         if (nc_put_var(ncid, 1, lon_data)) ERR;
+         if (nc_put_var(ncid, 2, lev_data)) ERR;
 
-/*          if (nc_close(ncid)) ERR; */
-/*          if (nc_open(filename, NC_WRITE, &ncid)) ERR; */
-/*          if (nc_redef(ncid)) ERR; */
+         if (nc_close(ncid)) ERR;
+         if (nc_open(filename, NC_WRITE, &ncid)) ERR;
+         if (nc_redef(ncid)) ERR;
 
-/*          /\* Rename the dimensions. *\/ */
-/*          if (nc_rename_dim(ncid, 0, DIM_X)) ERR; */
-/*          if (nc_rename_dim(ncid, 1, DIM_Y)) ERR; */
-/*          if (nc_rename_dim(ncid, 2, DIM_Z)) ERR; */
+         /* Rename the dimensions. */
+         if (nc_rename_dim(ncid, 0, DIM_X)) ERR;
+         if (nc_rename_dim(ncid, 1, DIM_Y)) ERR;
+         if (nc_rename_dim(ncid, 2, DIM_Z)) ERR;
 
-/*          /\* Close the file. *\/ */
-/*          if (nc_close(ncid)) ERR; */
+         /* Close the file. */
+         if (nc_close(ncid)) ERR;
 
-/*          /\* Reopen the file and check. *\/ */
-/*          if (nc_open(filename, NC_NOWRITE, &ncid)) ERR; */
-/*          if (nc_inq_dimid(ncid, DIM_X, &dimid_in)) ERR; */
-/*          if (dimid_in != 0) ERR; */
-/*          if (nc_inq_dimid(ncid, DIM_Y, &dimid_in)) ERR; */
-/*          if (dimid_in != 1) ERR; */
-/*          if (nc_inq_dimid(ncid, DIM_Z, &dimid_in)) ERR; */
-/*          if (dimid_in != 2) ERR; */
-/*          if (nc_close(ncid)) ERR; */
-/*       } */
-/*       SUMMARIZE_ERR; */
+         /* Reopen the file and check. */
+         if (nc_open(filename, NC_NOWRITE, &ncid)) ERR;
+         if (nc_inq_dimid(ncid, DIM_X, &dimid_in)) ERR;
+         if (dimid_in != 0) ERR;
+         if (nc_inq_dimid(ncid, DIM_Y, &dimid_in)) ERR;
+         if (dimid_in != 1) ERR;
+         if (nc_inq_dimid(ncid, DIM_Z, &dimid_in)) ERR;
+         if (dimid_in != 2) ERR;
+         if (nc_close(ncid)) ERR;
+      }
+      SUMMARIZE_ERR;
 
-/*    } /\* next format *\/ */
+   } /* next format */
 
-/* #define FILE_NAME1 "tst_dims_foo1.nc" */
-/* #define DIM_NAME "lat_T42" */
-/* #define VAR_NAME DIM_NAME */
-/* #define DIM_NAME2 "lat" */
-/* #define VAR_NAME2 DIM_NAME2 */
-/* #define RANK_lat_T42 1 */
-/*    fprintf(stderr,"*** test renaming with sync..."); */
-/*    { */
-/*       int ncid, dimid, varid; */
-/*       char file_name[NC_MAX_NAME + 1]; */
-/*       char name[NC_MAX_NAME + 1]; */
+#define FILE_NAME1 "tst_dims_foo1.nc"
+#define DIM_NAME "lat_T42"
+#define VAR_NAME DIM_NAME
+#define DIM_NAME2 "lat"
+#define VAR_NAME2 DIM_NAME2
+#define RANK_lat_T42 1
+   fprintf(stderr,"*** test renaming with sync...");
+   {
+      int ncid, dimid, varid;
+      char file_name[NC_MAX_NAME + 1];
+      char name[NC_MAX_NAME + 1];
 
-/*       /\* Create file with dim and associated coordinate var. *\/ */
-/*       sprintf(file_name, "%s_sync.nc", TEST_NAME); */
-/*       if (nc_create(file_name, NC_CLOBBER|NC_NETCDF4|NC_CLASSIC_MODEL, &ncid)) ERR; */
-/*       if (nc_def_dim(ncid, DIM_NAME_END, DIM1_LEN, &dimid)) ERR; */
-/*       if (nc_def_var(ncid, DIM_NAME_END, NC_INT, NDIM1, &dimid, &varid)) ERR; */
-/*       if (nc_close(ncid)) ERR; */
+      /* Create file with dim and associated coordinate var. */
+      sprintf(file_name, "%s_sync.nc", TEST_NAME);
+      if (nc_create(file_name, NC_CLOBBER|NC_NETCDF4|NC_CLASSIC_MODEL, &ncid)) ERR;
+      if (nc_def_dim(ncid, DIM_NAME_END, DIM1_LEN, &dimid)) ERR;
+      if (nc_def_var(ncid, DIM_NAME_END, NC_INT, NDIM1, &dimid, &varid)) ERR;
+      if (nc_close(ncid)) ERR;
 
-/*       if (nc_create(file_name, NC_CLOBBER|NC_NETCDF4|NC_CLASSIC_MODEL, &ncid)) ERR; */
-/*       if (nc_def_dim(ncid, DIM_NAME_START, DIM1_LEN, &dimid)) ERR; */
-/*       if (nc_def_var(ncid, DIM_NAME_END, NC_INT, NDIM1, &dimid, &varid)) ERR; */
-/*       if (nc_close(ncid)) ERR; */
+      if (nc_create(file_name, NC_CLOBBER|NC_NETCDF4|NC_CLASSIC_MODEL, &ncid)) ERR;
+      if (nc_def_dim(ncid, DIM_NAME_START, DIM1_LEN, &dimid)) ERR;
+      if (nc_def_var(ncid, DIM_NAME_END, NC_INT, NDIM1, &dimid, &varid)) ERR;
+      if (nc_close(ncid)) ERR;
 
-/*       if (nc_open(file_name, NC_WRITE, &ncid)) ERR; */
-/*       if (nc_rename_dim(ncid, dimid, DIM_NAME_END)) ERR; */
-/*       if (nc_close(ncid)) ERR; */
+      if (nc_open(file_name, NC_WRITE, &ncid)) ERR;
+      if (nc_rename_dim(ncid, dimid, DIM_NAME_END)) ERR;
+      if (nc_close(ncid)) ERR;
 
-/*       /\* Reopen file and check, *\/ */
-/*       if (nc_open(file_name, NC_WRITE, &ncid)) ERR; */
-/*       if (nc_inq_dimid(ncid, DIM_NAME_END, &dimid)) ERR; */
-/*       if (nc_inq_varid(ncid, DIM_NAME_END, &varid)) ERR; */
-/*       if (nc_inq_dimname(ncid, dimid, name)) ERR; */
-/*       if (strcmp(name, DIM_NAME_END)) ERR; */
-/*       if (nc_inq_varname(ncid, varid, name)) ERR; */
-/*       if (strcmp(name, DIM_NAME_END)) ERR; */
-/*       if (nc_close(ncid)) ERR; */
-/*    } */
-/*    SUMMARIZE_ERR; */
-/*    fprintf(stderr,"*** test renaming with sync..."); */
-/*    { */
-/*       int ncid, dimid, varid; */
-/*       char file_name[NC_MAX_NAME + 1]; */
-/*       char name[NC_MAX_NAME + 1]; */
+      /* Reopen file and check, */
+      if (nc_open(file_name, NC_WRITE, &ncid)) ERR;
+      if (nc_inq_dimid(ncid, DIM_NAME_END, &dimid)) ERR;
+      if (nc_inq_varid(ncid, DIM_NAME_END, &varid)) ERR;
+      if (nc_inq_dimname(ncid, dimid, name)) ERR;
+      if (strcmp(name, DIM_NAME_END)) ERR;
+      if (nc_inq_varname(ncid, varid, name)) ERR;
+      if (strcmp(name, DIM_NAME_END)) ERR;
+      if (nc_close(ncid)) ERR;
+   }
+   SUMMARIZE_ERR;
+   fprintf(stderr,"*** test renaming with sync...");
+   {
+      int ncid, dimid, varid;
+      char file_name[NC_MAX_NAME + 1];
+      char name[NC_MAX_NAME + 1];
 
-/*       /\* Create file with dim and associated coordinate var. *\/ */
-/*       sprintf(file_name, "%s_sync.nc", TEST_NAME); */
-/*       if (nc_create(file_name, NC_CLOBBER|NC_NETCDF4|NC_CLASSIC_MODEL, &ncid)) ERR; */
-/*       if (nc_def_dim(ncid, DIM_NAME_START, DIM1_LEN, &dimid)) ERR; */
-/*       if (nc_def_var(ncid, VAR_NAME_START, NC_INT, NDIM1, &dimid, &varid)) ERR; */
-/*       if (nc_close(ncid)) ERR; */
+      /* Create file with dim and associated coordinate var. */
+      sprintf(file_name, "%s_sync.nc", TEST_NAME);
+      if (nc_create(file_name, NC_CLOBBER|NC_NETCDF4|NC_CLASSIC_MODEL, &ncid)) ERR;
+      if (nc_def_dim(ncid, DIM_NAME_START, DIM1_LEN, &dimid)) ERR;
+      if (nc_def_var(ncid, VAR_NAME_START, NC_INT, NDIM1, &dimid, &varid)) ERR;
+      if (nc_close(ncid)) ERR;
 
-/*       /\* nc_set_log_level(4); *\/ */
-/*       /\* Open the file and rename the var. *\/ */
-/*       if (nc_open(file_name, NC_WRITE, &ncid)) ERR; */
-/*       if (nc_inq_dimid(ncid, DIM_NAME_START, &dimid)) ERR; */
-/*       if (nc_inq_varid(ncid, VAR_NAME_START, &varid)) ERR; */
-/*       if (nc_rename_var(ncid, varid, VAR_NAME_END)) ERR; */
+      /* nc_set_log_level(4); */
+      /* Open the file and rename the var. */
+      if (nc_open(file_name, NC_WRITE, &ncid)) ERR;
+      if (nc_inq_dimid(ncid, DIM_NAME_START, &dimid)) ERR;
+      if (nc_inq_varid(ncid, VAR_NAME_START, &varid)) ERR;
+      if (nc_rename_var(ncid, varid, VAR_NAME_END)) ERR;
 
-/*       /\* Sync to disk. Now the file has one dim and one var. The dim */
-/*        * is a dimscale only dataset, and the var is a dataset with a */
-/*        * dimscale attached pointing to the dim. *\/ */
-/*       /\* if (nc_sync(ncid)) ERR; *\/ */
-/*       if (nc_close(ncid)) ERR; */
-/*       if (nc_open(file_name, NC_WRITE, &ncid)) ERR; */
-/*       /\* Now rename the dim to the same name as the var. After this */
-/*        * there will be one dataset, called DIM_NAME_END, which will be */
-/*        * a dimscale. *\/ */
-/*       if (nc_rename_dim(ncid, dimid, DIM_NAME_END)) ERR; */
-/*       if (nc_close(ncid)) ERR; */
+      /* Sync to disk. Now the file has one dim and one var. The dim
+       * is a dimscale only dataset, and the var is a dataset with a
+       * dimscale attached pointing to the dim. */
+      /* if (nc_sync(ncid)) ERR; */
+      if (nc_close(ncid)) ERR;
+      if (nc_open(file_name, NC_WRITE, &ncid)) ERR;
+      /* Now rename the dim to the same name as the var. After this
+       * there will be one dataset, called DIM_NAME_END, which will be
+       * a dimscale. */
+      if (nc_rename_dim(ncid, dimid, DIM_NAME_END)) ERR;
+      if (nc_close(ncid)) ERR;
 
-/*       /\* Reopen file and check, *\/ */
-/*       if (nc_open(file_name, NC_WRITE, &ncid)) ERR; */
-/*       if (nc_inq_dimid(ncid, DIM_NAME_END, &dimid)) ERR; */
-/*       if (nc_inq_varid(ncid, VAR_NAME_END, &varid)) ERR; */
-/*       if (nc_inq_dimname(ncid, dimid, name)) ERR; */
-/*       if (strcmp(name, DIM_NAME_END)) ERR; */
-/*       if (nc_inq_varname(ncid, varid, name)) ERR; */
-/*       if (strcmp(name, VAR_NAME_END)) ERR; */
-/*       if (nc_close(ncid)) ERR; */
-/*    } */
-/*    SUMMARIZE_ERR; */
-   /* fprintf(stderr,"*** test renaming non-coord var to same name as dim..."); */
-   /* { */
-   /*    int ncid, dimid1, dimid2, varid1, varid2; */
-   /*    int dimid_in, varid_in; */
-   /*    char file_name[NC_MAX_NAME + 1]; */
-
-   /*    /\* Create file with dim and associated coordinate var. *\/ */
-   /*    sprintf(file_name, "%s_non_coord_to_dim.nc", TEST_NAME); */
-   /*    if (nc_create(file_name, NC_CLOBBER|NC_NETCDF4|NC_CLASSIC_MODEL, &ncid)) ERR; */
-   /*    if (nc_def_dim(ncid, D1_NAME, DIM1_LEN, &dimid1)) ERR; */
-   /*    if (nc_def_dim(ncid, D2_NAME, DIM1_LEN, &dimid2)) ERR; */
-   /*    if (nc_def_var(ncid, D1_NAME, NC_INT, NDIM1, &dimid1, &varid1)) ERR; */
-   /*    if (nc_def_var(ncid, D2_NAME, NC_INT, NDIM1, &dimid2, &varid2)) ERR; */
-   /*    if (nc_close(ncid)) ERR; */
-
-   /*    /\* Open the file and rename the vars. *\/ */
-   /*    nc_set_log_level(4); */
-   /*    if (nc_open(file_name, NC_WRITE, &ncid)) ERR; */
-   /*    if (nc_rename_var(ncid, varid1, TMP_NAME)) ERR; */
-   /*    if (nc_rename_var(ncid, varid2, D1_NAME)) ERR; */
-   /*    if (nc_close(ncid)) ERR; */
-
-   /*    /\* Reopen file and check, *\/ */
-   /*    if (nc_open(file_name, NC_WRITE, &ncid)) ERR; */
-   /*    if (nc_inq_dimid(ncid, D1_NAME, &dimid_in)) ERR; */
-   /*    if (dimid_in != dimid1) ERR; */
-   /*    if (nc_inq_dimid(ncid, D2_NAME, &dimid_in)) ERR; */
-   /*    if (dimid_in != dimid2) ERR; */
-   /*    if (nc_inq_dimid(ncid, TMP_NAME, &dimid_in) != NC_EBADDIM) ERR; */
-   /*    if (nc_inq_varid(ncid, TMP_NAME, &varid_in)) ERR; */
-   /*    if (varid_in != varid1) ERR; */
-   /*    if (nc_inq_varid(ncid, D1_NAME, &varid_in)) ERR; */
-   /*    if (varid_in != varid2) ERR; */
-   /*    if (nc_close(ncid)) ERR; */
-   /* } */
-   /* SUMMARIZE_ERR; */
-   fprintf(stderr,"*** test renaming coord var to non-coord var...");
+      /* Reopen file and check, */
+      if (nc_open(file_name, NC_WRITE, &ncid)) ERR;
+      if (nc_inq_dimid(ncid, DIM_NAME_END, &dimid)) ERR;
+      if (nc_inq_varid(ncid, VAR_NAME_END, &varid)) ERR;
+      if (nc_inq_dimname(ncid, dimid, name)) ERR;
+      if (strcmp(name, DIM_NAME_END)) ERR;
+      if (nc_inq_varname(ncid, varid, name)) ERR;
+      if (strcmp(name, VAR_NAME_END)) ERR;
+      if (nc_close(ncid)) ERR;
+   }
+   SUMMARIZE_ERR;
+   fprintf(stderr,"*** test renaming non-coord var to same name as dim...");
    {
       int ncid, dimid1, dimid2, varid1, varid2;
       int dimid_in, varid_in;
       char file_name[NC_MAX_NAME + 1];
 
-      /* Create file with two dims and associated coordinate vars. */
-      sprintf(file_name, "%s_coord_to_non_coord.nc", TEST_NAME);
+      /* Create file with dim and associated coordinate var. */
+      sprintf(file_name, "%s_non_coord_to_dim.nc", TEST_NAME);
       if (nc_create(file_name, NC_CLOBBER|NC_NETCDF4|NC_CLASSIC_MODEL, &ncid)) ERR;
       if (nc_def_dim(ncid, D1_NAME, DIM1_LEN, &dimid1)) ERR;
       if (nc_def_dim(ncid, D2_NAME, DIM1_LEN, &dimid2)) ERR;
@@ -288,81 +252,26 @@ main(int argc, char **argv)
       if (nc_def_var(ncid, D2_NAME, NC_INT, NDIM1, &dimid2, &varid2)) ERR;
       if (nc_close(ncid)) ERR;
 
-      /* Open the file and rename a var. */
+      /* Open the file and rename the vars. */
       nc_set_log_level(4);
       if (nc_open(file_name, NC_WRITE, &ncid)) ERR;
       if (nc_rename_var(ncid, varid1, TMP_NAME)) ERR;
+      if (nc_rename_var(ncid, varid2, D1_NAME)) ERR;
       if (nc_close(ncid)) ERR;
 
       /* Reopen file and check, */
       if (nc_open(file_name, NC_WRITE, &ncid)) ERR;
       if (nc_inq_dimid(ncid, D1_NAME, &dimid_in)) ERR;
-      printf("dimid_in %d\n", dimid_in);
       if (dimid_in != dimid1) ERR;
       if (nc_inq_dimid(ncid, D2_NAME, &dimid_in)) ERR;
       if (dimid_in != dimid2) ERR;
       if (nc_inq_dimid(ncid, TMP_NAME, &dimid_in) != NC_EBADDIM) ERR;
       if (nc_inq_varid(ncid, TMP_NAME, &varid_in)) ERR;
-      /* if (varid_in != varid1) ERR; */
-      if (nc_inq_varid(ncid, D1_NAME, &varid_in) != NC_ENOTVAR) ERR;
+      if (varid_in != varid1) ERR;
+      if (nc_inq_varid(ncid, D1_NAME, &varid_in)) ERR;
+      if (varid_in != varid2) ERR;
       if (nc_close(ncid)) ERR;
-
-      /* if (nc_open(file_name, NC_WRITE, &ncid)) ERR; */
-      /* if (nc_rename_var(ncid, varid2, D1_NAME)) ERR; */
-      /* if (nc_close(ncid)) ERR; */
-
-      /* /\* Reopen file and check, *\/ */
-      /* if (nc_open(file_name, NC_WRITE, &ncid)) ERR; */
-      /* if (nc_inq_dimid(ncid, D1_NAME, &dimid_in)) ERR; */
-      /* if (dimid_in != dimid1) ERR; */
-      /* if (nc_inq_dimid(ncid, D2_NAME, &dimid_in)) ERR; */
-      /* if (dimid_in != dimid2) ERR; */
-      /* if (nc_inq_dimid(ncid, TMP_NAME, &dimid_in) != NC_EBADDIM) ERR; */
-      /* if (nc_inq_varid(ncid, TMP_NAME, &varid_in)) ERR; */
-      /* if (varid_in != varid1) ERR; */
-      /* if (nc_inq_varid(ncid, D1_NAME, &varid_in)) ERR; */
-      /* if (varid_in != varid2) ERR; */
-      /* if (nc_close(ncid)) ERR; */
    }
    SUMMARIZE_ERR;
-   /* fprintf(stderr,"*** test exchanging names of two coord vars, making them non-coord vars with names same as dims..."); */
-   /* { */
-   /*    int ncid, dimid1, dimid2, varid1, varid2; */
-   /*    int dimid_in, varid_in; */
-   /*    char file_name[NC_MAX_NAME + 1]; */
-
-   /*    /\* Create file with dim and associated coordinate var. *\/ */
-   /*    sprintf(file_name, "%s_non_coord_to_dim.nc", TEST_NAME); */
-   /*    if (nc_create(file_name, NC_CLOBBER|NC_NETCDF4|NC_CLASSIC_MODEL, &ncid)) ERR; */
-   /*    if (nc_def_dim(ncid, D1_NAME, DIM1_LEN, &dimid1)) ERR; */
-   /*    if (nc_def_dim(ncid, D2_NAME, DIM1_LEN, &dimid2)) ERR; */
-   /*    if (nc_def_var(ncid, D1_NAME, NC_INT, NDIM1, &dimid1, &varid1)) ERR; */
-   /*    if (nc_def_var(ncid, D2_NAME, NC_INT, NDIM1, &dimid2, &varid2)) ERR; */
-   /*    if (nc_close(ncid)) ERR; */
-
-   /*    /\* Open the file and rename the vars. *\/ */
-   /*    nc_set_log_level(4); */
-   /*    if (nc_open(file_name, NC_WRITE, &ncid)) ERR; */
-   /*    if (nc_rename_var(ncid, varid1, TMP_NAME)) ERR; */
-   /*    nc_sync(ncid); */
-   /*    /\* if (nc_rename_var(ncid, varid2, D1_NAME)) ERR; *\/ */
-   /*    /\* nc_sync(ncid); *\/ */
-   /*    /\* if (nc_rename_var(ncid, varid1, D2_NAME)) ERR; *\/ */
-   /*    if (nc_close(ncid)) ERR; */
-
-   /*    /\* Reopen file and check, *\/ */
-   /*    if (nc_open(file_name, NC_WRITE, &ncid)) ERR; */
-   /*    /\* if (nc_inq_dimid(ncid, D1_NAME, &dimid_in)) ERR; *\/ */
-   /*    /\* if (dimid_in != dimid1) ERR; *\/ */
-   /*    /\* if (nc_inq_dimid(ncid, D2_NAME, &dimid_in)) ERR; *\/ */
-   /*    /\* if (dimid_in != dimid2) ERR; *\/ */
-   /*    /\* if (nc_inq_dimid(ncid, TMP_NAME, &dimid_in) != NC_EBADDIM) ERR; *\/ */
-   /*    /\* if (nc_inq_varid(ncid, TMP_NAME, &varid_in)) ERR; *\/ */
-   /*    /\* if (varid_in != varid1) ERR; *\/ */
-   /*    /\* if (nc_inq_varid(ncid, D1_NAME, &varid_in)) ERR; *\/ */
-   /*    /\* if (varid_in != varid2) ERR; *\/ */
-   /*    if (nc_close(ncid)) ERR; */
-   /* } */
-   /* SUMMARIZE_ERR; */
    FINAL_RESULTS;
 }

--- a/nc_test4/tst_rename2.c
+++ b/nc_test4/tst_rename2.c
@@ -18,7 +18,7 @@ See \ref copyright file for more info.
 #include "nc_tests.h"
 #include "err_macros.h"
 
-#define TEST_NAME "tst_rename"
+#define TEST_NAME "tst_rename2"
 #define LAT "lat"
 #define LON "lon"
 #define LEV "lev"
@@ -41,210 +41,246 @@ See \ref copyright file for more info.
 int
 main(int argc, char **argv)
 {
-#define NUM_FORMATS 2
-   int formats[NUM_FORMATS] = {NC_FORMAT_NETCDF4, NC_FORMAT_NETCDF4_CLASSIC};
-   int format;
+/* #define NUM_FORMATS 2 */
+/*    int formats[NUM_FORMATS] = {NC_FORMAT_NETCDF4, NC_FORMAT_NETCDF4_CLASSIC}; */
+/*    int format; */
 
-   fprintf(stderr,"*** Testing more renames\n");
+/*    fprintf(stderr,"*** Testing more renames\n"); */
 
-   for (format = 0; format < NUM_FORMATS; format++)
-   {
-      fprintf(stderr,"*** test renaming 3 dimensions with format %d...",
-              formats[format]);
-      {
-         char filename[NC_MAX_NAME + 1];
-         int ncid, dimid[NDIM3];
-         int dimid_in;
-         int enddef_setting;
+/*    for (format = 0; format < NUM_FORMATS; format++) */
+/*    { */
+/*       fprintf(stderr,"*** test renaming 3 dimensions with format %d...", */
+/*               formats[format]); */
+/*       { */
+/*          char filename[NC_MAX_NAME + 1]; */
+/*          int ncid, dimid[NDIM3]; */
+/*          int dimid_in; */
+/*          int enddef_setting; */
 
-         if (nc_set_default_format(formats[format], NULL)) ERR;
+/*          if (nc_set_default_format(formats[format], NULL)) ERR; */
 
-         for (enddef_setting = 0; enddef_setting < NUM_ENDDEF_SETTINGS;
-              enddef_setting++)
-         {
-            sprintf(filename, "%s_%d_%d.nc", TEST_NAME, formats[format],
-                    enddef_setting);
+/*          for (enddef_setting = 0; enddef_setting < NUM_ENDDEF_SETTINGS; */
+/*               enddef_setting++) */
+/*          { */
+/*             sprintf(filename, "%s_%d_%d.nc", TEST_NAME, formats[format], */
+/*                     enddef_setting); */
 
-            /* Create file with three dims. */
-            if (nc_create(filename, 0, &ncid)) ERR;
-            if (nc_def_dim(ncid, LAT, DIM1_LEN, &dimid[0])) ERR;
-            if (nc_def_dim(ncid, LON, DIM1_LEN, &dimid[1])) ERR;
-            if (nc_def_dim(ncid, LEV, DIM1_LEN, &dimid[2])) ERR;
+/*             /\* Create file with three dims. *\/ */
+/*             if (nc_create(filename, 0, &ncid)) ERR; */
+/*             if (nc_def_dim(ncid, LAT, DIM1_LEN, &dimid[0])) ERR; */
+/*             if (nc_def_dim(ncid, LON, DIM1_LEN, &dimid[1])) ERR; */
+/*             if (nc_def_dim(ncid, LEV, DIM1_LEN, &dimid[2])) ERR; */
 
-            if (enddef_setting)
-            {
-               if (nc_enddef(ncid)) ERR;
-               if (nc_redef(ncid)) ERR;
-            }
+/*             if (enddef_setting) */
+/*             { */
+/*                if (nc_enddef(ncid)) ERR; */
+/*                if (nc_redef(ncid)) ERR; */
+/*             } */
 
-            /* Rename the dimensions. */
-            if (nc_rename_dim(ncid, 0, DIM_X)) ERR;
-            if (nc_rename_dim(ncid, 1, DIM_Y)) ERR;
-            if (nc_rename_dim(ncid, 2, DIM_Z)) ERR;
+/*             /\* Rename the dimensions. *\/ */
+/*             if (nc_rename_dim(ncid, 0, DIM_X)) ERR; */
+/*             if (nc_rename_dim(ncid, 1, DIM_Y)) ERR; */
+/*             if (nc_rename_dim(ncid, 2, DIM_Z)) ERR; */
 
-            /* Close the file. */
-            if (nc_close(ncid)) ERR;
+/*             /\* Close the file. *\/ */
+/*             if (nc_close(ncid)) ERR; */
 
-            /* Reopen the file and check. */
-            if (nc_open(filename, NC_NOWRITE, &ncid)) ERR;
-            if (nc_inq_dimid(ncid, DIM_X, &dimid_in)) ERR;
-            if (dimid_in != 0) ERR;
-            if (nc_inq_dimid(ncid, DIM_Y, &dimid_in)) ERR;
-            if (dimid_in != 1) ERR;
-            if (nc_inq_dimid(ncid, DIM_Z, &dimid_in)) ERR;
-            if (dimid_in != 2) ERR;
-            if (nc_close(ncid)) ERR;
-         } /* next enddef setting */
-      }
-      SUMMARIZE_ERR;
+/*             /\* Reopen the file and check. *\/ */
+/*             if (nc_open(filename, NC_NOWRITE, &ncid)) ERR; */
+/*             if (nc_inq_dimid(ncid, DIM_X, &dimid_in)) ERR; */
+/*             if (dimid_in != 0) ERR; */
+/*             if (nc_inq_dimid(ncid, DIM_Y, &dimid_in)) ERR; */
+/*             if (dimid_in != 1) ERR; */
+/*             if (nc_inq_dimid(ncid, DIM_Z, &dimid_in)) ERR; */
+/*             if (dimid_in != 2) ERR; */
+/*             if (nc_close(ncid)) ERR; */
+/*          } /\* next enddef setting *\/ */
+/*       } */
+/*       SUMMARIZE_ERR; */
 
-      fprintf(stderr,"*** test renaming 3 dims with coord data format %d...",
-              formats[format]);
-      {
-         char filename[NC_MAX_NAME + 1];
-         int ncid, dimid[NDIM3], varid[NDIM3];
-         int dimid_in;
-         int lat_data[DIM1_LEN] = {0, 1, 2, 3};
-         int lon_data[DIM1_LEN] = {0, 10, 20, 30};
-         int lev_data[DIM1_LEN] = {0, 100, 200, 300};
+/*       fprintf(stderr,"*** test renaming 3 dims with coord data format %d...", */
+/*               formats[format]); */
+/*       { */
+/*          char filename[NC_MAX_NAME + 1]; */
+/*          int ncid, dimid[NDIM3], varid[NDIM3]; */
+/*          int dimid_in; */
+/*          int lat_data[DIM1_LEN] = {0, 1, 2, 3}; */
+/*          int lon_data[DIM1_LEN] = {0, 10, 20, 30}; */
+/*          int lev_data[DIM1_LEN] = {0, 100, 200, 300}; */
 
-         if (nc_set_default_format(formats[format], NULL)) ERR;
+/*          if (nc_set_default_format(formats[format], NULL)) ERR; */
 
-         sprintf(filename, "%s_data_%d.nc", TEST_NAME, formats[format]);
+/*          sprintf(filename, "%s_data_%d.nc", TEST_NAME, formats[format]); */
 
-         /* Create file with three dims. */
-         if (nc_create(filename, 0, &ncid)) ERR;
-         if (nc_def_dim(ncid, LAT, DIM1_LEN, &dimid[0])) ERR;
-         if (nc_def_dim(ncid, LON, DIM1_LEN, &dimid[1])) ERR;
-         if (nc_def_dim(ncid, LEV, DIM1_LEN, &dimid[2])) ERR;
+/*          /\* Create file with three dims. *\/ */
+/*          if (nc_create(filename, 0, &ncid)) ERR; */
+/*          if (nc_def_dim(ncid, LAT, DIM1_LEN, &dimid[0])) ERR; */
+/*          if (nc_def_dim(ncid, LON, DIM1_LEN, &dimid[1])) ERR; */
+/*          if (nc_def_dim(ncid, LEV, DIM1_LEN, &dimid[2])) ERR; */
 
-         /* Define coordinate data vars. */
-         if (nc_def_var(ncid, LAT, NC_INT, NDIM1, &dimid[0], &varid[0])) ERR;
-         if (nc_def_var(ncid, LON, NC_INT, NDIM1, &dimid[1], &varid[1])) ERR;
-         if (nc_def_var(ncid, LEV, NC_INT, NDIM1, &dimid[2], &varid[2])) ERR;
+/*          /\* Define coordinate data vars. *\/ */
+/*          if (nc_def_var(ncid, LAT, NC_INT, NDIM1, &dimid[0], &varid[0])) ERR; */
+/*          if (nc_def_var(ncid, LON, NC_INT, NDIM1, &dimid[1], &varid[1])) ERR; */
+/*          if (nc_def_var(ncid, LEV, NC_INT, NDIM1, &dimid[2], &varid[2])) ERR; */
 
-         if (nc_enddef(ncid)) ERR;
+/*          if (nc_enddef(ncid)) ERR; */
 
-         if (nc_put_var(ncid, 0, lat_data)) ERR;
-         if (nc_put_var(ncid, 1, lon_data)) ERR;
-         if (nc_put_var(ncid, 2, lev_data)) ERR;
+/*          if (nc_put_var(ncid, 0, lat_data)) ERR; */
+/*          if (nc_put_var(ncid, 1, lon_data)) ERR; */
+/*          if (nc_put_var(ncid, 2, lev_data)) ERR; */
 
-         if (nc_close(ncid)) ERR;
-         if (nc_open(filename, NC_WRITE, &ncid)) ERR;
-         if (nc_redef(ncid)) ERR;
+/*          if (nc_close(ncid)) ERR; */
+/*          if (nc_open(filename, NC_WRITE, &ncid)) ERR; */
+/*          if (nc_redef(ncid)) ERR; */
 
-         /* Rename the dimensions. */
-         if (nc_rename_dim(ncid, 0, DIM_X)) ERR;
-         if (nc_rename_dim(ncid, 1, DIM_Y)) ERR;
-         if (nc_rename_dim(ncid, 2, DIM_Z)) ERR;
+/*          /\* Rename the dimensions. *\/ */
+/*          if (nc_rename_dim(ncid, 0, DIM_X)) ERR; */
+/*          if (nc_rename_dim(ncid, 1, DIM_Y)) ERR; */
+/*          if (nc_rename_dim(ncid, 2, DIM_Z)) ERR; */
 
-         /* Close the file. */
-         if (nc_close(ncid)) ERR;
+/*          /\* Close the file. *\/ */
+/*          if (nc_close(ncid)) ERR; */
 
-         /* Reopen the file and check. */
-         if (nc_open(filename, NC_NOWRITE, &ncid)) ERR;
-         if (nc_inq_dimid(ncid, DIM_X, &dimid_in)) ERR;
-         if (dimid_in != 0) ERR;
-         if (nc_inq_dimid(ncid, DIM_Y, &dimid_in)) ERR;
-         if (dimid_in != 1) ERR;
-         if (nc_inq_dimid(ncid, DIM_Z, &dimid_in)) ERR;
-         if (dimid_in != 2) ERR;
-         if (nc_close(ncid)) ERR;
-      }
-      SUMMARIZE_ERR;
+/*          /\* Reopen the file and check. *\/ */
+/*          if (nc_open(filename, NC_NOWRITE, &ncid)) ERR; */
+/*          if (nc_inq_dimid(ncid, DIM_X, &dimid_in)) ERR; */
+/*          if (dimid_in != 0) ERR; */
+/*          if (nc_inq_dimid(ncid, DIM_Y, &dimid_in)) ERR; */
+/*          if (dimid_in != 1) ERR; */
+/*          if (nc_inq_dimid(ncid, DIM_Z, &dimid_in)) ERR; */
+/*          if (dimid_in != 2) ERR; */
+/*          if (nc_close(ncid)) ERR; */
+/*       } */
+/*       SUMMARIZE_ERR; */
 
-   } /* next format */
+/*    } /\* next format *\/ */
 
-#define FILE_NAME1 "tst_dims_foo1.nc"
-#define DIM_NAME "lat_T42"
-#define VAR_NAME DIM_NAME
-#define DIM_NAME2 "lat"
-#define VAR_NAME2 DIM_NAME2
-#define RANK_lat_T42 1
-   fprintf(stderr,"*** test renaming with sync...");
-   {
-      int ncid, dimid, varid;
-      char file_name[NC_MAX_NAME + 1];
-      char name[NC_MAX_NAME + 1];
+/* #define FILE_NAME1 "tst_dims_foo1.nc" */
+/* #define DIM_NAME "lat_T42" */
+/* #define VAR_NAME DIM_NAME */
+/* #define DIM_NAME2 "lat" */
+/* #define VAR_NAME2 DIM_NAME2 */
+/* #define RANK_lat_T42 1 */
+/*    fprintf(stderr,"*** test renaming with sync..."); */
+/*    { */
+/*       int ncid, dimid, varid; */
+/*       char file_name[NC_MAX_NAME + 1]; */
+/*       char name[NC_MAX_NAME + 1]; */
 
-      /* Create file with dim and associated coordinate var. */
-      sprintf(file_name, "%s_sync.nc", TEST_NAME);
-      if (nc_create(file_name, NC_CLOBBER|NC_NETCDF4|NC_CLASSIC_MODEL, &ncid)) ERR;
-      if (nc_def_dim(ncid, DIM_NAME_END, DIM1_LEN, &dimid)) ERR;
-      if (nc_def_var(ncid, DIM_NAME_END, NC_INT, NDIM1, &dimid, &varid)) ERR;
-      if (nc_close(ncid)) ERR;
+/*       /\* Create file with dim and associated coordinate var. *\/ */
+/*       sprintf(file_name, "%s_sync.nc", TEST_NAME); */
+/*       if (nc_create(file_name, NC_CLOBBER|NC_NETCDF4|NC_CLASSIC_MODEL, &ncid)) ERR; */
+/*       if (nc_def_dim(ncid, DIM_NAME_END, DIM1_LEN, &dimid)) ERR; */
+/*       if (nc_def_var(ncid, DIM_NAME_END, NC_INT, NDIM1, &dimid, &varid)) ERR; */
+/*       if (nc_close(ncid)) ERR; */
 
-      if (nc_create(file_name, NC_CLOBBER|NC_NETCDF4|NC_CLASSIC_MODEL, &ncid)) ERR;
-      if (nc_def_dim(ncid, DIM_NAME_START, DIM1_LEN, &dimid)) ERR;
-      if (nc_def_var(ncid, DIM_NAME_END, NC_INT, NDIM1, &dimid, &varid)) ERR;
-      if (nc_close(ncid)) ERR;
+/*       if (nc_create(file_name, NC_CLOBBER|NC_NETCDF4|NC_CLASSIC_MODEL, &ncid)) ERR; */
+/*       if (nc_def_dim(ncid, DIM_NAME_START, DIM1_LEN, &dimid)) ERR; */
+/*       if (nc_def_var(ncid, DIM_NAME_END, NC_INT, NDIM1, &dimid, &varid)) ERR; */
+/*       if (nc_close(ncid)) ERR; */
 
-      if (nc_open(file_name, NC_WRITE, &ncid)) ERR;
-      if (nc_rename_dim(ncid, dimid, DIM_NAME_END)) ERR;
-      if (nc_close(ncid)) ERR;
+/*       if (nc_open(file_name, NC_WRITE, &ncid)) ERR; */
+/*       if (nc_rename_dim(ncid, dimid, DIM_NAME_END)) ERR; */
+/*       if (nc_close(ncid)) ERR; */
 
-      /* Reopen file and check, */
-      if (nc_open(file_name, NC_WRITE, &ncid)) ERR;
-      if (nc_inq_dimid(ncid, DIM_NAME_END, &dimid)) ERR;
-      if (nc_inq_varid(ncid, DIM_NAME_END, &varid)) ERR;
-      if (nc_inq_dimname(ncid, dimid, name)) ERR;
-      if (strcmp(name, DIM_NAME_END)) ERR;
-      if (nc_inq_varname(ncid, varid, name)) ERR;
-      if (strcmp(name, DIM_NAME_END)) ERR;
-      if (nc_close(ncid)) ERR;
-   }
-   SUMMARIZE_ERR;
-   fprintf(stderr,"*** test renaming with sync...");
-   {
-      int ncid, dimid, varid;
-      char file_name[NC_MAX_NAME + 1];
-      char name[NC_MAX_NAME + 1];
+/*       /\* Reopen file and check, *\/ */
+/*       if (nc_open(file_name, NC_WRITE, &ncid)) ERR; */
+/*       if (nc_inq_dimid(ncid, DIM_NAME_END, &dimid)) ERR; */
+/*       if (nc_inq_varid(ncid, DIM_NAME_END, &varid)) ERR; */
+/*       if (nc_inq_dimname(ncid, dimid, name)) ERR; */
+/*       if (strcmp(name, DIM_NAME_END)) ERR; */
+/*       if (nc_inq_varname(ncid, varid, name)) ERR; */
+/*       if (strcmp(name, DIM_NAME_END)) ERR; */
+/*       if (nc_close(ncid)) ERR; */
+/*    } */
+/*    SUMMARIZE_ERR; */
+/*    fprintf(stderr,"*** test renaming with sync..."); */
+/*    { */
+/*       int ncid, dimid, varid; */
+/*       char file_name[NC_MAX_NAME + 1]; */
+/*       char name[NC_MAX_NAME + 1]; */
 
-      /* Create file with dim and associated coordinate var. */
-      sprintf(file_name, "%s_sync.nc", TEST_NAME);
-      if (nc_create(file_name, NC_CLOBBER|NC_NETCDF4|NC_CLASSIC_MODEL, &ncid)) ERR;
-      if (nc_def_dim(ncid, DIM_NAME_START, DIM1_LEN, &dimid)) ERR;
-      if (nc_def_var(ncid, VAR_NAME_START, NC_INT, NDIM1, &dimid, &varid)) ERR;
-      if (nc_close(ncid)) ERR;
+/*       /\* Create file with dim and associated coordinate var. *\/ */
+/*       sprintf(file_name, "%s_sync.nc", TEST_NAME); */
+/*       if (nc_create(file_name, NC_CLOBBER|NC_NETCDF4|NC_CLASSIC_MODEL, &ncid)) ERR; */
+/*       if (nc_def_dim(ncid, DIM_NAME_START, DIM1_LEN, &dimid)) ERR; */
+/*       if (nc_def_var(ncid, VAR_NAME_START, NC_INT, NDIM1, &dimid, &varid)) ERR; */
+/*       if (nc_close(ncid)) ERR; */
 
-      /* nc_set_log_level(4); */
-      /* Open the file and rename the var. */
-      if (nc_open(file_name, NC_WRITE, &ncid)) ERR;
-      if (nc_inq_dimid(ncid, DIM_NAME_START, &dimid)) ERR;
-      if (nc_inq_varid(ncid, VAR_NAME_START, &varid)) ERR;
-      if (nc_rename_var(ncid, varid, VAR_NAME_END)) ERR;
+/*       /\* nc_set_log_level(4); *\/ */
+/*       /\* Open the file and rename the var. *\/ */
+/*       if (nc_open(file_name, NC_WRITE, &ncid)) ERR; */
+/*       if (nc_inq_dimid(ncid, DIM_NAME_START, &dimid)) ERR; */
+/*       if (nc_inq_varid(ncid, VAR_NAME_START, &varid)) ERR; */
+/*       if (nc_rename_var(ncid, varid, VAR_NAME_END)) ERR; */
 
-      /* Sync to disk. Now the file has one dim and one var. The dim
-       * is a dimscale only dataset, and the var is a dataset with a
-       * dimscale attached pointing to the dim. */
-      /* if (nc_sync(ncid)) ERR; */
-      if (nc_close(ncid)) ERR;
-      if (nc_open(file_name, NC_WRITE, &ncid)) ERR;
-      /* Now rename the dim to the same name as the var. After this
-       * there will be one dataset, called DIM_NAME_END, which will be
-       * a dimscale. */
-      if (nc_rename_dim(ncid, dimid, DIM_NAME_END)) ERR;
-      if (nc_close(ncid)) ERR;
+/*       /\* Sync to disk. Now the file has one dim and one var. The dim */
+/*        * is a dimscale only dataset, and the var is a dataset with a */
+/*        * dimscale attached pointing to the dim. *\/ */
+/*       /\* if (nc_sync(ncid)) ERR; *\/ */
+/*       if (nc_close(ncid)) ERR; */
+/*       if (nc_open(file_name, NC_WRITE, &ncid)) ERR; */
+/*       /\* Now rename the dim to the same name as the var. After this */
+/*        * there will be one dataset, called DIM_NAME_END, which will be */
+/*        * a dimscale. *\/ */
+/*       if (nc_rename_dim(ncid, dimid, DIM_NAME_END)) ERR; */
+/*       if (nc_close(ncid)) ERR; */
 
-      /* Reopen file and check, */
-      if (nc_open(file_name, NC_WRITE, &ncid)) ERR;
-      if (nc_inq_dimid(ncid, DIM_NAME_END, &dimid)) ERR;
-      if (nc_inq_varid(ncid, VAR_NAME_END, &varid)) ERR;
-      if (nc_inq_dimname(ncid, dimid, name)) ERR;
-      if (strcmp(name, DIM_NAME_END)) ERR;
-      if (nc_inq_varname(ncid, varid, name)) ERR;
-      if (strcmp(name, VAR_NAME_END)) ERR;
-      if (nc_close(ncid)) ERR;
-   }
-   SUMMARIZE_ERR;
-   fprintf(stderr,"*** test renaming non-coord var to same name as dim...");
+/*       /\* Reopen file and check, *\/ */
+/*       if (nc_open(file_name, NC_WRITE, &ncid)) ERR; */
+/*       if (nc_inq_dimid(ncid, DIM_NAME_END, &dimid)) ERR; */
+/*       if (nc_inq_varid(ncid, VAR_NAME_END, &varid)) ERR; */
+/*       if (nc_inq_dimname(ncid, dimid, name)) ERR; */
+/*       if (strcmp(name, DIM_NAME_END)) ERR; */
+/*       if (nc_inq_varname(ncid, varid, name)) ERR; */
+/*       if (strcmp(name, VAR_NAME_END)) ERR; */
+/*       if (nc_close(ncid)) ERR; */
+/*    } */
+/*    SUMMARIZE_ERR; */
+   /* fprintf(stderr,"*** test renaming non-coord var to same name as dim..."); */
+   /* { */
+   /*    int ncid, dimid1, dimid2, varid1, varid2; */
+   /*    int dimid_in, varid_in; */
+   /*    char file_name[NC_MAX_NAME + 1]; */
+
+   /*    /\* Create file with dim and associated coordinate var. *\/ */
+   /*    sprintf(file_name, "%s_non_coord_to_dim.nc", TEST_NAME); */
+   /*    if (nc_create(file_name, NC_CLOBBER|NC_NETCDF4|NC_CLASSIC_MODEL, &ncid)) ERR; */
+   /*    if (nc_def_dim(ncid, D1_NAME, DIM1_LEN, &dimid1)) ERR; */
+   /*    if (nc_def_dim(ncid, D2_NAME, DIM1_LEN, &dimid2)) ERR; */
+   /*    if (nc_def_var(ncid, D1_NAME, NC_INT, NDIM1, &dimid1, &varid1)) ERR; */
+   /*    if (nc_def_var(ncid, D2_NAME, NC_INT, NDIM1, &dimid2, &varid2)) ERR; */
+   /*    if (nc_close(ncid)) ERR; */
+
+   /*    /\* Open the file and rename the vars. *\/ */
+   /*    nc_set_log_level(4); */
+   /*    if (nc_open(file_name, NC_WRITE, &ncid)) ERR; */
+   /*    if (nc_rename_var(ncid, varid1, TMP_NAME)) ERR; */
+   /*    if (nc_rename_var(ncid, varid2, D1_NAME)) ERR; */
+   /*    if (nc_close(ncid)) ERR; */
+
+   /*    /\* Reopen file and check, *\/ */
+   /*    if (nc_open(file_name, NC_WRITE, &ncid)) ERR; */
+   /*    if (nc_inq_dimid(ncid, D1_NAME, &dimid_in)) ERR; */
+   /*    if (dimid_in != dimid1) ERR; */
+   /*    if (nc_inq_dimid(ncid, D2_NAME, &dimid_in)) ERR; */
+   /*    if (dimid_in != dimid2) ERR; */
+   /*    if (nc_inq_dimid(ncid, TMP_NAME, &dimid_in) != NC_EBADDIM) ERR; */
+   /*    if (nc_inq_varid(ncid, TMP_NAME, &varid_in)) ERR; */
+   /*    if (varid_in != varid1) ERR; */
+   /*    if (nc_inq_varid(ncid, D1_NAME, &varid_in)) ERR; */
+   /*    if (varid_in != varid2) ERR; */
+   /*    if (nc_close(ncid)) ERR; */
+   /* } */
+   /* SUMMARIZE_ERR; */
+   fprintf(stderr,"*** test renaming coord var to non-coord var...");
    {
       int ncid, dimid1, dimid2, varid1, varid2;
       int dimid_in, varid_in;
       char file_name[NC_MAX_NAME + 1];
 
-      /* Create file with dim and associated coordinate var. */
-      sprintf(file_name, "%s_non_coord_to_dim.nc", TEST_NAME);
+      /* Create file with two dims and associated coordinate vars. */
+      sprintf(file_name, "%s_coord_to_non_coord.nc", TEST_NAME);
       if (nc_create(file_name, NC_CLOBBER|NC_NETCDF4|NC_CLASSIC_MODEL, &ncid)) ERR;
       if (nc_def_dim(ncid, D1_NAME, DIM1_LEN, &dimid1)) ERR;
       if (nc_def_dim(ncid, D2_NAME, DIM1_LEN, &dimid2)) ERR;
@@ -252,54 +288,31 @@ main(int argc, char **argv)
       if (nc_def_var(ncid, D2_NAME, NC_INT, NDIM1, &dimid2, &varid2)) ERR;
       if (nc_close(ncid)) ERR;
 
-      /* Open the file and rename the vars. */
-      /* nc_set_log_level(4); */
+      /* Open the file and rename a var. */
+      nc_set_log_level(4);
       if (nc_open(file_name, NC_WRITE, &ncid)) ERR;
       if (nc_rename_var(ncid, varid1, TMP_NAME)) ERR;
-      if (nc_rename_var(ncid, varid2, D1_NAME)) ERR;
       if (nc_close(ncid)) ERR;
 
       /* Reopen file and check, */
       if (nc_open(file_name, NC_WRITE, &ncid)) ERR;
       if (nc_inq_dimid(ncid, D1_NAME, &dimid_in)) ERR;
+      printf("dimid_in %d\n", dimid_in);
       if (dimid_in != dimid1) ERR;
       if (nc_inq_dimid(ncid, D2_NAME, &dimid_in)) ERR;
       if (dimid_in != dimid2) ERR;
       if (nc_inq_dimid(ncid, TMP_NAME, &dimid_in) != NC_EBADDIM) ERR;
       if (nc_inq_varid(ncid, TMP_NAME, &varid_in)) ERR;
-      if (varid_in != varid1) ERR;
-      if (nc_inq_varid(ncid, D1_NAME, &varid_in)) ERR;
-      if (varid_in != varid2) ERR;
-      if (nc_close(ncid)) ERR;
-   }
-   SUMMARIZE_ERR;
-   fprintf(stderr,"*** test exchanging names of two coord vars, making them non-coord vars with names same as dims...");
-   {
-      int ncid, dimid1, dimid2, varid1, varid2;
-      int dimid_in, varid_in;
-      char file_name[NC_MAX_NAME + 1];
-
-      /* Create file with dim and associated coordinate var. */
-      sprintf(file_name, "%s_non_coord_to_dim.nc", TEST_NAME);
-      if (nc_create(file_name, NC_CLOBBER|NC_NETCDF4|NC_CLASSIC_MODEL, &ncid)) ERR;
-      if (nc_def_dim(ncid, D1_NAME, DIM1_LEN, &dimid1)) ERR;
-      if (nc_def_dim(ncid, D2_NAME, DIM1_LEN, &dimid2)) ERR;
-      if (nc_def_var(ncid, D1_NAME, NC_INT, NDIM1, &dimid1, &varid1)) ERR;
-      if (nc_def_var(ncid, D2_NAME, NC_INT, NDIM1, &dimid2, &varid2)) ERR;
+      /* if (varid_in != varid1) ERR; */
+      if (nc_inq_varid(ncid, D1_NAME, &varid_in) != NC_ENOTVAR) ERR;
       if (nc_close(ncid)) ERR;
 
-      /* Open the file and rename the vars. */
-      nc_set_log_level(4);
-      if (nc_open(file_name, NC_WRITE, &ncid)) ERR;
-      if (nc_rename_var(ncid, varid1, TMP_NAME)) ERR;
-      nc_sync(ncid);
+      /* if (nc_open(file_name, NC_WRITE, &ncid)) ERR; */
       /* if (nc_rename_var(ncid, varid2, D1_NAME)) ERR; */
-      /* nc_sync(ncid); */
-      /* if (nc_rename_var(ncid, varid1, D2_NAME)) ERR; */
-      if (nc_close(ncid)) ERR;
+      /* if (nc_close(ncid)) ERR; */
 
-      /* Reopen file and check, */
-      if (nc_open(file_name, NC_WRITE, &ncid)) ERR;
+      /* /\* Reopen file and check, *\/ */
+      /* if (nc_open(file_name, NC_WRITE, &ncid)) ERR; */
       /* if (nc_inq_dimid(ncid, D1_NAME, &dimid_in)) ERR; */
       /* if (dimid_in != dimid1) ERR; */
       /* if (nc_inq_dimid(ncid, D2_NAME, &dimid_in)) ERR; */
@@ -309,8 +322,47 @@ main(int argc, char **argv)
       /* if (varid_in != varid1) ERR; */
       /* if (nc_inq_varid(ncid, D1_NAME, &varid_in)) ERR; */
       /* if (varid_in != varid2) ERR; */
-      if (nc_close(ncid)) ERR;
+      /* if (nc_close(ncid)) ERR; */
    }
    SUMMARIZE_ERR;
+   /* fprintf(stderr,"*** test exchanging names of two coord vars, making them non-coord vars with names same as dims..."); */
+   /* { */
+   /*    int ncid, dimid1, dimid2, varid1, varid2; */
+   /*    int dimid_in, varid_in; */
+   /*    char file_name[NC_MAX_NAME + 1]; */
+
+   /*    /\* Create file with dim and associated coordinate var. *\/ */
+   /*    sprintf(file_name, "%s_non_coord_to_dim.nc", TEST_NAME); */
+   /*    if (nc_create(file_name, NC_CLOBBER|NC_NETCDF4|NC_CLASSIC_MODEL, &ncid)) ERR; */
+   /*    if (nc_def_dim(ncid, D1_NAME, DIM1_LEN, &dimid1)) ERR; */
+   /*    if (nc_def_dim(ncid, D2_NAME, DIM1_LEN, &dimid2)) ERR; */
+   /*    if (nc_def_var(ncid, D1_NAME, NC_INT, NDIM1, &dimid1, &varid1)) ERR; */
+   /*    if (nc_def_var(ncid, D2_NAME, NC_INT, NDIM1, &dimid2, &varid2)) ERR; */
+   /*    if (nc_close(ncid)) ERR; */
+
+   /*    /\* Open the file and rename the vars. *\/ */
+   /*    nc_set_log_level(4); */
+   /*    if (nc_open(file_name, NC_WRITE, &ncid)) ERR; */
+   /*    if (nc_rename_var(ncid, varid1, TMP_NAME)) ERR; */
+   /*    nc_sync(ncid); */
+   /*    /\* if (nc_rename_var(ncid, varid2, D1_NAME)) ERR; *\/ */
+   /*    /\* nc_sync(ncid); *\/ */
+   /*    /\* if (nc_rename_var(ncid, varid1, D2_NAME)) ERR; *\/ */
+   /*    if (nc_close(ncid)) ERR; */
+
+   /*    /\* Reopen file and check, *\/ */
+   /*    if (nc_open(file_name, NC_WRITE, &ncid)) ERR; */
+   /*    /\* if (nc_inq_dimid(ncid, D1_NAME, &dimid_in)) ERR; *\/ */
+   /*    /\* if (dimid_in != dimid1) ERR; *\/ */
+   /*    /\* if (nc_inq_dimid(ncid, D2_NAME, &dimid_in)) ERR; *\/ */
+   /*    /\* if (dimid_in != dimid2) ERR; *\/ */
+   /*    /\* if (nc_inq_dimid(ncid, TMP_NAME, &dimid_in) != NC_EBADDIM) ERR; *\/ */
+   /*    /\* if (nc_inq_varid(ncid, TMP_NAME, &varid_in)) ERR; *\/ */
+   /*    /\* if (varid_in != varid1) ERR; *\/ */
+   /*    /\* if (nc_inq_varid(ncid, D1_NAME, &varid_in)) ERR; *\/ */
+   /*    /\* if (varid_in != varid2) ERR; *\/ */
+   /*    if (nc_close(ncid)) ERR; */
+   /* } */
+   /* SUMMARIZE_ERR; */
    FINAL_RESULTS;
 }

--- a/nc_test4/tst_rename2.c
+++ b/nc_test4/tst_rename2.c
@@ -273,5 +273,34 @@ main(int argc, char **argv)
       if (nc_close(ncid)) ERR;
    }
    SUMMARIZE_ERR;
+   fprintf(stderr,"*** test renaming affect on varids...");
+   {
+      int ncid, dimid1, dimid2, varid1, varid2;
+      int dimid_in, varid_in;
+      char file_name[NC_MAX_NAME + 1];
+
+      /* Create file with two scalar vars. */
+      sprintf(file_name, "%s_rename_affect_varid_order.nc", TEST_NAME);
+      if (nc_create(file_name, NC_CLOBBER|NC_NETCDF4|NC_CLASSIC_MODEL, &ncid)) ERR;
+      if (nc_def_var(ncid, D1_NAME, NC_INT, 0, NULL, &varid1)) ERR;
+      if (nc_def_var(ncid, D2_NAME, NC_INT, 0, NULL, &varid2)) ERR;
+      if (nc_close(ncid)) ERR;
+
+      /* Open the file and rename a var. */
+      nc_set_log_level(4);
+      if (nc_open(file_name, NC_WRITE, &ncid)) ERR;
+      if (nc_rename_var(ncid, varid1, TMP_NAME)) ERR;
+      if (nc_close(ncid)) ERR;
+
+      /* Reopen file and check, */
+      if (nc_open(file_name, NC_WRITE, &ncid)) ERR;
+      if (nc_inq_varid(ncid, TMP_NAME, &varid_in)) ERR;
+      if (varid_in != varid1) ERR;
+      if (nc_inq_varid(ncid, D1_NAME, &varid_in) != NC_ENOTVAR) ERR;
+      if (nc_inq_varid(ncid, D2_NAME, &varid_in)) ERR;
+      if (varid_in != varid2) ERR;
+      if (nc_close(ncid)) ERR;
+   }
+   SUMMARIZE_ERR;
    FINAL_RESULTS;
 }

--- a/nc_test4/tst_rename3.c
+++ b/nc_test4/tst_rename3.c
@@ -31,19 +31,18 @@ See \ref copyright file for more info.
 int
 main(int argc, char **argv)
 {
-   fprintf(stderr,"*** test renaming coord var to non-coord var...");
+   fprintf(stderr,"Test more renaming.\n");
+   fprintf(stderr,"*** test renaming affect on varids...");
    {
       int ncid, dimid1, dimid2, varid1, varid2;
       int dimid_in, varid_in;
       char file_name[NC_MAX_NAME + 1];
 
-      /* Create file with two dims and associated coordinate vars. */
+      /* Create file with two scalar vars. */
       sprintf(file_name, "%s_coord_to_non_coord.nc", TEST_NAME);
       if (nc_create(file_name, NC_CLOBBER|NC_NETCDF4|NC_CLASSIC_MODEL, &ncid)) ERR;
-      if (nc_def_dim(ncid, D1_NAME, DIM1_LEN, &dimid1)) ERR;
-      if (nc_def_dim(ncid, D2_NAME, DIM1_LEN, &dimid2)) ERR;
-      if (nc_def_var(ncid, D1_NAME, NC_INT, NDIM1, &dimid1, &varid1)) ERR;
-      if (nc_def_var(ncid, D2_NAME, NC_INT, NDIM1, &dimid2, &varid2)) ERR;
+      if (nc_def_var(ncid, D1_NAME, NC_INT, 0, NULL, &varid1)) ERR;
+      if (nc_def_var(ncid, D2_NAME, NC_INT, 0, NULL, &varid2)) ERR;
       if (nc_close(ncid)) ERR;
 
       /* Open the file and rename a var. */
@@ -54,35 +53,65 @@ main(int argc, char **argv)
 
       /* Reopen file and check, */
       if (nc_open(file_name, NC_WRITE, &ncid)) ERR;
-      if (nc_inq_dimid(ncid, D1_NAME, &dimid_in)) ERR;
-      printf("dimid_in %d\n", dimid_in);
-      if (dimid_in != dimid1) ERR;
-      if (nc_inq_dimid(ncid, D2_NAME, &dimid_in)) ERR;
-      if (dimid_in != dimid2) ERR;
-      if (nc_inq_dimid(ncid, TMP_NAME, &dimid_in) != NC_EBADDIM) ERR;
       if (nc_inq_varid(ncid, TMP_NAME, &varid_in)) ERR;
       /* if (varid_in != varid1) ERR; */
       if (nc_inq_varid(ncid, D1_NAME, &varid_in) != NC_ENOTVAR) ERR;
+      if (nc_inq_varid(ncid, D2_NAME, &varid_in)) ERR;
       if (nc_close(ncid)) ERR;
-
-      /* if (nc_open(file_name, NC_WRITE, &ncid)) ERR; */
-      /* if (nc_rename_var(ncid, varid2, D1_NAME)) ERR; */
-      /* if (nc_close(ncid)) ERR; */
-
-      /* /\* Reopen file and check, *\/ */
-      /* if (nc_open(file_name, NC_WRITE, &ncid)) ERR; */
-      /* if (nc_inq_dimid(ncid, D1_NAME, &dimid_in)) ERR; */
-      /* if (dimid_in != dimid1) ERR; */
-      /* if (nc_inq_dimid(ncid, D2_NAME, &dimid_in)) ERR; */
-      /* if (dimid_in != dimid2) ERR; */
-      /* if (nc_inq_dimid(ncid, TMP_NAME, &dimid_in) != NC_EBADDIM) ERR; */
-      /* if (nc_inq_varid(ncid, TMP_NAME, &varid_in)) ERR; */
-      /* if (varid_in != varid1) ERR; */
-      /* if (nc_inq_varid(ncid, D1_NAME, &varid_in)) ERR; */
-      /* if (varid_in != varid2) ERR; */
-      /* if (nc_close(ncid)) ERR; */
    }
    SUMMARIZE_ERR;
+   /* fprintf(stderr,"*** test renaming coord var to non-coord var..."); */
+   /* { */
+   /*    int ncid, dimid1, dimid2, varid1, varid2; */
+   /*    int dimid_in, varid_in; */
+   /*    char file_name[NC_MAX_NAME + 1]; */
+
+   /*    /\* Create file with two dims and associated coordinate vars. *\/ */
+   /*    sprintf(file_name, "%s_coord_to_non_coord.nc", TEST_NAME); */
+   /*    if (nc_create(file_name, NC_CLOBBER|NC_NETCDF4|NC_CLASSIC_MODEL, &ncid)) ERR; */
+   /*    if (nc_def_dim(ncid, D1_NAME, DIM1_LEN, &dimid1)) ERR; */
+   /*    if (nc_def_dim(ncid, D2_NAME, DIM1_LEN, &dimid2)) ERR; */
+   /*    if (nc_def_var(ncid, D1_NAME, NC_INT, NDIM1, &dimid1, &varid1)) ERR; */
+   /*    if (nc_def_var(ncid, D2_NAME, NC_INT, NDIM1, &dimid2, &varid2)) ERR; */
+   /*    if (nc_close(ncid)) ERR; */
+
+   /*    /\* Open the file and rename a var. *\/ */
+   /*    nc_set_log_level(4); */
+   /*    if (nc_open(file_name, NC_WRITE, &ncid)) ERR; */
+   /*    if (nc_rename_var(ncid, varid1, TMP_NAME)) ERR; */
+   /*    if (nc_close(ncid)) ERR; */
+
+   /*    /\* Reopen file and check, *\/ */
+   /*    if (nc_open(file_name, NC_WRITE, &ncid)) ERR; */
+   /*    if (nc_inq_dimid(ncid, D1_NAME, &dimid_in)) ERR; */
+   /*    printf("dimid_in %d\n", dimid_in); */
+   /*    if (dimid_in != dimid1) ERR; */
+   /*    if (nc_inq_dimid(ncid, D2_NAME, &dimid_in)) ERR; */
+   /*    if (dimid_in != dimid2) ERR; */
+   /*    if (nc_inq_dimid(ncid, TMP_NAME, &dimid_in) != NC_EBADDIM) ERR; */
+   /*    if (nc_inq_varid(ncid, TMP_NAME, &varid_in)) ERR; */
+   /*    /\* if (varid_in != varid1) ERR; *\/ */
+   /*    if (nc_inq_varid(ncid, D1_NAME, &varid_in) != NC_ENOTVAR) ERR; */
+   /*    if (nc_close(ncid)) ERR; */
+
+   /*    /\* if (nc_open(file_name, NC_WRITE, &ncid)) ERR; *\/ */
+   /*    /\* if (nc_rename_var(ncid, varid2, D1_NAME)) ERR; *\/ */
+   /*    /\* if (nc_close(ncid)) ERR; *\/ */
+
+   /*    /\* /\\* Reopen file and check, *\\/ *\/ */
+   /*    /\* if (nc_open(file_name, NC_WRITE, &ncid)) ERR; *\/ */
+   /*    /\* if (nc_inq_dimid(ncid, D1_NAME, &dimid_in)) ERR; *\/ */
+   /*    /\* if (dimid_in != dimid1) ERR; *\/ */
+   /*    /\* if (nc_inq_dimid(ncid, D2_NAME, &dimid_in)) ERR; *\/ */
+   /*    /\* if (dimid_in != dimid2) ERR; *\/ */
+   /*    /\* if (nc_inq_dimid(ncid, TMP_NAME, &dimid_in) != NC_EBADDIM) ERR; *\/ */
+   /*    /\* if (nc_inq_varid(ncid, TMP_NAME, &varid_in)) ERR; *\/ */
+   /*    /\* if (varid_in != varid1) ERR; *\/ */
+   /*    /\* if (nc_inq_varid(ncid, D1_NAME, &varid_in)) ERR; *\/ */
+   /*    /\* if (varid_in != varid2) ERR; *\/ */
+   /*    /\* if (nc_close(ncid)) ERR; *\/ */
+   /* } */
+   /* SUMMARIZE_ERR; */
    /* fprintf(stderr,"*** test exchanging names of two coord vars, making them non-coord vars with names same as dims..."); */
    /* { */
    /*    int ncid, dimid1, dimid2, varid1, varid2; */

--- a/nc_test4/tst_rename3.c
+++ b/nc_test4/tst_rename3.c
@@ -1,0 +1,126 @@
+/*! \file
+
+Copyright 1993, 1994, 1995, 1996, 1997, 1998, 1999, 2000, 2001, 2002,
+2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014,
+2015, 2016, 2017, 2018
+University Corporation for Atmospheric Research/Unidata.
+
+See \ref copyright file for more info.
+
+*/
+
+/*
+ * Test more renames of vars and dims.
+ *
+ * Ed Hartnett
+ */
+
+#include "nc_tests.h"
+#include "err_macros.h"
+
+#define TEST_NAME "tst_rename3"
+
+#define DIM1_LEN 4
+#define NDIM1 1
+#define NDIM3 3
+#define NUM_ENDDEF_SETTINGS 2
+#define D1_NAME "d1"
+#define D2_NAME "d2"
+#define TMP_NAME "t1"
+
+int
+main(int argc, char **argv)
+{
+   fprintf(stderr,"*** test renaming coord var to non-coord var...");
+   {
+      int ncid, dimid1, dimid2, varid1, varid2;
+      int dimid_in, varid_in;
+      char file_name[NC_MAX_NAME + 1];
+
+      /* Create file with two dims and associated coordinate vars. */
+      sprintf(file_name, "%s_coord_to_non_coord.nc", TEST_NAME);
+      if (nc_create(file_name, NC_CLOBBER|NC_NETCDF4|NC_CLASSIC_MODEL, &ncid)) ERR;
+      if (nc_def_dim(ncid, D1_NAME, DIM1_LEN, &dimid1)) ERR;
+      if (nc_def_dim(ncid, D2_NAME, DIM1_LEN, &dimid2)) ERR;
+      if (nc_def_var(ncid, D1_NAME, NC_INT, NDIM1, &dimid1, &varid1)) ERR;
+      if (nc_def_var(ncid, D2_NAME, NC_INT, NDIM1, &dimid2, &varid2)) ERR;
+      if (nc_close(ncid)) ERR;
+
+      /* Open the file and rename a var. */
+      nc_set_log_level(4);
+      if (nc_open(file_name, NC_WRITE, &ncid)) ERR;
+      if (nc_rename_var(ncid, varid1, TMP_NAME)) ERR;
+      if (nc_close(ncid)) ERR;
+
+      /* Reopen file and check, */
+      if (nc_open(file_name, NC_WRITE, &ncid)) ERR;
+      if (nc_inq_dimid(ncid, D1_NAME, &dimid_in)) ERR;
+      printf("dimid_in %d\n", dimid_in);
+      if (dimid_in != dimid1) ERR;
+      if (nc_inq_dimid(ncid, D2_NAME, &dimid_in)) ERR;
+      if (dimid_in != dimid2) ERR;
+      if (nc_inq_dimid(ncid, TMP_NAME, &dimid_in) != NC_EBADDIM) ERR;
+      if (nc_inq_varid(ncid, TMP_NAME, &varid_in)) ERR;
+      /* if (varid_in != varid1) ERR; */
+      if (nc_inq_varid(ncid, D1_NAME, &varid_in) != NC_ENOTVAR) ERR;
+      if (nc_close(ncid)) ERR;
+
+      /* if (nc_open(file_name, NC_WRITE, &ncid)) ERR; */
+      /* if (nc_rename_var(ncid, varid2, D1_NAME)) ERR; */
+      /* if (nc_close(ncid)) ERR; */
+
+      /* /\* Reopen file and check, *\/ */
+      /* if (nc_open(file_name, NC_WRITE, &ncid)) ERR; */
+      /* if (nc_inq_dimid(ncid, D1_NAME, &dimid_in)) ERR; */
+      /* if (dimid_in != dimid1) ERR; */
+      /* if (nc_inq_dimid(ncid, D2_NAME, &dimid_in)) ERR; */
+      /* if (dimid_in != dimid2) ERR; */
+      /* if (nc_inq_dimid(ncid, TMP_NAME, &dimid_in) != NC_EBADDIM) ERR; */
+      /* if (nc_inq_varid(ncid, TMP_NAME, &varid_in)) ERR; */
+      /* if (varid_in != varid1) ERR; */
+      /* if (nc_inq_varid(ncid, D1_NAME, &varid_in)) ERR; */
+      /* if (varid_in != varid2) ERR; */
+      /* if (nc_close(ncid)) ERR; */
+   }
+   SUMMARIZE_ERR;
+   /* fprintf(stderr,"*** test exchanging names of two coord vars, making them non-coord vars with names same as dims..."); */
+   /* { */
+   /*    int ncid, dimid1, dimid2, varid1, varid2; */
+   /*    int dimid_in, varid_in; */
+   /*    char file_name[NC_MAX_NAME + 1]; */
+
+   /*    /\* Create file with dim and associated coordinate var. *\/ */
+   /*    sprintf(file_name, "%s_non_coord_to_dim.nc", TEST_NAME); */
+   /*    if (nc_create(file_name, NC_CLOBBER|NC_NETCDF4|NC_CLASSIC_MODEL, &ncid)) ERR; */
+   /*    if (nc_def_dim(ncid, D1_NAME, DIM1_LEN, &dimid1)) ERR; */
+   /*    if (nc_def_dim(ncid, D2_NAME, DIM1_LEN, &dimid2)) ERR; */
+   /*    if (nc_def_var(ncid, D1_NAME, NC_INT, NDIM1, &dimid1, &varid1)) ERR; */
+   /*    if (nc_def_var(ncid, D2_NAME, NC_INT, NDIM1, &dimid2, &varid2)) ERR; */
+   /*    if (nc_close(ncid)) ERR; */
+
+   /*    /\* Open the file and rename the vars. *\/ */
+   /*    nc_set_log_level(4); */
+   /*    if (nc_open(file_name, NC_WRITE, &ncid)) ERR; */
+   /*    if (nc_rename_var(ncid, varid1, TMP_NAME)) ERR; */
+   /*    nc_sync(ncid); */
+   /*    /\* if (nc_rename_var(ncid, varid2, D1_NAME)) ERR; *\/ */
+   /*    /\* nc_sync(ncid); *\/ */
+   /*    /\* if (nc_rename_var(ncid, varid1, D2_NAME)) ERR; *\/ */
+   /*    if (nc_close(ncid)) ERR; */
+
+   /*    /\* Reopen file and check, *\/ */
+   /*    if (nc_open(file_name, NC_WRITE, &ncid)) ERR; */
+   /*    /\* if (nc_inq_dimid(ncid, D1_NAME, &dimid_in)) ERR; *\/ */
+   /*    /\* if (dimid_in != dimid1) ERR; *\/ */
+   /*    /\* if (nc_inq_dimid(ncid, D2_NAME, &dimid_in)) ERR; *\/ */
+   /*    /\* if (dimid_in != dimid2) ERR; *\/ */
+   /*    /\* if (nc_inq_dimid(ncid, TMP_NAME, &dimid_in) != NC_EBADDIM) ERR; *\/ */
+   /*    /\* if (nc_inq_varid(ncid, TMP_NAME, &varid_in)) ERR; *\/ */
+   /*    /\* if (varid_in != varid1) ERR; *\/ */
+   /*    /\* if (nc_inq_varid(ncid, D1_NAME, &varid_in)) ERR; *\/ */
+   /*    /\* if (varid_in != varid2) ERR; *\/ */
+   /*    if (nc_close(ncid)) ERR; */
+   /* } */
+   /* SUMMARIZE_ERR; */
+   FINAL_RESULTS;
+}


### PR DESCRIPTION
Part of #597.
Fixes #1307.

In this PR I fix the problem of vars changing order after a rename. After a var is renamed, it should have the same varid the next time the file is opened.

This includes all my outstanding PRs.

Part of #597.
Fixes #1305.
Fixes #1304.

This PR is ready to merge and should be merged soon so that rename work can continue.