### PR TITLE
Fix nc_test4/tst_filter.sh for big endian

### DIFF
--- a/nc_test4/ref_filteredvv.cdl
+++ b/nc_test4/ref_filteredvv.cdl
@@ -6,7 +6,6 @@ variables:
 	float var1(dim0, dim1) ;
 		var1:_Storage = "chunked" ;
 		var1:_ChunkSizes = 2, 2 ;
-		var1:_Endianness = "little" ;
 		var1:_Filter = "307,9,4" ;
 		var1:_NoFill = "true" ;
 
@@ -25,7 +24,6 @@ group: g {
   	float var2(dim0, dim1) ;
   		var2:_Storage = "chunked" ;
   		var2:_ChunkSizes = 2, 2 ;
-  		var2:_Endianness = "little" ;
   		var2:_Filter = "307,9,4" ;
   		var2:_NoFill = "true" ;
 

--- a/nc_test4/tst_filter.sh
+++ b/nc_test4/tst_filter.sh
@@ -19,23 +19,18 @@ echo "findplugin.sh loaded"
 # Function to remove selected -s attributes from file;
 # These attributes might be platform dependent
 sclean() {
-cat $1 \
-  | sed -e '/var:_Endianness/d' \
-  | sed -e '/_NCProperties/d' \
-  | sed -e '/_SuperblockVersion/d' \
-  | sed -e '/_IsNetcdf4/d' \
-  | cat > $2
+    cat $1 \
+	| sed -e '/:_Endianness/d' \
+	| sed -e '/_NCProperties/d' \
+	| sed -e '/_SuperblockVersion/d' \
+	| sed -e '/_IsNetcdf4/d' \
+	| cat > $2
 }
 
 # Function to extract _Filter attribute from a file
 # These attributes might be platform dependent
 getfilterattr() {
-case "$1" in
-var1) sed -e '/var1:_Filter/p' -ed <$1 >$2 ;;
-var2) sed -e '/var2:_Filter/p' -ed <$1 >$2 ;;
-var) sed -e '/var:_Filter/p' -ed <$1 >$2 ;;
-*) sed -e '/var:_Filter/p' -ed <$1 >$2 ;;
-esac
+sed -e '/var.*:_Filter/p' -ed <$1 >$2
 }
 
 trimleft() {

--- a/nc_test4/tst_filterparser.c
+++ b/nc_test4/tst_filterparser.c
@@ -11,6 +11,8 @@
 #include "netcdf.h"
 #include "netcdf_filter.h"
 
+#undef DEBUG
+
 #define PARAMS_ID 32768
 
 /* The C standard apparently defines all floating point constants as double;
@@ -177,7 +179,7 @@ buildbaseline(void)
     val8 = 18446744073709551615UL;
     insert(12,&val8,sizeof(val8)); /* unsigned long long */
     float8 = DBLVAL;
-    insert(114,&float8,sizeof(float8)); /* double */
+    insert(14,&float8,sizeof(float8)); /* double */
 }
 
 /**************************************************/
@@ -240,7 +242,8 @@ main(int argc, char **argv)
     return (nerrs > 0 ? 1 : 0);
 }
 
-#if 0
+#ifdef DEBUG
+
 /* Look at q0 and q1) to determine type */
 static int
 gettype(const int q0, const int q1, int* isunsignedp)
@@ -470,4 +473,5 @@ NC_filterfix8(unsigned char* mem, int decode)
 #endif	    
 }
 
-#endif /*0*/
+#endif /*DEBUG*/
+

--- a/plugins/H5Zutil.c
+++ b/plugins/H5Zutil.c
@@ -48,10 +48,9 @@ byteswap4(unsigned char* mem)
 void
 NC_filterfix8(void* mem0, int decode)
 {
-
-unsigned char* mem = mem0;
 #ifdef WORDS_BIGENDIAN
- if(decode) { /* Apply inverse of the encode case */
+    unsigned char* mem = mem0;
+    if(decode) { /* Apply inverse of the encode case */
 	byteswap4(mem); /* step 1: byte-swap each piece */
 	byteswap4(mem+4);
 	byteswap8(mem); /* step 2: convert to little endian format */
@@ -61,8 +60,6 @@ unsigned char* mem = mem0;
 	byteswap4(mem+4);
     }
 #else /* Little endian */
-
-
     /* No action is necessary */
 #endif
 }


### PR DESCRIPTION
re: issue https://github.com/Unidata/netcdf-c/issues/1338

Changes:

1. nc_test4/tst_filter.sh + nc_test4/ref_filteredvv.cdl --
   properly suppress _Endianness attribute
2. fix some warnings