### PR TITLE
An example argument typo

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -132,7 +132,7 @@ Next, specify where you want to install HDF5 in another shell variable, for exam
 ~~~~{.py}
     $ # Build and install HDF5
     $ H5DIR=/usr/local
-    $ ./configure --with-zlib=${ZDIR} --prefix=${H5DIR} --eanble-hl
+    $ ./configure --with-zlib=${ZDIR} --prefix=${H5DIR} --enable-hl
     $ make check
     $ make install   # or sudo make install, if root permissions required
 ~~~~


### PR DESCRIPTION
`./configure --with-zlib=${ZDIR} --prefix=${H5DIR} --eanble-hl` on line 135
command errors, but runs if changed to `enable-hl`