### PR TITLE
Make the dap4 code resistant to various server errors.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -365,11 +365,12 @@ fi
 # --enable-dap => enable-dap4
 enable_dap4=$enable_dap
 # Default is to do the short remote tests.
+# Temporary: Change default to npt do these tests
 AC_MSG_CHECKING([whether dap remote testing should be enabled (default on)])
 AC_ARG_ENABLE([dap-remote-tests],
               [AS_HELP_STRING([--disable-dap-remote-tests],
                                  [disable dap remote tests])])
-test "x$enable_dap_remote_tests" = xno || enable_dap_remote_tests=yes
+test "x$enable_dap_remote_tests" = xyes || enable_dap_remote_tests=no
 if test "x$enable_dap" = "xno" ; then
   enable_dap_remote_tests=no
 fi
@@ -399,7 +400,7 @@ AC_ARG_WITH([testservers],
             [REMOTETESTSERVERS=$with_testservers], [REMOTETESTSERVERS=no])
 msg="$REMOTETESTSERVERS"
 if test "x$REMOTETESTSERVERS" = xno ; then
-  svclist="149.165.169.123:8080,remotetest.unidata.ucar.edu"
+  svclist="remotetest.unidata.ucar.edu"
   REMOTETESTSERVERS="$svclist"
 fi
 AC_MSG_RESULT([$svclist])

--- a/libdap4/d4util.c
+++ b/libdap4/d4util.c
@@ -330,6 +330,22 @@ NCD4_entityescape(const char* s)
     return escaped;
 }
 
+/* Elide all nul characters from an XML document as a precaution*/
+size_t
+NCD4_elidenuls(char* s, size_t slen)
+{
+    size_t i,j;
+    for(j=0,i=0;i<slen;i++) {
+        int c = s[i];
+	if(c != 0)
+	    s[j++] = (char)c;
+    }       
+    /* if we remove any nuls then nul term */
+    if(j < i)
+	s[j] = '\0';
+    return j;
+}
+
 int
 NCD4_readfile(const char* filename, NCbytes* content)
 {

--- a/libdap4/ncd4.h
+++ b/libdap4/ncd4.h
@@ -45,6 +45,9 @@ defined here, including function-like #defines.
 #define FIXEDOPAQUE
 #define DFALTOPAQUESIZE 16
 
+/* Size of a chunk header */
+#define CHUNKHDRSIZE 4
+
 /**************************************************/
 
 #undef nullfree
@@ -137,6 +140,7 @@ extern char* NCD4_makeName(NCD4node*,const char* sep);
 extern int NCD4_parseFQN(const char* fqn0, NClist* pieces);
 extern char* NCD4_deescape(const char* esc);
 extern char* NCD4_entityescape(const char* s);
+extern size_t NCD4_elidenuls(char* s, size_t slen);
 
 /* From d4dump.c */
 extern void NCD4_dumpbytes(size_t size, const void* data0, int swap);

--- a/libdispatch/derror.c
+++ b/libdispatch/derror.c
@@ -177,9 +177,9 @@ const char *nc_strerror(int ncerr1)
       case NC_EDAS:
 	 return "NetCDF: Malformed or inaccessible DAP DAS";
       case NC_EDDS:
-	 return "NetCDF: Malformed or inaccessible DAP DDS";
+	 return "NetCDF: Malformed or inaccessible DAP2 DDS or DAP4 DMR response";
       case NC_EDATADDS:
-	 return "NetCDF: Malformed or inaccessible DAP DATADDS";
+	 return "NetCDF: Malformed or inaccessible DAP2 DATADDS or DAP4 DAP response";
       case NC_EDAPURL:
 	 return "NetCDF: Malformed URL";
       case NC_EDAPCONSTRAINT:

--- a/libdispatch/dhttp.c
+++ b/libdispatch/dhttp.c
@@ -263,6 +263,8 @@ setupconn(CURL* curl, const char* objecturl, NCbytes* buf)
     if (cstat != CURLE_OK) goto fail;
     cstat = CURLERR(curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 1));
     if (cstat != CURLE_OK) goto fail;
+    cstat = curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1); 
+    if (cstat != CURLE_OK) goto fail;
 
     if(buf != NULL) {
 	/* send all data to this function  */

--- a/libhdf5/nc4info.c
+++ b/libhdf5/nc4info.c
@@ -198,6 +198,8 @@ NC4_read_provenance(NC_FILE_INFO_T* file)
     provenance->superblockversion = superblock;
 
     /* Read the _NCProperties value from the file */
+    /* We do not return a size and assume the size is that upto the
+       first nul character */
     if((ncstat = NC4_read_ncproperties(file,&propstring))) goto done;
     provenance->ncproperties = propstring;
     propstring = NULL;

--- a/nc_test/tst_byterange.c
+++ b/nc_test/tst_byterange.c
@@ -33,7 +33,7 @@ struct TESTURLS {
     int format; /* instance of NC_FORMATX_XXX */
     const char* url;
 } testurls[] = {
-{NC_FORMAT_CLASSIC,"http://149.165.169.123:8080/thredds/fileServer/testdata/2004050300_eta_211.nc#bytes"},
+{NC_FORMAT_CLASSIC,"http://remotetest.unidata.ucar.edu/thredds/fileServer/testdata/2004050300_eta_211.nc#bytes"},
 #ifdef USE_NETCDF4
 {NC_FORMAT_NETCDF4,"http://noaa-goes16.s3.amazonaws.com/ABI-L1b-RadC/2017/059/03/OR_ABI-L1b-RadC-M3C13_G16_s20170590337505_e20170590340289_c20170590340316.nc#mode=bytes"},
 #endif
@@ -59,6 +59,7 @@ dotest(struct TESTURLS* test)
     int ncid;
     int format = -1;
 
+    fprintf(stderr,"Test: url=%s\n",test->url);
     /* First, try to open the url */
     if((ret = nc_open(test->url,0,&ncid))) return fail(ret);
 


### PR DESCRIPTION
Some versions of some servers are returning malformed responses.
Make the library either handle them or gracefully fail.
The three server errors "fixed" here are as follows.
1. The attribute _NCProperties sometimes has a trailing nul character
   in its value. Soln is to elide the nul(s).
2. Sometimes a DAP response has no data part, only a DMR.
   Soln is to detect and return an error code instead of crashing.
3. Sometimes a server returns a redirection, but our current
   openmagic() function was not following the redirect. Soln
   is to follow redirects.
Also because of #2, I am temporarily making --disable-dap-remote-tests
be the default.