### PR TITLE
Add a dispatch version number to netcdf_meta.h and libnetcdf.settings, in case we decide to change dispatch table in future

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1971,6 +1971,7 @@ is_enabled(JNA HAS_JNA)
 is_enabled(ENABLE_ZERO_LENGTH_COORD_BOUND RELAX_COORD_BOUND)
 is_enabled(USE_CDF5 HAS_CDF5)
 is_enabled(ENABLE_ERANGE_FILL HAS_ERANGE_FILL)
+is_enabled(DISPATCH_VERSION 1)
 
 # Generate file from template.
 CONFIGURE_FILE("${CMAKE_CURRENT_SOURCE_DIR}/libnetcdf.settings.in"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,9 @@ SET(netCDF_LIB_VERSION 15)
 SET(netCDF_SO_VERSION 15)
 SET(PACKAGE_VERSION ${VERSION})
 
+# Version of the dispatch table, in case we change it.
+SET(NC_DISPATCH_VERSION 1)
+
 # Get system configuration, Use it to determine osname, os release, cpu. These
 # will be used when committing to CDash.
 find_program(UNAME NAMES uname)
@@ -1971,7 +1974,6 @@ is_enabled(JNA HAS_JNA)
 is_enabled(ENABLE_ZERO_LENGTH_COORD_BOUND RELAX_COORD_BOUND)
 is_enabled(USE_CDF5 HAS_CDF5)
 is_enabled(ENABLE_ERANGE_FILL HAS_ERANGE_FILL)
-is_enabled(DISPATCH_VERSION 1)
 
 # Generate file from template.
 CONFIGURE_FILE("${CMAKE_CURRENT_SOURCE_DIR}/libnetcdf.settings.in"

--- a/configure.ac
+++ b/configure.ac
@@ -1496,6 +1496,7 @@ AX_SET_META([NC_HAS_CDF5],[$enable_cdf5],[yes])
 AX_SET_META([NC_HAS_ERANGE_FILL], [$enable_erange_fill],[yes])
 AX_SET_META([NC_RELAX_COORD_BOUND], [$enable_zero_length_coord_bound],[yes])
 AX_SET_META([NC_HAS_BYTERANGE],[$enable_byterange],[yes])
+AX_SET_META([NC_DISPATCH_VESION],[1],[1])
 #####
 # End netcdf_meta.h definitions.
 #####

--- a/configure.ac
+++ b/configure.ac
@@ -1496,7 +1496,7 @@ AX_SET_META([NC_HAS_CDF5],[$enable_cdf5],[yes])
 AX_SET_META([NC_HAS_ERANGE_FILL], [$enable_erange_fill],[yes])
 AX_SET_META([NC_RELAX_COORD_BOUND], [$enable_zero_length_coord_bound],[yes])
 AX_SET_META([NC_HAS_BYTERANGE],[$enable_byterange],[yes])
-AX_SET_META([NC_DISPATCH_VESION],[1],[1])
+AC_SUBST([NC_DISPATCH_VERSION], [1])
 #####
 # End netcdf_meta.h definitions.
 #####

--- a/include/netcdf_meta.h.in
+++ b/include/netcdf_meta.h.in
@@ -57,5 +57,6 @@
 #define NC_HAS_CDF5      @NC_HAS_CDF5@  /*!< CDF5 support. */
 #define NC_HAS_ERANGE_FILL @NC_HAS_ERANGE_FILL@ /*!< ERANGE_FILL Support */
 #define NC_RELAX_COORD_BOUND @NC_RELAX_COORD_BOUND@ /*!< RELAX_COORD_BOUND */
+#define NC_DISPATCH_VERSION @NC_DISPATCH_VERSION@ /*!< Dispatch table version */
 
 #endif

--- a/libnetcdf.settings.in
+++ b/libnetcdf.settings.in
@@ -39,3 +39,4 @@ JNA Support:		@HAS_JNA@
 CDF5 Support:		@HAS_CDF5@
 ERANGE Fill Support:	@HAS_ERANGE_FILL@
 Relaxed Boundary Check:	@RELAX_COORD_BOUND@
+Dispatch Version:       @DISPATCH_VERSION@

--- a/libnetcdf.settings.in
+++ b/libnetcdf.settings.in
@@ -39,4 +39,4 @@ JNA Support:		@HAS_JNA@
 CDF5 Support:		@HAS_CDF5@
 ERANGE Fill Support:	@HAS_ERANGE_FILL@
 Relaxed Boundary Check:	@RELAX_COORD_BOUND@
-Dispatch Version:       @DISPATCH_VERSION@
+Dispatch Version:       @NC_DISPATCH_VERSION@


### PR DESCRIPTION
Fixes #1469 

Adding a version number for the dispatch table, in case we decide to change it at some point.