### PR TITLE
Support installation of the bzip2 plugin under name libh5bzip2.so

### DIFF
--- a/examples/C/run_filter.sh
+++ b/examples/C/run_filter.sh
@@ -18,7 +18,7 @@ echo "*** running test_filter example..."
 
 # Locate the plugin path and the library names; argument order is critical
 # Find bzip2 and capture
-findplugin bzip2
+findplugin h5bzip2
 BZIP2PATH="${HDF5_PLUGIN_PATH}/${HDF5_PLUGIN_LIB}"
 # Verify
 if ! test -f ${BZIP2PATH} ; then echo "Unable to locate ${BZIP2PATH}"; exit 1; fi

--- a/nc_test4/tst_filter.sh
+++ b/nc_test4/tst_filter.sh
@@ -39,7 +39,7 @@ sed -e 's/[ 	]*\([^ 	].*\)/\1/' <$1 >$2
 
 # Locate the plugin path and the library names; argument order is critical
 # Find bzip2 and capture
-findplugin bzip2
+findplugin h5bzip2
 BZIP2PATH="${HDF5_PLUGIN_PATH}/${HDF5_PLUGIN_LIB}"
 # Find misc and capture
 findplugin misc

--- a/ncdump/Makefile.am
+++ b/ncdump/Makefile.am
@@ -4,10 +4,10 @@
 
 # Ed Hartnett, Dennis Heimbigner, Ward Fisher
 
-SH_LOG_DRIVER = $(SHELL) $(top_srcdir)/test-driver-verbose
-sh_LOG_DRIVER = $(SHELL) $(top_srcdir)/test-driver-verbose
-LOG_DRIVER = $(SHELL) $(top_srcdir)/test-driver-verbose
-TESTS_ENVIRONMENT = export SETX=1;
+#SH_LOG_DRIVER = $(SHELL) $(top_srcdir)/test-driver-verbose
+#sh_LOG_DRIVER = $(SHELL) $(top_srcdir)/test-driver-verbose
+#LOG_DRIVER = $(SHELL) $(top_srcdir)/test-driver-verbose
+#TESTS_ENVIRONMENT = export SETX=1;
 
 # Put together AM_CPPFLAGS and AM_LDFLAGS.
 include $(top_srcdir)/lib_flags.am

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -6,7 +6,7 @@
 # See netcdf-c/COPYRIGHT file for more info.
 SET(CMAKE_BUILD_TYPE "")
 
-SET(libbzip2_SOURCES blocksort.c huffman.c crctable.c randtable.c compress.c decompress.c bzlib.c H5Zbzip2.c)
+SET(libh5bzip2_SOURCES blocksort.c huffman.c crctable.c randtable.c compress.c decompress.c bzlib.c H5Zbzip2.c)
 
 SET(libmisc_SOURCES H5Zmisc.c H5Zutil.c h5misc.h)
 
@@ -23,11 +23,11 @@ ENDIF()
 
 # Note we use name test_bzip2 instead of bzip2 to avoid logical
 # target name clash with examples/C/hdf5plugins
-ADD_LIBRARY(test_bzip2 MODULE ${libbzip2_SOURCES})
+ADD_LIBRARY(test_bzip2 MODULE ${libh5bzip2_SOURCES})
 SET_TARGET_PROPERTIES(test_bzip2 PROPERTIES OUTPUT_NAME "bzip2")
-SET_TARGET_PROPERTIES(test_bzip2 PROPERTIES LIBRARY_OUTPUT_NAME "bzip2")
-SET_TARGET_PROPERTIES(test_bzip2 PROPERTIES ARCHIVE_OUTPUT_NAME "bzip2")
-SET_TARGET_PROPERTIES(test_bzip2 PROPERTIES RUNTIME_OUTPUT_NAME "bzip2")
+SET_TARGET_PROPERTIES(test_bzip2 PROPERTIES LIBRARY_OUTPUT_NAME "h5bzip2")
+SET_TARGET_PROPERTIES(test_bzip2 PROPERTIES ARCHIVE_OUTPUT_NAME "h5bzip2")
+SET_TARGET_PROPERTIES(test_bzip2 PROPERTIES RUNTIME_OUTPUT_NAME "h5bzip2")
 TARGET_LINK_LIBRARIES(test_bzip2 ${ALL_TLL_LIBS})
 
 ADD_LIBRARY(misc MODULE ${libmisc_SOURCES})

--- a/plugins/Makefile.am
+++ b/plugins/Makefile.am
@@ -16,10 +16,11 @@ HDF5PLUGINSRC=${PLUGINSRC} ${BZIP2SRC} ${PLUGINHDRS} ${BZIP2HDRS}
 
 if ENABLE_FILTER_TESTING
 
-lib_LTLIBRARIES = libbzip2.la libmisc.la
+noinst_LTLIBRARIES = libmisc.la
+lib_LTLIBRARIES = libh5bzip2.la
 
-libbzip2_la_SOURCES = ${HDF5PLUGINSRC}
-libbzip2_la_LDFLAGS = -module -avoid-version -shared -export-dynamic -no-undefined
+libh5bzip2_la_SOURCES = ${HDF5PLUGINSRC}
+libh5bzip2_la_LDFLAGS = -module -avoid-version -shared -export-dynamic -no-undefined
 
 libmisc_la_SOURCES = H5Zmisc.c H5Zutil.c h5misc.h
 libmisc_la_LDFLAGS = -module -avoid-version -shared -export-dynamic -no-undefined -rpath ${abs_builddir}


### PR DESCRIPTION
re: https://github.com/Unidata/netcdf-c/issues/1347

It turns out that the plugin libraries (bzip2 and misc) were
being installed as part of 'make install'. This was not intended
behavior. But after some discussion in the above issue, it was decided
to install the bzip2 plugin. However, in order to avoid naming conflicts,
the plugin is installed under the name 'libh5bzip2.so'.
Note that this is automake behavior only; the install does not
(yet) occur using cmake.

Misc. unrelated changes
-----------------------
1. turn off some debug output in ncdump/Makefile.am