### PR TITLE
Add Repology badge showing downstream package repos that carry netcdf-c

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://travis-ci.org/Unidata/netcdf-c.svg?branch=master)](https://travis-ci.org/Unidata/netcdf-c)
 [![Coverity Scan Build Status](https://scan.coverity.com/projects/157/badge.svg)](https://scan.coverity.com/projects/157)
+[![latest packaged version(s)](https://repology.org/badge/latest-versions/netcdf.svg)](https://repology.org/project/netcdf/badges)
 
 ### About
 The Unidata network Common Data Form (**netCDF**) is an interface for


### PR DESCRIPTION
Repology shows you in which repositories a given project is packaged, which version is the latest and which needs updating, who maintains the package, and other related information. Repology might be useful for package maintainers, software authors, and end users.