### PR TITLE
nccopy must use defaulting when there are no -c parameters

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,11 @@ This file contains a high-level description of this package's evolution. Release
 
 ## 4.7.1 - TBD
 
+* [Bug Fix] Reverted nccopy behavior so that if no -c parameters
+are given, then any default chunking is left to the netcdf-c library
+to decide.
+See [GitHub #1436](https://github.com/Unidata/netcdf-c/issues/1436)
+
 ## 4.7.0 - April 29, 2019
 
 * [Enhancement] Updated behavior of `pkgconfig` and `nc-config` to allow the use of the `--static` flags, e.g. `nc-config --libs --static`, which will show information for linking against `libnetcdf` statically. See [Github #1360](https://github.com/Unidata/netcdf-c/issues/1360) and [Github #1257](https://github.com/Unidata/netcdf-c/issues/1257) for more information.

--- a/ncdump/nccopy.1
+++ b/ncdump/nccopy.1
@@ -403,22 +403,27 @@ for each variable to be copied from input to output. The rules are
 written assuming we are trying to determine the chunking for a given
 output variable Vout that comes from an input variable Vin.
 .IP "1."
+If there is no '-c' option that applies to a variable and the
+corresponding input variable is contiguous or the input is some
+netcdf-3 variant, then let the netcdf-c library make all chunking
+decisions.
+.IP "2."
 For each dimension of Vout explicitly specified on the command line
 (using the '-c' option), apply the chunking value for that
 dimension regardless of input format or input properties.
-.IP "2."
-For dimensions of Vout not named on the command line, preserve chunk
-sizes from the corresponding input variable, if it is chunked.
 .IP "3."
+For dimensions of Vout not named on the command line in a '-c' option, preserve chunk
+sizes from the corresponding input variable, if it is chunked.
+.IP "4."
 If Vin is contiguous, and none of its dimensions are
 named on the command line, and chunking is not mandated by other
 options, then make Vout be contiguous.
-.IP "4."
+.IP "5."
 If the input variable is contiguous (or is some netcdf-3
 variant) and there are no options requiring chunking, or the '/'
 special case for the '-c' option is specified, then the output
 variable V is marked as contiguous.
-.IP "5."
+.IP "6."
 Final, default case: some or all chunk sizes are not
 determined by the command line or the input
 variable. This includes the non-chunked input cases such


### PR DESCRIPTION
* Fixes https://github.com/Unidata/netcdf-c/issues/1436

It used to be that when no -c parameters were specified
(and the input was some variant of netcdf-3) that nccopy
let the netcdf-c library decide on any default chunking.
Now, it attempts to do it itself and is not doing it
correctly when unlimited dimensions are involved.

So fix is to revert to previous behavior.

Note: The chunking rules are getting too complicated; consider revising.