### PR TITLE
PROOF-OF-CONCEPT: Allow use of HDF5 Compact storage in NetCDF

### DIFF
--- a/include/nc4internal.h
+++ b/include/nc4internal.h
@@ -205,6 +205,7 @@ typedef struct NC_VAR_INFO
     void *fill_value;
     size_t *chunksizes;
     nc_bool_t contiguous;        /**< True if variable is stored contiguously in HDF5 file */
+    nc_bool_t is_compact;
     int parallel_access;         /**< Type of parallel access for I/O on variable (collective or independent) */
     nc_bool_t dimscale;          /**< True if var is a dimscale */
     nc_bool_t *dimscale_attached;  /**< Array of flags that are true if dimscale is attached for that dim index */

--- a/libhdf5/hdf5var.c
+++ b/libhdf5/hdf5var.c
@@ -52,6 +52,7 @@ reportchunking(const char *title, NC_VAR_INFO_T *var)
 }
 #endif
 
+int nc_use_compact_storage = 0;
 /**
  * @internal If the HDF5 dataset for this variable is open, then close
  * it and reopen it, with the perhaps new settings for chunk caching.
@@ -145,6 +146,7 @@ check_chunksizes(NC_GRP_INFO_T *grp, NC_VAR_INFO_T *var, const size_t *chunksize
  * @returns ::NC_ENOTVAR Invalid variable ID.
  * @author Ed Hartnett, Dennis Heimbigner
  */
+
 static int
 nc4_find_default_chunksizes2(NC_GRP_INFO_T *grp, NC_VAR_INFO_T *var)
 {
@@ -499,6 +501,9 @@ NC4_def_var(int ncid, const char *name, nc_type xtype, int ndims,
      * same name as one of its dimensions. If it is a coordinate var,
      * is it a coordinate var in the same group as the dim? Also, check
      * whether we should use contiguous or chunked storage. */
+    if (nc_use_compact_storage == 1) {
+      var->is_compact = 1;
+    }
     var->contiguous = NC_TRUE;
     for (d = 0; d < ndims; d++)
     {

--- a/libhdf5/nc4hdf.c
+++ b/libhdf5/nc4hdf.c
@@ -996,8 +996,14 @@ var_create_dataset(NC_GRP_INFO_T *grp, NC_VAR_INFO_T *var, nc_bool_t write_dimid
 
         if (var->contiguous)
         {
+	  if (var->is_compact == 1) {
+            if (H5Pset_layout(plistid, H5D_COMPACT) < 0)
+	      BAIL(NC_EHDFERR);
+	  }
+	  else {
             if (H5Pset_layout(plistid, H5D_CONTIGUOUS) < 0)
                 BAIL(NC_EHDFERR);
+	  }
         }
         else
         {


### PR DESCRIPTION
Recent developments in the CGNS library have demostrated extreme parallel scalabilty performance gains through the use of the HDF5 "Compact Storage" See page 8 of https://cgns.github.io/CGNS_docs_current/hdf5/CGNS_cgp_open_study.pdf  (Note that the "unmodified" yellow line in this figure is actually *better* performance than unmodified due to some changes in the calling `io_shell` application; the true comparison is shown at the bottom of this PR

I have recently prototyped a similar capability for NetCDF and see improvements of over an order of magnitude on processor rank counts up to 16,384.  The figure below shows some of this:

![image](https://user-images.githubusercontent.com/897294/69446278-474c2880-0d11-11ea-8f99-fe210f976ccd.png)

The top two lines are unmodified NetCDF-devel.  I then added the code from the attached PR and modified my application to specify compact storage for the variables that are "metadata" or in other words, the same data is read/written on all processor ranks.  An example usage is:
```
   nc_use_compact_storage = 1;
   status = nc_def_var(exoid, VARIABLE, NC_CHAR, 2, dims, &variable);
   nc_use_compact_storage = 0;
```
Note that, unlike the CGNS library, I don't think that the NetCDF library itself will be able to decide which variables can use compact storage and which cannot, so it is up to the writing application to be able to tell NetCDF which variables are compact and which are not.  I'm not sure how best to represent this in the API -- does it warrant a new `nc_def_compact_var` function, or is there a function called prior to calling `nc_def_var` which specifies all variables up until the next call are considered compact... I don't have any suggestions, but I know that the potential performance improvements make this something worth looking into.

I did investigate whether setting the "fake dim vars" the NetCDF creates to represent the `dims` to compact storage made any difference and it doesn't.  I think that since those HDF5 variables are only defined and that no data is ever read/written from/to them, the storage type doesn't matter (I modified the vars so they were all of size 1 so compact storage would work). These results are shown as the `alldims` curves in the above plot.

The `fpp` lines are the performance from each MPI rank reading/writing its own file -- no parallel I/O and the `s36` lines are with Lustre stripe counts of 36. which makes a significant improvement once the compact storage improvements kick in. Note that the `s36` curves are at the same speed as the `fpp` lines.

Please ask for clarification if any of this is confusing or unclear; I see that this will be a potentially major improvement in NetCDF scalability as MPI rank counts grow into the 100,000s or more.

For reference, below is the CGNS performance gains showing the true unmodified CGNS performance:

![image](https://user-images.githubusercontent.com/897294/69446754-567fa600-0d12-11ea-98ae-5d4368a76712.png)
