### PR TITLE
Fix XGetopt.h inclusion for Windows/MinGW

### DIFF
--- a/ncdump/ncdump.c
+++ b/ncdump/ncdump.c
@@ -18,7 +18,7 @@ Research/Unidata. See \ref copyright file for more info.  */
 #include <fcntl.h>
 #endif
 
-#ifdef _WIN32
+#ifdef _MSC_VER
 #define snprintf _snprintf
 #include "XGetopt.h"
 int opterr;

--- a/ncdump/ocprint.c
+++ b/ncdump/ocprint.c
@@ -30,7 +30,7 @@
 #include "oc.h"
 #include "ocx.h"
 
-#ifdef _WIN32
+#ifdef _MSC_VER
 #include "XGetopt.h"
 int opterr, optind;
 char* optarg;


### PR DESCRIPTION
With MinGW, _WIN32 is defined and HAVE_GETOPT_H is also defined.

To avoid double inclusion of the function getopt(), the _WIN32 is replace with _MSC_VER, and it is unified the principe fir all XGetopt.h inclusion.