### PR TITLE
detect if HDF5 was built without zlib, and error out of configure/cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -778,6 +778,17 @@ FIND_PACKAGE(CURL)
 ADD_DEFINITIONS(-DCURL_STATICLIB=1)
 INCLUDE_DIRECTORIES(${CURL_INCLUDE_DIRS})
 
+# Check to ensure that HDF5 was built with zlib.
+CHECK_C_SOURCE_COMPILES("
+#include <H5pubconf.h>
+int main() {#if !H5_HAVE_ZLIB_H
+kkkk
+#endif
+int x = 1;}" HAVE_HDF5_ZLIB)
+IF(NOT HAVE_HDF5_ZLIB)
+    MESSAGE(FATAL_ERROR "HDF5 was built without zlib. Rebuild HDF5 with zlib.")
+ENDIF()
+
 # Check to see if CURLOPT_USERNAME is defined.
 # It is present starting version 7.19.1.
 CHECK_C_SOURCE_COMPILES("

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -751,6 +751,16 @@ IF(USE_HDF5 OR ENABLE_NETCDF_4)
 	SET(HDF5_CC h5cc)
   ENDIF()
 
+  # Check to ensure that HDF5 was built with zlib.
+  CHECK_C_SOURCE_COMPILES("#include <H5pubconf.h>
+   int main() {#if !H5_HAVE_ZLIB_H
+   #error
+   #endif
+   int x = 1;}" HAVE_HDF5_ZLIB)
+  IF(NOT HAVE_HDF5_ZLIB)
+    MESSAGE(FATAL_ERROR "HDF5 was built without zlib. Rebuild HDF5 with zlib.")
+  ENDIF()
+
   # Check to see if this is hdf5-1.10.3 or later.
   CHECK_LIBRARY_EXISTS(${HDF5_C_LIBRARY_hdf5} H5Dread_chunk "" HDF5_SUPPORTS_PAR_FILTERS)
 
@@ -777,17 +787,6 @@ ENDIF(USE_HDF5 OR ENABLE_NETCDF_4)
 FIND_PACKAGE(CURL)
 ADD_DEFINITIONS(-DCURL_STATICLIB=1)
 INCLUDE_DIRECTORIES(${CURL_INCLUDE_DIRS})
-
-# Check to ensure that HDF5 was built with zlib.
-CHECK_C_SOURCE_COMPILES("
-#include <H5pubconf.h>
-int main() {#if !H5_HAVE_ZLIB_H
-kkkk
-#endif
-int x = 1;}" HAVE_HDF5_ZLIB)
-IF(NOT HAVE_HDF5_ZLIB)
-    MESSAGE(FATAL_ERROR "HDF5 was built without zlib. Rebuild HDF5 with zlib.")
-ENDIF()
 
 # Check to see if CURLOPT_USERNAME is defined.
 # It is present starting version 7.19.1.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -751,16 +751,6 @@ IF(USE_HDF5 OR ENABLE_NETCDF_4)
 	SET(HDF5_CC h5cc)
   ENDIF()
 
-  # Check to ensure that HDF5 was built with zlib.
-  CHECK_C_SOURCE_COMPILES("#include <H5pubconf.h>
-   int main() {#if !H5_HAVE_ZLIB_H
-   #error
-   #endif
-   int x = 1;}" HAVE_HDF5_ZLIB)
-  IF(NOT HAVE_HDF5_ZLIB)
-    MESSAGE(FATAL_ERROR "HDF5 was built without zlib. Rebuild HDF5 with zlib.")
-  ENDIF()
-
   # Check to see if this is hdf5-1.10.3 or later.
   CHECK_LIBRARY_EXISTS(${HDF5_C_LIBRARY_hdf5} H5Dread_chunk "" HDF5_SUPPORTS_PAR_FILTERS)
 
@@ -776,6 +766,18 @@ IF(USE_HDF5 OR ENABLE_NETCDF_4)
   ELSE(NOT HAVE_HDF5_H)
     INCLUDE_DIRECTORIES(${HAVE_HDF5_H})
   ENDIF(NOT HAVE_HDF5_H)
+
+  # Check to ensure that HDF5 was built with zlib.
+  set (CMAKE_REQUIRED_INCLUDES ${HAVE_HDF5_H})
+  CHECK_C_SOURCE_COMPILES("#include <H5pubconf.h>
+   #if !H5_HAVE_ZLIB_H
+   #error
+   #endif
+   int main() {
+   int x = 1;}" HAVE_HDF5_ZLIB)
+  IF(NOT HAVE_HDF5_ZLIB)
+    MESSAGE(FATAL_ERROR "HDF5 was built without zlib. Rebuild HDF5 with zlib.")
+  ENDIF()
 
   #option to include HDF5 High Level header file (hdf5_hl.h) in case we are not doing a make install
   INCLUDE_DIRECTORIES(${HDF5_HL_INCLUDE_DIR})

--- a/configure.ac
+++ b/configure.ac
@@ -1038,6 +1038,13 @@ if test "x$enable_hdf5" = xyes; then
 
    AC_CHECK_HEADERS([hdf5.h], [], [AC_MSG_ERROR([Compiling a test with HDF5 failed.  Either hdf5.h cannot be found, or config.log should be checked for other reason.])])
 
+   # Was HDF5 built with zlib as netCDF requires?
+   AC_COMPILE_IFELSE([AC_LANG_PROGRAM([#include "H5pubconf.h"],
+   [[#if !H5_HAVE_ZLIB_H
+   # error
+   #endif]
+   ])], [], [AC_MSG_ERROR([HDF5 was not built with zlib, which is required. Rebuild HDF5 with zlib.])])
+
    # H5Pset_fapl_mpiposix and H5Pget_fapl_mpiposix have been removed since HDF5 1.8.12.
    # Use H5Pset_fapl_mpio and H5Pget_fapl_mpio, instead.
    AC_CHECK_FUNCS([H5Pget_fapl_mpio H5Pset_deflate H5Z_SZIP H5free_memory H5resize_memory H5allocate_memory H5Pset_libver_bounds H5Pset_all_coll_metadata_ops H5Z_SZIP H5Dread_chunk])


### PR DESCRIPTION
Fixes #1557 

We require that HDF5 be built with zlib, but we never checked that. This results in some problems when HDF5 was built without zlib (like #1562 for example).

In this PR I add checks to ensure that HDF5 was built with zlib. If not, then both the autotools and cmake build will error out, and tell the user that they need to rebuild HDF5 with zlib.

