### PR TITLE
Add hack to deal with DAP2 signed byte conversion.

### DIFF
--- a/oc2/ochttp.c
+++ b/oc2/ochttp.c
@@ -138,6 +138,7 @@ ocfetchurl(CURL* curl, const char* url, NCbytes* buf, long* filetime)
 fail:
 	nclog(NCLOGERR, "curl error: %s", curl_easy_strerror(cstat));
 	switch (httpcode) {
+	case 400: stat = OC_EBADURL; break;
 	case 401: stat = OC_EAUTH; break;
 	case 404: stat = OC_ENOFILE; break;
 	case 500: stat = OC_EDAPSVC; break;


### PR DESCRIPTION
re: issue https://github.com/Unidata/netcdf-c/issues/1316

The DAP2 data model does not have a signed byte type,
but netcdf-3 does have (only) a signed byte type.
So, when converting a netcdf-3 signed byte typed variable to
a DAP2 unsigned byte, the following actions are taken by thredds:
1. The variable type is marked as DAP2 (unsigned) byte.
2. A special attribute, "_Unsigned=false" is set for the variable
3. The corresponding "_FillValue" attribute, if any, is up-converted
   to the DAP2 Int16 type in order to hold, with sign, any signed byte
   fill value.

On the netcdf-c side, this looks like a fillvalue type mismatch and causes
an error. Instead, the netcdf-c dap2 conversion code needs to recognize
this hack and undo it locally.

So this change looks for the above case, and if found, then it properly
converts the _FillValue type to netcdf-3 signed byte.

Since DAP2 supports both signed and unsigned integers of sizes 16 and 32 bits,
this should be the only hack needed (famous last words).

It may later be desirable for the thredds DAP2 converter to modify its
behavior as well.