### PR TITLE
Fix CMake mmap() detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1422,10 +1422,10 @@ CHECK_FUNCTION_EXISTS(fileno HAVE_FILENO)
 
 # Check to see if MAP_ANONYMOUS is defined.
 CHECK_C_SOURCE_COMPILES("
-#include <sys/mmap.h>
+#include <sys/mman.h>
 int main() {int x = MAP_ANONYMOUS;}" HAVE_MAPANON)
 
-IF(NOT HAVE_MMMAP OR NOT HAVE_MREMAP OR NOT HAVE_MAPANON)
+IF(NOT HAVE_MMAP OR NOT HAVE_MREMAP OR NOT HAVE_MAPANON)
   MESSAGE(WARNING "mmap or mremap or MAP_ANONYMOUS not found: disabling MMAP support.")
   SET(ENABLE_MMAP OFF)
 ENDIF()

--- a/nc_test/run_mmap.sh
+++ b/nc_test/run_mmap.sh
@@ -46,7 +46,7 @@ rm -f tst_diskless3_file.cdl tst_diskless3_memory.cdl
 echo ""
 echo "**** Open and modify file using mmap"
 rm -f $FILE3
-${execdir}/tst_diskless3 diskless mmap
+${execdir}/tst_diskless3 mmap
 ${NCDUMP} $FILE3 >tst_diskless3_memory.cdl
 
 # compare


### PR DESCRIPTION
Correct typos in CMakeLists.txt to correctly detect mmap() support.