### PR TITLE
Add support for CURLOPT_CONNECTTIMEOUT

### DIFF
--- a/docs/DAP2.dox
+++ b/docs/DAP2.dox
@@ -626,7 +626,7 @@ follows.
 1. HTTP.TIMEOUT  
         Type: String ("dddddd")  
         Description: Specify the maximum time in seconds that you allow the http transfer operation to take.  
-        Related CURL Flags: CURLOPT_TIMEOUT, CURLOPT_NOSIGNAL  
+        Related CURL Flags: CURLOPT_TIMEOUT, CURLOPT_NOSIGNAL, CURLOPT_CONNECTIONTIMEOUT
 1. HTTP.PROXY_SERVER  
         Type: String representing url to access the proxy: (e.g.http://[username:password@]host[:port])  
         Description: Specify the needed information for accessing a proxy.  
@@ -636,12 +636,15 @@ follows.
         Description: Specify the the internal buffer size for curl reads.  
         Related CURL Flags: CURLOPT_BUFFERSIZE, CURL_MAX_WRITE_SIZE (16kB),  
                             CURL_MAX_READ_SIZE (512kB).  
-  
 1. HTTP.KEEPALIVE  
         Type: String ("on|n/m")  
         Description: Specify that TCP KEEPALIVE should be enabled and that the associated idle wait time is n and that the associated repeat interval is m. If the value is of the form is the string "on", then turn on keepalive, but do not set idle or interval.  
         Related CURL Flags: CURLOPT_TCP_KEEPALIVE, CURLOPT_TCP_KEEPIDLE,  
                             CURLOPT_TCP_KEEPINTVL.  
+1. HTTP.CONNECTIONTIMEOUT  
+        Type: String ("dddddd")  
+        Description: Specify the maximum time in seconds that you allow the http connection to complete.
+        Related CURL Flags: CURLOPT_TIMEOUT, CURLOPT_NOSIGNAL  
 
 The related curl flags line indicates the curl flags modified by this
 key. See the libcurl documentation of the _curl_easy_setopt()_ function

--- a/docs/DAP4.dox
+++ b/docs/DAP4.dox
@@ -206,7 +206,7 @@ follows.
 -# HTTP.TIMEOUT
         Type: String ("dddddd")
         Description: Specify the maximum time in seconds that you allow the http transfer operation to take.
-        Related CURL Flags: CURLOPT_TIMEOUT, CURLOPT_NOSIGNAL
+        Related CURL Flags: CURLOPT_TIMEOUT, CURLOPT_NOSIGNAL, CURLOPT_CONNECTIONTIMEOUT
 
 -# HTTP.PROXY_SERVER
         Type: String representing url to access the proxy: (e.g.http://[username:password@]host[:port])
@@ -224,6 +224,11 @@ follows.
         Description: Specify that TCP KEEPALIVE should be enabled and that the associated idle wait time is n and that the associated repeat interval is m. If the value is of the form is the string "on", then turn on keepalive, but do not set idle or interval.
         Related CURL Flags: CURLOPT_TCP_KEEPALIVE, CURLOPT_TCP_KEEPIDLE,
                             CURLOPT_TCP_KEEPINTVL.
+
+-# HTTP.CONNECTIONTIMEOUT
+        Type: String ("dddddd")
+        Description: Specify the maximum time in seconds that you allow the http connection to complete.
+        Related CURL Flags: CURLOPT_TIMEOUT, CURLOPT_NOSIGNAL
 
 The related curl flags line indicates the curl flags modified by this
 key. See the libcurl documentation of the _curl_easy_setopt()_ function

--- a/include/ncauth.h
+++ b/include/ncauth.h
@@ -21,6 +21,7 @@ typedef struct NCauth {
 	int compress; /*CURLOPT_ENCODING*/
 	int verbose; /*CURLOPT_ENCODING*/
 	int timeout; /*CURLOPT_TIMEOUT*/
+	int connecttimeout; /*CURLOPT_CONNECTTIMEOUT*/
 	int maxredirs; /*CURLOPT_MAXREDIRS*/
 	char* useragent; /*CURLOPT_USERAGENT*/
 	int cookiejarcreated;

--- a/include/nctestserver.h
+++ b/include/nctestserver.h
@@ -184,7 +184,8 @@ timedping(const char* url, long timeout)
     CERR((curl_easy_setopt(curl, CURLOPT_MAXREDIRS, 10L)));
     CERR((curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L)));
 
-    /* use a very short timeout: 10 seconds */
+    /* use very short timeouts: 10 seconds */
+    CERR((curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, (long)timeout)));
     CERR((curl_easy_setopt(curl, CURLOPT_TIMEOUT, (long)timeout)));
 
     /* fail on HTTP 400 code errors */

--- a/libdap4/d4curlfunctions.c
+++ b/libdap4/d4curlfunctions.c
@@ -90,6 +90,10 @@ set_curlflag(NCD4INFO* state, int flag)
 	if(state->auth.curlflags.timeout)
 	    CHECK(state, CURLOPT_TIMEOUT, (OPTARG)((long)state->auth.curlflags.timeout));
 	break;
+    case CURLOPT_CONNECTTIMEOUT:
+	if(state->auth.curlflags.connecttimeout)
+	    CHECK(state, CURLOPT_CONNECTTIMEOUT, (OPTARG)((long)state->auth.curlflags.connecttimeout));
+	break;
     case CURLOPT_USERAGENT:
         if(state->auth.curlflags.useragent)
 	    CHECK(state, CURLOPT_USERAGENT, state->auth.curlflags.useragent);
@@ -373,6 +377,9 @@ NCD4_set_curlstate(NCD4INFO* state, int flag, void* value)
 	break;
     case CURLOPT_TIMEOUT:
 	info->curlflags.timeout = (long)value;
+	break;
+    case CURLOPT_CONNECTTIMEOUT:
+	info->curlflags.connecttimeout = (long)value;
 	break;
     case CURLOPT_USERAGENT:
         if(info->curlflags.useragent != NULL) free(info->curlflags.useragent);

--- a/libdispatch/dauth.c
+++ b/libdispatch/dauth.c
@@ -31,6 +31,7 @@ See COPYRIGHT for license information.
 /* Define the curl flag defaults in envv style */
 static const char* AUTHDEFAULTS[] = {
 "HTTP.TIMEOUT","1800", /*seconds */ /* Long but not infinite */
+"HTTP.CONNECTTIMEOUT","50", /*seconds */ /* Long but not infinite */
 NULL
 };
 
@@ -107,6 +108,8 @@ NC_authsetup(NCauth* auth, NCURI* uri)
 			NC_rclookup("HTTP.VERBOSE",uri_hostport));
     setauthfield(auth,"HTTP.TIMEOUT",
 			NC_rclookup("HTTP.TIMEOUT",uri_hostport));
+    setauthfield(auth,"HTTP.CONNECTTIMEOUT",
+			NC_rclookup("HTTP.CONNECTTIMEOUT",uri_hostport));
     setauthfield(auth,"HTTP.USERAGENT",
 			NC_rclookup("HTTP.USERAGENT",uri_hostport));
     setauthfield(auth,"HTTP.COOKIEFILE",
@@ -217,6 +220,12 @@ setauthfield(NCauth* auth, const char* flag, const char* value)
         if(atoi(value)) auth->curlflags.timeout = atoi(value);
 #ifdef D4DEBUG
             nclog(NCLOGNOTE,"HTTP.TIMEOUT: %ld", auth->curlflags.timeout);
+#endif
+    }
+    if(strcmp(flag,"HTTP.CONNECTTIMEOUT")==0) {
+        if(atoi(value)) auth->curlflags.connecttimeout = atoi(value);
+#ifdef D4DEBUG
+            nclog(NCLOGNOTE,"HTTP.CONNECTTIMEOUT: %ld", auth->curlflags.connecttimeout);
 #endif
     }
     if(strcmp(flag,"HTTP.USERAGENT")==0) {

--- a/oc2/occurlflags.c
+++ b/oc2/occurlflags.c
@@ -12,7 +12,7 @@ static long maxflag = -1;
 static struct OCCURLFLAG* nameindices[26]; /* for radix access */
 static struct OCCURLFLAG** flagindices = NULL; /* for radix access */
 
-/* Define supported curl flags */
+/* Define supported curlflags */
 
 static struct OCCURLFLAG oc_curlflags[] = {
 #ifdef HAVE_CURLOPT_BUFFERSIZE
@@ -45,6 +45,7 @@ static struct OCCURLFLAG oc_curlflags[] = {
 {"CURLOPT_TCP_KEEPALIVE",CURLOPT_TCP_KEEPALIVE,213,CF_LONG},
 #endif
 {"CURLOPT_TIMEOUT",CURLOPT_TIMEOUT,13,CF_LONG},
+{"CURLOPT_CONNECTTIMEOUT",CURLOPT_CONNECTTIMEOUT,78,CF_LONG},
 {"CURLOPT_USERAGENT",CURLOPT_USERAGENT,10018,CF_STRING},
 {"CURLOPT_USERPWD",CURLOPT_USERPWD,10005,CF_STRING},
 {"CURLOPT_VERBOSE",CURLOPT_VERBOSE,41,CF_LONG},

--- a/oc2/occurlfunctions.c
+++ b/oc2/occurlfunctions.c
@@ -82,6 +82,11 @@ ocset_curlflag(OCstate* state, int flag)
 	    CHECK(state, CURLOPT_TIMEOUT, (OPTARG)((long)state->auth.curlflags.timeout));
 	break;
 
+    case CURLOPT_CONNECTTIMEOUT:
+	if(state->auth.curlflags.connecttimeout)
+	    CHECK(state, CURLOPT_CONNECTTIMEOUT, (OPTARG)((long)state->auth.curlflags.connecttimeout));
+	break;
+
     case CURLOPT_USERAGENT:
         if(state->auth.curlflags.useragent)
 	    CHECK(state, CURLOPT_USERAGENT, state->auth.curlflags.useragent);
@@ -189,6 +194,7 @@ ocset_flags_perlink(OCstate* state)
     if(stat == OC_NOERR) stat = ocset_curlflag(state,CURLOPT_NETRC);
     if(stat == OC_NOERR) stat = ocset_curlflag(state,CURLOPT_VERBOSE);
     if(stat == OC_NOERR) stat = ocset_curlflag(state,CURLOPT_TIMEOUT);
+    if(stat == OC_NOERR) stat = ocset_curlflag(state,CURLOPT_CONNECTTIMEOUT);
     if(stat == OC_NOERR) stat = ocset_curlflag(state,CURLOPT_USERAGENT);
     if(stat == OC_NOERR) stat = ocset_curlflag(state,CURLOPT_COOKIEJAR);
     if(stat == OC_NOERR) stat = ocset_curlflag(state,CURLOPT_USERPWD);

--- a/oc2/ochttp.c
+++ b/oc2/ochttp.c
@@ -274,7 +274,7 @@ ocfetchlastmodified(CURL* curl, char* url, long* filetime)
 
     /* Ask for head */
     cstat = CURLERR(curl_easy_setopt(curl, CURLOPT_TIMEOUT, 30)); /* 30sec timeout*/
-    cstat = CURLERR(curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 2));
+    cstat = CURLERR(curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 5));
     cstat = CURLERR(curl_easy_setopt(curl, CURLOPT_HEADER, 1));
     cstat = CURLERR(curl_easy_setopt(curl, CURLOPT_NOBODY, 1));
     cstat = CURLERR(curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 1));
@@ -310,6 +310,11 @@ ocping(const char* url)
     if (cstat != CURLE_OK)
         goto done;
     cstat = CURLERR(curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L));
+    if (cstat != CURLE_OK)
+        goto done;
+
+    /* use a very short conn timeout: 10 seconds */
+    cstat = CURLERR(curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, (long)10));
     if (cstat != CURLE_OK)
         goto done;
 


### PR DESCRIPTION
I see that there is no way to set CURLOPT_CONNECTTIMEOUT,
but there is support for CURLOPT_TIMEOUT.
So, accept the line 'HTTP.CONNECTTIMEOUT'
in .rc file to allow user to set CURLOPT_CONNECTTIMEOUT.