### PR TITLE
clean up freeing of libsrc4 metadata memory in HDF5 and HDF4

### DIFF
--- a/include/nc4internal.h
+++ b/include/nc4internal.h
@@ -335,7 +335,7 @@ int nc4_type_free(NC_TYPE_INFO_T *type);
 
 /* These list functions add and delete vars, atts. */
 int nc4_nc4f_list_add(NC *nc, const char *path, int mode);
-void nc4_file_list_del(NC *nc);
+int nc4_nc4f_list_del(NC_FILE_INFO_T *h5);
 int nc4_var_list_add(NC_GRP_INFO_T* grp, const char* name, int ndims,
                      NC_VAR_INFO_T **var);
 int nc4_var_list_add2(NC_GRP_INFO_T* grp, const char* name,

--- a/libhdf4/hdf4file.c
+++ b/libhdf4/hdf4file.c
@@ -627,9 +627,8 @@ NC_HDF4_open(const char *path, int mode, int basepe, size_t *chunksizehintp,
     /* Add necessary structs to hold netcdf-4 file data. */
     if ((retval = nc4_nc4f_list_add(nc_file, path, mode)))
         return retval;
-    nc4_info = NC4_DATA(nc_file);
-    assert(nc4_info && nc4_info->root_grp);
-    h5 = nc4_info;
+    h5 = (NC_FILE_INFO_T *)nc_file->dispatchdata;
+    assert(h5 && h5->root_grp);
     h5->no_write = NC_TRUE;
     h5->root_grp->atts_read = 1;
 

--- a/libhdf4/hdf4file.c
+++ b/libhdf4/hdf4file.c
@@ -724,6 +724,10 @@ NC_HDF4_close(int ncid, void *ignore)
     nclistfree(h5->allgroups);
     nclistfree(h5->alltypes);
 
+    /* Free the NC_FILE_INFO_T struct. */
+    if ((retval = nc4_nc4f_list_del(h5)))
+        return retval;
+
     /* Free the nc4_info struct; above code should have reclaimed
        everything else */
     free(h5);

--- a/libhdf4/hdf4file.c
+++ b/libhdf4/hdf4file.c
@@ -728,9 +728,5 @@ NC_HDF4_close(int ncid, void *ignore)
     if ((retval = nc4_nc4f_list_del(h5)))
         return retval;
 
-    /* Free the nc4_info struct; above code should have reclaimed
-       everything else */
-    free(h5);
-
     return NC_NOERR;
 }

--- a/libhdf4/hdf4file.c
+++ b/libhdf4/hdf4file.c
@@ -719,11 +719,6 @@ NC_HDF4_close(int ncid, void *ignore)
         return NC_EHDFERR;
     free(hdf4_file);
 
-    /* Misc. Cleanup */
-    nclistfree(h5->alldims);
-    nclistfree(h5->allgroups);
-    nclistfree(h5->alltypes);
-
     /* Free the NC_FILE_INFO_T struct. */
     if ((retval = nc4_nc4f_list_del(h5)))
         return retval;

--- a/libhdf4/hdf4file.c
+++ b/libhdf4/hdf4file.c
@@ -708,11 +708,6 @@ NC_HDF4_close(int ncid, void *ignore)
     if ((retval = hdf4_rec_grp_del(h5->root_grp)))
         return retval;
 
-    /* Delete all the list contents for vars, dims, and atts, in each
-     * group. */
-    if ((retval = nc4_rec_grp_del(h5->root_grp)))
-        return retval;
-
     /* Close hdf4 file and free HDF4 file info. */
     hdf4_file = (NC_HDF4_FILE_INFO_T *)h5->format_file_info;
     if (SDend(hdf4_file->sdid))

--- a/libhdf4/hdf4file.c
+++ b/libhdf4/hdf4file.c
@@ -604,8 +604,7 @@ NC_HDF4_open(const char *path, int mode, int basepe, size_t *chunksizehintp,
     int32 num_datasets, num_gatts;
     int32 sdid;
     int v, a;
-    NC_FILE_INFO_T* nc4_info = NULL;
-    int retval = NC_NOERR;
+    int retval;
 
     /* Check inputs. */
     assert(nc_file && path);

--- a/libhdf5/hdf5file.c
+++ b/libhdf5/hdf5file.c
@@ -252,11 +252,6 @@ nc4_close_netcdf4_file(NC_FILE_INFO_T *h5, int abort, NC_memio *memio)
     /* Get HDF5 specific info. */
     hdf5_info = (NC_HDF5_FILE_INFO_T *)h5->format_file_info;
 
-    /* Delete all the list contents for vars, dims, and atts, in each
-     * group. */
-    if ((retval = nc4_rec_grp_del(h5->root_grp)))
-        return retval;
-
 #ifdef USE_PARALLEL4
     /* Free the MPI Comm & Info objects, if we opened the file in
      * parallel. */

--- a/libhdf5/hdf5file.c
+++ b/libhdf5/hdf5file.c
@@ -257,11 +257,6 @@ nc4_close_netcdf4_file(NC_FILE_INFO_T *h5, int abort, NC_memio *memio)
     if ((retval = nc4_rec_grp_del(h5->root_grp)))
         return retval;
 
-    /* Free lists of dims, groups, and types in the root group. */
-    nclistfree(h5->alldims);
-    nclistfree(h5->allgroups);
-    nclistfree(h5->alltypes);
-
 #ifdef USE_PARALLEL4
     /* Free the MPI Comm & Info objects, if we opened the file in
      * parallel. */

--- a/libhdf5/hdf5file.c
+++ b/libhdf5/hdf5file.c
@@ -311,6 +311,10 @@ nc4_close_netcdf4_file(NC_FILE_INFO_T *h5, int abort, NC_memio *memio)
     if (h5->format_file_info)
         free(h5->format_file_info);
 
+    /* Free the NC_FILE_INFO_T struct. */
+    if ((retval = nc4_nc4f_list_del(h5)))
+        return retval;
+
     /* Free the nc4_info struct; above code should have reclaimed
        everything else */
     free(h5);

--- a/libhdf5/hdf5file.c
+++ b/libhdf5/hdf5file.c
@@ -283,15 +283,18 @@ nc4_close_netcdf4_file(NC_FILE_INFO_T *h5, int abort, NC_memio *memio)
 
     /* If inmemory is used and user wants the final memory block,
        then capture and return the final memory block else free it */
-    if(h5->mem.inmemory) {
+    if (h5->mem.inmemory)
+    {
         /* Pull out the final memory */
         (void)NC4_extract_file_image(h5);
-        if(!abort && memio != NULL) {
+        if (!abort && memio != NULL)
+        {
             *memio = h5->mem.memio; /* capture it */
             h5->mem.memio.memory = NULL; /* avoid duplicate free */
         }
         /* If needed, reclaim extraneous memory */
-        if(h5->mem.memio.memory != NULL) {
+        if (h5->mem.memio.memory != NULL)
+        {
             /* If the original block of memory is not resizeable, then
                it belongs to the caller and we should not free it. */
             if(!h5->mem.locked)

--- a/libhdf5/hdf5file.c
+++ b/libhdf5/hdf5file.c
@@ -315,10 +315,6 @@ nc4_close_netcdf4_file(NC_FILE_INFO_T *h5, int abort, NC_memio *memio)
     if ((retval = nc4_nc4f_list_del(h5)))
         return retval;
 
-    /* Free the nc4_info struct; above code should have reclaimed
-       everything else */
-    free(h5);
-
     return NC_NOERR;
 }
 

--- a/libsrc4/nc4internal.c
+++ b/libsrc4/nc4internal.c
@@ -1379,6 +1379,9 @@ int
 nc4_nc4f_list_del(NC_FILE_INFO_T *h5)
 {
     assert(h5);
+
+    free(h5);
+
     return NC_NOERR;
 }
 

--- a/libsrc4/nc4internal.c
+++ b/libsrc4/nc4internal.c
@@ -1273,13 +1273,15 @@ dim_free(NC_DIM_INFO_T *dim)
  * @author Dennis Heimbigner
  */
 int
-nc4_dim_list_del(NC_GRP_INFO_T* grp, NC_DIM_INFO_T *dim)
+nc4_dim_list_del(NC_GRP_INFO_T *grp, NC_DIM_INFO_T *dim)
 {
-    if(grp && dim) {
-        int pos = ncindexfind(grp->dim,(NC_OBJ*)dim);
+    if (grp && dim)
+    {
+        int pos = ncindexfind(grp->dim, (NC_OBJ *)dim);
         if(pos >= 0)
-            ncindexidel(grp->dim,pos);
+            ncindexidel(grp->dim, pos);
     }
+
     return dim_free(dim);
 }
 
@@ -1362,6 +1364,22 @@ nc4_att_list_del(NCindex *list, NC_ATT_INFO_T *att)
     assert(att && list);
     ncindexidel(list, ((NC_OBJ *)att)->id);
     return att_free(att);
+}
+
+/**
+ * @internal Free all resources and memory associated with a
+ * NC_FILE_INFO_T.
+ *
+ * @param h5 Pointer to NC_FILE_INFO_T to be freed.
+ *
+ * @return ::NC_NOERR No error.
+ * @author Ed Hartnett
+ */
+int
+nc4_nc4f_list_del(NC_FILE_INFO_T *h5)
+{
+    assert(h5);
+    return NC_NOERR;
 }
 
 /**

--- a/libsrc4/nc4internal.c
+++ b/libsrc4/nc4internal.c
@@ -1380,6 +1380,12 @@ nc4_nc4f_list_del(NC_FILE_INFO_T *h5)
 {
     assert(h5);
 
+    /* Cleanup these (extra) lists of all dims, groups, and types. */
+    nclistfree(h5->alldims);
+    nclistfree(h5->allgroups);
+    nclistfree(h5->alltypes);
+
+    /* Free the NC_FILE_INFO_T struct. */
     free(h5);
 
     return NC_NOERR;

--- a/libsrc4/nc4internal.c
+++ b/libsrc4/nc4internal.c
@@ -1378,7 +1378,14 @@ nc4_att_list_del(NCindex *list, NC_ATT_INFO_T *att)
 int
 nc4_nc4f_list_del(NC_FILE_INFO_T *h5)
 {
+    int retval;
+
     assert(h5);
+
+    /* Delete all the list contents for vars, dims, and atts, in each
+     * group. */
+    if ((retval = nc4_rec_grp_del(h5->root_grp)))
+        return retval;
 
     /* Cleanup these (extra) lists of all dims, groups, and types. */
     nclistfree(h5->alldims);


### PR DESCRIPTION
Fixes #1433 
Part of #1426 

The current code to close a file needs a little cleanup for PIO use of the UDF feature.

In this PR I add function nc4_nc4f_list_del() to go with nc4_nc4f_list_add(). This new function cleans up the memory that was allocated by libsrc4 code. This allows some duplicate code to be removed from hdf4file.c and hdf5file.c, as well as making it easier for layers like PIO to use the libsrc4 metadata handling code.

This change is required for the netCDF/PIO integration. See https://github.com/NCAR/ParallelIO/pull/1566.