### PR TITLE
move checking for flag conflict to nc_create_par

### DIFF
--- a/include/netcdf.h
+++ b/include/netcdf.h
@@ -150,17 +150,15 @@ Use this in mode flags for both nc_create() and nc_open(). */
 
 #define NC_NETCDF4       0x1000  /**< Use netCDF-4/HDF5 format. Mode flag for nc_create(). */
 
-/** Turn on MPI I/O.
-Use this in mode flags for both nc_create() and nc_open(). */
+/** The following 3 flags are deprecated as of 4.6.2. Parallel I/O is now
+ * initiated by calling nc_create_par and nc_open_par, no longer by flags.
+ */
 #define NC_MPIIO         0x2000 /**< \deprecated */
-/** Turn on MPI POSIX I/O.
-Use this in mode flags for both nc_create() and nc_open(). */
-#define NC_MPIPOSIX      NC_MPIIO /**< \deprecated As of libhdf5 1.8.13. Now an alias */
+#define NC_MPIPOSIX      NC_MPIIO /**< \deprecated */
+#define NC_PNETCDF       (NC_MPIIO) /**< \deprecated */
 
 #define NC_PERSIST       0x4000  /**< Save diskless contents to disk. Mode flag for nc_open() or nc_create() */
 #define NC_INMEMORY      0x8000  /**< Read from memory. Mode flag for nc_open() or nc_create() */
-
-#define NC_PNETCDF       (NC_MPIIO) /**< \deprecated Use PnetCDF library; alias for NC_MPIIO. */
 
 #define NC_MAX_MAGIC_NUMBER_LEN 8 /**< Max len of user-defined format magic number. */
 

--- a/libdispatch/dfile.c
+++ b/libdispatch/dfile.c
@@ -1973,10 +1973,6 @@ check_create_mode(int mode)
     /* mmap is not allowed for netcdf-4 */
     if(mmap && (mode & NC_NETCDF4)) return NC_EINVAL;
 
-    /* Can't use both parallel and diskless|inmemory|mmap. */
-    if (mode & NC_MPIIO && mode & (NC_DISKLESS|NC_INMEMORY|NC_MMAP))
-	return NC_EINVAL;
-
 #ifndef USE_NETCDF4
    /* If the user asks for a netCDF-4 file, and the library was built
     * without netCDF-4, then return an error.*/

--- a/libdispatch/dparallel.c
+++ b/libdispatch/dparallel.c
@@ -123,6 +123,10 @@ int nc_create_par(const char *path, int cmode, MPI_Comm comm,
         return NC_ENOTBUILT;
 #endif
 
+    /* Can't use both parallel and diskless|inmemory|mmap. */
+    if (cmode & (NC_DISKLESS|NC_INMEMORY|NC_MMAP))
+        return NC_EINVAL;
+
     data.comm = comm;
     data.info = info;
     return NC_create(path, cmode, 0, 0, NULL, 1, &data, ncidp);


### PR DESCRIPTION
As NC_MPIIO has deprecated, move checking for flag conflict of parallel and diskless|inmemory|mmap to nc_create_par.