### PR TITLE
Move endinness from type to var

### DIFF
--- a/include/nc4internal.h
+++ b/include/nc4internal.h
@@ -212,6 +212,7 @@ typedef struct NC_VAR_INFO
     int deflate_level;
     nc_bool_t shuffle;           /**< True if var has shuffle filter applied */
     nc_bool_t fletcher32;        /**< True if var has fletcher32 filter applied */
+    int endianness;              /**< What endianness for the variable? */
     size_t chunk_cache_size, chunk_cache_nelems;
     float chunk_cache_preemption;
     void *format_var_info;       /**< Pointer to any binary format info. */
@@ -246,7 +247,6 @@ typedef struct NC_TYPE_INFO
     NC_OBJ hdr;            /**< The hdr contains the name and ID. */
     struct NC_GRP_INFO *container; /**< Containing group */
     unsigned rc;                 /**< Ref. count of objects using this type */
-    int endianness;              /**< What endianness for the type? */
     size_t size;                 /**< Size of the type in memory, in bytes */
     nc_bool_t committed;         /**< True when datatype is committed in the file */
     nc_type nc_type_class;       /**< NC_VLEN, NC_COMPOUND, NC_OPAQUE, NC_ENUM, NC_INT, NC_FLOAT, or NC_STRING. */

--- a/libhdf5/hdf5var.c
+++ b/libhdf5/hdf5var.c
@@ -417,7 +417,6 @@ NC4_def_var(int ncid, const char *name, nc_type xtype, int ndims,
         /* Create new NC_TYPE_INFO_T struct for this atomic type. */
         if ((retval = nc4_type_new(len, nc4_atomic_name[xtype], xtype, &type)))
             BAIL(retval);
-        type->endianness = NC_ENDIAN_NATIVE;
         type->size = len;
 
         /* Allocate storage for HDF5-specific type info. */
@@ -427,7 +426,7 @@ NC4_def_var(int ncid, const char *name, nc_type xtype, int ndims,
 
         /* Get HDF5 typeids. */
         if ((retval = nc4_get_hdf_typeid(h5, xtype, &hdf5_type->hdf_typeid,
-                                         type->endianness)))
+                                         NC_ENDIAN_NATIVE)))
             BAIL(retval);
 
         /* Get the native HDF5 typeid. */
@@ -824,7 +823,7 @@ nc_def_var_extra(int ncid, int varid, int *shuffle, int *deflate,
         default:
             return NC_EINVAL;
         }
-        var->type_info->endianness = *endianness;
+        var->endianness = *endianness;
     }
 
     return NC_NOERR;

--- a/libhdf5/nc4hdf.c
+++ b/libhdf5/nc4hdf.c
@@ -855,7 +855,7 @@ var_create_dataset(NC_GRP_INFO_T *grp, NC_VAR_INFO_T *var, nc_bool_t write_dimid
 
     /* Find the HDF5 type of the dataset. */
     if ((retval = nc4_get_hdf_typeid(grp->nc4_info, var->type_info->hdr.id, &typeid,
-                                     var->type_info->endianness)))
+                                     var->endianness)))
         BAIL(retval);
 
     /* Figure out what fill value to set, if any. */
@@ -1187,7 +1187,7 @@ commit_type(NC_GRP_INFO_T *grp, NC_TYPE_INFO_T *type)
             field = (NC_FIELD_INFO_T *)nclistget(type->u.c.field, i);
             assert(field);
             if ((retval = nc4_get_hdf_typeid(grp->nc4_info, field->nc_typeid,
-                                             &hdf_base_typeid, type->endianness)))
+                                             &hdf_base_typeid, NC_ENDIAN_NATIVE)))
                 return retval;
 
             /* If this is an array, create a special array type. */
@@ -1223,7 +1223,7 @@ commit_type(NC_GRP_INFO_T *grp, NC_TYPE_INFO_T *type)
     {
         /* Find the HDF typeid of the base type of this vlen. */
         if ((retval = nc4_get_hdf_typeid(grp->nc4_info, type->u.v.base_nc_typeid,
-                                         &base_hdf_typeid, type->endianness)))
+                                         &base_hdf_typeid, NC_ENDIAN_NATIVE)))
             return retval;
 
         /* Create a vlen type. */
@@ -1246,7 +1246,7 @@ commit_type(NC_GRP_INFO_T *grp, NC_TYPE_INFO_T *type)
 
         /* Find the HDF typeid of the base type of this enum. */
         if ((retval = nc4_get_hdf_typeid(grp->nc4_info, type->u.e.base_nc_typeid,
-                                         &base_hdf_typeid, type->endianness)))
+                                         &base_hdf_typeid, NC_ENDIAN_NATIVE)))
             return retval;
 
         /* Create an enum type. */

--- a/libsrc4/nc4var.c
+++ b/libsrc4/nc4var.c
@@ -265,7 +265,7 @@ NC4_inq_var_all(int ncid, int varid, char *name, nc_type *xtypep,
 
     /* Does the user want the endianness of this variable? */
     if (endiannessp)
-        *endiannessp = var->type_info->endianness;
+        *endiannessp = var->endianness;
 
     return NC_NOERR;
 }


### PR DESCRIPTION
Currently, endianness is associated with the NC_TYPE_INFO_T
object. This is a holdover from HDF5 where type objects could
be cloned to have different endian values. This is inconsistent
with the netcdf API (nc_def_var_endian), which is var based.

Changes:
1. store endianness with variable
2. move the endianness in NC_TYPE_INFO_T to put it
   into the HDF5 specific structure pointed to
   by NC_TYPE_INFO_T.format_type_info field.