### PR TITLE
 remove unused macro USE_REFCOUNT

### DIFF
--- a/include/nc.h
+++ b/include/nc.h
@@ -31,9 +31,6 @@ typedef struct NC {
 	char* path;
 	int   mode; /* as provided to nc_open/nc_create */
         struct NCmodel*  model; /* as determined by libdispatch/dfile.c */
-#ifdef USE_REFCOUNT
-	int   refcount; /* To enable multiple name-based opens */
-#endif
 } NC;
 
 /*

--- a/libdispatch/dfile.c
+++ b/libdispatch/dfile.c
@@ -1893,11 +1893,6 @@ NC_create(const char *path0, int cmode, size_t initialsz,
     /* Add to list of known open files and define ext_ncid */
     add_to_NCList(ncp);
 
-#ifdef USE_REFCOUNT
-    /* bump the refcount */
-    ncp->refcount++;
-#endif
-
     /* Assume create will fill in remaining ncp fields */
     if ((stat = dispatcher->create(ncp->path, cmode, initialsz, basepe, chunksizehintp,
 				  parameters, dispatcher, ncp))) {
@@ -1987,17 +1982,6 @@ NC_open(const char *path0, int omode, int basepe, size_t *chunksizehintp,
 	path = nulldup(p);
 #endif
    }
-
-#ifdef USE_REFCOUNT
-    /* If this path is already open, then bump the refcount and return it */
-    ncp = find_in_NCList_by_name(path);
-    if(ncp != NULL) {
-	nullfree(path);
-	ncp->refcount++;
-	if(ncidp) *ncidp = ncp->ext_ncid;
-	return NC_NOERR;
-    }
-#endif
 
     memset(&model,0,sizeof(model));
     /* Infer model implementation and format, possibly by reading the file */
@@ -2102,11 +2086,6 @@ NC_open(const char *path0, int omode, int basepe, size_t *chunksizehintp,
 
     /* Add to list of known open files */
     add_to_NCList(ncp);
-
-#ifdef USE_REFCOUNT
-    /* bump the refcount */
-    ncp->refcount++;
-#endif
 
     /* Assume open will fill in remaining ncp fields */
     stat = dispatcher->open(ncp->path, omode, basepe, chunksizehintp,

--- a/libdispatch/dfile.c
+++ b/libdispatch/dfile.c
@@ -1223,12 +1223,6 @@ nc_abort(int ncid)
    int stat = NC_check_id(ncid, &ncp);
    if(stat != NC_NOERR) return stat;
 
-#ifdef USE_REFCOUNT
-   /* What to do if refcount > 0? */
-   /* currently, forcibly abort */
-   ncp->refcount = 0;
-#endif
-
    stat = ncp->dispatch->abort(ncid);
    del_from_NCList(ncp);
    free_NC(ncp);

--- a/libdispatch/nclistmgr.c
+++ b/libdispatch/nclistmgr.c
@@ -43,11 +43,6 @@ add_to_NCList(NC* ncp)
 	    return NC_ENOMEM;
 	numfiles = 0;
     }
-#ifdef USE_REFCOUNT
-    /* Check the refcount */
-    if(ncp->refcount > 0)
-	return NC_NOERR;
-#endif
 
     new_id = 0; /* id's begin at 1 */
     for(i=1; i < NCFILELISTLENGTH; i++) {
@@ -67,11 +62,6 @@ del_from_NCList(NC* ncp)
    unsigned int ncid = ((unsigned int)ncp->ext_ncid) >> ID_SHIFT;
    if(numfiles == 0 || ncid == 0 || nc_filelist == NULL) return;
    if(nc_filelist[ncid] != ncp) return;
-#ifdef USE_REFCOUNT
-   /* Check the refcount */
-   if(ncp->refcount > 0)
-	return; /* assume caller has decrecmented */
-#endif
 
    nc_filelist[ncid] = NULL;
    numfiles--;


### PR DESCRIPTION
Fixes #1427.

As discussed with Dennis, I've removed this unused macro, which is an artifact of programming efforts of the past.