### PR TITLE
Use quiet comparison when converting from double to float

### DIFF
--- a/libsrc4/nc4var.c
+++ b/libsrc4/nc4var.c
@@ -1212,7 +1212,7 @@ nc4_convert_type(const void *src, void *dest, const nc_type src_type,
         case NC_FLOAT:
             for (dp = (double *)src, fp = dest; count < len; count++)
             {
-                if (*dp > X_FLOAT_MAX || *dp < X_FLOAT_MIN)
+                if (isgreater(*dp, X_FLOAT_MAX) || isless(*dp, X_FLOAT_MIN))
                     (*range_error)++;
                 *fp++ = *dp++;
             }


### PR DESCRIPTION
Fixes #1412 

This only fixes it for the NetCDF4 API. A similar fix is needed for the v3 API, but I couldn't see how to regenerate `ncx.c` from `ncx.m4` (and I'm not 100% sure of the needed change there).

The other conversion cases could also use these non-signalling macros, but then the conversion itself will signal. I don't know what the expected behaviour is from the library when writing a NaN to an integral type, so I didn't change the other comparisons -- it's a simple regex though, so I can do so if wished.

As an aside, this function generates a _lot_ of conversion warnings. Explicit casts would silence them -- would you like those adding (perhaps in a separate PR)?