### PR TITLE
removed unneeded setting of int_ncid by libhdf5 layer

### DIFF
--- a/libhdf5/hdf5create.c
+++ b/libhdf5/hdf5create.c
@@ -290,16 +290,13 @@ NC4_create(const char* path, int cmode, size_t initialsz, int basepe,
     hdf5_set_log_level();
 #endif /* LOGGING */
 
-    /* Check the cmode for validity. */
+    /* Check the cmode for validity. Checking parallel against
+     * NC_DISKLESS already done in NC_create(). */
     if((cmode & ILLEGAL_CREATE_FLAGS) != 0)
-    {res = NC_EINVAL; goto done;}
+        return NC_EINVAL
 
-    /* check parallel against NC_DISKLESS already done in NC_create() */
-
-    nc_file->int_ncid = nc_file->ext_ncid;
-
+    /* Create the netCDF-4/HDF5 file. */
     res = nc4_create_file(path, cmode, initialsz, parameters, nc_file);
 
-done:
     return res;
 }

--- a/libhdf5/hdf5create.c
+++ b/libhdf5/hdf5create.c
@@ -27,9 +27,10 @@ extern int NC4_create_image_file(NC_FILE_INFO_T* h5, size_t);
  *
  * @param path The file name of the new file.
  * @param cmode The creation mode flag.
- * @param initialsz The proposed initial file size (advisory)
- * @param parameters extra parameter info (like  MPI communicator)
- * @param nc Pointer to an instance of NC.
+ * @param initialsz The proposed initial file size (advisory, for
+ * in-memory netCDF-4/HDF5 files only).
+ * @param parameters extra parameter info (like MPI communicator).
+ * @param nc Pointer to an already-existing instance of NC.
  *
  * @return ::NC_NOERR No error.
  * @return ::NC_EINVAL Invalid input (check cmode).

--- a/libhdf5/hdf5create.c
+++ b/libhdf5/hdf5create.c
@@ -294,7 +294,7 @@ NC4_create(const char* path, int cmode, size_t initialsz, int basepe,
     /* Check the cmode for validity. Checking parallel against
      * NC_DISKLESS already done in NC_create(). */
     if((cmode & ILLEGAL_CREATE_FLAGS) != 0)
-        return NC_EINVAL
+        return NC_EINVAL;
 
     /* Create the netCDF-4/HDF5 file. */
     res = nc4_create_file(path, cmode, initialsz, parameters, nc_file);

--- a/libhdf5/hdf5open.c
+++ b/libhdf5/hdf5open.c
@@ -887,8 +887,6 @@ NC4_open(const char *path, int mode, int basepe, size_t *chunksizehintp,
     hdf5_set_log_level();
 #endif /* LOGGING */
 
-    nc_file->int_ncid = nc_file->ext_ncid;
-
     /* Open the file. */
     return nc4_open_file(path, mode, parameters, nc_file);
 }


### PR DESCRIPTION
Part of #1426 

In this PR I remove the setting of int_ncid by libhdf5 code. This turns out to be unnecessary.

This is useful both to reduce code clutter and confusion, and also because this was the only use of the NC structure in the HDF5 code. 