### PR TITLE
Fix documentation for `nc_put_att_text`

### DIFF
--- a/libdispatch/dattput.c
+++ b/libdispatch/dattput.c
@@ -83,9 +83,9 @@ be assigned or ::NC_GLOBAL for a global attribute.
 \param name Attribute \ref object_name. \ref attribute_conventions may
 apply.
 
-\param len Number of values provided for the attribute.
+\param len Length of `value` not including trailing null.
 
-\param value Pointer to one or more values.
+\param value Pointer to text value.
 
 \returns ::NC_NOERR No error.
 \returns ::NC_EINVAL More than one value for _FillValue or trying to set global _FillValue.


### PR DESCRIPTION
The `nc_put_att_text` function creates an attribute consisting of a single value unlike the other functions which can output more than one value.  Update documentation to make this clear.  The `len` argument is length of text and not the number of text items.