### PR TITLE
Adding rest of unit_tests to CMake build, but not running them on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -934,12 +934,16 @@ IF(ENABLE_TESTS)
   OPTION(ENABLE_FAILING_TESTS "Run tests which are known to fail, check to see if any have been fixed." OFF)
 
   ###
-  # Option to turn on unit testing. See https://github.com/Unidata/netcdf-c/pull/1472 for more information.
-  # Currently (August 21, 2019): Will not work with Visual Studio
+  # Option to turn on unit testing. See
+  # https://github.com/Unidata/netcdf-c/pull/1472 for more
+  # information.  Currently (August 21, 2019): Will not work with
+  # Visual Studio. The unit tests are for internal netCDF functions,
+  # so we don't want to make them external, which would be required to
+  # run on Windows.
   ###
-#  IF(NOT MSVC)
+  IF(NOT MSVC)
     OPTION(ENABLE_UNIT_TESTS "Run Unit Tests." ON)
-#  ENDIF(NOT MSVC)
+  ENDIF(NOT MSVC)
   ###
   # End known-failures.
   ###

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -934,9 +934,9 @@ IF(ENABLE_TESTS)
   # Option to turn on unit testing. See https://github.com/Unidata/netcdf-c/pull/1472 for more information.
   # Currently (August 21, 2019): Will not work with Visual Studio
   ###
-  IF(NOT MSVC)
+#  IF(NOT MSVC)
     OPTION(ENABLE_UNIT_TESTS "Run Unit Tests." ON)
-  ENDIF(NOT MSVC)
+#  ENDIF(NOT MSVC)
   ###
   # End known-failures.
   ###

--- a/unit_test/CMakeLists.txt
+++ b/unit_test/CMakeLists.txt
@@ -10,7 +10,7 @@
 
 # Some unit testing
 
-SET(UNIT_TESTS tst_nclist)
+SET(UNIT_TESTS tst_nclist test_ncuri test_pathcvt)
 
 IF(ENABLE_NETCDF_4)
   SET(UNIT_TESTS ${UNIT_TESTS} tst_nc4internal)


### PR DESCRIPTION
Fixes #1458 

Turning on rest of unit tests in CMake build, seeing if they work on Windows...

they do not. And to make them work we would need to EXTERNL every internal function we are testing in the unit_test directory. This is not something we want to do, so I suspect unit_test directory will never run on Windows, which I think is OK.