### PR TITLE
URL with username+pwd in url is not working.

### DIFF
--- a/libdispatch/dauth.c
+++ b/libdispatch/dauth.c
@@ -160,8 +160,8 @@ NC_authsetup(NCauth* auth, NCURI* uri)
           if(ret) {nullfree(uri_hostport); return ret;}
 	    }
       }
-      setauthfield(auth,"HTTP.USERNAME",user);
-      setauthfield(auth,"HTTP.PASSWORD",pwd);
+      setauthfield(auth,"HTTP.CREDENTIALS.USERNAME",user);
+      setauthfield(auth,"HTTP.CREDENTIALS.PASSWORD",pwd);
       nullfree(user);
       nullfree(pwd);
       nullfree(uri_hostport);


### PR DESCRIPTION
re: esupport (DVK-211460)

Turns out it was a typo in libdispatch/dauth.c
Fix is to Change:
HTTP.USERNAME -> HTTP.CREDENTIALS.USERNAME
and
HTTP.PASSWORD-> HTTP.CREDENTIALS.PASSWORD