### PR TITLE
fix memory issue that may occur for some HDF5 file opens

### DIFF
--- a/libhdf5/hdf5open.c
+++ b/libhdf5/hdf5open.c
@@ -2532,6 +2532,10 @@ rec_read_metadata(NC_GRP_INFO_T *grp)
     /* Get HDF5-specific group info. */
     hdf5_grp = (NC_HDF5_GRP_INFO_T *)grp->format_grp_info;
 
+    /* Set user data for iteration over any child groups. */
+    udata.grp = grp;
+    udata.grps = nclistnew();
+
     /* Open this HDF5 group and retain its grpid. It will remain open
      * with HDF5 until this file is nc_closed. */
     if (!hdf5_grp->hdf_grpid)
@@ -2578,10 +2582,6 @@ rec_read_metadata(NC_GRP_INFO_T *grp)
 
         iter_index = H5_INDEX_NAME;
     }
-
-    /* Set user data for iteration over any child groups. */
-    udata.grp = grp;
-    udata.grps = nclistnew();
 
     /* Iterate over links in this group, building lists for the types,
      * datasets and groups encountered. A pointer to udata will be

--- a/nc_test4/tst_interops5.c
+++ b/nc_test4/tst_interops5.c
@@ -255,7 +255,10 @@ main(int argc, char **argv)
    }
    SUMMARIZE_ERR;
 #endif /* USE_SZIP */
-
+   /* This test suggested by user brentd42 to find a memory problem in
+    * function rec_read_metadata(). This test demonstrates the bug on
+    * address sanitizer runs. See
+    * https://github.com/Unidata/netcdf-c/issues/1558. */
    printf("*** testing error when opening HDF5 file without creating ordering...");
    {
        hid_t file_hid;

--- a/nc_test4/tst_interops5.c
+++ b/nc_test4/tst_interops5.c
@@ -263,7 +263,7 @@ main(int argc, char **argv)
    {
        hid_t file_hid;
        int ncid;
-       char *filename = "foo.h5";
+       char *filename = "tst_interops5.h5";
 
        /* Create a HDF5 file, but don't set creation ordering on. */
        file_hid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);

--- a/nc_test4/tst_interops5.c
+++ b/nc_test4/tst_interops5.c
@@ -1,8 +1,10 @@
-/* This is part of the netCDF package. Copyright 2005-2018, University
-   Corporation for Atmospheric Research/Unidata.  See COPYRIGHT file
+/* This is part of the netCDF package. Copyright 2005-2019, University
+   Corporation for Atmospheric Research/Unidata. See COPYRIGHT file
    for conditions of use.
 
    Test that HDF5 and NetCDF-4 can read and write the same file.
+
+   Ed Hartnett
 */
 #include <config.h>
 #include <nc_tests.h>
@@ -253,5 +255,21 @@ main(int argc, char **argv)
    }
    SUMMARIZE_ERR;
 #endif /* USE_SZIP */
+
+   printf("*** testing error when opening HDF5 file without creating ordering...");
+   {
+       hid_t file_hid;
+       int ncid;
+       char *filename = "foo.h5";
+
+       /* Create a HDF5 file, but don't set creation ordering on. */
+       file_hid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+       H5Fclose(file_hid);
+
+       /* Open the file with netCDF. */
+       nc_set_log_level(3);
+       if (nc_open(filename, NC_WRITE, &ncid) != NC_ECANTWRITE) ERR;
+   }
+   SUMMARIZE_ERR;
    FINAL_RESULTS;
 }


### PR DESCRIPTION
Fixes #1558 

Fixes a memory problem that can occur on failed HDF5 file opens. The test fails address sanitizer with current master, but passes with fix.

Fix is just to move initialization of udata.grp to top of function, before any BAIL macros are called.

Thanks @brentd42 for finding this one.