### PR TITLE
Centralize calls to curl_global_init and curl_global_cleanup

### DIFF
--- a/libdap2/ncd2dispatch.c
+++ b/libdap2/ncd2dispatch.c
@@ -200,7 +200,6 @@ NCD2_initialize(void)
 int
 NCD2_finalize(void)
 {
-    curl_global_cleanup();
     return NC_NOERR;
 }
 

--- a/libdap4/ncd4dispatch.c
+++ b/libdap4/ncd4dispatch.c
@@ -61,7 +61,6 @@ NCD4_initialize(void)
 int
 NCD4_finalize(void)
 {
-    curl_global_cleanup();
     return THROW(NC_NOERR);
 }
 
@@ -793,13 +792,6 @@ static int
 globalinit(void)
 {
     int stat = NC_NOERR;
-    {
-	CURLcode cstat = curl_global_init(CURL_GLOBAL_DEFAULT);
-	if(cstat != CURLE_OK)
-	    fprintf(stderr,"curl_global_init failed!\n");
-    }
-
-
     return stat;
 }
 

--- a/libdispatch/ddispatch.c
+++ b/libdispatch/ddispatch.c
@@ -22,6 +22,9 @@ See LICENSE.txt for license information.
 #define getcwd _getcwd
 #endif
 
+#if defined(ENABLE_BYTERANGE) || defined(ENABLE_DAP) || defined(ENABLE_DAP4)
+#include <curl/curl.h>
+#endif
 
 /* Define vectors of zeros and ones for use with various nc_get_varX function*/
 const size_t NC_coord_zero[NC_MAX_VAR_DIMS];
@@ -122,6 +125,14 @@ NCDISPATCH_initialize(void)
     /* Compute type alignments */
     NC_compute_alignments();
 
+    /* Initialize curl if it is being used */
+#if defined(ENABLE_BYTERANGE) || defined(ENABLE_DAP) || defined(ENABLE_DAP4)
+    {    
+        CURLcode cstat = curl_global_init(CURL_GLOBAL_ALL);
+	if(cstat != CURLE_OK)
+	    status = NC_ECURL;
+    }
+#endif
     return status;
 }
 
@@ -130,6 +141,9 @@ NCDISPATCH_finalize(void)
 {
     int status = NC_NOERR;
     ncrc_freeglobalstate();
+#if defined(ENABLE_BYTERANGE) || defined(ENABLE_DAP) || defined(ENABLE_DAP4)
+    curl_global_cleanup();
+#endif
     return status;
 }
 

--- a/libhdf5/hdf5dispatch.c
+++ b/libhdf5/hdf5dispatch.c
@@ -125,7 +125,7 @@ NC_HDF5_initialize(void)
 
 #ifdef ENABLE_BYTERANGE
     (void)H5FD_http_init();
-#endif  
+#endif
     return NC4_provenance_init();
 }
 

--- a/libsrc/mmapio.c
+++ b/libsrc/mmapio.c
@@ -21,6 +21,7 @@
 #include <unistd.h>
 #endif
 #include "nc3internal.h"
+#include "ncwinpath.h"
 
 #undef DEBUG
 
@@ -242,17 +243,13 @@ mmapio_create(const char* path, int ioflags,
     	oflags |= (O_CREAT|O_TRUNC);
         if(fIsSet(ioflags,NC_NOCLOBBER))
 	    oflags |= O_EXCL;
-#ifdef vms
-        fd = open(path, oflags, 0, "ctx=stm");
-#else
-        fd  = open(path, oflags, OPENMODE);
-#endif
+        fd  = NCopen3(path, oflags, OPENMODE);
         if(fd < 0) {status = errno; goto unwind_open;}
 	mmapio->mapfd = fd;
 
 	{ /* Cause the output file to have enough allocated space */
 	lseek(fd,mmapio->alloc-1,SEEK_SET); /* cause file to appear */
-        write(fd,"",mmapio->alloc);
+        write(fd,"",1);
 	lseek(fd,0,SEEK_SET); /* rewind */
 	}
         mmapio->memory = (char*)mmap(NULL,mmapio->alloc,
@@ -337,11 +334,7 @@ mmapio_open(const char* path,
     fSet(oflags, O_BINARY);
 #endif
     oflags |= O_EXCL;
-#ifdef vms
-    fd = open(path, oflags, 0, "ctx=stm");
-#else
-    fd  = open(path, oflags, OPENMODE);
-#endif
+    fd  = NCopen3(path, oflags, OPENMODE);
     if(fd < 0) {status = errno; goto unwind_open;}
 
     /* get current filesize  = max(|file|,initialize)*/
@@ -420,7 +413,6 @@ static int
 mmapio_pad_length(ncio* nciop, off_t length)
 {
     NCMMAPIO* mmapio;
-    int persist = 0;
 
     if(nciop == NULL || nciop->pvt == NULL) return NC_EINVAL;
     mmapio = (NCMMAPIO*)nciop->pvt;
@@ -430,9 +422,6 @@ mmapio_pad_length(ncio* nciop, off_t length)
 
     if(mmapio->locked > 0)
 	return NC_EDISKLESS;
-
-    if(mmapio->mapfd >= 0)
-	persist = 1;
 
     if(length > mmapio->alloc) {
         /* Realloc the allocated memory to a multiple of the pagesize*/
@@ -455,8 +444,9 @@ mmapio_pad_length(ncio* nciop, off_t length)
 	newmem = (char*)mremap(mmapio->memory,mmapio->alloc,newsize,MREMAP_MAYMOVE);
 	if(newmem == NULL) return NC_ENOMEM;
 #else
+        /* note: mmapio->mapfd >= 0 => persist */
         newmem = (char*)mmap(NULL,newsize,
-                                    persist?(PROT_READ|PROT_WRITE):(PROT_READ),
+                                    mmpio->mapfd >= 0?(PROT_READ|PROT_WRITE):(PROT_READ),
 				    MAP_SHARED,
                                     mmapio->mapfd,0);
 	if(newmem == NULL) return NC_ENOMEM;

--- a/oc2/ocinternal.c
+++ b/oc2/ocinternal.c
@@ -64,7 +64,6 @@ OCerror
 ocinternalinitialize(void)
 {
     int stat = OC_NOERR;
-    CURLcode cstat = CURLE_OK;
 
     if(ocinitialized) return OC_NOERR;
     ocinitialized = 1;
@@ -78,10 +77,6 @@ ocinternalinitialize(void)
 	*/
     }
 #endif
-
-     cstat = curl_global_init(CURL_GLOBAL_ALL);
-     if(cstat != CURLE_OK)
-	fprintf(stderr,"curl_global_init failed!\n");
 
     /* Compute some xdr related flags */
     xxdr_init();


### PR DESCRIPTION
re: https://github.com/Unidata/netcdf-c/issues/1388

1. Centralize calls to curl_global_init and curl_global_cleanup
   to libdispatch/ddispatch.c
2. Make the above calls if options require curl: currently
   any of DAP2, DAP4, or byterange.
3. Side issue: Fix obscure bug in mmapio.c involving non-persistent mmap.