### PR TITLE
Provide Transient Properties on netCDF Library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2043,6 +2043,7 @@ set(ConfigPackageLocation ${CMAKE_INSTALL_LIBDIR}/cmake/netCDF)
 install(EXPORT netCDFTargets
   DESTINATION ${ConfigPackageLocation}
   COMPONENT headers
+  NAMESPACE netCDF::
   )
 
 include(CMakePackageConfigHelpers)
@@ -2063,6 +2064,7 @@ INSTALL(
   COMPONENT headers
   )
 
+add_library(netCDF::netcdf ALIAS netcdf)
 target_include_directories(netcdf
     PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2063,6 +2063,12 @@ INSTALL(
   COMPONENT headers
   )
 
+target_include_directories(netcdf
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
+
 # Create export configuration
 write_basic_package_version_file(
   "${CMAKE_CURRENT_BINARY_DIR}/netCDF/netCDFConfigVersion.cmake"


### PR DESCRIPTION
CMake provides the means to track the transient dependencies of a library, like its include directories, by setting the appropriate property on the target(s).  This pull request does two things.  The first add the include directories to the `netcdf` library so that downstream usage only requires adding the link library. Specifically

    add_executable(myprog ...)
    target_link_libraries(myprog netcdf ...)
    target_include_directories(myprog ${netCDF_INCLUDE_DIRS} ...)

becomes

    add_executable(myprog ...)
    target_link_libraries(myprog netcdf ...)

This helps CMake to correctly track the implicit dependencies and get linking orders correct.

The second change (second commit) is adding a namespace for the netCDF targets.  Namespaces are advised by most tutorials (I'm thinking [this one in particular](https://pabloariasal.github.io/2018/02/19/its-time-to-do-cmake-right/)), but are in reality not critical.

Closes #1539 