### PR TITLE
If HDF5 dataset has multiple anonymous dimensions of the same size, assume they are different dimensions

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,8 @@ This file contains a high-level description of this package's evolution. Release
 
 ## 4.7.3 - TBD
 
+* [Bug Fix][Enhancement] Corrected assignment of anonymous (a.k.a. phony) dimensions in an HDF5 file. Now when a dataset uses multiple dimensions of the same size, netcdf assumes they are different dimensions. See [GitHub #1484](https://github.com/Unidata/netcdf-c/issues/1484) for more information.
+
 ## 4.7.2 - October 22, 2019
 
 * [Bug Fix][Enhancement] Various bug fixes and enhancements.

--- a/docs/tutorial.dox
+++ b/docs/tutorial.dox
@@ -708,7 +708,9 @@ deserve what you get, which will be a mess.
 Additionally, netCDF stores some extra information for dimensions
 without dimension scale information. (That is, a dimension without an
 associated coordinate variable). So HDF5 users should not write data
-to a netCDF-4 file which extends any unlimited dimension.
+to a netCDF-4 file which extends any unlimited dimension, or change
+any of the extra attributes used by netCDF to track dimension
+information.
 
 Also there are some types allowed in HDF5, but not allowed in netCDF-4
 (for example the time type). Using any such type in a netCDF-4 file
@@ -736,7 +738,20 @@ example, a user might have 1D dimension scales for lat and lon, and a
 the second.
 
 If dimension scales are not used, then netCDF-4 can still edit the
-file, and will invent anonymous dimensions for each variable shape.
+file, and will invent anonymous dimensions for each variable
+shape. This is done by iterating through the space of each dataset. As
+each space size is encountered, a phony dimension of that size is
+checked for. It it does not exist, a new phony dimension is created
+for that size. In this way, a HDF5 file with datasets that are using
+shared dimensions can be seen properly in netCDF-4. (There is no
+shared dimension in HDF5, but data users will freqently write many
+datasets with the same shape, and intend these to be shared
+dimensions.)
+
+Starting with version 4.7.3, if a dataset is encountered with uses the
+same size for two or more of its dataspace lengths, then a new phony
+dimension will be created for each. That is, a dataset with size
+[100][100] will result in two phony dimensions, each of size 100.
 
 \page groups Groups
 

--- a/libdispatch/dinfermodel.c
+++ b/libdispatch/dinfermodel.c
@@ -395,6 +395,16 @@ NC_omodeinfer(int useparallel, int cmode, NCmodel* model)
 
     /* Process the cmode; may override some already set flags */
 
+    if(fIsSet(cmode,(NC_UDF0|NC_UDF1))) {
+	model->format = NC_FORMAT_NETCDF4;
+        if(fIsSet(cmode,NC_UDF0)) {
+	    model->impl = NC_FORMATX_UDF0;
+	} else {
+	    model->impl = NC_FORMATX_UDF1;
+	}
+	goto done;
+    }
+
     if(fIsSet(cmode,NC_64BIT_OFFSET)) {
 	model->impl = NC_FORMATX_NC3;
 	model->format = NC_FORMAT_64BIT_OFFSET;
@@ -414,16 +424,6 @@ NC_omodeinfer(int useparallel, int cmode, NCmodel* model)
 	else
 	    model->format = NC_FORMAT_NETCDF4;
         goto done;
-    }
-
-    if(fIsSet(cmode,(NC_UDF0|NC_UDF1))) {
-	model->format = NC_FORMAT_NETCDF4;
-        if(fIsSet(cmode,NC_UDF0)) {
-	    model->impl = NC_FORMATX_UDF0;
-	} else {
-	    model->impl = NC_FORMATX_UDF1;
-	}
-	goto done;
     }
 
     /* Default to classic model */

--- a/libhdf5/hdf5open.c
+++ b/libhdf5/hdf5open.c
@@ -357,8 +357,11 @@ dimscale_visitor(hid_t did, unsigned dim, hid_t dsid,
 }
 
 /**
- * @internal For files without any netCDF-4 dimensions defined, create phony
- * dimension to match the available datasets.
+ * @internal For files without any netCDF-4 dimensions defined, create
+ * phony dimension to match the available datasets. Each new dimension
+ * of a new size gets a phony dimension. However, if a var has more
+ * than one dimension defined, and they are the same size, they each
+ * get their own phony dimension (starting in netcdf-c-4.7.3).
  *
  * @param grp Pointer to the group info.
  * @param hdf_datasetid HDF5 datsetid for the var's dataset.

--- a/nc_test4/CMakeLists.txt
+++ b/nc_test4/CMakeLists.txt
@@ -13,7 +13,7 @@ SET(NC4_TESTS tst_dims tst_dims2 tst_dims3 tst_files tst_files4
   tst_vars tst_varms tst_unlim_vars tst_converts tst_converts2
   tst_grps tst_grps2 tst_compounds tst_compounds2 tst_compounds3
   tst_opaques tst_strings tst_strings2 tst_interops tst_interops4
-  tst_interops6 tst_enums tst_coords tst_coords2 tst_coords3 tst_vars3
+  tst_interops6 tst_interops_dims tst_enums tst_coords tst_coords2 tst_coords3 tst_vars3
   tst_vars4 tst_chunks tst_chunks2 tst_utf8 tst_fills tst_fills2
   tst_fillbug tst_xplatform2 tst_endian_fill tst_atts t_type
   cdm_sea_soundings tst_vl tst_atts1 tst_atts2 tst_vars2 tst_files5

--- a/nc_test4/Makefile.am
+++ b/nc_test4/Makefile.am
@@ -27,15 +27,16 @@ NC4_TESTS = tst_dims tst_dims2 tst_dims3 tst_files tst_files4		\
 tst_vars tst_varms tst_unlim_vars tst_converts tst_converts2 tst_grps	\
 tst_grps2 tst_compounds tst_compounds2 tst_compounds3 tst_opaques	\
 tst_strings tst_strings2 tst_interops tst_interops4 tst_interops5	\
-tst_interops6 tst_enums tst_coords tst_coords2 tst_coords3 tst_vars3	\
-tst_vars4 tst_chunks tst_chunks2 tst_utf8 tst_fills tst_fills2		\
-tst_fillbug tst_xplatform tst_xplatform2 tst_endian_fill tst_atts	\
-t_type cdm_sea_soundings tst_camrun tst_vl tst_atts1 tst_atts2		\
-tst_vars2 tst_files5 tst_files6 tst_sync tst_h_scalar tst_rename	\
-tst_rename2 tst_rename3 tst_h5_endians tst_atts_string_rewrite		\
-tst_hdf5_file_compat tst_fill_attr_vanish tst_rehash tst_filterparser	\
-tst_bug324 tst_types tst_atts3 tst_put_vars tst_elatefill tst_udf	\
-tst_put_vars_two_unlim_dim tst_bug1442
+tst_interops6 tst_interops_dims tst_enums tst_coords tst_coords2	\
+tst_coords3 tst_vars3 tst_vars4 tst_chunks tst_chunks2 tst_utf8		\
+tst_fills tst_fills2 tst_fillbug tst_xplatform tst_xplatform2		\
+tst_endian_fill tst_atts t_type cdm_sea_soundings tst_camrun tst_vl	\
+tst_atts1 tst_atts2 tst_vars2 tst_files5 tst_files6 tst_sync		\
+tst_h_scalar tst_rename tst_rename2 tst_rename3 tst_h5_endians		\
+tst_atts_string_rewrite tst_hdf5_file_compat tst_fill_attr_vanish	\
+tst_rehash tst_filterparser tst_bug324 tst_types tst_atts3		\
+tst_put_vars tst_elatefill tst_udf tst_put_vars_two_unlim_dim		\
+tst_bug1442
 
 # Temporary I hoped, but hoped in vain.
 if !ISCYGWIN

--- a/nc_test4/tst_interops_dims.c
+++ b/nc_test4/tst_interops_dims.c
@@ -59,7 +59,7 @@ main(int argc, char **argv)
                ERR;
            if (nc_inq(ncid, &ndims, &nvars, &ngatts, &unlimdimid))
                ERR;
-           if (ndims != 1 || nvars != 1 || ngatts != 0 || unlimdimid != -1)
+           if (ndims != 2 || nvars != 1 || ngatts != 0 || unlimdimid != -1)
                ERR;
            if (nc_close(ncid))
                ERR;

--- a/nc_test4/tst_interops_dims.c
+++ b/nc_test4/tst_interops_dims.c
@@ -1,0 +1,70 @@
+/* This is part of the netCDF package.  Copyright 2019 University
+   Corporation for Atmospheric Research/Unidata See COPYRIGHT file for
+   conditions of user Kai Mühlbauer.
+
+   Test handling of anonymous dimensions when netCDF reads a HDF5
+   file. This test partially contributed by user
+
+   Ed Hartnett, 11/13/2019
+*/
+#include <config.h>
+#include <nc_tests.h>
+#include "err_macros.h"
+#include <hdf5.h>
+#include <H5DSpublic.h>
+
+#define FILE_NAME "tst_interops_dims.h5"
+
+int
+main(int argc, char **argv)
+{
+   printf("\n*** Testing HDF5/NetCDF-4 interoperability handling of HDF5 dimensions.\n");
+   printf("*** Checking handling of a HDF5 file with anon dims...");
+   {
+       hid_t       file_id, dataset_id, dataspace_id;  /* identifiers */
+       hsize_t     dims[2];
+
+       /* Create a new file using default properties. */
+       if ((file_id = H5Fcreate(FILE_NAME, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
+           ERR;
+
+       /* Create the data space for the dataset. */
+       dims[0] = 100;
+       dims[1] = 100;
+       if ((dataspace_id = H5Screate_simple(2, dims, NULL)) < 0)
+           ERR;
+
+       /* Create the dataset. */
+       dataset_id = H5Dcreate2(file_id, "/dset", H5T_STD_I32BE, dataspace_id,
+                               H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+
+       /* End access to the dataset and release resources used by it. */
+       if (H5Dclose(dataset_id) < 0)
+           ERR;
+
+       /* Terminate access to the data space. */
+       if (H5Sclose(dataspace_id) < 0)
+           ERR;
+
+       /* Close the file. */
+       if (H5Fclose(file_id) < 0)
+           ERR;
+
+       /* Now open the file with netCDF. */
+       {
+           int ndims, nvars, ngatts, unlimdimid;
+           int ncid;
+
+           if (nc_open(FILE_NAME, NC_NOWRITE, &ncid))
+               ERR;
+           if (nc_inq(ncid, &ndims, &nvars, &ngatts, &unlimdimid))
+               ERR;
+           if (ndims != 1 || nvars != 1 || ngatts != 0 || unlimdimid != -1)
+               ERR;
+           if (nc_close(ncid))
+               ERR;
+       }
+   }
+   SUMMARIZE_ERR;
+   FINAL_RESULTS;
+}

--- a/nc_test4/tst_udf.c
+++ b/nc_test4/tst_udf.c
@@ -185,7 +185,7 @@ main(int argc, char **argv)
          if (nc_close(ncid)) ERR;
 
          /* Open file again and abort, which is the same as closing it. */
-         if (nc_open(FILE_NAME, mode[i], &ncid)) ERR;
+         if (nc_open(FILE_NAME, mode[i]|NC_NETCDF4, &ncid)) ERR;
          if (nc_inq_format(ncid, NULL) != TEST_VAL_42) ERR;
          if (nc_inq_format_extended(ncid, NULL, NULL) != TEST_VAL_42) ERR;
          if (nc_abort(ncid) != TEST_VAL_42) ERR;


### PR DESCRIPTION
Fixes #1484 

When reading a HDF5 file (i.e. not a netCDF-4/HDF5 file), the library has to make assumptions about dimensions.

Until now, each dataspace length got it's own phony dimension, unless it was the same length as a previously assigned anon dimension.

That meant a HDF5 file with a 2-D dataspace of 100x100 would look like this:

```
netcdf dset {
dimensions:
        phony_dim_0 = 100 ;
variables:
        int dset(phony_dim_0, phony_dim_0) ;
}

```

This is probably not what the data writer intended. The two dimensions of the dataset should be two different dimensions, even though they are (coincidentally) the same size.

Now, if an anon dimension of the same size is found, it is also checked to see if it was already used in this dataset. If so, we now assume that it is a new dimension.

So now a HDF5 file, with two datasets of size 100 x 100 will look like this to netCDF:

```
netcdf tst_interops_dims {
dimensions:
	phony_dim_0 = 100 ;
	phony_dim_1 = 100 ;
variables:
	int dset(phony_dim_0, phony_dim_1) ;
	int dset2(phony_dim_0, phony_dim_1) ;
```

Note: this PR also includes #1523 