### PR TITLE
User-defined formats must come first in NC_infermodel, plus test

### DIFF
--- a/libdispatch/dinfermodel.c
+++ b/libdispatch/dinfermodel.c
@@ -395,6 +395,16 @@ NC_omodeinfer(int useparallel, int cmode, NCmodel* model)
 
     /* Process the cmode; may override some already set flags */
 
+    if(fIsSet(cmode,(NC_UDF0|NC_UDF1))) {
+	model->format = NC_FORMAT_NETCDF4;
+        if(fIsSet(cmode,NC_UDF0)) {
+	    model->impl = NC_FORMATX_UDF0;
+	} else {
+	    model->impl = NC_FORMATX_UDF1;
+	}
+	goto done;
+    }
+
     if(fIsSet(cmode,NC_64BIT_OFFSET)) {
 	model->impl = NC_FORMATX_NC3;
 	model->format = NC_FORMAT_64BIT_OFFSET;
@@ -414,16 +424,6 @@ NC_omodeinfer(int useparallel, int cmode, NCmodel* model)
 	else
 	    model->format = NC_FORMAT_NETCDF4;
         goto done;
-    }
-
-    if(fIsSet(cmode,(NC_UDF0|NC_UDF1))) {
-	model->format = NC_FORMAT_NETCDF4;
-        if(fIsSet(cmode,NC_UDF0)) {
-	    model->impl = NC_FORMATX_UDF0;
-	} else {
-	    model->impl = NC_FORMATX_UDF1;
-	}
-	goto done;
     }
 
     /* Default to classic model */

--- a/libdispatch/dinfermodel.c
+++ b/libdispatch/dinfermodel.c
@@ -393,8 +393,11 @@ NC_omodeinfer(int useparallel, int cmode, NCmodel* model)
     if(!fIsSet(cmode,NC_FORMAT_ALL))
 	set_default_mode(&cmode);
 
-    /* Process the cmode; may override some already set flags */
-
+    /* Process the cmode; may override some already set flags. The
+     * user-defined formats must be checked first. They may choose to
+     * use some of the other flags, like NC_NETCDF4, so we must fist
+     * check NC_UDF0 and NC_UDF1 before checking for any other
+     * flag. */
     if(fIsSet(cmode,(NC_UDF0|NC_UDF1))) {
 	model->format = NC_FORMAT_NETCDF4;
         if(fIsSet(cmode,NC_UDF0)) {

--- a/nc_test4/tst_udf.c
+++ b/nc_test4/tst_udf.c
@@ -184,7 +184,11 @@ main(int argc, char **argv)
          if (nc_open(FILE_NAME, mode[i], &ncid)) ERR;
          if (nc_close(ncid)) ERR;
 
-         /* Open file again and abort, which is the same as closing it. */
+         /* Open file again and abort, which is the same as closing
+          * it. This also tests that the UDF flags are given
+          * priority. If NC_NETCDF4 flag were given priority, then
+          * nc_abort() will not return TEST_VAL_42, but instead will
+          * return 0. */
          if (nc_open(FILE_NAME, mode[i]|NC_NETCDF4, &ncid)) ERR;
          if (nc_inq_format(ncid, NULL) != TEST_VAL_42) ERR;
          if (nc_inq_format_extended(ncid, NULL, NULL) != TEST_VAL_42) ERR;

--- a/nc_test4/tst_udf.c
+++ b/nc_test4/tst_udf.c
@@ -185,7 +185,7 @@ main(int argc, char **argv)
          if (nc_close(ncid)) ERR;
 
          /* Open file again and abort, which is the same as closing it. */
-         if (nc_open(FILE_NAME, mode[i], &ncid)) ERR;
+         if (nc_open(FILE_NAME, mode[i]|NC_NETCDF4, &ncid)) ERR;
          if (nc_inq_format(ncid, NULL) != TEST_VAL_42) ERR;
          if (nc_inq_format_extended(ncid, NULL, NULL) != TEST_VAL_42) ERR;
          if (nc_abort(ncid) != TEST_VAL_42) ERR;


### PR DESCRIPTION
Fixes #1522 

Also modified tst_udf.c to detect this problem. Also added comments to dinfermodel.c and tst_udf.c to describe what is going on.

@DennisHeimbigner this PR will be of interest to you.

@WardF we absolutely want this in before the next release.