### PR TITLE
Support parallel functions in MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -615,7 +615,7 @@ IF(USE_HDF5 OR ENABLE_NETCDF_4)
     #####
     IF(MSVC)
       SET(SEARCH_PACKAGE_NAME ${HDF5_PACKAGE_NAME})
-      FIND_PACKAGE(HDF5 NAMES ${SEARCH_PACKAGE_NAME} COMPONENTS C HL NO_MODULES REQUIRED ${NC_HDF5_LINK_TYPE})
+      FIND_PACKAGE(HDF5 NAMES ${SEARCH_PACKAGE_NAME} COMPONENTS C HL CONFIG REQUIRED ${NC_HDF5_LINK_TYPE})
     ELSE(MSVC)
       FIND_PACKAGE(HDF5 COMPONENTS C HL REQUIRED)
     ENDIF(MSVC)
@@ -699,28 +699,23 @@ IF(USE_HDF5 OR ENABLE_NETCDF_4)
     SET(HDF5_C_LIBRARY_hdf5 "${HDF5_C_LIBRARY}")
   ENDIF()
 
-  ###
-  # The following options are not used in Windows currently.
-  ###
-  IF(NOT MSVC)
-    # Find out if HDF5 was built with parallel support.
-    # Do that by checking for the targets H5Pget_fapl_mpiposx and
-    # H5Pget_fapl_mpio in ${HDF5_LIB}.
+  # Find out if HDF5 was built with parallel support.
+  # Do that by checking for the targets H5Pget_fapl_mpiposx and
+  # H5Pget_fapl_mpio in ${HDF5_LIB}.
 
-    # H5Pset_fapl_mpiposix and H5Pget_fapl_mpiposix have been removed since HDF5 1.8.12.
-    # Use H5Pset_fapl_mpio and H5Pget_fapl_mpio, instead.
-    # CHECK_LIBRARY_EXISTS(${HDF5_C_LIBRARY_hdf5} H5Pget_fapl_mpiposix "" HDF5_IS_PARALLEL_MPIPOSIX)
+  # H5Pset_fapl_mpiposix and H5Pget_fapl_mpiposix have been removed since HDF5 1.8.12.
+  # Use H5Pset_fapl_mpio and H5Pget_fapl_mpio, instead.
+  # CHECK_LIBRARY_EXISTS(${HDF5_C_LIBRARY_hdf5} H5Pget_fapl_mpiposix "" HDF5_IS_PARALLEL_MPIPOSIX)
 
-    CHECK_LIBRARY_EXISTS(${HDF5_C_LIBRARY_hdf5} H5Pget_fapl_mpio "" HDF5_IS_PARALLEL_MPIO)
-    IF(HDF5_IS_PARALLEL_MPIO)
-      SET(HDF5_PARALLEL ON)
-    ELSE()
-      SET(HDF5_PARALLEL OFF)
-    ENDIF()
+  CHECK_LIBRARY_EXISTS(${HDF5_C_LIBRARY_hdf5} H5Pget_fapl_mpio "" HDF5_IS_PARALLEL_MPIO)
+  IF(HDF5_IS_PARALLEL_MPIO)
+    SET(HDF5_PARALLEL ON)
+  ELSE()
+    SET(HDF5_PARALLEL OFF)
+  ENDIF()
 
-    #Check to see if HDF5 library has collective metadata APIs, (HDF5 >= 1.10.0)
-    CHECK_LIBRARY_EXISTS(${HDF5_C_LIBRARY_hdf5} H5Pset_all_coll_metadata_ops "" HDF5_HAS_COLL_METADATA_OPS)
-  ENDIF(NOT MSVC)
+  #Check to see if HDF5 library has collective metadata APIs, (HDF5 >= 1.10.0)
+  CHECK_LIBRARY_EXISTS(${HDF5_C_LIBRARY_hdf5} H5Pset_all_coll_metadata_ops "" HDF5_HAS_COLL_METADATA_OPS)
 
   #Check to see if H5Z_SZIP exists in HDF5_Libraries. If so, we must use szip.
   CHECK_LIBRARY_EXISTS(${HDF5_C_LIBRARY_hdf5} H5Z_SZIP "" USE_SZIP)
@@ -1006,6 +1001,10 @@ IF(ENABLE_PARALLEL4 AND ENABLE_NETCDF_4)
     SET(USE_PARALLEL OFF CACHE BOOL "")
     MESSAGE(STATUS "Cannot find HDF5 library built with parallel support. Disabling parallel build.")
   ELSE()
+    IF(MSVC)
+      FIND_PACKAGE(MPI REQUIRED)
+      INCLUDE_DIRECTORIES(${MPI_C_INCLUDE_PATH})
+    ENDIF()
     SET(HDF5_PARALLEL ON CACHE BOOL "")
     SET(USE_PARALLEL ON CACHE BOOL "")
     SET(USE_PARALLEL4 ON CACHE BOOL "")

--- a/include/netcdf_par.h
+++ b/include/netcdf_par.h
@@ -14,6 +14,7 @@
 #define NETCDF_PAR_H 1
 
 #include <mpi.h>
+#include "ncexternl.h"
 
 #if defined(__cplusplus)
 extern "C" {
@@ -25,24 +26,24 @@ extern "C" {
 #define NC_COLLECTIVE 1
 
 /* Create a file and enable parallel I/O. */
-    extern int
+    EXTERNL int
     nc_create_par(const char *path, int cmode, MPI_Comm comm, MPI_Info info,
                   int *ncidp);
 
 /* Open a file and enable parallel I/O. */
-    extern int
+    EXTERNL int
     nc_open_par(const char *path, int mode, MPI_Comm comm, MPI_Info info,
                 int *ncidp);
 
 /* Change a variable from independent (the default) to collective
  * access. */
-    extern int
+    EXTERNL int
     nc_var_par_access(int ncid, int varid, int par_access);
 
-    extern int
+    EXTERNL int
     nc_create_par_fortran(const char *path, int cmode, int comm,
                           int info, int *ncidp);
-    extern int
+    EXTERNL int
     nc_open_par_fortran(const char *path, int mode, int comm,
                         int info, int *ncidp);
 


### PR DESCRIPTION
This PR enables building netCDF with parallel I/O support under MSVC. This only requires minor changes as HDF5-1.10.5 supports Microsoft MPI by default with `HDF5_ENABLE_PARALLEL`. All tests are passing on my end except **tst_parallel5** - I'll look into it.

The change to `FIND_PACKAGE(HDF5)` is minor to correct a typo, `NO_MODULES` should be `NO_MODULE|CONFIG` (synonyms). While this fixes HDF5 linkage on my system (I'm using the [CMake Package](https://www.hdfgroup.org/downloads/hdf5/source-code/) from HDF Group), I think more extensive changes may be needed to make this more generic. You might consider integrating the changes in vcpkg, see for example microsoft/vcpkg#6771.

This should also fix the incomplete library exports discussed in #554 and [netcdf-fortran#48](https://github.com/Unidata/netcdf-fortran/issues/48#issuecomment-277710507), at least when parallel I/O is enabled.

**Supporting Info**
[Configuration Summary](https://github.com/Unidata/netcdf-c/files/3639282/configuration_summary.txt)
[Test Results](https://github.com/Unidata/netcdf-c/files/3639284/test_results.txt)
