### PR TITLE
Modified how libsz is being detected in automake-based builds.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1047,7 +1047,7 @@ if test "x$enable_hdf5" = xyes; then
 
    # Check to see if we need to search for and link against szlib.
    if test "x$ac_cv_func_H5Z_SZIP" = xyes; then
-      AC_SEARCH_LIBS([SZ_Compress], [szip sz], [],
+      AC_SEARCH_LIBS([SZ_BufftoBuffCompress], [szip sz], [],
       [AC_MSG_ERROR([libhdf5 installed with szip support, but cannot find or link to the szip library.])])
    fi
 


### PR DESCRIPTION
Observed an issue on systems using `libsz` as provided by the `libaec` package instead of being built from scratch.  Discovered after a CI bug report by @edhartnett, and was able to recreate.  The libaec-provided libsz does not contain the symbol `SZ_Compress`, and so the netcdf-c `configure` script returned a false negative.  

Fix was to modify `libsz` detection to mirror how `libhdf5` is detecting it.  