### PR TITLE
Remove netcdf-4 conditional on the dispatch table.

### DIFF
--- a/include/netcdf_dispatch.h
+++ b/include/netcdf_dispatch.h
@@ -87,11 +87,12 @@ struct NC_Dispatch
     int (*var_par_access)(int, int, int);
     int (*def_var_fill)(int, int, int, const void *);
 
-/* Note the following may still be invoked by netcdf client code
-   even when the file is a classic file; they will just return an error or
-   be ignored.
+/* Note the following are specific to netcdf4, but must still be
+   implemented by all dispatch tables. They may still be invoked by
+   netcdf client code even when the file is a classic file; they
+   will just return an error or be ignored.
 */
-#ifdef USE_NETCDF4
+
     int (*show_metadata)(int);
     int (*inq_unlimdims)(int, int*, int*);
     int (*inq_ncid)(int, const char*, int*);
@@ -132,7 +133,6 @@ struct NC_Dispatch
     int (*set_var_chunk_cache)(int, int, size_t, size_t, float);
     int (*get_var_chunk_cache)(int ncid, int varid, size_t *sizep,
                                size_t *nelemsp, float *preemptionp);
-#endif /*USE_NETCDF4*/
 };
 
 /* Read-only dispatch layers can use these functions to return

--- a/libdap2/ncd2dispatch.c
+++ b/libdap2/ncd2dispatch.c
@@ -138,7 +138,6 @@ NCD2_inq_var_all,
 NCD2_var_par_access,
 NCD2_def_var_fill,
 
-#ifdef USE_NETCDF4
 NCD2_show_metadata,
 NCD2_inq_unlimdims,
 NCD2_inq_ncid,
@@ -176,8 +175,6 @@ NCD2_def_var_endian,
 NCD2_def_var_filter,
 NCD2_set_var_chunk_cache,
 NCD2_get_var_chunk_cache,
-
-#endif /*USE_NETCDF4*/
 
 };
 
@@ -2484,8 +2481,6 @@ NCD2_def_var_fill(int ncid, int p2, int p3, const void* p4)
     return THROW(ret);
 }
 
-#ifdef USE_NETCDF4
-
 int
 NCD2_inq_ncid(int ncid, const char* name, int* grp_ncid)
 {
@@ -2852,4 +2847,3 @@ NCD2_get_var_chunk_cache(int ncid, int p2, size_t* p3, size_t* p4, float* p5)
     return THROW(ret);
 }
 
-#endif /* USE_NETCDF4 */

--- a/libdap2/ncd2dispatch.h
+++ b/libdap2/ncd2dispatch.h
@@ -1,35 +1,35 @@
 /*
- * Copyright 1993-2018 University Corporation for Atmospheric Research/Unidata
- *
- * Portions of this software were developed by the Unidata Program at the
- * University Corporation for Atmospheric Research.
- *
- * Access and use of this software shall impose the following obligations
- * and understandings on the user. The user is granted the right, without
- * any fee or cost, to use, copy, modify, alter, enhance and distribute
- * this software, and any derivative works thereof, and its supporting
- * documentation for any purpose whatsoever, provided that this entire
- * notice appears in all copies of the software, derivative works and
- * supporting documentation.  Further, UCAR requests that the user credit
- * UCAR/Unidata in any publications that result from the use of this
- * software or in any product that includes this software. The names UCAR
- * and/or Unidata, however, may not be used in any advertising or publicity
- * to endorse or promote any products or commercial entity unless specific
- * written permission is obtained from UCAR/Unidata. The user also
- * understands that UCAR/Unidata is not obligated to provide the user with
- * any support, consulting, training or assistance of any kind with regard
- * to the use, operation and performance of this software nor to provide
- * the user with any updates, revisions, new versions or "bug fixes."
- *
- * THIS SOFTWARE IS PROVIDED BY UCAR/UNIDATA "AS IS" AND ANY EXPRESS OR
- * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL UCAR/UNIDATA BE LIABLE FOR ANY SPECIAL,
- * INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING
- * FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
- * NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION
- * WITH THE ACCESS, USE OR PERFORMANCE OF THIS SOFTWARE.
- */
+* Copyright 1993-2018 University Corporation for Atmospheric Research/Unidata
+*
+* Portions of this software were developed by the Unidata Program at the
+* University Corporation for Atmospheric Research.
+*
+* Access and use of this software shall impose the following obligations
+* and understandings on the user. The user is granted the right, without
+* any fee or cost, to use, copy, modify, alter, enhance and distribute
+* this software, and any derivative works thereof, and its supporting
+* documentation for any purpose whatsoever, provided that this entire
+* notice appears in all copies of the software, derivative works and
+* supporting documentation.  Further, UCAR requests that the user credit
+* UCAR/Unidata in any publications that result from the use of this
+* software or in any product that includes this software. The names UCAR
+* and/or Unidata, however, may not be used in any advertising or publicity
+* to endorse or promote any products or commercial entity unless specific
+* written permission is obtained from UCAR/Unidata. The user also
+* understands that UCAR/Unidata is not obligated to provide the user with
+* any support, consulting, training or assistance of any kind with regard
+* to the use, operation and performance of this software nor to provide
+* the user with any updates, revisions, new versions or "bug fixes."
+*
+* THIS SOFTWARE IS PROVIDED BY UCAR/UNIDATA "AS IS" AND ANY EXPRESS OR
+* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL UCAR/UNIDATA BE LIABLE FOR ANY SPECIAL,
+* INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING
+* FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
+* NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION
+* WITH THE ACCESS, USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
 
 #ifndef _NCD2DISPATCH_H
 #define _NCD2DISPATCH_H
@@ -45,8 +45,8 @@ extern "C" {
 
 extern int
 NCD2_open(const char *path, int mode,
-         int basepe, size_t *chunksizehintp,
-         void* mpidata, const struct NC_Dispatch* dispatch, NC* ncp);
+       int basepe, size_t *chunksizehintp,
+       void* mpidata, const struct NC_Dispatch* dispatch, NC* ncp);
 
 extern int
 NCD2_close(int ncid,void*);
@@ -130,21 +130,21 @@ NCD2_def_var(int ncid, const char *name,
 
 extern int
 NCD2_inq_var_all(int ncid, int varid, char *name, nc_type *xtypep,
-               int *ndimsp, int *dimidsp, int *nattsp,
-               int *shufflep, int *deflatep, int *deflate_levelp,
-               int *fletcher32p, int *contiguousp, size_t *chunksizesp,
-               int *no_fill, void *fill_valuep, int *endiannessp,
+             int *ndimsp, int *dimidsp, int *nattsp,
+             int *shufflep, int *deflatep, int *deflate_levelp,
+             int *fletcher32p, int *contiguousp, size_t *chunksizesp,
+             int *no_fill, void *fill_valuep, int *endiannessp,
 	       unsigned int* idp, size_t* nparamsp, unsigned int* params
-               );
+             );
 
 extern int
 NC3_inq_var_all(int ncid, int varid, char *name, nc_type *xtypep,
-               int *ndimsp, int *dimidsp, int *nattsp,
-               int *shufflep, int *deflatep, int *deflate_levelp,
-               int *fletcher32p, int *contiguousp, size_t *chunksizesp,
-               int *no_fill, void *fill_valuep, int *endiannessp,
+             int *ndimsp, int *dimidsp, int *nattsp,
+             int *shufflep, int *deflatep, int *deflate_levelp,
+             int *fletcher32p, int *contiguousp, size_t *chunksizesp,
+             int *no_fill, void *fill_valuep, int *endiannessp,
 	       unsigned int* idp, size_t* nparamsp, unsigned int* params
-               );
+             );
 
 extern int
 NCD2_inq_varid(int ncid, const char *name, int *varidp);
@@ -160,121 +160,118 @@ NCD2_var_par_access(int, int, int);
 extern int
 NCD2_def_var_fill(int, int, int, const void *);
 
-  /* netCDF4 API only */
-#ifdef USE_NETCDF4
-  extern int
-  NCD2_inq_ncid(int, const char *, int *);
+/* netCDF4 API only. but still need to be defined */
+extern int
+NCD2_inq_ncid(int, const char *, int *);
 
-  extern int
-  NCD2_inq_grps(int, int *, int *);
+extern int
+NCD2_inq_grps(int, int *, int *);
 
-  extern int
-  NCD2_inq_grpname(int, char *);
+extern int
+NCD2_inq_grpname(int, char *);
 
-  extern int
-  NCD2_inq_grpname_full(int, size_t *, char *);
+extern int
+NCD2_inq_grpname_full(int, size_t *, char *);
 
-  extern int
-  NCD2_inq_grp_parent(int, int *);
+extern int
+NCD2_inq_grp_parent(int, int *);
 
-  extern int
-  NCD2_inq_grp_full_ncid(int, const char *, int *);
+extern int
+NCD2_inq_grp_full_ncid(int, const char *, int *);
 
-  extern int
-  NCD2_inq_varids(int, int * nvars, int *);
+extern int
+NCD2_inq_varids(int, int * nvars, int *);
 
-  extern int
-  NCD2_inq_dimids(int, int * ndims, int *, int);
+extern int
+NCD2_inq_dimids(int, int * ndims, int *, int);
 
-  extern int
-  NCD2_inq_typeids(int, int * ntypes, int *);
+extern int
+NCD2_inq_typeids(int, int * ntypes, int *);
 
-  extern int
-  NCD2_inq_type_equal(int, nc_type, int, nc_type, int *);
+extern int
+NCD2_inq_type_equal(int, nc_type, int, nc_type, int *);
 
-  extern int
-  NCD2_rename_grp(int, const char *);
+extern int
+NCD2_rename_grp(int, const char *);
 
-  extern int
-  NCD2_inq_user_type(int, nc_type, char *, size_t *, nc_type *,
-                     size_t *, int *);
+extern int
+NCD2_inq_user_type(int, nc_type, char *, size_t *, nc_type *,
+                   size_t *, int *);
 
-  extern int
-  NCD2_insert_compound(int, nc_type, const char *, size_t, nc_type);
+extern int
+NCD2_insert_compound(int, nc_type, const char *, size_t, nc_type);
 
-  extern int
-  NCD2_insert_array_compound(int, nc_type, const char *, size_t,
-                             nc_type, int, const int *);
+extern int
+NCD2_insert_array_compound(int, nc_type, const char *, size_t,
+                           nc_type, int, const int *);
 
-  extern int
-  NCD2_inq_typeid(int, const char *, nc_type *);
+extern int
+NCD2_inq_typeid(int, const char *, nc_type *);
 
-  extern int
-  NCD2_inq_compound_field(int, nc_type, int, char *, size_t *,
-                          nc_type *, int *, int *);
+extern int
+NCD2_inq_compound_field(int, nc_type, int, char *, size_t *,
+                        nc_type *, int *, int *);
 
-  extern int
-  NCD2_inq_compound_fieldindex(int, nc_type, const char *, int *);
+extern int
+NCD2_inq_compound_fieldindex(int, nc_type, const char *, int *);
 
-  extern int
-  NCD2_def_vlen(int, const char *, nc_type base_typeid, nc_type *);
+extern int
+NCD2_def_vlen(int, const char *, nc_type base_typeid, nc_type *);
 
-  extern int
-  NCD2_put_vlen_element(int, int, void *, size_t, const void *);
+extern int
+NCD2_put_vlen_element(int, int, void *, size_t, const void *);
 
-  extern int
-  NCD2_get_vlen_element(int, int, const void *, size_t *, void *);
+extern int
+NCD2_get_vlen_element(int, int, const void *, size_t *, void *);
 
-  extern int
-  NCD2_insert_enum(int, nc_type, const char *, const void *);
+extern int
+NCD2_insert_enum(int, nc_type, const char *, const void *);
 
-  extern int
-  NCD2_inq_enum_member(int, nc_type, int, char *, void *);
+extern int
+NCD2_inq_enum_member(int, nc_type, int, char *, void *);
 
-  extern int
-  NCD2_inq_enum_ident(int, nc_type, long long, char *);
+extern int
+NCD2_inq_enum_ident(int, nc_type, long long, char *);
 
-  extern int
-  NCD2_def_var_deflate(int, int, int, int, int);
+extern int
+NCD2_def_var_deflate(int, int, int, int, int);
 
-  extern int
-  NCD2_def_var_fletcher32(int, int, int);
+extern int
+NCD2_def_var_fletcher32(int, int, int);
 
-  extern int
-  NCD2_def_var_chunking(int, int, int, const size_t *);
+extern int
+NCD2_def_var_chunking(int, int, int, const size_t *);
 
-  extern int
-  NCD2_def_var_endian(int, int, int);
+extern int
+NCD2_def_var_endian(int, int, int);
 
-  extern int
-  NCD2_def_var_filter(int, int, unsigned int, size_t, const unsigned int*);
+extern int
+NCD2_def_var_filter(int, int, unsigned int, size_t, const unsigned int*);
 
-  extern int
-  NCD2_inq_unlimdims(int, int *, int *);
+extern int
+NCD2_inq_unlimdims(int, int *, int *);
 
-  extern int
-  NCD2_show_metadata(int);
+extern int
+NCD2_show_metadata(int);
 
-  extern int
-  NCD2_def_compound(int, size_t, const char *, nc_type *);
+extern int
+NCD2_def_compound(int, size_t, const char *, nc_type *);
 
-  extern int
-  NCD2_def_enum(int, nc_type, const char *, nc_type *);
+extern int
+NCD2_def_enum(int, nc_type, const char *, nc_type *);
 
-  extern int
-  NCD2_def_grp(int, const char *, int *);
+extern int
+NCD2_def_grp(int, const char *, int *);
 
-  extern int
-  NCD2_def_opaque(int, size_t, const char *, nc_type *);
+extern int
+NCD2_def_opaque(int, size_t, const char *, nc_type *);
 
-  extern int
-  NCD2_set_var_chunk_cache(int, int, size_t, size_t, float);
+extern int
+NCD2_set_var_chunk_cache(int, int, size_t, size_t, float);
 
 
 extern int
 NCD2_get_var_chunk_cache(int, int, size_t *, size_t *, float *);
-
-#endif /*USE_NETCDF4*/
 
 #if defined(__cplusplus)
 }

--- a/libdap4/ncd4dispatch.c
+++ b/libdap4/ncd4dispatch.c
@@ -464,8 +464,6 @@ NCD4_var_par_access(int ncid, int p2, int p3)
 }
 
 
-#ifdef USE_NETCDF4
-
 static int
 NCD4_inq_ncid(int ncid, const char* name, int* grp_ncid)
 {
@@ -727,8 +725,6 @@ NCD4_get_var_chunk_cache(int ncid, int p2, size_t* p3, size_t* p4, float* p5)
     return (ret);
 }
 
-#endif /*USE_NETCDF4*/
-
 /**************************************************/
 /*
 Following functions are overridden to handle 
@@ -847,7 +843,6 @@ NCD4_inq_var_all,
 NCD4_var_par_access,
 NCD4_def_var_fill,
 
-#ifdef USE_NETCDF4
 NCD4_show_metadata,
 NCD4_inq_unlimdims,
 NCD4_inq_ncid,
@@ -885,8 +880,6 @@ NCD4_def_var_endian,
 NCD4_def_var_filter,
 NCD4_set_var_chunk_cache,
 NCD4_get_var_chunk_cache,
-
-#endif /*USE_NETCDF4*/
 
 };
 

--- a/libdispatch/CMakeLists.txt
+++ b/libdispatch/CMakeLists.txt
@@ -6,9 +6,8 @@
 # See netcdf-c/COPYRIGHT file for more info.
 SET(libdispatch_SOURCES dparallel.c dcopy.c dfile.c ddim.c datt.c dattinq.c dattput.c dattget.c derror.c dvar.c dvarget.c dvarput.c dvarinq.c ddispatch.c nclog.c dstring.c dutf8.c dinternal.c doffsets.c ncuri.c nclist.c ncbytes.c nchashmap.c nctime.c nc.c nclistmgr.c utf8proc.h utf8proc.c dwinpath.c dutil.c drc.c dauth.c dreadonly.c dnotnc4.c dnotnc3.c crc32.c daux.c dinfermodel.c)
 
-IF(USE_NETCDF4)
-  SET(libdispatch_SOURCES ${libdispatch_SOURCES} dgroup.c dvlen.c dcompound.c dtype.c denum.c dopaque.c dfilter.c)
-ENDIF(USE_NETCDF4)
+# Netcdf-4 only functions. Must be defined even if not used
+SET(libdispatch_SOURCES ${libdispatch_SOURCES} dgroup.c dvlen.c dcompound.c dtype.c denum.c dopaque.c dfilter.c)
 
 IF(BUILD_V2)
   SET(libdispatch_SOURCES ${libdispatch_SOURCES} dv2i.c)

--- a/libdispatch/Makefile.am
+++ b/libdispatch/Makefile.am
@@ -31,10 +31,9 @@ libdispatch_la_SOURCES += utf8proc.c utf8proc.h
 libdispatch_la_SOURCES += drc.c
 
 # Add functions only found in netCDF-4.
-if USE_NETCDF4
+# They are always defined, even if they just return an error
 libdispatch_la_SOURCES += dgroup.c dvlen.c dcompound.c dtype.c denum.c	\
 dopaque.c dfilter.c
-endif # USE_NETCDF4
 
 # Add V2 API convenience library if needed.
 if BUILD_V2

--- a/libdispatch/dcopy.c
+++ b/libdispatch/dcopy.c
@@ -323,10 +323,8 @@ nc_copy_var(int ncid_in, int varid_in, int ncid_out)
          return retval;
    }
 
-#ifdef USE_NETCDF4
    LOG((2, "nc_copy_var: ncid_in 0x%x varid_in %d ncid_out 0x%x",
         ncid_in, varid_in, ncid_out));
-#endif
 
    /* Make sure we are not trying to write into a netcdf-3 file
     * anything that won't fit in netcdf-3. */
@@ -343,9 +341,7 @@ nc_copy_var(int ncid_in, int varid_in, int ncid_out)
    /* Later on, we will need to know the size of this type. */
    if ((retval = nc_inq_type(ncid_in, xtype, type_name, &type_size)))
       return retval;
-#ifdef USE_NETCDF4
    LOG((3, "type %s has size %d", type_name, type_size));
-#endif
 
    /* Switch back to define mode, and create the output var. */
    retval = nc_redef(ncid_out);
@@ -395,9 +391,7 @@ nc_copy_var(int ncid_in, int varid_in, int ncid_out)
    {
       if ((retval = nc_inq_dimlen(ncid_in, dimids_in[d], &dimlen[d])))
          BAIL(retval);
-#ifdef USE_NETCDF4
       LOG((4, "nc_copy_var: there are %d data", dimlen[d]));
-#endif
    }
 
    /* If this is really a scalar, then set the dimlen to 1. */

--- a/libdispatch/dfile.c
+++ b/libdispatch/dfile.c
@@ -87,7 +87,6 @@ interfaces, the rest of this chapter presents a detailed description
 of the interfaces for these operations.
 */
 
-#ifdef USE_NETCDF4
 /**
  * Add handling of user-defined format.
  *
@@ -172,7 +171,6 @@ nc_inq_user_format(int mode_flag, NC_Dispatch **dispatch_table, char *magic_numb
 
    return NC_NOERR;
 }
-#endif /* USE_NETCDF4 */
 
 /**  \ingroup datasets
 Create a new netCDF file.

--- a/libdispatch/dvar.c
+++ b/libdispatch/dvar.c
@@ -311,7 +311,6 @@ nc_def_var_fill(int ncid, int varid, int no_fill, const void *fill_value)
     return ncp->dispatch->def_var_fill(ncid,varid,no_fill,fill_value);
 }
 
-#ifdef USE_NETCDF4
 /**
    Set the compression settings for a netCDF-4/HDF5 variable.
 
@@ -651,7 +650,6 @@ nc_def_var_filter(int ncid, int varid, unsigned int id,
     if(stat != NC_NOERR) return stat;
     return ncp->dispatch->def_var_filter(ncid,varid,id,nparams,parms);
 }
-#endif /* USE_NETCDF4 */
 
 /** @} */
 
@@ -1096,7 +1094,6 @@ nc_free_string(size_t len, char **data)
 }
 /** @} */
 
-#ifdef USE_NETCDF4
 /**
    @name Variables Chunk Caches
 
@@ -1208,5 +1205,4 @@ nc_get_var_chunk_cache(int ncid, int varid, size_t *sizep, size_t *nelemsp,
                                               nelemsp, preemptionp);
 }
 /** @} */
-#endif /* USE_NETCDF4 */
 /** @} */

--- a/libdispatch/dvarget.c
+++ b/libdispatch/dvarget.c
@@ -850,7 +850,6 @@ nc_get_vara_ulonglong(int ncid, int varid, const size_t *startp,
    return NC_get_vara(ncid,varid,startp,countp, (void *)ip,NC_UINT64);
 }
 
-#ifdef USE_NETCDF4
 int
 nc_get_vara_string(int ncid, int varid, const size_t *startp,
                    const size_t *countp, char* *ip)
@@ -858,7 +857,6 @@ nc_get_vara_string(int ncid, int varid, const size_t *startp,
    return NC_get_vara(ncid,varid,startp,countp, (void *)ip,NC_STRING);
 }
 
-#endif /*USE_NETCDF4*/
 /**@}*/
 
 /** \ingroup variables
@@ -988,13 +986,12 @@ nc_get_var1_ulonglong(int ncid, int varid, const size_t *indexp,
    return NC_get_var1(ncid, varid, indexp, (void *)ip, NC_UINT64);
 }
 
-#ifdef USE_NETCDF4
 int
 nc_get_var1_string(int ncid, int varid, const size_t *indexp, char* *ip)
 {
    return NC_get_var1(ncid, varid, indexp, (void *)ip, NC_STRING);
 }
-#endif /*USE_NETCDF4*/
+
 /** \} */
 
 /** \ingroup variables
@@ -1125,13 +1122,11 @@ nc_get_var_ulonglong(int ncid, int varid, unsigned long long *ip)
    return NC_get_var(ncid,varid, (void *)ip,NC_UINT64);
 }
 
-#ifdef USE_NETCDF4
 int
 nc_get_var_string(int ncid, int varid, char* *ip)
 {
    return NC_get_var(ncid,varid, (void *)ip,NC_STRING);
 }
-#endif /*USE_NETCDF4*/
 /** \} */
 
 /** \ingroup variables
@@ -1301,7 +1296,6 @@ nc_get_vars_ulonglong(int ncid, int varid, const size_t *startp,
 		      (void *)ip, NC_UINT64);
 }
 
-#ifdef USE_NETCDF4
 int
 nc_get_vars_string(int ncid, int varid,
 		   const size_t *startp, const size_t *countp,
@@ -1311,7 +1305,7 @@ nc_get_vars_string(int ncid, int varid,
    return NC_get_vars(ncid, varid, startp, countp, stridep,
 		      (void *)ip, NC_STRING);
 }
-#endif /*USE_NETCDF4*/
+
 /** \} */
 
 /** \ingroup variables
@@ -1499,7 +1493,6 @@ nc_get_varm_text(int ncid, int varid, const size_t *startp,
 		      (void *)ip, NC_CHAR);
 }
 
-#ifdef USE_NETCDF4
 int
 nc_get_varm_string(int ncid, int varid, const size_t *startp,
 		   const size_t *countp, const ptrdiff_t *stridep,
@@ -1509,7 +1502,6 @@ nc_get_varm_string(int ncid, int varid, const size_t *startp,
 		      (void *)ip, NC_STRING);
 }
 /** \} */
-#endif /*USE_NETCDF4*/
 
 
 /*! \} */ /* End of named group... */

--- a/libdispatch/dvarput.c
+++ b/libdispatch/dvarput.c
@@ -752,7 +752,6 @@ nc_put_vara_ulonglong(int ncid, int varid, const size_t *startp,
 		      NC_UINT64);
 }
 
-#ifdef USE_NETCDF4
 int
 nc_put_vara_string(int ncid, int varid, const size_t *startp,
 		   const size_t *countp, const char* *op)
@@ -761,7 +760,6 @@ nc_put_vara_string(int ncid, int varid, const size_t *startp,
 		      NC_STRING);
 }
 
-#endif /*USE_NETCDF4*/
 /**@}*/
 
 /** \ingroup variables
@@ -871,13 +869,12 @@ nc_put_var1_ulonglong(int ncid, int varid, const size_t *indexp, const unsigned 
    return NC_put_var1(ncid, varid, indexp, (void *)op, NC_UINT64);
 }
 
-#ifdef USE_NETCDF4
 int
 nc_put_var1_string(int ncid, int varid, const size_t *indexp, const char* *op)
 {
    return NC_put_var1(ncid, varid, indexp, (void*)op, NC_STRING);
 }
-#endif /*USE_NETCDF4*/
+
 /**@}*/
 
 /** \ingroup variables
@@ -1011,13 +1008,12 @@ nc_put_var_ulonglong(int ncid, int varid, const unsigned long long *op)
    return NC_put_var(ncid,varid,(void*)op,NC_UINT64);
 }
 
-#ifdef USE_NETCDF4
 int
 nc_put_var_string(int ncid, int varid, const char* *op)
 {
    return NC_put_var(ncid,varid,(void*)op,NC_STRING);
 }
-#endif /*USE_NETCDF4*/
+
 /**\} */
 
 /** \ingroup variables
@@ -1187,7 +1183,6 @@ nc_put_vars_ulonglong(int ncid, int varid,
 		      stridep, (void *)op, NC_UINT64);
 }
 
-#ifdef USE_NETCDF4
 int
 nc_put_vars_string(int ncid, int varid,
 		   const size_t *startp, const size_t *countp,
@@ -1197,7 +1192,7 @@ nc_put_vars_string(int ncid, int varid,
    return NC_put_vars(ncid, varid, startp, countp, stridep,
 		      (void *)op, NC_STRING);
 }
-#endif /*USE_NETCDF4*/
+
 /**\} */
 
 /** \ingroup variables
@@ -1381,7 +1376,6 @@ nc_put_varm_ulonglong(int ncid, int varid,
 		      (void *)op, NC_UINT64);
 }
 
-#ifdef USE_NETCDF4
 int
 nc_put_varm_string(int ncid, int varid,
 		   const size_t *startp, const size_t *countp,
@@ -1391,7 +1385,7 @@ nc_put_varm_string(int ncid, int varid,
    return NC_put_varm(ncid, varid, startp, countp, stridep, imapp,
 		      (void *)op, NC_STRING);
 }
-#endif /*USE_NETCDF4*/
+
 /**\} */
 
 /*! \} */ /*End of named group... */

--- a/libhdf5/hdf5dispatch.c
+++ b/libhdf5/hdf5dispatch.c
@@ -65,7 +65,6 @@ static const NC_Dispatch HDF5_dispatcher = {
     NC4_var_par_access,
     NC4_def_var_fill,
 
-#ifdef USE_NETCDF4
     NC4_show_metadata,
     NC4_inq_unlimdims,
 
@@ -104,7 +103,6 @@ static const NC_Dispatch HDF5_dispatcher = {
     NC4_def_var_filter,
     NC4_HDF5_set_var_chunk_cache,
     NC4_get_var_chunk_cache,
-#endif
 
 };
 

--- a/libsrc/nc3dispatch.c
+++ b/libsrc/nc3dispatch.c
@@ -40,7 +40,6 @@ static int NC3_inq_var_all(int ncid, int varid, char *name, nc_type *xtypep,
 
 static int NC3_var_par_access(int,int,int);
 
-#ifdef USE_NETCDF4
 static int NC3_show_metadata(int);
 static int NC3_inq_unlimdims(int,int*,int*);
 static int NC3_inq_ncid(int,const char*,int*);
@@ -78,7 +77,6 @@ static int NC3_def_var_filter(int, int, unsigned int, size_t, const unsigned int
 
 static int NC3_set_var_chunk_cache(int,int,size_t,size_t,float);
 static int NC3_get_var_chunk_cache(int,int,size_t*,size_t*,float*);
-#endif /*USE_NETCDF4*/
 
 static const NC_Dispatch NC3_dispatcher = {
 
@@ -130,7 +128,6 @@ NC3_inq_var_all,
 NC3_var_par_access,
 NC3_def_var_fill,
 
-#ifdef USE_NETCDF4
 NC3_show_metadata,
 NC3_inq_unlimdims,
 NC3_inq_ncid,
@@ -168,8 +165,6 @@ NC3_def_var_endian,
 NC3_def_var_filter,
 NC3_set_var_chunk_cache,
 NC3_get_var_chunk_cache,
-
-#endif /*_NC4DISPATCH_H*/
 
 };
 
@@ -215,8 +210,6 @@ NC3_var_par_access(int ncid, int varid, int par_access)
 {
     return NC_NOERR; /* no-op for netcdf classic */
 }
-    
-#ifdef USE_NETCDF4
 
 static int
 NC3_inq_unlimdims(int ncid, int *ndimsp, int *unlimdimidsp)
@@ -515,6 +508,4 @@ NC3_def_var_filter(int ncid, int varid, unsigned int id, size_t nparams, const u
 {
     return NC_ENOTNC4;
 }
-
-#endif /*USE_NETCDF4*/
     

--- a/libsrcp/ncpdispatch.c
+++ b/libsrcp/ncpdispatch.c
@@ -1201,8 +1201,6 @@ NCP_var_par_access(int ncid, int varid, int par_access)
     return NC_NOERR;
 }
 
-#ifdef USE_NETCDF4
-
 static int
 NCP_show_metadata(int ncid)
 {
@@ -1375,8 +1373,6 @@ NCP_inq_user_type(int ncid, nc_type typeid, char *name, size_t *size,
     return NC_ENOTNC4;
 }
 
-#endif /*USE_NETCDF4*/
-
 /**************************************************/
 /* Pnetcdf Dispatch table */
 
@@ -1430,7 +1426,6 @@ NCP_inq_var_all,
 NCP_var_par_access,
 NCP_def_var_fill,
 
-#ifdef USE_NETCDF4
 NCP_show_metadata,
 NCP_inq_unlimdims,
 
@@ -1469,7 +1464,6 @@ NC_NOTNC4_def_var_endian,
 NC_NOTNC4_def_var_filter,
 NC_NOTNC4_set_var_chunk_cache,
 NC_NOTNC4_get_var_chunk_cache,
-#endif /*USE_NETCDF4*/
 
 };
 

--- a/ncdump/nctrunc.c
+++ b/ncdump/nctrunc.c
@@ -15,7 +15,7 @@ main(int argc, char** argv)
     unsigned char buffer[BUFLEN];
     size_t count, red, avail, trunc;
     unsigned char* p = buffer;
-    long i;
+    size_t i;
     FILE* input = stdin;
 
     if(argc > 1) {

--- a/ncdump/ncvalidator.c
+++ b/ncdump/ncvalidator.c
@@ -1357,7 +1357,7 @@ val_get_NC_attrV(int         fd,
         memset(pad, 0, X_ALIGN-1);
         if (memcmp(gbp->pos, pad, padding) != 0) {
             /* This is considered not a fatal error, we continue to validate */
-            if (verbose) printf("Error @ [0x%8.8zx]:\n", ERR_ADDR);
+            if (verbose) printf("Error @ [0x%8.8zx]:\n", (size_t)ERR_ADDR);
             if (verbose) printf("\t%s: value padding is non-null byte\n", loc);
             DEBUG_ASSIGN_ERROR(status, NC_ENULLPAD)
             if (repair) {
@@ -1729,7 +1729,7 @@ val_get_NC_var(int          fd,
         err = val_check_buffer(fd, gbp, (gbp->version < 5 ? 4 : 8));
         if (err != NC_NOERR) {
             if (trace) printf("\n");
-            if (verbose) printf("Error @ [0x%8.8zx]:\n", ERR_ADDR);
+            if (verbose) printf("Error @ [0x%8.8zx]:\n", (size_t)ERR_ADDR);
             if (verbose) printf("\t%s: Fail to read dimid[%d]\n",xloc,dim);
             free_NC_var(varp);
             return err;
@@ -1791,7 +1791,7 @@ val_get_NC_var(int          fd,
 
     err = val_check_buffer(fd, gbp, (gbp->version == 1 ? 4 : 8));
     if (err != NC_NOERR) {
-        if (verbose) printf("Error @ [0x%8.8zx]:\n", ERR_ADDR);
+        if (verbose) printf("Error @ [0x%8.8zx]:\n", (size_t)ERR_ADDR);
         if (verbose) printf("\t%s: Fail to read begin\n",xloc);
         free_NC_var(varp);
         return err;
@@ -2278,7 +2278,6 @@ usage(char *argv0)
 
 int main(int argc, char **argv)
 {
-    extern int optind;
     char filename[512], *path;
     int i, omode, fd, status=NC_NOERR;
     NC *ncp=NULL;


### PR DESCRIPTION
Partially address: https://github.com/Unidata/netcdf-c/issues/1056

Currently, some of the entries in the dispatch table
are conditional'd on USE_NETCDF4.

As a step in upgrading the dispatch table for use
with user-defined tables, we remove that conditional.
This means that all dispatch tables must implement the
netcdf-4 specific functions even if only to make them
return NC_ENOTNC4. To simplify this, a set of default
functions are defined in libdispatch/dnotnc4.c to provide this
behavior. The file libdispatch/dnotnc3.c is also relevant to
this.

The primary fix is to modify the various dispatch tables to
remove the conditional and use the functions in
libdispatch/dnotnc4.c as appropriate. In practice, all of the
existing tables are prepared to handle this, so the only
real change is to remove the conditionals.

Misc. Unrelated fixes
1. Fix some annoying warnings in ncvalidator.

Notes:
1. This has not been tested with either pnetcdf or hdf4 enabled.
   When those are enabled, it is possible that there are still
   some conditionals that need to be fixed.