### PR TITLE
Option --disable-byterange fails if libcurl is not found

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -885,7 +885,7 @@ AC_ARG_ENABLE([byterange],
 test "x$enable_byterange" = xyes || enable_byterange=no
 AC_MSG_RESULT($enable_byterange)
 # Need curl for byte ranges
-if test "x$found_curl" = xno ; then
+if test "x$found_curl" = xno && test "x$enable_byterange" = xyes ; then
   AC_MSG_ERROR([curl required for byte range support. Install curl or build without --enable-byterange.])
   enable_byterange=no
 fi

--- a/libsrc/mmapio.c
+++ b/libsrc/mmapio.c
@@ -446,7 +446,7 @@ mmapio_pad_length(ncio* nciop, off_t length)
 #else
         /* note: mmapio->mapfd >= 0 => persist */
         newmem = (char*)mmap(NULL,newsize,
-                                    mmpio->mapfd >= 0?(PROT_READ|PROT_WRITE):(PROT_READ),
+                                    mmapio->mapfd >= 0?(PROT_READ|PROT_WRITE):(PROT_READ),
 				    MAP_SHARED,
                                     mmapio->mapfd,0);
 	if(newmem == NULL) return NC_ENOMEM;


### PR DESCRIPTION
* Fixes https://github.com/Unidata/netcdf-c/issues/1390

Change configure.ac to properly test for
combination of no-curl and disable-byterange.