### PR TITLE
Remove incorrect comment

### DIFF
--- a/libdispatch/drc.c
+++ b/libdispatch/drc.c
@@ -415,7 +415,6 @@ rclocate(const char* key, const char* hostport)
 
 /**
  * Locate rc file by searching in directory prefix.
- * Prefix must end in '/'
  */
 static
 int


### PR DESCRIPTION
The comment states that prefix must end in '/', but the '/' is added in the function itself, so the prefix should *not* end in '/' and the comment is incorrect.