### PR TITLE
Fix nccopy to use NC_PERSIST so that -w actually persists the output.

### DIFF
--- a/docs/inmemory.md
+++ b/docs/inmemory.md
@@ -53,8 +53,9 @@ bytes in length. On a 64-bit machine, the size must be less than 2^64 bytes.
 
 Also note that for a diskless file, there are two notions of
 *write* with respect to the file. The first notion is that the
-file is read-only through the netCDF API. For example, if the file
-is read-only, then a call to, for example, _nc_def_dim()_ will fail.
+file is writeable through the netCDF API, but on disk, the file is
+read-only. This means a call to, for example, _nc_def_dim()_ will succeed,
+but no changes will be written to disk.
 The second notion of *write* refers to the file on disk to which 
 the contents of memory might be persisted.
 

--- a/ncdump/CMakeLists.txt
+++ b/ncdump/CMakeLists.txt
@@ -168,8 +168,10 @@ ENDIF(MSVC)
   ENDIF(CMAKE_COMPILER_IS_GNUCC OR APPLE)
 
   add_sh_test(ncdump tst_inmemory_nc3)
+  add_sh_test(ncdump tst_nccopy_w3)
   IF(USE_NETCDF4)
       add_sh_test(ncdump tst_inmemory_nc4)
+      add_sh_test(ncdump tst_nccopy_w4)
   ENDIF(USE_NETCDF4)
 
   IF(USE_NETCDF4)

--- a/ncdump/Makefile.am
+++ b/ncdump/Makefile.am
@@ -4,10 +4,10 @@
 
 # Ed Hartnett, Dennis Heimbigner, Ward Fisher
 
-SH_LOG_DRIVER = $(SHELL) $(top_srcdir)/test-driver-verbose
-sh_LOG_DRIVER = $(SHELL) $(top_srcdir)/test-driver-verbose
-LOG_DRIVER = $(SHELL) $(top_srcdir)/test-driver-verbose
-TESTS_ENVIRONMENT = export SETX=1;
+#SH_LOG_DRIVER = $(SHELL) $(top_srcdir)/test-driver-verbose
+#sh_LOG_DRIVER = $(SHELL) $(top_srcdir)/test-driver-verbose
+#LOG_DRIVER = $(SHELL) $(top_srcdir)/test-driver-verbose
+#TESTS_ENVIRONMENT = export SETX=1;
 
 # Put together AM_CPPFLAGS and AM_LDFLAGS.
 include $(top_srcdir)/lib_flags.am
@@ -93,9 +93,9 @@ tst_fillbug.log tst_netcdf4_4.log tst_h_scalar.log
 tst_nccopy5.log: tst_nccopy4.log
 endif #!USE_HDF5
 
-TESTS += tst_inmemory_nc3.sh
+TESTS += tst_inmemory_nc3.sh tst_nccopy_w3.sh
 if USE_HDF5
-TESTS += tst_inmemory_nc4.sh
+TESTS += tst_inmemory_nc4.sh tst_nccopy_w4.sh
 endif
 
 endif BUILD_TESTSETS
@@ -134,7 +134,8 @@ ref_nccopy3_subset.nc ref_test_corrupt_magic.nc tst_ncgen_shared.sh	\
 tst_ncgen4.sh tst_ncgen4_classic.sh tst_ncgen4_diff.sh			\
 tst_ncgen4_cycle.sh tst_null_byte_padding.sh				\
 ref_null_byte_padding_test.nc ref_tst_irish_rover.nc ref_provenance_v1.nc \
-ref_tst_radix.cdl tst_radix.cdl test_radix.sh 
+ref_tst_radix.cdl tst_radix.cdl test_radix.sh                           \
+ref_nccopy_w.cdl tst_nccopy_w3.sh tst_nccopy_w4.sh
 
 # The L512.bin file is file containing exactly 512 bytes each of value 0.
 # It is used for creating hdf5 files with varying offsets for testing.

--- a/ncdump/nccopy.c
+++ b/ncdump/nccopy.c
@@ -1894,7 +1894,7 @@ copy(char* infile, char* outfile)
     }
 
     if(option_write_diskless)
-	create_mode |= NC_WRITE | NC_DISKLESS; /* NC_WRITE persists diskless file on close */
+	create_mode |= NC_PERSIST | NC_DISKLESS; /* NC_WRITE persists diskless file on close */
     switch(outkind) {
     case NC_FORMAT_CLASSIC:
 	/* nothing to do */

--- a/ncdump/ref_nccopy_w.cdl
+++ b/ncdump/ref_nccopy_w.cdl
@@ -1,0 +1,15 @@
+netcdf nccopy_w {
+dimensions:
+	d = 3 ;
+variables:
+	byte b(d) ;
+	short s(d) ;
+	int i(d) ;
+data:
+
+ b = -127, 127, -1 ;
+
+ s = 32767, -32766, -1 ;
+
+ i = -2147483646, 2147483647, -1 ;
+}

--- a/ncdump/tst_nccopy_w3.sh
+++ b/ncdump/tst_nccopy_w3.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+if test "x$srcdir" = x ; then srcdir=`pwd`; fi 
+. ../test_common.sh
+
+set -e
+
+echo "*** Test nccopy -w on netcdf classic file"
+echo "*** create nccopy_w3.nc from ref_nccopy_w.cdl..."
+${NCGEN} -lb -o nccopy_w3.nc -N nccopy_w $srcdir/ref_nccopy_w.cdl
+echo "*** diskless copy nccopy_w3.nc to nccopy_w3c.nc..."
+${NCCOPY} -w nccopy_w3.nc nccopy_w3c.nc
+echo "*** Convert nccopy_w3c.nc to nccopy_w3c.cdl..."
+${NCDUMP} -n nccopy_w nccopy_w3c.nc > nccopy_w3c.cdl
+echo "*** comparing ref_nccopy_w.cdl nccopy_w3c.cdl..."
+diff -b -w $srcdir/ref_nccopy_w.cdl nccopy_w3c.cdl
+
+rm -f nccopy_w3c.cdl nccopy_w3.nc nccopy_w3c.nc
+
+exit 0

--- a/ncdump/tst_nccopy_w4.sh
+++ b/ncdump/tst_nccopy_w4.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+if test "x$srcdir" = x ; then srcdir=`pwd`; fi 
+. ../test_common.sh
+
+set -e
+
+echo "*** Test nccopy -w on netcdf enhanced file"
+echo "*** create nccopy_w4.nc from ref_nccopy_w.cdl..."
+${NCGEN} -lb -o nccopy_w4.nc -N nccopy_w $srcdir/ref_nccopy_w.cdl
+echo "*** diskless copy nccopy_w4.nc to nccopy_w4c.nc..."
+${NCCOPY} -w nccopy_w4.nc nccopy_w4c.nc
+echo "*** Convert nccopy_w4c.nc to nccopy_w4c.cdl..."
+${NCDUMP} -n nccopy_w nccopy_w4c.nc > nccopy_w4c.cdl
+echo "*** comparing ref_nccopy_w.cdl nccopy_w4c.cdl..."
+diff -b -w $srcdir/ref_nccopy_w.cdl nccopy_w4c.cdl
+
+rm -f nccopy_w4c.cdl
+rm -f nccopy_w4.nc nccopy_w4c.nc
+
+exit 0


### PR DESCRIPTION
* Fixes https://github.com/Unidata/netcdf-c/issues/1365

At some point (4.6.1) we changed the diskless handling of flags
and added a new NC_PERSIST flag. Looks like we did not fix all
occurrences of the old flag set, specifically for 'nccopy -w' command.
Also added some tests (tst_nccopy_w{3,4}.sh) for this situation.