### PR TITLE
Update FAQ based on actual usage of HDF5 variables

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1938,8 +1938,8 @@ It depends on the library.  To specify a custom `ZLib`, for example, you would d
 
 `HDF5` is more complex, since it requires both the `hdf5` and `hdf5_hl` libraries. You would specify custom `HDF5` libraries as follows:
 
-        $ cmake [Source Directory] -DHDF5_LIB=/path/to/hdf5.lib \
-            -DHDF5_HL_LIB=/path/to/hdf5_hl.lib \
+        $ cmake [Source Directory] -DHDF5_C_LIBRARY=/path/to/hdf5.lib \
+            -DHDF5_HL_LIBRARY=/path/to/hdf5_hl.lib \
             -DHDF5_INCLUDE_DIR=/path/to/hdf5/include
 
 
@@ -1971,8 +1971,8 @@ If cmake is having problems finding the parallel `HDF5` install, you can specify
 
 
         $ cmake [Source Directory] -DENABLE_PARALLEL=ON \
-            -DHDF5_LIB=/usr/lib64/openmpi/lib/libhdf5.so \
-            -DHDF5_HL_LIB=/usr/lib64/openmpi/lib/libhdf5.hl.so \
+            -DHDF5_C_LIBRARY=/usr/lib64/openmpi/lib/libhdf5.so \
+            -DHDF5_HL_LIBRARY=/usr/lib64/openmpi/lib/libhdf5.hl.so \
             -DHDF5_INCLUDE_DIR=/usr/include/openmpi-x86_64 \
 
 You will, of course, need to use the location of the libraries specific to your development environment.


### PR DESCRIPTION
The CMakeLists.txt actually uses `HDF5_C_LIBRARY` and `HDF5_HL_LIBRARY` to find non-standard HDF5 installation.  This just updates the FAQ with the correct usage.

This addresses issue #1533.