### PR TITLE
include config.h in ncconfigure.h

### DIFF
--- a/include/ncconfigure.h
+++ b/include/ncconfigure.h
@@ -9,6 +9,7 @@
 
 #ifndef NCCONFIGURE_H
 #define NCCONFIGURE_H 1
+#include "config.h"
 
 #ifdef HAVE_STDLIB_H
 #include <stdlib.h>


### PR DESCRIPTION
We had to add this patch `ncconfigure.h` to be able to build `4.7.0` in `conda-forge`.

Ping @isuruf who helped us find fix this problem.