### PR TITLE
NC4_get_vars(): fix out-of-bounds write with unlimited dimension

### DIFF
--- a/libhdf5/hdf5var.c
+++ b/libhdf5/hdf5var.c
@@ -2092,7 +2092,7 @@ NC4_get_vars(int ncid, int varid, const size_t *startp, const size_t *countp,
         /* Skip past the real data we've already read. */
         if (!no_read)
             for (real_data_size = file_type_size, d2 = 0; d2 < var->ndims; d2++)
-                real_data_size *= (count[d2] - start[d2]);
+                real_data_size *= count[d2];
 
         /* Get the fill value from the HDF5 variable. Memory will be
          * allocated. */

--- a/nc_test4/CMakeLists.txt
+++ b/nc_test4/CMakeLists.txt
@@ -20,7 +20,7 @@ SET(NC4_TESTS tst_dims tst_dims2 tst_dims3 tst_files tst_files4
   tst_files6 tst_sync tst_h_strbug tst_h_refs tst_h_scalar tst_rename
   tst_rename2 tst_rename3 tst_h5_endians tst_atts_string_rewrite tst_put_vars_two_unlim_dim
   tst_hdf5_file_compat tst_fill_attr_vanish tst_rehash tst_types tst_bug324
-  tst_atts3 tst_put_vars tst_elatefill tst_udf)
+  tst_atts3 tst_put_vars tst_elatefill tst_udf tst_bug1442)
 
 # Note, renamegroup needs to be compiled before run_grp_rename
 

--- a/nc_test4/Makefile.am
+++ b/nc_test4/Makefile.am
@@ -33,7 +33,7 @@ tst_vars2 tst_files5 tst_files6 tst_sync tst_h_scalar tst_rename	\
 tst_rename2 tst_rename3 tst_h5_endians tst_atts_string_rewrite		\
 tst_hdf5_file_compat tst_fill_attr_vanish tst_rehash tst_filterparser	\
 tst_bug324 tst_types tst_atts3 tst_put_vars tst_elatefill tst_udf	\
-tst_put_vars_two_unlim_dim
+tst_put_vars_two_unlim_dim tst_bug1442
 
 # Temporary I hoped, but hoped in vain.
 if !ISCYGWIN

--- a/nc_test4/tst_bug1442.c
+++ b/nc_test4/tst_bug1442.c
@@ -30,8 +30,9 @@ main(int argc, char **argv)
     int other_var;
     size_t start[1];
     size_t count[1];
-    double three_zeros[3] = {0, 0, 0};
-    double* two_double = (double*)calloc(2, sizeof(double));
+    double five_zeros[5] = {0, 0, 0, 0, 0};
+    double one_two[2] = {1, 2};
+    double* four_double = (double*)calloc(4, sizeof(double));
 
     status = nc_create(FILENAME, NC_NETCDF4, &cdfid);
     if( status ) ERR;
@@ -48,25 +49,33 @@ main(int argc, char **argv)
     status = nc_enddef(cdfid);
     if( status ) ERR;
 
-    /* Write 3 elements to set the size of the unlimited dim to 3 */
+    /* Write 5 elements to set the size of the unlimited dim to 5 */
     start[0] = 0;
-    count[0] = 3;
-    status = nc_put_vara_double(cdfid, other_var, start, count, three_zeros);
+    count[0] = 5;
+    status = nc_put_vara_double(cdfid, other_var, start, count, five_zeros);
     if( status ) ERR;
 
-    /* Read 2 elements starting with index=1 */
-    start[0] = 1;
+    /* Write 2 elements in my_var */
+    start[0] = 0;
     count[0] = 2;
-    status = nc_get_vara_double(cdfid, varid, start, count, two_double);
+    status = nc_put_vara_double(cdfid, varid, start, count, one_two);
     if( status ) ERR;
 
-    if( two_double[0] != NC_FILL_DOUBLE ) ERR;
-    if( two_double[1] != NC_FILL_DOUBLE ) ERR;
+    /* Read 4 elements starting with index=1 */
+    start[0] = 1;
+    count[0] = 4;
+    status = nc_get_vara_double(cdfid, varid, start, count, four_double);
+    if( status ) ERR;
+
+    if( four_double[0] != 2 ) ERR;
+    if( four_double[1] != NC_FILL_DOUBLE ) ERR;
+    if( four_double[2] != NC_FILL_DOUBLE ) ERR;
+    if( four_double[3] != NC_FILL_DOUBLE ) ERR;
 
     status = nc_close(cdfid);
     if( status ) ERR;
 
-    free(two_double);
+    free(four_double);
 
     SUMMARIZE_ERR;
     FINAL_RESULTS;

--- a/nc_test4/tst_bug1442.c
+++ b/nc_test4/tst_bug1442.c
@@ -3,6 +3,8 @@
 Copyright 2019
 University Corporation for Atmospheric Research/Unidata.
 
+Author: Even Rouault
+
 See \ref copyright file for more info.
 
 */
@@ -12,7 +14,7 @@ See \ref copyright file for more info.
 #include <stdlib.h>
 #include <netcdf.h>
 
-#define FILENAME "tst_bug1442nc"
+#define FILENAME "tst_bug1442.nc"
 
 int
 main(int argc, char **argv)

--- a/nc_test4/tst_bug1442.c
+++ b/nc_test4/tst_bug1442.c
@@ -1,0 +1,73 @@
+/*! \file
+
+Copyright 2019
+University Corporation for Atmospheric Research/Unidata.
+
+See \ref copyright file for more info.
+
+*/
+#include <nc_tests.h>
+#include "err_macros.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <netcdf.h>
+
+#define FILENAME "tst_bug1442nc"
+
+int
+main(int argc, char **argv)
+{
+    /* Test bugfix for https://github.com/Unidata/netcdf-c/pull/1442 */
+    /* that is using nc_get_vara_xxx() with a offset[] != 0 on a variable */
+    /* indexed by a unlimited dimension, and the size taken by that variable */
+    /* does not reach the actual size of that dimension */
+    int status;
+    int cdfid = -1;
+    int unlimited_dim;
+    int varid;
+    int other_var;
+    size_t start[1];
+    size_t count[1];
+    double three_zeros[3] = {0, 0, 0};
+    double* two_double = (double*)calloc(2, sizeof(double));
+
+    status = nc_create(FILENAME, NC_NETCDF4, &cdfid);
+    if( status ) ERR;
+
+    status = nc_def_dim(cdfid, "unlimited_dim", NC_UNLIMITED, &unlimited_dim);
+    if( status ) ERR;
+
+    status = nc_def_var(cdfid, "my_var", NC_DOUBLE, 1, &unlimited_dim, &varid);
+    if( status ) ERR;
+
+    status = nc_def_var(cdfid, "other_var", NC_DOUBLE, 1, &unlimited_dim, &other_var);
+    if( status ) ERR;
+
+    status = nc_enddef(cdfid);
+    if( status ) ERR;
+
+    /* Write 3 elements to set the size of the unlimited dim to 3 */
+    start[0] = 0;
+    count[0] = 3;
+    status = nc_put_vara_double(cdfid, other_var, start, count, three_zeros);
+    if( status ) ERR;
+
+    /* Read 2 elements starting with index=1 */
+    start[0] = 1;
+    count[0] = 2;
+    status = nc_get_vara_double(cdfid, varid, start, count, two_double);
+    if( status ) ERR;
+
+    if( two_double[0] != NC_FILL_DOUBLE ) ERR;
+    if( two_double[1] != NC_FILL_DOUBLE ) ERR;
+
+    status = nc_close(cdfid);
+    if( status ) ERR;
+
+    free(two_double);
+
+    SUMMARIZE_ERR;
+    FINAL_RESULTS;
+
+    return 0;
+}


### PR DESCRIPTION
This fixes an issue hit by GDAL, and that is found in netcdf 4.6.3
and 4.7.0

git bisect pointed the problem to have started with

```
77ab979c5fd7151f8583c7698498bb8cb0dafb63 is the first bad commit
commit 77ab979c5fd7151f8583c7698498bb8cb0dafb63
Author: Ed Hartnett <edwardjameshartnett@gmail.com>
Date:   Sat Jun 16 09:58:48 2018 -0600

    using get_vars but not put_vars

:040000 040000 8611e77aaea4f130ca769a852e2c3b26373a78fa fc9ffd1d13d8f5db5ab888044e0cec4def26eba1 M	libsrc4
```

where nc_get_vara_double() started using nc4_get_vars() underneath.

It turns out that nc4_get_vars() was buggy in the situation exercised by GDAL.

This can be reproduced with the following simple test case:

```

int main()
{
    int status;
    int cdfid = -1;
    int first_dim;
    int varid;
    int other_var;
    size_t anStart[NC_MAX_DIMS];
    size_t anCount[NC_MAX_DIMS];
    double* val = (double*)calloc(3, sizeof(double));

    status = nc_create("foo.nc", NC_NETCDF4, &cdfid);
    assert( status == NC_NOERR );

    status = nc_def_dim(cdfid, "unlimited_dim", NC_UNLIMITED, &first_dim);
    assert( status == NC_NOERR );

    status = nc_def_var(cdfid, "my_var", NC_DOUBLE, 1, &first_dim, &varid);
    assert( status == NC_NOERR );

    status = nc_def_var(cdfid, "other_var", NC_DOUBLE, 1, &first_dim, &other_var);
    assert( status == NC_NOERR );

    status = nc_enddef(cdfid);
    assert( status == NC_NOERR );

    /* Write 3 elements to set the size of the unlimited dim to 3 */
    anStart[0] = 0;
    anCount[0] = 3;
    status = nc_put_vara_double(cdfid, other_var, anStart, anCount, val);
    assert( status == NC_NOERR );

    /* Read 2 elements starting with index=1 */
    anStart[0] = 1;
    anCount[0] = 2;
    status = nc_get_vara_double(cdfid, varid, anStart, anCount, val);
    assert( status == NC_NOERR );

    status = nc_close(cdfid);
    assert( status == NC_NOERR );

    free(val);

    return 0;
}
```

Running it under Valgrind without this patch leads to
```
==19637==
==19637== Invalid write of size 8
==19637==    at 0x4C326CB: memcpy@@GLIBC_2.14 (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==19637==    by 0x4EDBE3D: NC4_get_vars (hdf5var.c:2131)
==19637==    by 0x4EDA24C: NC4_get_vara (hdf5var.c:1342)
==19637==    by 0x4E68878: NC_get_vara (dvarget.c:104)
==19637==    by 0x4E69FDB: nc_get_vara_double (dvarget.c:815)
==19637==    by 0x400C08: main (in /home/even/netcdf-c/build/test)
==19637==  Address 0xb70e3e8 is 8 bytes before a block of size 24 alloc'd
==19637==    at 0x4C2FB55: calloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==19637==    by 0x4009E8: main (in /home/even/netcdf-c/build/test)
==19637==
```