### PR TITLE
removed unrelaxed coord bounds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -246,15 +246,6 @@ AC_ARG_ENABLE([remote-fortran-bootstrap], [AS_HELP_STRING([--enable-remote-fortr
 test "x$enable_remote_fortran_bootstrap" = xyes || enable_remote_fortran_bootstrap=no
 AC_MSG_RESULT([$enable_remote_fortran_bootstrap])
 
-# Does the user want to run extra example tests
-AC_MSG_CHECKING([whether extra example tests should be run])
-AC_ARG_ENABLE([extra-example-tests],
-              [AS_HELP_STRING([--enable-extra-example-tests],
-                              [Run extra example tests; requires GNU sed. Ignored if \
-                               netCDF-4 is not enabled.])])
-test "x$enable_extra_example_tests" = xyes || enable_extra_example_tests=no
-AC_MSG_RESULT($enable_extra_example_tests)
-
 # Does the user want to run extra parallel tests when parallel netCDF-4 is built?
 AC_MSG_CHECKING([whether parallel IO tests should be run])
 AC_ARG_ENABLE([parallel-tests],
@@ -1259,7 +1250,6 @@ AM_CONDITIONAL(ENABLE_CDF5, [test "x$enable_cdf5" = xyes])
 AM_CONDITIONAL(ENABLE_DAP_REMOTE_TESTS, [test "x$enable_dap_remote_tests" = xyes])
 AM_CONDITIONAL(ENABLE_DAP_AUTH_TESTS, [test "x$enable_dap_auth_tests" = xyes])
 AM_CONDITIONAL(ENABLE_DAP_LONG_TESTS, [test "x$enable_dap_long_tests" = xyes])
-AM_CONDITIONAL(EXTRA_EXAMPLE_TESTS, [test "x$enable_extra_example_tests" = xyes])
 AM_CONDITIONAL(USE_SZIP, [test "x$ac_cv_func_H5Z_SZIP" = xyes])
 AM_CONDITIONAL(USE_PNETCDF_DIR, [test ! "x$PNETCDFDIR" = x])
 AM_CONDITIONAL(USE_LOGGING, [test "x$enable_logging" = xyes])

--- a/configure.ac
+++ b/configure.ac
@@ -1477,9 +1477,9 @@ cd $srcdir
 abs_top_srcdir=`pwd`
 cd $abs_top_builddir
 
-
 AC_SUBST([ISCMAKE], [])
 AC_SUBST([MSVC], [])
+
 AC_MSG_NOTICE([generating header files, makefiles, generated tests, and nc-config])
 AC_CONFIG_FILES(test_common.sh:test_common.in)
 AC_CONFIG_FILES(nc_test4/findplugin.sh:nc_test4/findplugin.in)

--- a/configure.ac
+++ b/configure.ac
@@ -1194,10 +1194,8 @@ AC_ARG_ENABLE([erange_fill],
 
 dnl Always build with relaxed coord bound checking, to prevent API
 dnl incompatibilities between different installs of netCDF.
-AC_ARG_ENABLE([zero-length-coord-bound],
-   [AS_HELP_STRING([--disable-zero-length-coord-bound],
-                   [Disable relaxed boundary error check. Deprecated. Using this can cause API incompatibilities. This option will be removed in the next release of netCDF.])])
-test "x$enable_zero_length_coord_bound" = xno || enable_zero_length_coord_bound=yes
+enable_zero_length_coord_bound=yes
+AC_DEFINE([RELAX_COORD_BOUND], [1], [if true, NC_EINVALCOORDS check is more relaxed])
 
 # check PnetCDF's settings on enable_erange_fill and relax_coord_bound
 if test "x$enable_pnetcdf" = xyes; then
@@ -1233,10 +1231,6 @@ if test "x$enable_pnetcdf" = xyes; then
 else
    # default setting
    enable_erange_fill=no
-fi
-
-if test "x$enable_zero_length_coord_bound" = xyes; then
-   AC_DEFINE([RELAX_COORD_BOUND], [1], [if true, NC_EINVALCOORDS check is more relaxed])
 fi
 
 if test "x$enable_erange_fill" = xyes ; then
@@ -1424,9 +1418,7 @@ AC_SUBST(HAS_PARALLEL4,[$enable_parallel4])
 AC_SUBST(HAS_DISKLESS,[yes])
 AC_SUBST(HAS_MMAP,[$enable_mmap])
 AC_SUBST(HAS_JNA,[$enable_jna])
-AC_SUBST(RELAX_COORD_BOUND,[$enable_zero_length_coord_bound])
 AC_SUBST(HAS_ERANGE_FILL,[$enable_erange_fill])
-
 
 # Include some specifics for netcdf on windows.
 #AH_VERBATIM([_WIN32_STRICMP],

--- a/configure.ac
+++ b/configure.ac
@@ -1466,6 +1466,10 @@ AX_SET_META([NC_HAS_CDF5],[$enable_cdf5],[yes])
 AX_SET_META([NC_HAS_ERANGE_FILL], [$enable_erange_fill],[yes])
 AX_SET_META([NC_RELAX_COORD_BOUND], [$enable_zero_length_coord_bound],[yes])
 
+#####
+# End netcdf_meta.h definitions.
+#####
+
 # Automake says that this is always run in top_builddir
 # and that srcdir is defined (== top_srcdir)
 abs_top_builddir=`pwd`
@@ -1473,26 +1477,15 @@ cd $srcdir
 abs_top_srcdir=`pwd`
 cd $abs_top_builddir
 
-# test_common.sh setup
-AC_CONFIG_FILES(test_common.sh:test_common.in)
-#rm -f ${abs_top_builddir}/test_common.sh
-#sed -e "s|@TOPSRCDIR@|${abs_top_srcdir}|" -e "s|@TOPBUILDDIR@|${abs_top_builddir}|" <${abs_top_srcdir}/test_common.in >${abs_top_builddir}/test_common.sh
 
-# nc_test4/findplugin.sh setup
 AC_SUBST([ISCMAKE], [])
 AC_SUBST([MSVC], [])
+AC_MSG_NOTICE([generating header files, makefiles, generated tests, and nc-config])
+AC_CONFIG_FILES(test_common.sh:test_common.in)
 AC_CONFIG_FILES(nc_test4/findplugin.sh:nc_test4/findplugin.in)
 AC_CONFIG_FILES(examples/C/findplugin.sh:nc_test4/findplugin.in)
-
-# DAP 2/4 findtestserver[4].c setup
 AC_CONFIG_FILES(ncdap_test/findtestserver.c:ncdap_test/findtestserver.c.in)
 AC_CONFIG_FILES(dap4_test/findtestserver4.c:ncdap_test/findtestserver.c.in)
-
-#####
-# End netcdf_meta.h definitions.
-#####
-
-AC_MSG_NOTICE([generating header files and makefiles])
 AC_CONFIG_FILES([nc_test4/run_par_test.sh], [chmod ugo+x nc_test4/run_par_test.sh])
 AC_CONFIG_FILES([nc_test4/run_par_bm_test.sh], [chmod ugo+x nc_test4/run_par_bm_test.sh])
 AC_CONFIG_FILES([examples/C/run_par_test.sh], [chmod ugo+x examples/C/run_par_test.sh])

--- a/configure.ac
+++ b/configure.ac
@@ -367,7 +367,7 @@ if test "x$enable_dap" = "xno" ; then
 fi
 AC_MSG_RESULT($enable_dap_remote_tests)
 
-# Default is now to do the remote authorization tests
+# Default is not to do the remote authorization tests
 AC_MSG_CHECKING([whether dap remote authorization testing should be enabled (default off)])
 AC_ARG_ENABLE([dap-auth-tests],
               [AS_HELP_STRING([--enable-dap-auth-tests],

--- a/configure.ac
+++ b/configure.ac
@@ -1,12 +1,9 @@
 #                                               -*- Autoconf -*-
 ## Process this file with autoconf to produce a configure script.
 
-# This is part of Unidata's netCDF package. Copyright 2005-2018, see
+# This is part of Unidata's netCDF package. Copyright 2005-2019, see
 # the COPYRIGHT file for more information.
 # Ed Hartnett, Ward Fisher, Dennis Heimbigner
-
-# Recall that ${VAR-exp} expands to $VAR if var is set (even to null),
-# and to exp otherwise.
 
 # Running autoconf on this file will trigger a warning if
 # autoconf is not at least the specified version.

--- a/configure.ac
+++ b/configure.ac
@@ -639,15 +639,6 @@ AC_ARG_WITH([udf1-magic-number],
             [UDF1_MAGIC_NUMBER=$with_udf1_magic_number])
 AC_MSG_RESULT([$UDF1_MAGIC_NUMBER])
 
-# Did the user specify a default cache preemption?
-AC_MSG_CHECKING([whether a default cache preemption for HDF5 was specified])
-AC_ARG_WITH([chunk-cache-preemption],
-              [AS_HELP_STRING([--with-chunk-cache-preemption=<float between 0 and 1 inclusive>],
-                              [Specify default file chunk cache preemption policy for HDF5 files (a number between 0 and 1, inclusive).])],
-            [CHUNK_CACHE_PREEMPTION=$with_chunk_cache_preemption], [CHUNK_CACHE_PREEMPTION=0.75])
-AC_MSG_RESULT([$CHUNK_CACHE_PREEMPTION])
-AC_DEFINE_UNQUOTED([CHUNK_CACHE_PREEMPTION], [$CHUNK_CACHE_PREEMPTION], [default file chunk cache preemption policy.])
-
 # According to the autoconf mailing list gurus, we must test for
 # compilers unconditionally. That is, we can't skip looking for the
 # fortran compilers, just because the user doesn't want fortran. This

--- a/configure.ac
+++ b/configure.ac
@@ -1173,9 +1173,8 @@ AC_ARG_ENABLE([erange_fill],
 
 dnl Always build with relaxed coord bound checking, to prevent API
 dnl incompatibilities between different installs of netCDF.
-enable_zero_length_coord_bound=yes
 AC_DEFINE([RELAX_COORD_BOUND], [1], [if true, NC_EINVALCOORDS check is more relaxed])
-AC_SUBST(RELAX_COORD_BOUND, [$enable_zero_length_coord_bound])
+AC_SUBST(RELAX_COORD_BOUND, [yes])
 
 # check PnetCDF's settings on enable_erange_fill and relax_coord_bound
 if test "x$enable_pnetcdf" = xyes; then

--- a/configure.ac
+++ b/configure.ac
@@ -1196,6 +1196,7 @@ dnl Always build with relaxed coord bound checking, to prevent API
 dnl incompatibilities between different installs of netCDF.
 enable_zero_length_coord_bound=yes
 AC_DEFINE([RELAX_COORD_BOUND], [1], [if true, NC_EINVALCOORDS check is more relaxed])
+AC_SUBST(RELAX_COORD_BOUND, [$enable_zero_length_coord_bound])
 
 # check PnetCDF's settings on enable_erange_fill and relax_coord_bound
 if test "x$enable_pnetcdf" = xyes; then

--- a/configure.ac
+++ b/configure.ac
@@ -1495,6 +1495,7 @@ AC_CONFIG_FILES(dap4_test/findtestserver4.c:ncdap_test/findtestserver.c.in)
 AC_MSG_NOTICE([generating header files and makefiles])
 AC_CONFIG_FILES([nc_test4/run_par_test.sh], [chmod ugo+x nc_test4/run_par_test.sh])
 AC_CONFIG_FILES([nc_test4/run_par_bm_test.sh], [chmod ugo+x nc_test4/run_par_bm_test.sh])
+AC_CONFIG_FILES([examples/C/run_par_test.sh], [chmod ugo+x examples/C/run_par_test.sh])
 AC_CONFIG_FILES([nc-config], [chmod 755 nc-config])
 AC_CONFIG_FILES([Makefile
                  netcdf.pc

--- a/examples/C/Makefile.am
+++ b/examples/C/Makefile.am
@@ -36,13 +36,13 @@ endif #USE_HDF5
 if USE_PNETCDF
 # This is the pnetcdf example.
 check_PROGRAMS += parallel_vara
-TESTS += parallel_vara
+TESTS += run_par_test.sh
 endif #USE_PNETCDF
 
 # These files are created by the tests.
 CLEANFILES = *.nc
 
 EXTRA_DIST = CMakeLists.txt run_examples.sh run_examples4.sh	\
-run_filter.sh
+run_filter.sh run_par_test.sh.in
 
-DISTCLEANFILES = findplugin.sh
+DISTCLEANFILES = findplugin.sh run_par_test.sh

--- a/examples/C/Makefile.am
+++ b/examples/C/Makefile.am
@@ -34,7 +34,7 @@ endif
 endif #USE_HDF5
 
 if USE_PNETCDF
-# These are the extra pnetcdf examples.
+# This is the pnetcdf example.
 check_PROGRAMS += parallel_vara
 TESTS += parallel_vara
 endif #USE_PNETCDF
@@ -42,6 +42,7 @@ endif #USE_PNETCDF
 # These files are created by the tests.
 CLEANFILES = *.nc
 
-EXTRA_DIST = CMakeLists.txt run_examples.sh run_examples4.sh run_filter.sh
+EXTRA_DIST = CMakeLists.txt run_examples.sh run_examples4.sh	\
+run_filter.sh
 
 DISTCLEANFILES = findplugin.sh

--- a/examples/C/Makefile.am
+++ b/examples/C/Makefile.am
@@ -11,40 +11,33 @@
 
 LDADD = -lm
 AM_CPPFLAGS = -I$(top_srcdir)/include
-AM_LDFLAGS =
+AM_CPPFLAGS += -I$(top_builddir)/liblib
+AM_LDFLAGS = ${top_builddir}/liblib/libnetcdf.la
 
 # These are the netCDF-3 examples.
 check_PROGRAMS = simple_xy_wr simple_xy_rd sfc_pres_temp_wr	\
 sfc_pres_temp_rd pres_temp_4D_wr pres_temp_4D_rd
-
 TESTS = run_examples.sh
 
 # To build netcdf-4, or not to build netcdf-4, that is the question...
 if USE_HDF5
-# These are the extra netCDF-4 examples.
+# These are the netCDF-4 examples.
 check_PROGRAMS += simple_nc4_wr simple_nc4_rd simple_xy_nc4_wr	\
 simple_xy_nc4_rd
+TESTS += run_examples4.sh
 
 if ENABLE_FILTER_TESTING
 # filter_example.c should be same as nc_test4/test_filter.c
 check_PROGRAMS += filter_example
 TESTS += run_filter.sh
 endif
-
 endif #USE_HDF5
 
 if USE_PNETCDF
-# These are the extra netCDF-4 examples.
+# These are the extra pnetcdf examples.
 check_PROGRAMS += parallel_vara
 TESTS += parallel_vara
 endif #USE_PNETCDF
-
-AM_CPPFLAGS += -I$(top_builddir)/liblib
-AM_LDFLAGS += ${top_builddir}/liblib/libnetcdf.la
-
-if USE_HDF5
-TESTS += run_examples4.sh
-endif #USE_HDF5
 
 # These files are created by the tests.
 CLEANFILES = *.nc

--- a/examples/C/run_par_test.sh.in
+++ b/examples/C/run_par_test.sh.in
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# This .in file is processed at build time into a shell that runs a
+# parallel I/O example for pnetcdf.
+
+# Ed Hartnett
+
+set -e
+echo
+echo "Runnung pnetcdf parallel I/O example..."
+@MPIEXEC@ -n 4 ./parallel_vara
+echo '*** SUCCESS!!!'

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -15,4 +15,4 @@ endif
 # These are the subdirectories that will be built.
 SUBDIRS = C $(CDL_DIR)
 
-EXTRA_DIST=CMakeLists.txt
+EXTRA_DIST = CMakeLists.txt

--- a/libdispatch/dvarget.c
+++ b/libdispatch/dvarget.c
@@ -226,11 +226,7 @@ NCDEFAULT_get_vars(int ncid, int varid, const size_t * start,
         /* illegal value checks */
 	dimlen = (i == 0 && isrecvar ? numrecs : varshape[i]);
         /* mystart is unsigned, never < 0 */
-#ifdef RELAX_COORD_BOUND
 	if (mystart[i] > dimlen) return NC_EINVALCOORDS;
-#else
-	if (mystart[i] >= dimlen) return NC_EINVALCOORDS;
-#endif
 	if(edges == NULL) {
 	   if(i == 0 && isrecvar)
   	      myedges[i] = numrecs - start[i];
@@ -238,9 +234,7 @@ NCDEFAULT_get_vars(int ncid, int varid, const size_t * start,
 	      myedges[i] = varshape[i] - mystart[i];
 	} else
 	    myedges[i] = edges[i];
-#ifdef RELAX_COORD_BOUND
 	if (mystart[i] == dimlen && myedges[i] > 0) return NC_EINVALCOORDS;
-#endif
         /* myedges is unsigned, never < 0 */
 	if(mystart[i] + myedges[i] > dimlen)
 	  return NC_EEDGE;
@@ -416,11 +410,7 @@ NCDEFAULT_get_varm(int ncid, int varid, const size_t *start,
 	    ? start[idim]
 	    : 0;
 
-#ifdef RELAX_COORD_BOUND
 	 if (mystart[idim] > dimlen)
-#else
-	 if (mystart[idim] >= dimlen)
-#endif
 	 {
 	    status = NC_EINVALCOORDS;
 	    goto done;
@@ -441,13 +431,11 @@ NCDEFAULT_get_varm(int ncid, int varid, const size_t *start,
 	    myedges[idim] = varshape[idim] - mystart[idim];
 #endif
 
-#ifdef RELAX_COORD_BOUND
 	 if (mystart[idim] == dimlen && myedges[idim] > 0)
 	 {
 	    status = NC_EINVALCOORDS;
 	    goto done;
 	 }
-#endif
 
 	 if (mystart[idim] + myedges[idim] > dimlen)
 	 {

--- a/libhdf5/hdf5var.c
+++ b/libhdf5/hdf5var.c
@@ -1508,19 +1508,12 @@ NC4_put_vars(int ncid, int varid, const size_t *startp, const size_t *countp,
             endindex = start[d2]; /* fixup for zero read count */
         if (!dim->unlimited)
         {
-#ifdef RELAX_COORD_BOUND
             /* Allow start to equal dim size if count is zero. */
             if (start[d2] > (hssize_t)fdims[d2] ||
                 (start[d2] == (hssize_t)fdims[d2] && count[d2] > 0))
                 BAIL_QUIET(NC_EINVALCOORDS);
             if (!zero_count && endindex >= fdims[d2])
                 BAIL_QUIET(NC_EEDGE);
-#else
-            if (start[d2] >= (hssize_t)fdims[d2])
-                BAIL_QUIET(NC_EINVALCOORDS);
-            if (endindex >= fdims[d2])
-                BAIL_QUIET(NC_EEDGE);
-#endif
         }
     }
 
@@ -1842,15 +1835,10 @@ NC4_get_vars(int ncid, int varid, const size_t *startp, const size_t *countp,
                 BAIL(retval);
 
             /* Check for out of bound requests. */
-#ifdef RELAX_COORD_BOUND
             /* Allow start to equal dim size if count is zero. */
             if (start[d2] > (hssize_t)ulen ||
                 (start[d2] == (hssize_t)ulen && count[d2] > 0))
                 BAIL_QUIET(NC_EINVALCOORDS);
-#else
-            if (start[d2] >= (hssize_t)ulen && ulen > 0)
-                BAIL_QUIET(NC_EINVALCOORDS);
-#endif
             if (count[d2] && endindex >= ulen)
                 BAIL_QUIET(NC_EEDGE);
 
@@ -1872,15 +1860,10 @@ NC4_get_vars(int ncid, int varid, const size_t *startp, const size_t *countp,
         else /* Dim is not unlimited. */
         {
             /* Check for out of bound requests. */
-#ifdef RELAX_COORD_BOUND
             /* Allow start to equal dim size if count is zero. */
             if (start[d2] > (hssize_t)fdims[d2] ||
                 (start[d2] == (hssize_t)fdims[d2] && count[d2] > 0))
                 BAIL_QUIET(NC_EINVALCOORDS);
-#else
-            if (start[d2] >= (hssize_t)fdims[d2])
-                BAIL_QUIET(NC_EINVALCOORDS);
-#endif
             if (count[d2] && endindex >= fdims[d2])
                 BAIL_QUIET(NC_EEDGE);
 

--- a/nc_test/test_put.m4
+++ b/nc_test/test_put.m4
@@ -778,13 +778,8 @@ ifdef(`PNETCDF',`dnl
                 start[j] = 0;
                 continue;
             }
-#ifdef RELAX_COORD_BOUND
             IF (err != NC_NOERR) /* allowed when edge[j]==0 */
                 EXPECT_ERR(NC_NOERR, err)
-#else
-            IF (err != NC_EINVALCOORDS) /* not allowed even when edge[j]==0 */
-                EXPECT_ERR(NC_EINVALCOORDS, err)
-#endif
             ELSE_NOK
             start[j] = var_shape[i][j]+1; /* out of boundary check */
             err = PutVara($1)(ncid, i, start, edge, value);
@@ -1007,13 +1002,8 @@ ifdef(`PNETCDF',`dnl
                 start[j] = 0;
                 continue;
             }
-#ifdef RELAX_COORD_BOUND
             IF (err != NC_NOERR) /* allowed when edge[j]==0 */
                 EXPECT_ERR(NC_NOERR, err)
-#else
-            IF (err != NC_EINVALCOORDS) /* not allowed even when edge[j]==0 */
-                EXPECT_ERR(NC_EINVALCOORDS, err)
-#endif
             ELSE_NOK
             start[j] = var_shape[i][j]+1; /* out of boundary check */
             err = PutVars($1)(ncid, i, start, edge, stride, value);
@@ -1259,13 +1249,8 @@ ifdef(`PNETCDF',`dnl
                 start[j] = 0;
                 continue;
             }
-#ifdef RELAX_COORD_BOUND
             IF (err != NC_NOERR) /* allowed when edge[j]==0 */
                 EXPECT_ERR(NC_NOERR, err)
-#else
-            IF (err != NC_EINVALCOORDS) /* not allowed even when edge[j]==0 */
-                EXPECT_ERR(NC_EINVALCOORDS, err)
-#endif
             ELSE_NOK
             start[j] = var_shape[i][j]+1; /* out of boundary check */
             err = PutVarm($1)(ncid, i, start, edge, stride, imap, value);

--- a/nc_test/test_read.m4
+++ b/nc_test/test_read.m4
@@ -1207,13 +1207,8 @@ ifdef(`PNETCDF',`dnl
             if (var_dimid[i][j] == RECDIM) continue; /* skip record dim */
             start[j] = var_shape[i][j];
             err = GetVara(ncid, i, start, edge, buf, 0, datatype);
-#ifdef RELAX_COORD_BOUND
             IF (err != NC_NOERR) /* allowed when edge[j]==0 */
                 EXPECT_ERR(NC_NOERR, err)
-#else
-            IF (err != NC_EINVALCOORDS) /* not allowed even when edge[j]==0 */
-                EXPECT_ERR(NC_EINVALCOORDS, err)
-#endif
             ELSE_NOK
             start[j] = var_shape[i][j]+1;  /* out of boundary check */
             err = GetVara(ncid, i, start, edge, buf, 1, datatype);
@@ -1399,13 +1394,8 @@ ifdef(`PNETCDF',`dnl
             if (var_dimid[i][j] == RECDIM) continue; /* skip record dim */
             start[j] = var_shape[i][j];
             err = GetVars(ncid, i, start, edge, stride, buf, 0, datatype);
-#ifdef RELAX_COORD_BOUND
             IF (err != NC_NOERR) /* allowed when edge[j]==0 */
                 EXPECT_ERR(NC_NOERR, err)
-#else
-            IF (err != NC_EINVALCOORDS) /* not allowed even when edge[j]==0 */
-                EXPECT_ERR(NC_EINVALCOORDS, err)
-#endif
             ELSE_NOK
             start[j] = var_shape[i][j]+1;  /* out of boundary check */
             err = GetVars(ncid, i, start, edge, stride, buf, 1, datatype);
@@ -1628,13 +1618,8 @@ ifdef(`PNETCDF',`dnl
             if (var_dimid[i][j] == RECDIM) continue; /* skip record dim */
             start[j] = var_shape[i][j];
             err = GetVarm(ncid, i, start, edge, stride, imap, buf, 0, datatype);
-#ifdef RELAX_COORD_BOUND
             IF (err != NC_NOERR) /* allowed when edge[j]==0 */
                 EXPECT_ERR(NC_NOERR, err)
-#else
-            IF (err != NC_EINVALCOORDS) /* not allowed even when edge[j]==0 */
-                EXPECT_ERR(NC_EINVALCOORDS, err)
-#endif
             ELSE_NOK
             start[j] = var_shape[i][j]+1;  /* out of boundary check */
             err = GetVarm(ncid, i, start, edge, stride, imap, buf, 1, datatype);

--- a/nc_test/test_write.m4
+++ b/nc_test/test_write.m4
@@ -1043,13 +1043,8 @@ ifdef(`PNETCDF',`dnl
             if (var_dimid[i][j] == RECDIM) continue; /* skip record dim */
             start[j] = var_shape[i][j];
             err = PutVara(ncid, i, start, edge, buf, 0, datatype);
-#ifdef RELAX_COORD_BOUND
             IF (err != NC_NOERR) /* allowed when edge[j]==0 */
                 EXPECT_ERR(NC_NOERR, err)
-#else
-            IF (err != NC_EINVALCOORDS) /* not allowed even when edge[j]==0 */
-                EXPECT_ERR(NC_EINVALCOORDS, err)
-#endif
             ELSE_NOK
             start[j] = var_shape[i][j]+1; /* out of boundary check */
             err = PutVara(ncid, i, start, edge, buf, 1, datatype);
@@ -1236,13 +1231,8 @@ ifdef(`PNETCDF',`dnl
             if (var_dimid[i][j] == 0) continue; /* skip record dim */
             start[j] = var_shape[i][j];
             err = PutVars(ncid, i, start, edge, stride, buf, 0, datatype);
-#ifdef RELAX_COORD_BOUND
             IF (err != NC_NOERR) /* allowed when edge[j]==0 */
                 EXPECT_ERR(NC_NOERR, err)
-#else
-            IF (err != NC_EINVALCOORDS) /* not allowed even when edge[j]==0 */
-                EXPECT_ERR(NC_EINVALCOORDS, err)
-#endif
             ELSE_NOK
             start[j] = var_shape[i][j]+1; /* out of boundary check */
             err = PutVars(ncid, i, start, edge, stride, buf, 1, datatype);
@@ -1459,13 +1449,8 @@ ifdef(`PNETCDF',`dnl
             if (var_dimid[i][j] == 0) continue; /* skip record dim */
             start[j] = var_shape[i][j];
             err = PutVarm(ncid, i, start, edge, stride, imap, buf, 0, datatype);
-#ifdef RELAX_COORD_BOUND
             IF (err != NC_NOERR) /* allowed when edge[j]==0 */
                 EXPECT_ERR(NC_NOERR, err)
-#else
-            IF (err != NC_EINVALCOORDS) /* not allowed even when edge[j]==0 */
-                EXPECT_ERR(NC_EINVALCOORDS, err)
-#endif
             ELSE_NOK
             start[j] = var_shape[i][j]+1; /* out of boundary check */
             err = PutVarm(ncid, i, start, edge, stride, imap, buf, 1, datatype);

--- a/nc_test4/Makefile.am
+++ b/nc_test4/Makefile.am
@@ -98,8 +98,8 @@ if TEST_PARALLEL4
 TESTS += run_par_bm_test.sh
 # This benchmark depends on tst_create_files being run.
 run_par_bm_test.log: tst_create_files.log
-endif # BUILD_UTILITIES
 endif # TEST_PARALLEL4
+endif # BUILD_UTILITIES
 endif # BUILD_BENCHMARKS
 
 # Szip Tests (requires ncdump)

--- a/nc_test4/Makefile.am
+++ b/nc_test4/Makefile.am
@@ -154,7 +154,7 @@ foo1.nc tst_*.h4 test.nc testszip.nc test.h5 szip_dump.cdl		\
 perftest.txt bigmeta.nc bigvars.nc *.gz MSGCPP_*.nc floats*.nc		\
 floats*.cdl shorts*.nc shorts*.cdl ints*.nc ints*.cdl
 
-DISTCLEANFILES = findplugin.sh run_par_test.sh
+DISTCLEANFILES = findplugin.sh run_par_test.sh run_par_bm_test.sh
 
 # If valgrind is present, add valgrind targets.
 @VALGRIND_CHECK_RULES@

--- a/nc_test4/Makefile.am
+++ b/nc_test4/Makefile.am
@@ -83,20 +83,22 @@ TESTS += tst_ar4_3d tst_create_files run_bm_elena.sh			\
 run_tst_chunks.sh tst_files3 tst_mem run_knmi_bm.sh tst_wrf_reads	\
 tst_attsperf
 
+run_bm_elena.log: tst_create_files.log tst_files.log
+
+# These tests depend on ncgen/ncdump.
 if BUILD_UTILITIES
 TESTS += run_bm_test2.sh run_bm_test1.sh
-endif
 
 # tst_create_files creates files for other tests.
 run_bm_test1.log: tst_create_files.log
 run_bm_test2.log: tst_create_files.log
-run_bm_elena.log: tst_create_files.log tst_files.log
 
 # This will run a parallel I/O benchmark for parallel builds.
 if TEST_PARALLEL4
 TESTS += run_par_bm_test.sh
 # This benchmark depends on tst_create_files being run.
 run_par_bm_test.log: tst_create_files.log
+endif # BUILD_UTILITIES
 endif # TEST_PARALLEL4
 endif # BUILD_BENCHMARKS
 

--- a/nc_test4/Makefile.am
+++ b/nc_test4/Makefile.am
@@ -34,7 +34,7 @@ tst_rename2 tst_rename3 tst_h5_endians tst_atts_string_rewrite		\
 tst_hdf5_file_compat tst_fill_attr_vanish tst_rehash tst_filterparser	\
 tst_bug324 tst_types tst_atts3 tst_put_vars tst_elatefill tst_udf
 
-# Temporary I hope
+# Temporary I hoped, but hoped in vain.
 if !ISCYGWIN
 NC4_TESTS += tst_h_strbug tst_h_refs
 endif
@@ -141,8 +141,9 @@ run_grp_rename.sh tst_h5_endians.c tst_atts_string_rewrite.c		\
 tst_put_vars_two_unlim_dim.c tst_empty_vlen_unlim.c			\
 run_empty_vlen_test.sh ref_hdf5_compat1.nc ref_hdf5_compat2.nc		\
 ref_hdf5_compat3.nc tst_misc.sh tdset.h5 tst_szip.sh ref_szip.h5	\
-ref_szip.cdl tst_filter.sh bzip2.cdl ref_filtered.cdl ref_unfiltered.cdl \
-ref_bzip2.c findplugin.in perftest.sh ref_unfilteredvv.cdl ref_filteredvv.cdl
+ref_szip.cdl tst_filter.sh bzip2.cdl ref_filtered.cdl			\
+ref_unfiltered.cdl ref_bzip2.c findplugin.in perftest.sh		\
+ref_unfilteredvv.cdl ref_filteredvv.cdl
 
 CLEANFILES = tst_mpi_parallel.bin cdm_sea_soundings.nc bm_chunking.nc	\
 tst_floats_1D.cdl floats_1D_3.nc floats_1D.cdl tst_*.nc			\
@@ -150,8 +151,8 @@ tst_floats2_*.cdl tst_ints2_*.cdl tst_shorts2_*.cdl tst_elena_*.cdl	\
 tst_simple*.cdl tst_chunks.cdl pr_A1.* tauu_A1.* usi_01.* thetau_01.*	\
 tst_*.h5 tst_grp_rename.cdl tst_grp_rename.dmp ref_grp_rename.cdl	\
 foo1.nc tst_*.h4 test.nc testszip.nc test.h5 szip_dump.cdl		\
-perftest.txt bigmeta.nc bigvars.nc *.gz MSGCPP_*.nc	\
-floats*.nc floats*.cdl shorts*.nc shorts*.cdl ints*.nc ints*.cdl
+perftest.txt bigmeta.nc bigvars.nc *.gz MSGCPP_*.nc floats*.nc		\
+floats*.cdl shorts*.nc shorts*.cdl ints*.nc ints*.cdl
 
 DISTCLEANFILES = findplugin.sh run_par_test.sh
 

--- a/nc_test4/Makefile.am
+++ b/nc_test4/Makefile.am
@@ -79,9 +79,13 @@ bm_file_SOURCES = bm_file.c tst_utils.c
 tst_knmi_SOURCES = tst_knmi.c tst_utils.c
 tst_wrf_reads_SOURCES = tst_wrf_reads.c tst_utils.c
 
-TESTS += tst_ar4_3d tst_create_files run_bm_test1.sh run_bm_elena.sh	\
-run_bm_test2.sh run_tst_chunks.sh tst_files3 tst_mem run_knmi_bm.sh	\
-tst_wrf_reads tst_attsperf
+TESTS += tst_ar4_3d tst_create_files run_bm_elena.sh			\
+run_tst_chunks.sh tst_files3 tst_mem run_knmi_bm.sh tst_wrf_reads	\
+tst_attsperf
+
+if BUILD_UTILITIES
+TESTS += run_bm_test2.sh run_bm_test1.sh
+endif
 
 # tst_create_files creates files for other tests.
 run_bm_test1.log: tst_create_files.log

--- a/nc_test4/tst_filter.sh
+++ b/nc_test4/tst_filter.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
 
-export SETX=1
 if test "x$srcdir" = x ; then srcdir=`pwd`; fi
 . ../test_common.sh
 

--- a/ncdump/Makefile.am
+++ b/ncdump/Makefile.am
@@ -7,7 +7,7 @@
 SH_LOG_DRIVER = $(SHELL) $(top_srcdir)/test-driver-verbose
 sh_LOG_DRIVER = $(SHELL) $(top_srcdir)/test-driver-verbose
 LOG_DRIVER = $(SHELL) $(top_srcdir)/test-driver-verbose
-TESTS_ENVIRONMENT = export SETX=1;
+#TESTS_ENVIRONMENT = export SETX=1;
 
 # Put together AM_CPPFLAGS and AM_LDFLAGS.
 include $(top_srcdir)/lib_flags.am

--- a/ncdump/run_tests.sh
+++ b/ncdump/run_tests.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # This shell script runs the ncdump tests.
-# $Id: run_tests.sh,v 1.18 2010/05/19 13:43:39 ed Exp $
+# Ed Hartnett, Dennis Heimbigner
 
 if test "x$srcdir" = x ; then srcdir=`pwd`; fi
 . ../test_common.sh


### PR DESCRIPTION
Fixes #1010.
Fixes #1355.
Fixes #1349.
Fixes #1357.
Fixes #1358.
Fixes #1356.

As discussed, we deprecated the option to turn off relaxed coord checking for a release.

Now it's time to remove the non-relaxed code from the build. Only relaxed coord checking will ever be allowed. This is necessary to support parallel I/O builds without creating installations of netcdf which react differently to the same code.

Also removed unused config option --enable-extra-example-tests. Also removed redundant option code for --with-chunk-cache-preemption.

Also added a run script to run the pnetcdf example code in parallel.