### PR TITLE
Improve the fix for #350 included in #1119

### DIFF
--- a/libhdf5/nc4hdf.c
+++ b/libhdf5/nc4hdf.c
@@ -512,7 +512,6 @@ put_att_grpa(NC_GRP_INFO_T *grp, int varid, NC_ATT_INFO_T *att)
     hid_t existing_att_typeid = 0, existing_attid = 0, existing_spaceid = 0;
     hsize_t dims[1]; /* netcdf attributes always 1-D. */
     htri_t attr_exists;
-    int reuse_att = 0; /* Will be true if we can re-use an existing att. */
     void *data;
     int phoney_data = 99;
     int retval = NC_NOERR;
@@ -612,31 +611,59 @@ put_att_grpa(NC_GRP_INFO_T *grp, int varid, NC_ATT_INFO_T *att)
             BAIL(NC_EATTMETA);
 
         /* How big is the attribute? */
-        if ((existing_spaceid = H5Aget_space(existing_attid)) < 0)
-            BAIL(NC_EATTMETA);
-        if ((npoints = H5Sget_simple_extent_npoints(existing_spaceid)) < 0)
-            BAIL(NC_EATTMETA);
-
-        /* Delete the attribute. */
-        if (file_typeid != existing_att_typeid || npoints != att->len)
-        {
-            if (H5Adelete(locid, att->hdr.name) < 0)
-                BAIL(NC_EHDFERR);
+        if (att->nc_typeid == NC_CHAR) {
+          /* For text attributes the size is specified in the datatype
+             and it is enough to compare types using H5Tequal(). Here
+             we set npoints to disable the second part of the
+             comparison below. */
+          npoints = att->len;
         }
         else
         {
-            reuse_att++;
+          if ((existing_spaceid = H5Aget_space(existing_attid)) < 0)
+            BAIL(NC_EATTMETA);
+          if ((npoints = H5Sget_simple_extent_npoints(existing_spaceid)) < 0)
+            BAIL(NC_EATTMETA);
         }
+
+        if (!H5Tequal(file_typeid, existing_att_typeid) || npoints != att->len)
+        {
+          /* The attribute exists but we cannot re-use it. */
+
+          /* Delete the attribute. */
+            if (H5Adelete(locid, att->hdr.name) < 0)
+                BAIL(NC_EHDFERR);
+
+            /* Re-create the attribute with the type and length
+               reflecting the new value (or values). */
+            if ((attid = H5Acreate(locid, att->hdr.name, file_typeid, spaceid,
+                                   H5P_DEFAULT)) < 0)
+              BAIL(NC_EATTMETA);
+
+            /* Write the values, (even if length is zero). */
+            if (H5Awrite(attid, file_typeid, data) < 0)
+              BAIL(NC_EATTMETA);
+        }
+        else
+        {
+          /* The attribute exists and we can re-use it. */
+
+          /* Write the values, re-using the existing attribute. */
+          if (H5Awrite(existing_attid, file_typeid, data) < 0)
+            BAIL(NC_EATTMETA);
+        }
+    } else {
+      /* The attribute does not exist yet. */
+
+      /* Create the attribute. */
+      if ((attid = H5Acreate(locid, att->hdr.name, file_typeid, spaceid,
+                             H5P_DEFAULT)) < 0)
+        BAIL(NC_EATTMETA);
+
+      /* Write the values, (even if length is zero). */
+      if (H5Awrite(attid, file_typeid, data) < 0)
+        BAIL(NC_EATTMETA);
     }
-
-    /* Create the attribute. */
-    if ((attid = H5Acreate(locid, att->hdr.name, file_typeid, spaceid,
-                           H5P_DEFAULT)) < 0)
-        BAIL(NC_EATTMETA);
-
-    /* Write the values, (even if length is zero). */
-    if (H5Awrite(attid, file_typeid, data) < 0)
-        BAIL(NC_EATTMETA);
 
 exit:
     if (file_typeid && H5Tclose(file_typeid))

--- a/libhdf5/nc4hdf.c
+++ b/libhdf5/nc4hdf.c
@@ -611,22 +611,15 @@ put_att_grpa(NC_GRP_INFO_T *grp, int varid, NC_ATT_INFO_T *att)
             BAIL(NC_EATTMETA);
 
         /* How big is the attribute? */
-        if (att->nc_typeid == NC_CHAR) {
-          /* For text attributes the size is specified in the datatype
-             and it is enough to compare types using H5Tequal(). Here
-             we set npoints to disable the second part of the
-             comparison below. */
-          npoints = att->len;
-        }
-        else
-        {
-          if ((existing_spaceid = H5Aget_space(existing_attid)) < 0)
-            BAIL(NC_EATTMETA);
-          if ((npoints = H5Sget_simple_extent_npoints(existing_spaceid)) < 0)
-            BAIL(NC_EATTMETA);
-        }
+        if ((existing_spaceid = H5Aget_space(existing_attid)) < 0)
+          BAIL(NC_EATTMETA);
+        if ((npoints = H5Sget_simple_extent_npoints(existing_spaceid)) < 0)
+          BAIL(NC_EATTMETA);
 
-        if (!H5Tequal(file_typeid, existing_att_typeid) || npoints != att->len)
+        /* For text attributes the size is specified in the datatype
+           and it is enough to compare types using H5Tequal(). */
+        if (!H5Tequal(file_typeid, existing_att_typeid) ||
+            (att->nc_typeid != NC_CHAR && npoints != att->len))
         {
           /* The attribute exists but we cannot re-use it. */
 

--- a/libhdf5/nc4hdf.c
+++ b/libhdf5/nc4hdf.c
@@ -612,18 +612,18 @@ put_att_grpa(NC_GRP_INFO_T *grp, int varid, NC_ATT_INFO_T *att)
 
         /* How big is the attribute? */
         if ((existing_spaceid = H5Aget_space(existing_attid)) < 0)
-          BAIL(NC_EATTMETA);
+            BAIL(NC_EATTMETA);
         if ((npoints = H5Sget_simple_extent_npoints(existing_spaceid)) < 0)
-          BAIL(NC_EATTMETA);
+            BAIL(NC_EATTMETA);
 
         /* For text attributes the size is specified in the datatype
            and it is enough to compare types using H5Tequal(). */
         if (!H5Tequal(file_typeid, existing_att_typeid) ||
             (att->nc_typeid != NC_CHAR && npoints != att->len))
         {
-          /* The attribute exists but we cannot re-use it. */
+            /* The attribute exists but we cannot re-use it. */
 
-          /* Delete the attribute. */
+            /* Delete the attribute. */
             if (H5Adelete(locid, att->hdr.name) < 0)
                 BAIL(NC_EHDFERR);
 
@@ -631,31 +631,33 @@ put_att_grpa(NC_GRP_INFO_T *grp, int varid, NC_ATT_INFO_T *att)
                reflecting the new value (or values). */
             if ((attid = H5Acreate(locid, att->hdr.name, file_typeid, spaceid,
                                    H5P_DEFAULT)) < 0)
-              BAIL(NC_EATTMETA);
+                BAIL(NC_EATTMETA);
 
             /* Write the values, (even if length is zero). */
             if (H5Awrite(attid, file_typeid, data) < 0)
-              BAIL(NC_EATTMETA);
+                BAIL(NC_EATTMETA);
         }
         else
         {
-          /* The attribute exists and we can re-use it. */
+            /* The attribute exists and we can re-use it. */
 
-          /* Write the values, re-using the existing attribute. */
-          if (H5Awrite(existing_attid, file_typeid, data) < 0)
-            BAIL(NC_EATTMETA);
+            /* Write the values, re-using the existing attribute. */
+            if (H5Awrite(existing_attid, file_typeid, data) < 0)
+                BAIL(NC_EATTMETA);
         }
-    } else {
-      /* The attribute does not exist yet. */
+    }
+    else
+    {
+        /* The attribute does not exist yet. */
 
-      /* Create the attribute. */
-      if ((attid = H5Acreate(locid, att->hdr.name, file_typeid, spaceid,
-                             H5P_DEFAULT)) < 0)
-        BAIL(NC_EATTMETA);
+        /* Create the attribute. */
+        if ((attid = H5Acreate(locid, att->hdr.name, file_typeid, spaceid,
+                               H5P_DEFAULT)) < 0)
+            BAIL(NC_EATTMETA);
 
-      /* Write the values, (even if length is zero). */
-      if (H5Awrite(attid, file_typeid, data) < 0)
-        BAIL(NC_EATTMETA);
+        /* Write the values, (even if length is zero). */
+        if (H5Awrite(attid, file_typeid, data) < 0)
+            BAIL(NC_EATTMETA);
     }
 
 exit:


### PR DESCRIPTION
1) We have to use `H5Tequal()` to compare HDF5 type IDs.
2) When checking if we can re-use an `NC_CHAR` attribute it is enough to compare data types (`H5Tequal()` takes care of the size comparison).
3) This PR adds missing code (`reuse_att` was set but not used).

Now an attribute in a NetCDF-4 file can be modified as many times as necessary, as long its type and length remain the same.

Modifications changing either type or length of an attribute require deleting and re-creating an attribute which increments the attribute order creation index. Once this index reaches 65535 all attribute modifications (for a particular group or variable) will fail.