### PR TITLE
removed commented lines refering to run_par_test2.sh, which does not exist

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1005,15 +1005,9 @@ IF(ENABLE_PARALLEL4 AND ENABLE_NETCDF_4)
     SET(STATUS_PARALLEL "ON")
     configure_file("${netCDF_SOURCE_DIR}/nc_test4/run_par_test.sh.in"
       "${netCDF_BINARY_DIR}/tmp/run_par_test.sh" @ONLY NEWLINE_STYLE LF)
-    #configure_file("${netCDF_SOURCE_DIR}/nc_test4/run_par_test2.sh.in"
-    #  "${netCDF_BINARY_DIR}/tmp/run_par_test2.sh" @ONLY NEWLINE_STYLE LF)
     FILE(COPY "${netCDF_BINARY_DIR}/tmp/run_par_test.sh"
       DESTINATION ${netCDF_BINARY_DIR}/nc_test4
       FILE_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
-    #FILE(COPY "${netCDF_BINARY_DIR}/tmp/run_par_test2.sh"
-    #  DESTINATION ${netCDF_BINARY_DIR}/nc_test4
-    #  FILE_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
-
   ENDIF()
 ENDIF()
 


### PR DESCRIPTION
Fixes #1372

Remove mention of run_par_tests2.sh from CMakeList.txt. It is no longer used.

This is just PR #1454 again, with up-to-date master, trying to pass the DAP tests in Travis.