### PR TITLE
Fix ncconfigure.h to solve a -ansi problem with strdup()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -819,7 +819,7 @@ AC_CHECK_HEADERS([sys/resource.h])
 AC_CHECK_HEADERS([ftw.h])
 
 # Check for these functions...
-AC_CHECK_FUNCS([strlcat snprintf \
+AC_CHECK_FUNCS([strlcat snprintf strcasecmp fileno \
                 strdup strtoll strtoull \
 		mkstemp mktemp random \
 		getrlimit gettimeofday fsync MPI_Comm_f2c MPI_Info_f2c])

--- a/debug/cf.cmake
+++ b/debug/cf.cmake
@@ -53,7 +53,8 @@ fi
 if test "x$NC4" = x ; then
 FLAGS="$FLAGS -DENABLE_NETCDF_4=false"
 else
-FLAGS="-DHDF5_C_LIBRARY=${NCC}/lib/hdf5 -DHDF5_HL_LIBRARY=${NCC}/lib/hdf5_hl -DHDF5_INCLUDE_DIR=${NCC}/include"
+ignore=1
+#FLAGS="-DHDF5_C_LIBRARY=${NCC}/lib/hdf5 -DHDF5_HL_LIBRARY=${NCC}/lib/hdf5_hl -DHDF5_INCLUDE_DIR=${NCC}/include"
 fi
 if test "x$CDF5" != x ; then
 FLAGS="$FLAGS -DENABLE_CDF5=true"
@@ -98,7 +99,8 @@ export PATH="${NCLIB}:${PATH}"
 #G=
 cmake ${TR} "$G" -DCMAKE_BUILD_TYPE=${CFG} $FLAGS ..
 if test "x$NOBUILD" = x ; then
-cmake ${TR} --build . --config ${CFG} --target ZERO_CHECK
+#cmake ${TR} --build . --config ${CFG} --target ZERO_CHECK
+cmake ${TR} --build . --config ${CFG} --target ALL_BUILD
 if test "x$NOTEST" = x ; then
 cmake ${TR} --build . --config ${CFG} --target RUN_TESTS
 fi

--- a/include/ncconfigure.h
+++ b/include/ncconfigure.h
@@ -25,20 +25,7 @@ missing functions should be
 defined and missing types defined.
 */
 
-#ifndef HAVE_STRDUP
-extern char* strdup(const char*);
-#endif
-
-/* handle null arguments */
-#ifndef nulldup
-#ifdef HAVE_STRDUP
-#define nulldup(s) ((s)==NULL?NULL:strdup(s))
-#else
-char *nulldup(const char* s);
-#endif
-#endif
-
-#ifdef _MSC_VER
+#ifdef _WIN32
 #ifndef HAVE_SSIZE_T
 #include <basetsd.h>
 typedef SSIZE_T ssize_t;
@@ -51,22 +38,25 @@ typedef SSIZE_T ssize_t;
 #ifndef _WIN32
 #if __STDC__ == 1 /*supposed to be same as -ansi flag */
 
+/* WARNING: in some systems, these functions may be defined as macros, so check */
 #ifndef strdup
 extern char* strdup(const char*);
 #endif
-
 #ifndef strlcat
 extern size_t strlcat(char*,const char*,size_t);
 #endif
-
 #ifndef snprintf
 extern int snprintf(char*, size_t, const char*, ...);
 #endif
-
+#ifndef strcasecmp
 extern int strcasecmp(const char*, const char*);
+#endif
+#ifndef strtoll
 extern long long int strtoll(const char*, char**, int);
+#endif
+#ifndef strtoull
 extern unsigned long long int strtoull(const char*, char**, int);
-
+#endif
 #ifndef fileno
 extern int fileno(FILE*);
 #endif
@@ -75,18 +65,24 @@ extern int fileno(FILE*);
 #endif /*!WIN32*/
 
 #ifdef _WIN32
-#ifndef strlcat
+#ifndef HAVE_STRLCAT
 #define strlcat(d,s,n) strcat_s((d),(n),(s))
 #endif
 #endif
 
 /* handle null arguments */
 #ifndef nulldup
+#ifdef HAVE_STRDUP
 #define nulldup(s) ((s)==NULL?NULL:strdup(s))
+#else
+extern char *nulldup(const char* s);
 #endif
+#endif
+
 #ifndef nulllen
 #define nulllen(s) ((s)==NULL?0:strlen(s))
 #endif
+
 #ifndef nullfree
 #define nullfree(s) {if((s)!=NULL) {free(s);} else {}}
 #endif

--- a/libdispatch/nctime.c
+++ b/libdispatch/nctime.c
@@ -16,6 +16,7 @@
  * the CDMS library, get the original sources from LLNL.
  */
 
+#include "config.h"
 #include <stdlib.h>
 #include <stdio.h>
 #include <ctype.h>
@@ -23,7 +24,6 @@
 #include <string.h>
 #include <stdarg.h>
 #include <assert.h>
-#include "ncconfigure.h"
 #include "nctime.h"
 
 static const cdCompTime ZA = {1582, 10, 5, 0.0};


### PR DESCRIPTION
re: https://github.com/Unidata/netcdf-c/issues/1408

1. Add some function tests to configure.ac; these are functions
   not defined with -ansi.
2. When using -ansi, fix include/ncconfigure.h to check for
   the possibilty that certain functions are being defined
   by macros. Apparently Debian does this for some reason.
   No idea why.

Unrelated: modify the debug/cf.cmake debug shell script.