### PR TITLE
now allow nc_inq_var_szip() to return that szip is not in use for a var, without error, even when szip is not built into hdf5

### DIFF
--- a/h5_test/tst_h_vars.c
+++ b/h5_test/tst_h_vars.c
@@ -420,6 +420,11 @@ main()
         hsize_t my_dims[NDIM1];
         int i;
 
+        /* For info about HDF5 and szip, see
+         * https://support.hdfgroup.org/HDF5/doc/RM/RM_H5P.html#Property-SetSzip
+         * and
+         * https://support.hdfgroup.org/doc_resource/SZIP/index.html. */
+
         for (i = 0; i < SZIP_DIM1_LEN; i++)
             data[i] = i;
 

--- a/h5_test/tst_h_vars.c
+++ b/h5_test/tst_h_vars.c
@@ -461,55 +461,27 @@ main()
             H5Fclose(fileid) < 0)
             ERR;
 
-        /* /\* Now reopen the file and check. *\/ */
-        /* int data[SZIP_DIM1_LEN], data_in[SZIP_DIM1_LEN]; */
-        /* hid_t typeid, native_typeid; */
-        /* hid_t native_did; */
-        /* H5T_order_t order; */
-        /* htri_t equal; */
-        /* int i; */
+        {
+            /* Now reopen the file and check. */
+            int data_in[SZIP_DIM1_LEN];
+            hid_t native_did;
+            int i;
 
-        /* if ((fileid = H5Fopen(FILE_NAME, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0) ERR; */
-        /* if ((grpid = H5Gopen(fileid, GRP_NAME)) < 0) ERR; */
+            if ((fileid = H5Fopen(FILE_NAME, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0) ERR;
+            if ((grpid = H5Gopen(fileid, GRP_NAME)) < 0) ERR;
 
-        /* if ((native_did = H5Dopen1(grpid, NATIVE_VAR_NAME)) < 0) ERR; */
-        /* if ((typeid = H5Dget_type(native_did)) < 0) ERR; */
-        /* if ((native_typeid = H5Tget_native_type(typeid, H5T_DIR_DESCEND)) < 0) ERR; */
-        /* if ((order = H5Tget_order(typeid)) < 0) ERR; */
-        /* if ((equal = H5Tequal(typeid, native_typeid)) < 0) ERR; */
-        /* if (!equal) ERR; */
+            if ((native_did = H5Dopen1(grpid, SZIP_VAR_NAME)) < 0) ERR;
 
-        /* if (H5Dread(native_did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, */
-        /*             data_in) < 0) ERR; */
-        /* for (i = 0; i < SZIP_DIM1_LEN; i++) */
-        /*     if (data[i] != data_in[i]) ERR; */
+            if (H5Dread(native_did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT,
+                        data_in) < 0) ERR;
+            for (i = 0; i < SZIP_DIM1_LEN; i++)
+                if (data[i] != data_in[i]) ERR;
 
-        /* if ((le_did = H5Dopen1(grpid, LE_VAR_NAME)) < 0) ERR; */
-        /* if ((typeid = H5Dget_type(le_did)) < 0) ERR; */
-        /* if ((order = H5Tget_order(typeid)) < 0) ERR; */
-        /* if (order != H5T_ORDER_LE) ERR; */
-
-        /* if (H5Dread(le_did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, */
-        /*             data_in) < 0) ERR; */
-        /* for (i = 0; i < SZIP_DIM1_LEN; i++) */
-        /*     if (data[i] != data_in[i]) ERR; */
-
-        /* if ((be_did = H5Dopen1(grpid, BE_VAR_NAME)) < 0) ERR; */
-        /* if ((typeid = H5Dget_type(be_did)) < 0) ERR; */
-        /* if ((order = H5Tget_order(typeid)) < 0) ERR; */
-        /* if (order != H5T_ORDER_BE) ERR; */
-
-        /* if (H5Dread(be_did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, */
-        /*             data_in) < 0) ERR; */
-        /* for (i = 0; i < SZIP_DIM1_LEN; i++) */
-        /*     if (data[i] != data_in[i]) ERR; */
-
-        /* if (H5Dclose(native_did) < 0 || */
-        /*     H5Dclose(le_did) < 0 || */
-        /*     H5Dclose(be_did) < 0 || */
-        /*     H5Gclose(grpid) < 0 || */
-        /*     H5Fclose(fileid) < 0) */
-        /*     ERR; */
+            if (H5Dclose(native_did) < 0 ||
+                H5Gclose(grpid) < 0 ||
+                H5Fclose(fileid) < 0)
+                ERR;
+        }
     }
     SUMMARIZE_ERR;
 #endif /* USE_SZIP */

--- a/h5_test/tst_h_vars.c
+++ b/h5_test/tst_h_vars.c
@@ -1,5 +1,5 @@
 /* This is part of the netCDF package.
-   Copyright 2018 University Corporation for Atmospheric Research/Unidata
+   Copyright 2020 University Corporation for Atmospheric Research/Unidata
    See COPYRIGHT file for conditions of use.
 
    Test HDF5 file code. These are not intended to be exhaustive tests,
@@ -20,6 +20,7 @@
 #define GRP2_NAME "Some_3D_Met_Data"
 #define DIM1_LEN 3
 #define MAX_DIMS 255
+#define NDIM1 1
 
 int
 main()
@@ -410,17 +411,16 @@ main()
 #ifdef USE_SZIP
     printf("*** Checking szip functionality...");
 #define SZIP_VAR_NAME "szip_var"
-#define LE_VAR_NAME "le_var"
-#define BE_VAR_NAME "be_var"
+#define SZIP_DIM1_LEN 32
     {
-        int data[DIM1_LEN], data_in[DIM1_LEN];
-        hid_t typeid, native_typeid;
-        hid_t native_did;
-        H5T_order_t order;
-        htri_t equal;
+        int data[DIM1_LEN];
+        hid_t plistid;
+        hsize_t chunksize[NDIM1] = {SZIP_DIM1_LEN};
+        int options_mask = 32, pixels_per_block = 4;
+        hsize_t my_dims[NDIM1];
         int i;
 
-        for (i = 0; i < DIM1_LEN; i++)
+        for (i = 0; i < SZIP_DIM1_LEN; i++)
             data[i] = i;
 
         /* Open file and create group. */
@@ -428,20 +428,47 @@ main()
                                 H5P_DEFAULT)) < 0) ERR;
         if ((grpid = H5Gcreate(fileid, GRP_NAME, 0)) < 0) ERR;
 
-        /* Create a dataset of native endian. */
-        dims[0] = DIM1_LEN;
-        if ((spaceid = H5Screate_simple(1, dims, dims)) < 0) ERR;
-        if ((native_did = H5Dcreate(grpid, SZIP_VAR_NAME, H5T_NATIVE_INT,
-                                    spaceid, H5P_DEFAULT)) < 0) ERR;
-        if (H5Dwrite(native_did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT,
+        /* Create dataset creation property list. */
+        if ((plistid = H5Pcreate(H5P_DATASET_CREATE)) < 0) ERR;
+
+        /* Turn on chunking. */
+        if (H5Pset_chunk(plistid, NDIM1, chunksize) < 0) ERR;
+
+        /* Turn off object tracking times in HDF5 (as netcdf-4 does). */
+        if (H5Pset_obj_track_times(plistid, 0) < 0) ERR;
+
+        /* Turn on szip compression. */
+        if (H5Pset_szip(plistid, options_mask, pixels_per_block) < 0) ERR;
+
+        /* Create a space. */
+        my_dims[0] = SZIP_DIM1_LEN;
+        if ((spaceid = H5Screate_simple(1, my_dims, my_dims)) < 0) ERR;
+
+        /* Create a dataset. */
+        if ((datasetid = H5Dcreate2(grpid, SZIP_VAR_NAME, H5T_NATIVE_INT,
+                                    spaceid, H5P_DEFAULT, plistid,
+                                    H5P_DEFAULT)) < 0) ERR;
+
+        /* Write data. */
+        if (H5Dwrite(datasetid, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT,
                      data) < 0) ERR;
-        if (H5Dclose(native_did) < 0 ||
+
+        /* Release resources. */
+        if (H5Dclose(datasetid) < 0 ||
             H5Sclose(spaceid) < 0 ||
+            H5Pclose(plistid) < 0 ||
             H5Gclose(grpid) < 0 ||
             H5Fclose(fileid) < 0)
             ERR;
 
         /* /\* Now reopen the file and check. *\/ */
+        /* int data[SZIP_DIM1_LEN], data_in[SZIP_DIM1_LEN]; */
+        /* hid_t typeid, native_typeid; */
+        /* hid_t native_did; */
+        /* H5T_order_t order; */
+        /* htri_t equal; */
+        /* int i; */
+
         /* if ((fileid = H5Fopen(FILE_NAME, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0) ERR; */
         /* if ((grpid = H5Gopen(fileid, GRP_NAME)) < 0) ERR; */
 
@@ -454,7 +481,7 @@ main()
 
         /* if (H5Dread(native_did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, */
         /*             data_in) < 0) ERR; */
-        /* for (i = 0; i < DIM1_LEN; i++) */
+        /* for (i = 0; i < SZIP_DIM1_LEN; i++) */
         /*     if (data[i] != data_in[i]) ERR; */
 
         /* if ((le_did = H5Dopen1(grpid, LE_VAR_NAME)) < 0) ERR; */
@@ -464,7 +491,7 @@ main()
 
         /* if (H5Dread(le_did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, */
         /*             data_in) < 0) ERR; */
-        /* for (i = 0; i < DIM1_LEN; i++) */
+        /* for (i = 0; i < SZIP_DIM1_LEN; i++) */
         /*     if (data[i] != data_in[i]) ERR; */
 
         /* if ((be_did = H5Dopen1(grpid, BE_VAR_NAME)) < 0) ERR; */
@@ -474,7 +501,7 @@ main()
 
         /* if (H5Dread(be_did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, */
         /*             data_in) < 0) ERR; */
-        /* for (i = 0; i < DIM1_LEN; i++) */
+        /* for (i = 0; i < SZIP_DIM1_LEN; i++) */
         /*     if (data[i] != data_in[i]) ERR; */
 
         /* if (H5Dclose(native_did) < 0 || */

--- a/h5_test/tst_h_vars.c
+++ b/h5_test/tst_h_vars.c
@@ -7,6 +7,8 @@
    tests don't work, than netCDF-4 won't work either.
 
    This files tests dataset creation and writing.
+
+   Ed Hartnett
 */
 
 #include "h5_err_macros.h"
@@ -22,35 +24,35 @@
 int
 main()
 {
-   hid_t fileid, grpid, spaceid, datasetid;
-   int bool_out[DIM1_LEN] = {0, 1, 0};
-   hsize_t dims[1];
+    hid_t fileid, grpid, spaceid, datasetid;
+    int bool_out[DIM1_LEN] = {0, 1, 0};
+    hsize_t dims[1];
 
-   printf("\n*** Checking HDF5 variable functions.\n");
-   printf("*** Checking HDF5 boolean variables...");
+    printf("\n*** Checking HDF5 variable functions.\n");
+    printf("*** Checking HDF5 boolean variables...");
 
-   /* Open file and create group. */
-   if ((fileid = H5Fcreate(FILE_NAME, H5F_ACC_TRUNC, H5P_DEFAULT,
-			   H5P_DEFAULT)) < 0) ERR;
-   if ((grpid = H5Gcreate(fileid, GRP_NAME, 0)) < 0) ERR;
+    /* Open file and create group. */
+    if ((fileid = H5Fcreate(FILE_NAME, H5F_ACC_TRUNC, H5P_DEFAULT,
+                            H5P_DEFAULT)) < 0) ERR;
+    if ((grpid = H5Gcreate(fileid, GRP_NAME, 0)) < 0) ERR;
 
-   /* Write an array of bools. */
-   dims[0] = DIM1_LEN;
-   if ((spaceid = H5Screate_simple(1, dims, dims)) < 0) ERR;
-   if ((datasetid = H5Dcreate(grpid, VAR_BOOL_NAME, H5T_NATIVE_HBOOL,
-			      spaceid, H5P_DEFAULT)) < 0) ERR;
-   if (H5Dwrite(datasetid, H5T_NATIVE_HBOOL, H5S_ALL, H5S_ALL, H5P_DEFAULT,
-		bool_out) < 0) ERR;
-   if (H5Dclose(datasetid) < 0 ||
-       H5Sclose(spaceid) < 0 ||
-       H5Gclose(grpid) < 0 ||
-       H5Fclose(fileid) < 0)
-      ERR;
+    /* Write an array of bools. */
+    dims[0] = DIM1_LEN;
+    if ((spaceid = H5Screate_simple(1, dims, dims)) < 0) ERR;
+    if ((datasetid = H5Dcreate(grpid, VAR_BOOL_NAME, H5T_NATIVE_HBOOL,
+                               spaceid, H5P_DEFAULT)) < 0) ERR;
+    if (H5Dwrite(datasetid, H5T_NATIVE_HBOOL, H5S_ALL, H5S_ALL, H5P_DEFAULT,
+                 bool_out) < 0) ERR;
+    if (H5Dclose(datasetid) < 0 ||
+        H5Sclose(spaceid) < 0 ||
+        H5Gclose(grpid) < 0 ||
+        H5Fclose(fileid) < 0)
+        ERR;
 
-   SUMMARIZE_ERR;
+    SUMMARIZE_ERR;
 
-   printf("*** Checking HDF5 variable with unlimited dimension...");
-   {
+    printf("*** Checking HDF5 variable with unlimited dimension...");
+    {
 #define LAT_LEN 2
 #define LON_LEN 3
 #define NDIMS 3
@@ -60,350 +62,350 @@ main()
 #define PRES_NAME "Pressure"
 #define TEMP_NAME "Temperature"
 
-      hid_t fileid, grpid, spaceid, write_spaceid, spaceid_in, mem_spaceid;
-      hid_t pres_dsid, temp_dsid, cparmsid;
-      float float_data_out[LAT_LEN][LON_LEN];
-      hsize_t dims[NDIMS], max_dims[NDIMS];
-      hsize_t dims_in[NDIMS], max_dims_in[NDIMS];
-      hsize_t start[MAX_DIMS], count[MAX_DIMS];
-      int lat, lon;
+        hid_t fileid, grpid, spaceid, write_spaceid, spaceid_in, mem_spaceid;
+        hid_t pres_dsid, temp_dsid, cparmsid;
+        float float_data_out[LAT_LEN][LON_LEN];
+        hsize_t dims[NDIMS], max_dims[NDIMS];
+        hsize_t dims_in[NDIMS], max_dims_in[NDIMS];
+        hsize_t start[MAX_DIMS], count[MAX_DIMS];
+        int lat, lon;
 
-      /* Set up some phoney data, 1 record's worth. In C, first
-       * dimension varies most slowly. */
-      for (lat = 0; lat < LAT_LEN; lat++)
-	 for (lon = 0; lon < LON_LEN; lon++)
-	    float_data_out[lat][lon] = -666.666;
+        /* Set up some phoney data, 1 record's worth. In C, first
+         * dimension varies most slowly. */
+        for (lat = 0; lat < LAT_LEN; lat++)
+            for (lon = 0; lon < LON_LEN; lon++)
+                float_data_out[lat][lon] = -666.666;
 
-      /* Create file and group. */
-      if ((fileid = H5Fcreate(FILE_NAME, H5F_ACC_TRUNC, H5P_DEFAULT,
-			      H5P_DEFAULT)) < 0) ERR;
-      if ((grpid = H5Gcreate(fileid, GRP2_NAME, 0)) < 0) ERR;
+        /* Create file and group. */
+        if ((fileid = H5Fcreate(FILE_NAME, H5F_ACC_TRUNC, H5P_DEFAULT,
+                                H5P_DEFAULT)) < 0) ERR;
+        if ((grpid = H5Gcreate(fileid, GRP2_NAME, 0)) < 0) ERR;
 
-      /* Create a space corresponding to these three dimensions. */
-      dims[0] = 0;
-      dims[1] = LAT_LEN;
-      dims[2] = LON_LEN;
-      max_dims[0] = H5S_UNLIMITED;
-      max_dims[1] = LAT_LEN;
-      max_dims[2] = LON_LEN;
-      if ((spaceid = H5Screate_simple(NDIMS, dims, max_dims)) < 0) ERR;
+        /* Create a space corresponding to these three dimensions. */
+        dims[0] = 0;
+        dims[1] = LAT_LEN;
+        dims[2] = LON_LEN;
+        max_dims[0] = H5S_UNLIMITED;
+        max_dims[1] = LAT_LEN;
+        max_dims[2] = LON_LEN;
+        if ((spaceid = H5Screate_simple(NDIMS, dims, max_dims)) < 0) ERR;
 
-      /* Enable chunking for unlimited datasets.  */
-      if ((cparmsid = H5Pcreate(H5P_DATASET_CREATE)) < 0) ERR;
-      dims[0] = 1;
-      dims[1] = 1;
-      dims[2] = 1;
-      if (H5Pset_chunk(cparmsid, NDIMS, dims) < 0) ERR;
+        /* Enable chunking for unlimited datasets.  */
+        if ((cparmsid = H5Pcreate(H5P_DATASET_CREATE)) < 0) ERR;
+        dims[0] = 1;
+        dims[1] = 1;
+        dims[2] = 1;
+        if (H5Pset_chunk(cparmsid, NDIMS, dims) < 0) ERR;
 
-      /* Create two variables which use this space. */
-      if ((pres_dsid = H5Dcreate(grpid, PRES_NAME, H5T_NATIVE_FLOAT,
-				 spaceid, cparmsid)) < 0) ERR;
-      if ((temp_dsid = H5Dcreate(grpid, TEMP_NAME, H5T_NATIVE_FLOAT,
-				 spaceid, cparmsid)) < 0) ERR;
+        /* Create two variables which use this space. */
+        if ((pres_dsid = H5Dcreate(grpid, PRES_NAME, H5T_NATIVE_FLOAT,
+                                   spaceid, cparmsid)) < 0) ERR;
+        if ((temp_dsid = H5Dcreate(grpid, TEMP_NAME, H5T_NATIVE_FLOAT,
+                                   spaceid, cparmsid)) < 0) ERR;
 
-      /* Get the spaceid and check various things. */
-      if ((spaceid_in = H5Dget_space(pres_dsid)) < 0) ERR;
-      if (H5Sget_simple_extent_dims(spaceid_in, dims_in,
-				    max_dims_in) < 0) ERR;
-      if (dims_in[0] != 0 || dims_in[1] != LAT_LEN || dims_in[2] != LON_LEN) ERR;
-      if (max_dims_in[0] != H5S_UNLIMITED || max_dims_in[1] != LAT_LEN || max_dims_in[2] != LON_LEN) ERR;
+        /* Get the spaceid and check various things. */
+        if ((spaceid_in = H5Dget_space(pres_dsid)) < 0) ERR;
+        if (H5Sget_simple_extent_dims(spaceid_in, dims_in,
+                                      max_dims_in) < 0) ERR;
+        if (dims_in[0] != 0 || dims_in[1] != LAT_LEN || dims_in[2] != LON_LEN) ERR;
+        if (max_dims_in[0] != H5S_UNLIMITED || max_dims_in[1] != LAT_LEN || max_dims_in[2] != LON_LEN) ERR;
 
-      /* Extend each of them to hold one record. */
-      dims[0] = 1;
-      dims[1] = LAT_LEN;
-      dims[2] = LON_LEN;
-      if (H5Dextend(pres_dsid, dims) < 0) ERR;
-      if (H5Dextend(temp_dsid, dims) < 0) ERR;
+        /* Extend each of them to hold one record. */
+        dims[0] = 1;
+        dims[1] = LAT_LEN;
+        dims[2] = LON_LEN;
+        if (H5Dextend(pres_dsid, dims) < 0) ERR;
+        if (H5Dextend(temp_dsid, dims) < 0) ERR;
 
-      /* Create a space to deal with one record at a time in memory. */
-      if ((mem_spaceid = H5Screate_simple(NDIMS, dims, NULL)) < 0) ERR;
+        /* Create a space to deal with one record at a time in memory. */
+        if ((mem_spaceid = H5Screate_simple(NDIMS, dims, NULL)) < 0) ERR;
 
-      /* Create a space to write one record. */
-      if ((write_spaceid = H5Screate_simple(NDIMS, dims, NULL)) < 0) ERR;
+        /* Create a space to write one record. */
+        if ((write_spaceid = H5Screate_simple(NDIMS, dims, NULL)) < 0) ERR;
 
-      /* Write one record of data to each dataset. */
-      if (H5Dwrite(pres_dsid, H5T_IEEE_F32BE, mem_spaceid, write_spaceid,
-		   H5P_DEFAULT, float_data_out) < 0) ERR;
-      if (H5Dwrite(temp_dsid, H5T_IEEE_F32LE, mem_spaceid, write_spaceid,
-		   H5P_DEFAULT, float_data_out) < 0) ERR;
+        /* Write one record of data to each dataset. */
+        if (H5Dwrite(pres_dsid, H5T_IEEE_F32BE, mem_spaceid, write_spaceid,
+                     H5P_DEFAULT, float_data_out) < 0) ERR;
+        if (H5Dwrite(temp_dsid, H5T_IEEE_F32LE, mem_spaceid, write_spaceid,
+                     H5P_DEFAULT, float_data_out) < 0) ERR;
 
-      /* Get the spaceid and check various things. */
-      if ((spaceid_in = H5Dget_space(temp_dsid)) < 0) ERR;
-      if (H5Sget_simple_extent_dims(spaceid_in, dims_in,
-				    max_dims_in) < 0) ERR;
-      if (dims_in[0] != 1 || dims_in[1] != LAT_LEN || dims_in[2] != LON_LEN) ERR;
-      if (max_dims_in[0] != H5S_UNLIMITED || max_dims_in[1] != LAT_LEN || max_dims_in[2] != LON_LEN) ERR;
+        /* Get the spaceid and check various things. */
+        if ((spaceid_in = H5Dget_space(temp_dsid)) < 0) ERR;
+        if (H5Sget_simple_extent_dims(spaceid_in, dims_in,
+                                      max_dims_in) < 0) ERR;
+        if (dims_in[0] != 1 || dims_in[1] != LAT_LEN || dims_in[2] != LON_LEN) ERR;
+        if (max_dims_in[0] != H5S_UNLIMITED || max_dims_in[1] != LAT_LEN || max_dims_in[2] != LON_LEN) ERR;
 
-      /* Extend each of them to hold a second record. */
-      dims[0] = 2;
-      dims[1] = LAT_LEN;
-      dims[2] = LON_LEN;
-      if (H5Dextend(pres_dsid, dims) < 0) ERR;
-      if (H5Dextend(temp_dsid, dims) < 0) ERR;
+        /* Extend each of them to hold a second record. */
+        dims[0] = 2;
+        dims[1] = LAT_LEN;
+        dims[2] = LON_LEN;
+        if (H5Dextend(pres_dsid, dims) < 0) ERR;
+        if (H5Dextend(temp_dsid, dims) < 0) ERR;
 
-      /* Create a space to write second record. */
-      if ((write_spaceid = H5Screate_simple(NDIMS, dims, NULL)) < 0) ERR;
-      count[0] = 1;
-      count[1] = LAT_LEN;
-      count[2] = LON_LEN;
-      start[0] = 1;
-      start[1] = 0;
-      start[2] = 0;
-      if (H5Sselect_hyperslab(write_spaceid, H5S_SELECT_SET,
-			      start, NULL, count, NULL) < 0) ERR;
+        /* Create a space to write second record. */
+        if ((write_spaceid = H5Screate_simple(NDIMS, dims, NULL)) < 0) ERR;
+        count[0] = 1;
+        count[1] = LAT_LEN;
+        count[2] = LON_LEN;
+        start[0] = 1;
+        start[1] = 0;
+        start[2] = 0;
+        if (H5Sselect_hyperslab(write_spaceid, H5S_SELECT_SET,
+                                start, NULL, count, NULL) < 0) ERR;
 
-      /* Write second record of data to each dataset. */
-      if (H5Dwrite(pres_dsid, H5T_IEEE_F32LE, mem_spaceid, write_spaceid,
-		   H5P_DEFAULT, float_data_out) < 0) ERR;
-      if (H5Dwrite(temp_dsid, H5T_IEEE_F32LE, mem_spaceid, write_spaceid,
-		   H5P_DEFAULT, float_data_out) < 0) ERR;
+        /* Write second record of data to each dataset. */
+        if (H5Dwrite(pres_dsid, H5T_IEEE_F32LE, mem_spaceid, write_spaceid,
+                     H5P_DEFAULT, float_data_out) < 0) ERR;
+        if (H5Dwrite(temp_dsid, H5T_IEEE_F32LE, mem_spaceid, write_spaceid,
+                     H5P_DEFAULT, float_data_out) < 0) ERR;
 
-      /* Get the spaceid and check various things. */
-      if ((spaceid_in = H5Dget_space(pres_dsid)) < 0) ERR;
-      if (H5Sget_simple_extent_dims(spaceid_in, dims_in,
-				    max_dims_in) < 0) ERR;
-      if (dims_in[0] != 2 || dims_in[1] != LAT_LEN || dims_in[2] != LON_LEN) ERR;
-      if (max_dims_in[0] != H5S_UNLIMITED || max_dims_in[1] != LAT_LEN || max_dims_in[2] != LON_LEN) ERR;
+        /* Get the spaceid and check various things. */
+        if ((spaceid_in = H5Dget_space(pres_dsid)) < 0) ERR;
+        if (H5Sget_simple_extent_dims(spaceid_in, dims_in,
+                                      max_dims_in) < 0) ERR;
+        if (dims_in[0] != 2 || dims_in[1] != LAT_LEN || dims_in[2] != LON_LEN) ERR;
+        if (max_dims_in[0] != H5S_UNLIMITED || max_dims_in[1] != LAT_LEN || max_dims_in[2] != LON_LEN) ERR;
 
-      /* Close up the shop. */
-      if (H5Dclose(pres_dsid) < 0 ||
-	  H5Dclose(temp_dsid) < 0 ||
-	  H5Sclose(spaceid) < 0 ||
-	  H5Gclose(grpid) < 0 ||
-	  H5Fclose(fileid) < 0) ERR;
+        /* Close up the shop. */
+        if (H5Dclose(pres_dsid) < 0 ||
+            H5Dclose(temp_dsid) < 0 ||
+            H5Sclose(spaceid) < 0 ||
+            H5Gclose(grpid) < 0 ||
+            H5Fclose(fileid) < 0) ERR;
 
-   }
+    }
 
-   SUMMARIZE_ERR;
-   printf("*** Checking HDF5 deflate filter setting and getting...");
+    SUMMARIZE_ERR;
+    printf("*** Checking HDF5 deflate filter setting and getting...");
 #define DEFLATE_LEVEL 9
 #define MAX_NAME 100
 #define NUM_CD_ELEM 10
 /* HDF5 defines this... */
 #define DEFLATE_NAME "deflate"
-   {
-      H5Z_filter_t filter;
-      int num_filters;
-      hid_t propid;
-      unsigned int flags, cd_values[NUM_CD_ELEM], filter_config;
-      size_t cd_nelems = NUM_CD_ELEM;
-      size_t namelen = MAX_NAME;
-      char name[MAX_NAME + 1];
+    {
+        H5Z_filter_t filter;
+        int num_filters;
+        hid_t propid;
+        unsigned int flags, cd_values[NUM_CD_ELEM], filter_config;
+        size_t cd_nelems = NUM_CD_ELEM;
+        size_t namelen = MAX_NAME;
+        char name[MAX_NAME + 1];
 
 
-      /* Open file and create group. */
-      if ((fileid = H5Fcreate(FILE_NAME, H5F_ACC_TRUNC, H5P_DEFAULT,
-			      H5P_DEFAULT)) < 0) ERR;
-      if ((grpid = H5Gcreate(fileid, GRP_NAME, 0)) < 0) ERR;
+        /* Open file and create group. */
+        if ((fileid = H5Fcreate(FILE_NAME, H5F_ACC_TRUNC, H5P_DEFAULT,
+                                H5P_DEFAULT)) < 0) ERR;
+        if ((grpid = H5Gcreate(fileid, GRP_NAME, 0)) < 0) ERR;
 
-      /* Write an array of bools, with compression. */
-      dims[0] = DIM1_LEN;
-      if ((propid = H5Pcreate(H5P_DATASET_CREATE)) < 0) ERR;
-      if (H5Pset_layout(propid, H5D_CHUNKED)) ERR;
-      if (H5Pset_chunk(propid, 1, dims)) ERR;
-      if (H5Pset_deflate(propid, DEFLATE_LEVEL)) ERR;
-      if ((spaceid = H5Screate_simple(1, dims, dims)) < 0) ERR;
-      if ((datasetid = H5Dcreate(grpid, VAR_BOOL_NAME, H5T_NATIVE_HBOOL,
-				 spaceid, propid)) < 0) ERR;
-      if (H5Dwrite(datasetid, H5T_NATIVE_HBOOL, H5S_ALL, H5S_ALL, H5P_DEFAULT,
-		   bool_out) < 0) ERR;
-      if (H5Dclose(datasetid) < 0 ||
-	  H5Pclose(propid) < 0 ||
-	  H5Sclose(spaceid) < 0 ||
-	  H5Gclose(grpid) < 0 ||
-	  H5Fclose(fileid) < 0)
-	 ERR;
+        /* Write an array of bools, with compression. */
+        dims[0] = DIM1_LEN;
+        if ((propid = H5Pcreate(H5P_DATASET_CREATE)) < 0) ERR;
+        if (H5Pset_layout(propid, H5D_CHUNKED)) ERR;
+        if (H5Pset_chunk(propid, 1, dims)) ERR;
+        if (H5Pset_deflate(propid, DEFLATE_LEVEL)) ERR;
+        if ((spaceid = H5Screate_simple(1, dims, dims)) < 0) ERR;
+        if ((datasetid = H5Dcreate(grpid, VAR_BOOL_NAME, H5T_NATIVE_HBOOL,
+                                   spaceid, propid)) < 0) ERR;
+        if (H5Dwrite(datasetid, H5T_NATIVE_HBOOL, H5S_ALL, H5S_ALL, H5P_DEFAULT,
+                     bool_out) < 0) ERR;
+        if (H5Dclose(datasetid) < 0 ||
+            H5Pclose(propid) < 0 ||
+            H5Sclose(spaceid) < 0 ||
+            H5Gclose(grpid) < 0 ||
+            H5Fclose(fileid) < 0)
+            ERR;
 
-      /* Now reopen the file and check. */
-      if ((fileid = H5Fopen(FILE_NAME, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0) ERR;
-      if ((grpid = H5Gopen(fileid, GRP_NAME)) < 0) ERR;
-      if ((datasetid = H5Dopen1(grpid, VAR_BOOL_NAME)) < 0) ERR;
-      if ((propid = H5Dget_create_plist(datasetid)) < 0) ERR;
+        /* Now reopen the file and check. */
+        if ((fileid = H5Fopen(FILE_NAME, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0) ERR;
+        if ((grpid = H5Gopen(fileid, GRP_NAME)) < 0) ERR;
+        if ((datasetid = H5Dopen1(grpid, VAR_BOOL_NAME)) < 0) ERR;
+        if ((propid = H5Dget_create_plist(datasetid)) < 0) ERR;
 
-      /* The possible values of filter (which is just an int) can be
-       * found in H5Zpublic.h. */
-      if ((num_filters = H5Pget_nfilters(propid)) < 0) ERR;
-      if (num_filters != 1) ERR;
-      if ((filter = H5Pget_filter2(propid, 0, &flags, &cd_nelems, cd_values,
-				  namelen, name, &filter_config)) < 0) ERR;
-      if (filter != H5Z_FILTER_DEFLATE || cd_nelems != 1 ||
-	  cd_values[0] != DEFLATE_LEVEL || strcmp(name, DEFLATE_NAME)) ERR;
+        /* The possible values of filter (which is just an int) can be
+         * found in H5Zpublic.h. */
+        if ((num_filters = H5Pget_nfilters(propid)) < 0) ERR;
+        if (num_filters != 1) ERR;
+        if ((filter = H5Pget_filter2(propid, 0, &flags, &cd_nelems, cd_values,
+                                     namelen, name, &filter_config)) < 0) ERR;
+        if (filter != H5Z_FILTER_DEFLATE || cd_nelems != 1 ||
+            cd_values[0] != DEFLATE_LEVEL || strcmp(name, DEFLATE_NAME)) ERR;
 
-      if (H5Dclose(datasetid) < 0 ||
-	  H5Pclose(propid) < 0 ||
-	  H5Gclose(grpid) < 0 ||
-	  H5Fclose(fileid) < 0)
-	 ERR;
-   }
+        if (H5Dclose(datasetid) < 0 ||
+            H5Pclose(propid) < 0 ||
+            H5Gclose(grpid) < 0 ||
+            H5Fclose(fileid) < 0)
+            ERR;
+    }
 
-   SUMMARIZE_ERR;
-   printf("*** Checking HDF5 deflate, fletcher32, shuffle filter setting and getting...");
-   {
-      H5Z_filter_t filter;
-      int num_filters;
-      hid_t propid;
-      unsigned int flags, cd_values[NUM_CD_ELEM], filter_config;
-      size_t cd_nelems = NUM_CD_ELEM;
-      size_t namelen = MAX_NAME;
-      char name[MAX_NAME + 1];
-      int found_shuffle = 0, found_fletcher32 = 0, found_deflate = 0;
-      int f;
+    SUMMARIZE_ERR;
+    printf("*** Checking HDF5 deflate, fletcher32, shuffle filter setting and getting...");
+    {
+        H5Z_filter_t filter;
+        int num_filters;
+        hid_t propid;
+        unsigned int flags, cd_values[NUM_CD_ELEM], filter_config;
+        size_t cd_nelems = NUM_CD_ELEM;
+        size_t namelen = MAX_NAME;
+        char name[MAX_NAME + 1];
+        int found_shuffle = 0, found_fletcher32 = 0, found_deflate = 0;
+        int f;
 
-      /* Open file and create group. */
-      if ((fileid = H5Fcreate(FILE_NAME, H5F_ACC_TRUNC, H5P_DEFAULT,
-			      H5P_DEFAULT)) < 0) ERR;
-      if ((grpid = H5Gcreate(fileid, GRP_NAME, 0)) < 0) ERR;
+        /* Open file and create group. */
+        if ((fileid = H5Fcreate(FILE_NAME, H5F_ACC_TRUNC, H5P_DEFAULT,
+                                H5P_DEFAULT)) < 0) ERR;
+        if ((grpid = H5Gcreate(fileid, GRP_NAME, 0)) < 0) ERR;
 
-      /* Write an array of bools, with compression, fletcher32
-       * checksum, shuffle filters. Like a hoogie with "the works." */
-      dims[0] = DIM1_LEN;
-      if ((propid = H5Pcreate(H5P_DATASET_CREATE)) < 0) ERR;
-      if (H5Pset_layout(propid, H5D_CHUNKED)) ERR;
-      if (H5Pset_chunk(propid, 1, dims)) ERR;
-      if (H5Pset_shuffle(propid)) ERR;
-      if (H5Pset_deflate(propid, DEFLATE_LEVEL)) ERR;
-      if (H5Pset_fletcher32(propid)) ERR;
-      if ((spaceid = H5Screate_simple(1, dims, dims)) < 0) ERR;
-      if ((datasetid = H5Dcreate(grpid, VAR_BOOL_NAME, H5T_NATIVE_HBOOL,
-				 spaceid, propid)) < 0) ERR;
-      if (H5Dwrite(datasetid, H5T_NATIVE_HBOOL, H5S_ALL, H5S_ALL, H5P_DEFAULT,
-		   bool_out) < 0) ERR;
-      if (H5Dclose(datasetid) < 0 ||
-	  H5Pclose(propid) < 0 ||
-	  H5Sclose(spaceid) < 0 ||
-	  H5Gclose(grpid) < 0 ||
-	  H5Fclose(fileid) < 0)
-	 ERR;
+        /* Write an array of bools, with compression, fletcher32
+         * checksum, shuffle filters. Like a hoogie with "the works." */
+        dims[0] = DIM1_LEN;
+        if ((propid = H5Pcreate(H5P_DATASET_CREATE)) < 0) ERR;
+        if (H5Pset_layout(propid, H5D_CHUNKED)) ERR;
+        if (H5Pset_chunk(propid, 1, dims)) ERR;
+        if (H5Pset_shuffle(propid)) ERR;
+        if (H5Pset_deflate(propid, DEFLATE_LEVEL)) ERR;
+        if (H5Pset_fletcher32(propid)) ERR;
+        if ((spaceid = H5Screate_simple(1, dims, dims)) < 0) ERR;
+        if ((datasetid = H5Dcreate(grpid, VAR_BOOL_NAME, H5T_NATIVE_HBOOL,
+                                   spaceid, propid)) < 0) ERR;
+        if (H5Dwrite(datasetid, H5T_NATIVE_HBOOL, H5S_ALL, H5S_ALL, H5P_DEFAULT,
+                     bool_out) < 0) ERR;
+        if (H5Dclose(datasetid) < 0 ||
+            H5Pclose(propid) < 0 ||
+            H5Sclose(spaceid) < 0 ||
+            H5Gclose(grpid) < 0 ||
+            H5Fclose(fileid) < 0)
+            ERR;
 
-      /* Now reopen the file and check. */
-      if ((fileid = H5Fopen(FILE_NAME, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0) ERR;
-      if ((grpid = H5Gopen(fileid, GRP_NAME)) < 0) ERR;
-      if ((datasetid = H5Dopen1(grpid, VAR_BOOL_NAME)) < 0) ERR;
-      if ((propid = H5Dget_create_plist(datasetid)) < 0) ERR;
+        /* Now reopen the file and check. */
+        if ((fileid = H5Fopen(FILE_NAME, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0) ERR;
+        if ((grpid = H5Gopen(fileid, GRP_NAME)) < 0) ERR;
+        if ((datasetid = H5Dopen1(grpid, VAR_BOOL_NAME)) < 0) ERR;
+        if ((propid = H5Dget_create_plist(datasetid)) < 0) ERR;
 
-      /* The possible values of filter (which is just an int) can be
-       * found in H5Zpublic.h. */
-      if ((num_filters = H5Pget_nfilters(propid)) < 0) ERR;
-      if (num_filters != 3) ERR;
-      for (f = 0; f < num_filters; f++)
-      {
-	 if ((filter = H5Pget_filter2(propid, f, &flags, &cd_nelems, cd_values,
-				      namelen, name, &filter_config)) < 0) ERR;
-	 switch (filter)
-	 {
-	    case H5Z_FILTER_SHUFFLE:
-	       found_shuffle++;
-	       break;
-	    case H5Z_FILTER_FLETCHER32:
-	       found_fletcher32++;
-	       break;
-	    case H5Z_FILTER_DEFLATE:
-	       found_deflate++;
-	       if (cd_nelems != 1 || cd_values[0] != DEFLATE_LEVEL ||
-		   strcmp(name, DEFLATE_NAME)) ERR;
-	       break;
-	    default:
-	       break;
-	 }
-      }
-      if (!found_fletcher32 || !found_deflate || !found_shuffle) ERR;
+        /* The possible values of filter (which is just an int) can be
+         * found in H5Zpublic.h. */
+        if ((num_filters = H5Pget_nfilters(propid)) < 0) ERR;
+        if (num_filters != 3) ERR;
+        for (f = 0; f < num_filters; f++)
+        {
+            if ((filter = H5Pget_filter2(propid, f, &flags, &cd_nelems, cd_values,
+                                         namelen, name, &filter_config)) < 0) ERR;
+            switch (filter)
+            {
+            case H5Z_FILTER_SHUFFLE:
+                found_shuffle++;
+                break;
+            case H5Z_FILTER_FLETCHER32:
+                found_fletcher32++;
+                break;
+            case H5Z_FILTER_DEFLATE:
+                found_deflate++;
+                if (cd_nelems != 1 || cd_values[0] != DEFLATE_LEVEL ||
+                    strcmp(name, DEFLATE_NAME)) ERR;
+                break;
+            default:
+                break;
+            }
+        }
+        if (!found_fletcher32 || !found_deflate || !found_shuffle) ERR;
 
-      if (H5Dclose(datasetid) < 0 ||
-	  H5Pclose(propid) < 0 ||
-	  H5Gclose(grpid) < 0 ||
-	  H5Fclose(fileid) < 0)
-	 ERR;
-   }
+        if (H5Dclose(datasetid) < 0 ||
+            H5Pclose(propid) < 0 ||
+            H5Gclose(grpid) < 0 ||
+            H5Fclose(fileid) < 0)
+            ERR;
+    }
 
-   SUMMARIZE_ERR;
-   printf("*** Checking HDF5 endianness control...");
+    SUMMARIZE_ERR;
+    printf("*** Checking HDF5 endianness control...");
 
 #define NATIVE_VAR_NAME "native_var"
 #define LE_VAR_NAME "le_var"
 #define BE_VAR_NAME "be_var"
-   {
-      int data[DIM1_LEN], data_in[DIM1_LEN];
-      hid_t typeid, native_typeid;
-      hid_t native_did, le_did, be_did;
-      H5T_order_t order;
-      htri_t equal;
-      int i;
+    {
+        int data[DIM1_LEN], data_in[DIM1_LEN];
+        hid_t typeid, native_typeid;
+        hid_t native_did, le_did, be_did;
+        H5T_order_t order;
+        htri_t equal;
+        int i;
 
-      for (i = 0; i < DIM1_LEN; i++)
-	 data[i] = i;
+        for (i = 0; i < DIM1_LEN; i++)
+            data[i] = i;
 
-      /* Open file and create group. */
-      if ((fileid = H5Fcreate(FILE_NAME, H5F_ACC_TRUNC, H5P_DEFAULT,
-			      H5P_DEFAULT)) < 0) ERR;
-      if ((grpid = H5Gcreate(fileid, GRP_NAME, 0)) < 0) ERR;
+        /* Open file and create group. */
+        if ((fileid = H5Fcreate(FILE_NAME, H5F_ACC_TRUNC, H5P_DEFAULT,
+                                H5P_DEFAULT)) < 0) ERR;
+        if ((grpid = H5Gcreate(fileid, GRP_NAME, 0)) < 0) ERR;
 
-      /* Create a dataset of native endian. */
-      dims[0] = DIM1_LEN;
-      if ((spaceid = H5Screate_simple(1, dims, dims)) < 0) ERR;
-      if ((native_did = H5Dcreate(grpid, NATIVE_VAR_NAME, H5T_NATIVE_INT,
-				  spaceid, H5P_DEFAULT)) < 0) ERR;
-      if ((le_did = H5Dcreate(grpid, LE_VAR_NAME, H5T_STD_I32LE,
-			      spaceid, H5P_DEFAULT)) < 0) ERR;
-      if ((be_did = H5Dcreate(grpid, BE_VAR_NAME, H5T_STD_I32BE,
-			      spaceid, H5P_DEFAULT)) < 0) ERR;
-      if (H5Dwrite(native_did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT,
-		   data) < 0) ERR;
-      if (H5Dwrite(le_did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT,
-		   data) < 0) ERR;
-      if (H5Dwrite(be_did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT,
-		   data) < 0) ERR;
-      if (H5Dclose(native_did) < 0 ||
-	  H5Dclose(le_did) < 0 ||
-	  H5Dclose(be_did) < 0 ||
-	  H5Sclose(spaceid) < 0 ||
-	  H5Gclose(grpid) < 0 ||
-	  H5Fclose(fileid) < 0)
-	 ERR;
+        /* Create a dataset of native endian. */
+        dims[0] = DIM1_LEN;
+        if ((spaceid = H5Screate_simple(1, dims, dims)) < 0) ERR;
+        if ((native_did = H5Dcreate(grpid, NATIVE_VAR_NAME, H5T_NATIVE_INT,
+                                    spaceid, H5P_DEFAULT)) < 0) ERR;
+        if ((le_did = H5Dcreate(grpid, LE_VAR_NAME, H5T_STD_I32LE,
+                                spaceid, H5P_DEFAULT)) < 0) ERR;
+        if ((be_did = H5Dcreate(grpid, BE_VAR_NAME, H5T_STD_I32BE,
+                                spaceid, H5P_DEFAULT)) < 0) ERR;
+        if (H5Dwrite(native_did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT,
+                     data) < 0) ERR;
+        if (H5Dwrite(le_did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT,
+                     data) < 0) ERR;
+        if (H5Dwrite(be_did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT,
+                     data) < 0) ERR;
+        if (H5Dclose(native_did) < 0 ||
+            H5Dclose(le_did) < 0 ||
+            H5Dclose(be_did) < 0 ||
+            H5Sclose(spaceid) < 0 ||
+            H5Gclose(grpid) < 0 ||
+            H5Fclose(fileid) < 0)
+            ERR;
 
-      /* Now reopen the file and check. */
-      if ((fileid = H5Fopen(FILE_NAME, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0) ERR;
-      if ((grpid = H5Gopen(fileid, GRP_NAME)) < 0) ERR;
+        /* Now reopen the file and check. */
+        if ((fileid = H5Fopen(FILE_NAME, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0) ERR;
+        if ((grpid = H5Gopen(fileid, GRP_NAME)) < 0) ERR;
 
-      if ((native_did = H5Dopen1(grpid, NATIVE_VAR_NAME)) < 0) ERR;
-      if ((typeid = H5Dget_type(native_did)) < 0) ERR;
-      if ((native_typeid = H5Tget_native_type(typeid, H5T_DIR_DESCEND)) < 0) ERR;
-      if ((order = H5Tget_order(typeid)) < 0) ERR;
-      if ((equal = H5Tequal(typeid, native_typeid)) < 0) ERR;
-      if (!equal) ERR;
+        if ((native_did = H5Dopen1(grpid, NATIVE_VAR_NAME)) < 0) ERR;
+        if ((typeid = H5Dget_type(native_did)) < 0) ERR;
+        if ((native_typeid = H5Tget_native_type(typeid, H5T_DIR_DESCEND)) < 0) ERR;
+        if ((order = H5Tget_order(typeid)) < 0) ERR;
+        if ((equal = H5Tequal(typeid, native_typeid)) < 0) ERR;
+        if (!equal) ERR;
 
-      if (H5Dread(native_did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT,
-		   data_in) < 0) ERR;
-      for (i = 0; i < DIM1_LEN; i++)
-	 if (data[i] != data_in[i]) ERR;
+        if (H5Dread(native_did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT,
+                    data_in) < 0) ERR;
+        for (i = 0; i < DIM1_LEN; i++)
+            if (data[i] != data_in[i]) ERR;
 
-      if ((le_did = H5Dopen1(grpid, LE_VAR_NAME)) < 0) ERR;
-      if ((typeid = H5Dget_type(le_did)) < 0) ERR;
-      if ((order = H5Tget_order(typeid)) < 0) ERR;
-      if (order != H5T_ORDER_LE) ERR;
+        if ((le_did = H5Dopen1(grpid, LE_VAR_NAME)) < 0) ERR;
+        if ((typeid = H5Dget_type(le_did)) < 0) ERR;
+        if ((order = H5Tget_order(typeid)) < 0) ERR;
+        if (order != H5T_ORDER_LE) ERR;
 
-      if (H5Dread(le_did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT,
-		   data_in) < 0) ERR;
-      for (i = 0; i < DIM1_LEN; i++)
-	 if (data[i] != data_in[i]) ERR;
+        if (H5Dread(le_did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT,
+                    data_in) < 0) ERR;
+        for (i = 0; i < DIM1_LEN; i++)
+            if (data[i] != data_in[i]) ERR;
 
-      if ((be_did = H5Dopen1(grpid, BE_VAR_NAME)) < 0) ERR;
-      if ((typeid = H5Dget_type(be_did)) < 0) ERR;
-      if ((order = H5Tget_order(typeid)) < 0) ERR;
-      if (order != H5T_ORDER_BE) ERR;
+        if ((be_did = H5Dopen1(grpid, BE_VAR_NAME)) < 0) ERR;
+        if ((typeid = H5Dget_type(be_did)) < 0) ERR;
+        if ((order = H5Tget_order(typeid)) < 0) ERR;
+        if (order != H5T_ORDER_BE) ERR;
 
-      if (H5Dread(be_did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT,
-		   data_in) < 0) ERR;
-      for (i = 0; i < DIM1_LEN; i++)
-	 if (data[i] != data_in[i]) ERR;
+        if (H5Dread(be_did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT,
+                    data_in) < 0) ERR;
+        for (i = 0; i < DIM1_LEN; i++)
+            if (data[i] != data_in[i]) ERR;
 
-      if (H5Dclose(native_did) < 0 ||
-	  H5Dclose(le_did) < 0 ||
-	  H5Dclose(be_did) < 0 ||
-	  H5Gclose(grpid) < 0 ||
-	  H5Fclose(fileid) < 0)
-	 ERR;
-   }
+        if (H5Dclose(native_did) < 0 ||
+            H5Dclose(le_did) < 0 ||
+            H5Dclose(be_did) < 0 ||
+            H5Gclose(grpid) < 0 ||
+            H5Fclose(fileid) < 0)
+            ERR;
+    }
 
-   SUMMARIZE_ERR;
-   FINAL_RESULTS;
+    SUMMARIZE_ERR;
+    FINAL_RESULTS;
 }

--- a/h5_test/tst_h_vars.c
+++ b/h5_test/tst_h_vars.c
@@ -407,5 +407,84 @@ main()
     }
 
     SUMMARIZE_ERR;
+#ifdef USE_SZIP
+    printf("*** Checking szip functionality...");
+#define SZIP_VAR_NAME "szip_var"
+#define LE_VAR_NAME "le_var"
+#define BE_VAR_NAME "be_var"
+    {
+        int data[DIM1_LEN], data_in[DIM1_LEN];
+        hid_t typeid, native_typeid;
+        hid_t native_did;
+        H5T_order_t order;
+        htri_t equal;
+        int i;
+
+        for (i = 0; i < DIM1_LEN; i++)
+            data[i] = i;
+
+        /* Open file and create group. */
+        if ((fileid = H5Fcreate(FILE_NAME, H5F_ACC_TRUNC, H5P_DEFAULT,
+                                H5P_DEFAULT)) < 0) ERR;
+        if ((grpid = H5Gcreate(fileid, GRP_NAME, 0)) < 0) ERR;
+
+        /* Create a dataset of native endian. */
+        dims[0] = DIM1_LEN;
+        if ((spaceid = H5Screate_simple(1, dims, dims)) < 0) ERR;
+        if ((native_did = H5Dcreate(grpid, SZIP_VAR_NAME, H5T_NATIVE_INT,
+                                    spaceid, H5P_DEFAULT)) < 0) ERR;
+        if (H5Dwrite(native_did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT,
+                     data) < 0) ERR;
+        if (H5Dclose(native_did) < 0 ||
+            H5Sclose(spaceid) < 0 ||
+            H5Gclose(grpid) < 0 ||
+            H5Fclose(fileid) < 0)
+            ERR;
+
+        /* /\* Now reopen the file and check. *\/ */
+        /* if ((fileid = H5Fopen(FILE_NAME, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0) ERR; */
+        /* if ((grpid = H5Gopen(fileid, GRP_NAME)) < 0) ERR; */
+
+        /* if ((native_did = H5Dopen1(grpid, NATIVE_VAR_NAME)) < 0) ERR; */
+        /* if ((typeid = H5Dget_type(native_did)) < 0) ERR; */
+        /* if ((native_typeid = H5Tget_native_type(typeid, H5T_DIR_DESCEND)) < 0) ERR; */
+        /* if ((order = H5Tget_order(typeid)) < 0) ERR; */
+        /* if ((equal = H5Tequal(typeid, native_typeid)) < 0) ERR; */
+        /* if (!equal) ERR; */
+
+        /* if (H5Dread(native_did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, */
+        /*             data_in) < 0) ERR; */
+        /* for (i = 0; i < DIM1_LEN; i++) */
+        /*     if (data[i] != data_in[i]) ERR; */
+
+        /* if ((le_did = H5Dopen1(grpid, LE_VAR_NAME)) < 0) ERR; */
+        /* if ((typeid = H5Dget_type(le_did)) < 0) ERR; */
+        /* if ((order = H5Tget_order(typeid)) < 0) ERR; */
+        /* if (order != H5T_ORDER_LE) ERR; */
+
+        /* if (H5Dread(le_did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, */
+        /*             data_in) < 0) ERR; */
+        /* for (i = 0; i < DIM1_LEN; i++) */
+        /*     if (data[i] != data_in[i]) ERR; */
+
+        /* if ((be_did = H5Dopen1(grpid, BE_VAR_NAME)) < 0) ERR; */
+        /* if ((typeid = H5Dget_type(be_did)) < 0) ERR; */
+        /* if ((order = H5Tget_order(typeid)) < 0) ERR; */
+        /* if (order != H5T_ORDER_BE) ERR; */
+
+        /* if (H5Dread(be_did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, */
+        /*             data_in) < 0) ERR; */
+        /* for (i = 0; i < DIM1_LEN; i++) */
+        /*     if (data[i] != data_in[i]) ERR; */
+
+        /* if (H5Dclose(native_did) < 0 || */
+        /*     H5Dclose(le_did) < 0 || */
+        /*     H5Dclose(be_did) < 0 || */
+        /*     H5Gclose(grpid) < 0 || */
+        /*     H5Fclose(fileid) < 0) */
+        /*     ERR; */
+    }
+    SUMMARIZE_ERR;
+#endif /* USE_SZIP */
     FINAL_RESULTS;
 }

--- a/libdispatch/dvarinq.c
+++ b/libdispatch/dvarinq.c
@@ -676,7 +676,8 @@ nc_inq_ncid().
 \param options_maskp The szip options mask will be copied to this
 pointer. Note that the HDF5 layer modifies the options_mask, so this
 value will be different from the value used when setting szip
-compression. \ref ignored_if_null.
+compression. If a zero is returned, then szip compression is not in
+use for this var. \ref ignored_if_null.
 \param pixels_per_blockp The szip pixels per block will be copied
 here. The HDF5 layer may change this value, so this may not match the
 value passed in when setting szip compression. \ref ignored_if_null.
@@ -723,8 +724,17 @@ nc_inq_var_szip(int ncid, int varid, int *options_maskp, int *pixels_per_blockp)
       NULL
       );
    if(stat != NC_NOERR) return stat;
+
+   /* If ID is not szip, then szip is not in use. */
+   if(id != H5Z_FILTER_SZIP)
+   {
+       if(options_maskp)
+           *options_maskp = 0;
+       return NC_NOERR;
+   }
+
    /* Warning: the szip filter internally expands the set of parameters */
-   if(id != H5Z_FILTER_SZIP || nparams != 4)
+   if(id == H5Z_FILTER_SZIP && nparams != 4)
 	return NC_EFILTER; /* not szip or bad # params */
    /* Get params */
    stat = ncp->dispatch->inq_var_all(

--- a/libdispatch/dvarinq.c
+++ b/libdispatch/dvarinq.c
@@ -660,33 +660,34 @@ nc_inq_var_filter(int ncid, int varid, unsigned int* idp, size_t* nparamsp, unsi
       idp, nparamsp, params);
 }
 
-/** \ingroup variables
+/**
+\ingroup variables
 Learn the szip settings of a variable.
-Similar to nc_inq_var_deflate.
 
-This function returns the szip settings for a variable.
-With the introduction of general filter support,
-szip inquiry is converted to use the filter interface.
-
-This is a wrapper for nc_inq_var_filter().
+This function returns the szip settings for a variable. For more
+information on HDF5 and szip see
+https://support.hdfgroup.org/HDF5/doc/RM/RM_H5P.html#Property-SetSzip
+and https://support.hdfgroup.org/doc_resource/SZIP/index.html.
 
 \param ncid NetCDF or group ID, from a previous call to nc_open(),
 nc_create(), nc_def_grp(), or associated inquiry functions such as
 nc_inq_ncid().
-
 \param varid Variable ID
-
 \param options_maskp The szip options mask will be copied to this
-pointer. \ref ignored_if_null.
-
+pointer. Note that the HDF5 layer modifies the options_mask, so this
+value will be different from the value used when setting szip
+compression. \ref ignored_if_null.
 \param pixels_per_blockp The szip pixels per block will be copied
-here. \ref ignored_if_null.
+here. The HDF5 layer may change this value, so this may not match the
+value passed in when setting szip compression. \ref ignored_if_null.
 
 \returns ::NC_NOERR No error.
 \returns ::NC_EBADID Bad ncid.
 \returns ::NC_ENOTNC4 Not a netCDF-4 file.
 \returns ::NC_ENOTVAR Invalid variable ID.
 \returns ::NC_EFILTER Variable is not szip encoded
+
+\author Ed Hartnett, Dennis Heimbigner
 */
 int
 nc_inq_var_szip(int ncid, int varid, int *options_maskp, int *pixels_per_blockp)

--- a/nc_test4/tst_vars2.c
+++ b/nc_test4/tst_vars2.c
@@ -1,6 +1,6 @@
 /* This is part of the netCDF package.
    Copyright 2018 University Corporation for Atmospheric Research/Unidata
-    See COPYRIGHT file for conditions of use.
+   See COPYRIGHT file for conditions of use.
 
    Test netcdf-4 variables.
    Ed Hartnett
@@ -24,234 +24,234 @@
 int
 main(int argc, char **argv)
 {
-   int ncid, dimids[NUM_DIMS];
-   int varid;
-   int nvars_in, varids_in[NUM_VARS] = {0};
-   signed char fill_value = 42, fill_value_in;
-   nc_type xtype_in;
-   size_t len_in;
-   char name_in[NC_MAX_NAME + 1];
-   int attnum_in;
-   int cnum;
-   char too_long_name[NC_MAX_NAME + 2];
+    int ncid, dimids[NUM_DIMS];
+    int varid;
+    int nvars_in, varids_in[NUM_VARS] = {0};
+    signed char fill_value = 42, fill_value_in;
+    nc_type xtype_in;
+    size_t len_in;
+    char name_in[NC_MAX_NAME + 1];
+    int attnum_in;
+    int cnum;
+    char too_long_name[NC_MAX_NAME + 2];
 
-   /* Set up a name that is too long for netCDF. */
-   memset(too_long_name, 'a', NC_MAX_NAME + 1);
-   too_long_name[NC_MAX_NAME + 1] = 0;
+    /* Set up a name that is too long for netCDF. */
+    memset(too_long_name, 'a', NC_MAX_NAME + 1);
+    too_long_name[NC_MAX_NAME + 1] = 0;
 
-   printf("\n*** Testing netcdf-4 variable functions, even more.\n");
-   for (cnum = 0; cnum < MAX_CNUM; cnum++)
-   {
-      int cmode = 0;
+    printf("\n*** Testing netcdf-4 variable functions, even more.\n");
+    for (cnum = 0; cnum < MAX_CNUM; cnum++)
+    {
+        int cmode = 0;
 
-      switch(cnum)
-      {
-         case 0:
+        switch(cnum)
+        {
+        case 0:
             printf("*** Testing with classic format:\n");
             cmode = 0;
             break;
-         case 1:
+        case 1:
             printf("*** Testing with 64-bit offset format:\n");
             cmode = NC_64BIT_OFFSET;
             break;
-         case 2:
+        case 2:
             printf("*** Testing with HDF5:\n");
             cmode = NC_NETCDF4|NC_CLOBBER;
             break;
-         case 3:
+        case 3:
             printf("*** Testing with HDF5, netCDF Classic Model:\n");
             cmode = NC_CLASSIC_MODEL | NC_NETCDF4;
-	    break;
-	 default:
-	    return 1;
-      }
+            break;
+        default:
+            return 1;
+        }
 
 #define FILE_NAME2 "tst_vars2_latefill.nc"
-      printf("**** testing simple fill value attribute creation...");
-      {
-         int schar_data = 0;
-         size_t index[1] = {0};
-         int expected_ret;
-         int dimid;
+        printf("**** testing simple fill value attribute creation...");
+        {
+            int schar_data = 0;
+            size_t index[1] = {0};
+            int expected_ret;
+            int dimid;
 
-         /* Determined the expected result of setting fill value
-          * late. For historical reasons this is allowed for classic
-          * and 64-bit offset formats, but should never be done. */
-         if (cmode == 0 || cmode == NC_64BIT_OFFSET)
-            expected_ret = NC_NOERR;
-         else
-            expected_ret = NC_ELATEFILL;
-            
-         /* Create a netcdf-4 file with one scalar var. Add fill
-          * value. */
-         if (nc_create(FILE_NAME2, cmode, &ncid)) ERR;
-         if (nc_def_dim(ncid, VAR_NAME, TEST_VAL_42, &dimid)) ERR;
-         if (nc_def_var(ncid, VAR_NAME, NC_BYTE, 1, &dimid, &varid)) ERR;
-         if (nc_put_att_schar(ncid, varid, _FillValue, NC_BYTE, 1, &fill_value)) ERR;
-         if (nc_enddef(ncid)) ERR;
-         if (nc_put_var1(ncid, varid, index, &schar_data)) ERR;
-         if (nc_redef(ncid)) ERR;
-         if (nc_put_att_schar(ncid, varid, _FillValue, NC_BYTE, 1,
-                              &fill_value) != expected_ret) ERR;
-         if (nc_close(ncid)) ERR;
+            /* Determined the expected result of setting fill value
+             * late. For historical reasons this is allowed for classic
+             * and 64-bit offset formats, but should never be done. */
+            if (cmode == 0 || cmode == NC_64BIT_OFFSET)
+                expected_ret = NC_NOERR;
+            else
+                expected_ret = NC_ELATEFILL;
 
-         /* Open the file and check. */
-         if (nc_open(FILE_NAME2, NC_WRITE, &ncid)) ERR;
-         if (nc_inq_varids(ncid, &nvars_in, varids_in)) ERR;
-         if (nvars_in != 1 || varids_in[0] != 0) ERR;
-         if (nc_inq_varname(ncid, 0, name_in)) ERR;
-         if (strcmp(name_in, VAR_NAME)) ERR;
-         if (nc_inq_att(ncid, varid, _FillValue, &xtype_in, &len_in)) ERR;
-         if (xtype_in != NC_BYTE || len_in != 1) ERR;
-         if (nc_get_att(ncid, varid, _FillValue, &fill_value_in)) ERR;
-         if (fill_value_in != fill_value) ERR;
-         if (nc_close(ncid)) ERR;
-      }
+            /* Create a netcdf-4 file with one scalar var. Add fill
+             * value. */
+            if (nc_create(FILE_NAME2, cmode, &ncid)) ERR;
+            if (nc_def_dim(ncid, VAR_NAME, TEST_VAL_42, &dimid)) ERR;
+            if (nc_def_var(ncid, VAR_NAME, NC_BYTE, 1, &dimid, &varid)) ERR;
+            if (nc_put_att_schar(ncid, varid, _FillValue, NC_BYTE, 1, &fill_value)) ERR;
+            if (nc_enddef(ncid)) ERR;
+            if (nc_put_var1(ncid, varid, index, &schar_data)) ERR;
+            if (nc_redef(ncid)) ERR;
+            if (nc_put_att_schar(ncid, varid, _FillValue, NC_BYTE, 1,
+                                 &fill_value) != expected_ret) ERR;
+            if (nc_close(ncid)) ERR;
 
-      SUMMARIZE_ERR;
-      printf("**** testing simple fill value with data read...");
-      {
-         size_t start[NUM_DIMS], count[NUM_DIMS];
-         signed char data = 99, data_in;
+            /* Open the file and check. */
+            if (nc_open(FILE_NAME2, NC_WRITE, &ncid)) ERR;
+            if (nc_inq_varids(ncid, &nvars_in, varids_in)) ERR;
+            if (nvars_in != 1 || varids_in[0] != 0) ERR;
+            if (nc_inq_varname(ncid, 0, name_in)) ERR;
+            if (strcmp(name_in, VAR_NAME)) ERR;
+            if (nc_inq_att(ncid, varid, _FillValue, &xtype_in, &len_in)) ERR;
+            if (xtype_in != NC_BYTE || len_in != 1) ERR;
+            if (nc_get_att(ncid, varid, _FillValue, &fill_value_in)) ERR;
+            if (fill_value_in != fill_value) ERR;
+            if (nc_close(ncid)) ERR;
+        }
 
-         /* Create a netcdf-4 file with one unlimited dim and one
-          * var. Add fill value. */
-         if (nc_create(FILE_NAME, cmode, &ncid)) ERR;
-         if (nc_def_dim(ncid, DIM1_NAME, DIM1_LEN, &dimids[0])) ERR;
-         if (nc_def_var(ncid, VAR_NAME, NC_BYTE, NUM_DIMS, dimids, &varid)) ERR;
-         if (nc_put_att_schar(ncid, varid, _FillValue, NC_BYTE, 1, &fill_value)) ERR;
-         if (nc_enddef(ncid)) ERR;
+        SUMMARIZE_ERR;
+        printf("**** testing simple fill value with data read...");
+        {
+            size_t start[NUM_DIMS], count[NUM_DIMS];
+            signed char data = 99, data_in;
 
-         /* Write the second record. */
-         start[0] = 1;
-         count[0] = 1;
-         if (nc_put_vara_schar(ncid, varid, start, count, &data)) ERR;
+            /* Create a netcdf-4 file with one unlimited dim and one
+             * var. Add fill value. */
+            if (nc_create(FILE_NAME, cmode, &ncid)) ERR;
+            if (nc_def_dim(ncid, DIM1_NAME, DIM1_LEN, &dimids[0])) ERR;
+            if (nc_def_var(ncid, VAR_NAME, NC_BYTE, NUM_DIMS, dimids, &varid)) ERR;
+            if (nc_put_att_schar(ncid, varid, _FillValue, NC_BYTE, 1, &fill_value)) ERR;
+            if (nc_enddef(ncid)) ERR;
 
-         /* Read the first record, it should be the fill value. */
-         start[0] = 0;
-         if (nc_get_vara_schar(ncid, varid, start, count, &data_in)) ERR;
-         if (data_in != fill_value) ERR;
+            /* Write the second record. */
+            start[0] = 1;
+            count[0] = 1;
+            if (nc_put_vara_schar(ncid, varid, start, count, &data)) ERR;
 
-         /* Read the second record, it should be the value we just wrote
-          * there. */
-         start[0] = 1;
-         if (nc_get_vara_schar(ncid, varid, start, count, &data_in)) ERR;
-         if (data_in != data) ERR;
+            /* Read the first record, it should be the fill value. */
+            start[0] = 0;
+            if (nc_get_vara_schar(ncid, varid, start, count, &data_in)) ERR;
+            if (data_in != fill_value) ERR;
 
-         /* Close up. */
-         if (nc_close(ncid)) ERR;
+            /* Read the second record, it should be the value we just wrote
+             * there. */
+            start[0] = 1;
+            if (nc_get_vara_schar(ncid, varid, start, count, &data_in)) ERR;
+            if (data_in != data) ERR;
 
-         /* Open the file and check. */
-         if (nc_open(FILE_NAME, NC_NOWRITE, &ncid)) ERR;
+            /* Close up. */
+            if (nc_close(ncid)) ERR;
 
-         /* This will not work because file was opened read-only. */
-          if (nc_rename_var(ncid, 0, "something_very_new") != NC_EPERM) ERR;
+            /* Open the file and check. */
+            if (nc_open(FILE_NAME, NC_NOWRITE, &ncid)) ERR;
 
-         /* Check metadata. */
-         if (nc_inq_varids(ncid, &nvars_in, varids_in)) ERR;
-         if (nvars_in != 1 || varids_in[0] != 0) ERR;
-         if (nc_inq_varname(ncid, 0, name_in)) ERR;
-         if (strcmp(name_in, VAR_NAME)) ERR;
+            /* This will not work because file was opened read-only. */
+            if (nc_rename_var(ncid, 0, "something_very_new") != NC_EPERM) ERR;
 
-         /* Check fill value att. */
-         if (nc_inq_att(ncid, varid, _FillValue, &xtype_in, &len_in)) ERR;
-         if (xtype_in != NC_BYTE || len_in != 1) ERR;
-         if (nc_get_att(ncid, varid, _FillValue, &fill_value_in)) ERR;
-         if (fill_value_in != fill_value) ERR;
+            /* Check metadata. */
+            if (nc_inq_varids(ncid, &nvars_in, varids_in)) ERR;
+            if (nvars_in != 1 || varids_in[0] != 0) ERR;
+            if (nc_inq_varname(ncid, 0, name_in)) ERR;
+            if (strcmp(name_in, VAR_NAME)) ERR;
 
-         /* Read the first record, it should be the fill value. */
-         start[0] = 0;
-         if (nc_get_vara_schar(ncid, varid, start, count, &data_in)) ERR;
-         if (data_in != fill_value) ERR;
+            /* Check fill value att. */
+            if (nc_inq_att(ncid, varid, _FillValue, &xtype_in, &len_in)) ERR;
+            if (xtype_in != NC_BYTE || len_in != 1) ERR;
+            if (nc_get_att(ncid, varid, _FillValue, &fill_value_in)) ERR;
+            if (fill_value_in != fill_value) ERR;
 
-         /* Read the second record, it should be the value we just wrote
-          * there. */
-         start[0] = 1;
-         if (nc_get_vara_schar(ncid, varid, start, count, &data_in)) ERR;
-         if (data_in != data) ERR;
+            /* Read the first record, it should be the fill value. */
+            start[0] = 0;
+            if (nc_get_vara_schar(ncid, varid, start, count, &data_in)) ERR;
+            if (data_in != fill_value) ERR;
 
-         if (nc_close(ncid)) ERR;
-      }
+            /* Read the second record, it should be the value we just wrote
+             * there. */
+            start[0] = 1;
+            if (nc_get_vara_schar(ncid, varid, start, count, &data_in)) ERR;
+            if (data_in != data) ERR;
 
-      SUMMARIZE_ERR;
-      printf("**** testing fill value with one other attribute...");
+            if (nc_close(ncid)) ERR;
+        }
 
-      {
-         int losses_value = 192, losses_value_in;
+        SUMMARIZE_ERR;
+        printf("**** testing fill value with one other attribute...");
 
-         /* Create a netcdf-4 file with one dim and one var. Add another
-          * attribute, then fill value. */
-         if (nc_create(FILE_NAME, cmode, &ncid)) ERR;
-         if (nc_def_dim(ncid, DIM1_NAME, DIM1_LEN, &dimids[0])) ERR;
-         if (nc_def_var(ncid, VAR_NAME, NC_BYTE, NUM_DIMS, dimids, &varid)) ERR;
-         if (nc_put_att_int(ncid, varid, LOSSES_NAME, NC_INT, 1, &losses_value)) ERR;
-         if (nc_put_att_schar(ncid, varid, _FillValue, NC_BYTE, 1, &fill_value)) ERR;
-         if (nc_close(ncid)) ERR;
+        {
+            int losses_value = 192, losses_value_in;
 
-         /* Open the file and check. */
-         if (nc_open(FILE_NAME, NC_NOWRITE, &ncid)) ERR;
-         if (nc_inq_att(ncid, 0, LOSSES_NAME, &xtype_in, &len_in)) ERR;
-         if (xtype_in != NC_INT || len_in != 1) ERR;
-         if (nc_get_att(ncid, 0, LOSSES_NAME, &losses_value_in)) ERR;
-         if (losses_value_in != losses_value) ERR;
-         if (nc_inq_att(ncid, 0, _FillValue, &xtype_in, &len_in)) ERR;
-         if (xtype_in != NC_BYTE || len_in != 1) ERR;
-         if (nc_get_att(ncid, 0, _FillValue, &fill_value_in)) ERR;
-         if (fill_value_in != fill_value) ERR;
-         if (nc_inq_attid(ncid, 0, LOSSES_NAME, &attnum_in)) ERR;
-         if (attnum_in != 0) ERR;
-         if (nc_inq_attid(ncid, 0, _FillValue, &attnum_in)) ERR;
-         if (attnum_in != 1) ERR;
-         if (nc_close(ncid)) ERR;
-      }
+            /* Create a netcdf-4 file with one dim and one var. Add another
+             * attribute, then fill value. */
+            if (nc_create(FILE_NAME, cmode, &ncid)) ERR;
+            if (nc_def_dim(ncid, DIM1_NAME, DIM1_LEN, &dimids[0])) ERR;
+            if (nc_def_var(ncid, VAR_NAME, NC_BYTE, NUM_DIMS, dimids, &varid)) ERR;
+            if (nc_put_att_int(ncid, varid, LOSSES_NAME, NC_INT, 1, &losses_value)) ERR;
+            if (nc_put_att_schar(ncid, varid, _FillValue, NC_BYTE, 1, &fill_value)) ERR;
+            if (nc_close(ncid)) ERR;
 
-      SUMMARIZE_ERR;
-      printf("**** testing fill value with three other attributes...");
-      {
+            /* Open the file and check. */
+            if (nc_open(FILE_NAME, NC_NOWRITE, &ncid)) ERR;
+            if (nc_inq_att(ncid, 0, LOSSES_NAME, &xtype_in, &len_in)) ERR;
+            if (xtype_in != NC_INT || len_in != 1) ERR;
+            if (nc_get_att(ncid, 0, LOSSES_NAME, &losses_value_in)) ERR;
+            if (losses_value_in != losses_value) ERR;
+            if (nc_inq_att(ncid, 0, _FillValue, &xtype_in, &len_in)) ERR;
+            if (xtype_in != NC_BYTE || len_in != 1) ERR;
+            if (nc_get_att(ncid, 0, _FillValue, &fill_value_in)) ERR;
+            if (fill_value_in != fill_value) ERR;
+            if (nc_inq_attid(ncid, 0, LOSSES_NAME, &attnum_in)) ERR;
+            if (attnum_in != 0) ERR;
+            if (nc_inq_attid(ncid, 0, _FillValue, &attnum_in)) ERR;
+            if (attnum_in != 1) ERR;
+            if (nc_close(ncid)) ERR;
+        }
+
+        SUMMARIZE_ERR;
+        printf("**** testing fill value with three other attributes...");
+        {
 #define NUM_LEADERS 3
-         char leader[NUM_LEADERS][NC_MAX_NAME + 1] = {"hair_length_of_strategoi",
-                                                      "hair_length_of_Miltiades",
-                                                      "hair_length_of_Darius_I"};
-         short hair_length[NUM_LEADERS] = {3, 11, 4};
-         short short_in;
-         int a;
+            char leader[NUM_LEADERS][NC_MAX_NAME + 1] = {"hair_length_of_strategoi",
+                                                         "hair_length_of_Miltiades",
+                                                         "hair_length_of_Darius_I"};
+            short hair_length[NUM_LEADERS] = {3, 11, 4};
+            short short_in;
+            int a;
 
-         /* Create a netcdf file with one dim and one var. Add 3
-          * attributes, then fill value. */
-         if (nc_create(FILE_NAME, cmode, &ncid)) ERR;
-         if (nc_def_dim(ncid, DIM1_NAME, DIM1_LEN, &dimids[0])) ERR;
-         if (nc_def_var(ncid, VAR_NAME, NC_BYTE, NUM_DIMS, dimids, &varid)) ERR;
-         for (a = 0; a < NUM_LEADERS; a++)
-            if (nc_put_att_short(ncid, varid, leader[a], NC_SHORT, 1, &hair_length[a])) ERR;
-         if (nc_put_att_schar(ncid, varid, _FillValue, NC_BYTE, 1, &fill_value)) ERR;
-         if (nc_close(ncid)) ERR;
+            /* Create a netcdf file with one dim and one var. Add 3
+             * attributes, then fill value. */
+            if (nc_create(FILE_NAME, cmode, &ncid)) ERR;
+            if (nc_def_dim(ncid, DIM1_NAME, DIM1_LEN, &dimids[0])) ERR;
+            if (nc_def_var(ncid, VAR_NAME, NC_BYTE, NUM_DIMS, dimids, &varid)) ERR;
+            for (a = 0; a < NUM_LEADERS; a++)
+                if (nc_put_att_short(ncid, varid, leader[a], NC_SHORT, 1, &hair_length[a])) ERR;
+            if (nc_put_att_schar(ncid, varid, _FillValue, NC_BYTE, 1, &fill_value)) ERR;
+            if (nc_close(ncid)) ERR;
 
-         /* Open the file. */
-         if (nc_open(FILE_NAME, NC_NOWRITE, &ncid)) ERR;
+            /* Open the file. */
+            if (nc_open(FILE_NAME, NC_NOWRITE, &ncid)) ERR;
 
-         /* Check our three hair-related attributes. */
-         for (a = 0; a < NUM_LEADERS; a++)
-         {
-            if (nc_inq_att(ncid, 0, leader[a], &xtype_in, &len_in)) ERR;
-            if (xtype_in != NC_SHORT || len_in != 1) ERR;
-            if (nc_get_att(ncid, 0, leader[a], &short_in)) ERR;
-            if (short_in != hair_length[a]) ERR;
-            if (nc_inq_attid(ncid, 0, leader[a], &attnum_in)) ERR;
-            if (attnum_in != a) ERR;
-         }
+            /* Check our three hair-related attributes. */
+            for (a = 0; a < NUM_LEADERS; a++)
+            {
+                if (nc_inq_att(ncid, 0, leader[a], &xtype_in, &len_in)) ERR;
+                if (xtype_in != NC_SHORT || len_in != 1) ERR;
+                if (nc_get_att(ncid, 0, leader[a], &short_in)) ERR;
+                if (short_in != hair_length[a]) ERR;
+                if (nc_inq_attid(ncid, 0, leader[a], &attnum_in)) ERR;
+                if (attnum_in != a) ERR;
+            }
 
-         /* Check our fill value attribute. */
-         if (nc_inq_att(ncid, 0, _FillValue, &xtype_in, &len_in)) ERR;
-         if (xtype_in != NC_BYTE || len_in != 1) ERR;
-         if (nc_get_att(ncid, 0, _FillValue, &fill_value_in)) ERR;
-         if (fill_value_in != fill_value) ERR;
+            /* Check our fill value attribute. */
+            if (nc_inq_att(ncid, 0, _FillValue, &xtype_in, &len_in)) ERR;
+            if (xtype_in != NC_BYTE || len_in != 1) ERR;
+            if (nc_get_att(ncid, 0, _FillValue, &fill_value_in)) ERR;
+            if (fill_value_in != fill_value) ERR;
 
-         if (nc_close(ncid)) ERR;
-      }
+            if (nc_close(ncid)) ERR;
+        }
 
-      SUMMARIZE_ERR;
-      printf("**** testing fill value with simple example...");
-      {
+        SUMMARIZE_ERR;
+        printf("**** testing fill value with simple example...");
+        {
 /* Dims stuff. */
 #define NDIMS 3
 #define VAR_DIMS 3
@@ -272,65 +272,65 @@ main(int argc, char **argv)
 #define UNITS "units"
 #define HECTOPASCALS "hectopascals"
 
-         int dimid[NDIMS], var_dimids[VAR_DIMS] = {2, 1, 0};
-         float fill_value = -9999.0f;
-         char long_name[] = PRES_MAX_WIND;
+            int dimid[NDIMS], var_dimids[VAR_DIMS] = {2, 1, 0};
+            float fill_value = -9999.0f;
+            char long_name[] = PRES_MAX_WIND;
 
-         if (nc_create(FILE_NAME, cmode, &ncid)) ERR;
+            if (nc_create(FILE_NAME, cmode, &ncid)) ERR;
 
-         /* Create dims. */
-         if (nc_def_dim(ncid, DIM_A, DIM_A_LEN, &dimid[0])) ERR;
-         if (nc_def_dim (ncid, DIM_B, DIM_B_LEN, &dimid[1])) ERR;
-         if (nc_def_dim(ncid, DIM_C, DIM_C_LEN, &dimid[2])) ERR;
+            /* Create dims. */
+            if (nc_def_dim(ncid, DIM_A, DIM_A_LEN, &dimid[0])) ERR;
+            if (nc_def_dim (ncid, DIM_B, DIM_B_LEN, &dimid[1])) ERR;
+            if (nc_def_dim(ncid, DIM_C, DIM_C_LEN, &dimid[2])) ERR;
 
-         /* Create var. */
-         if (nc_def_var(ncid, CXX_VAR_NAME, NC_FLOAT, VAR_DIMS,
-                        var_dimids, &varid)) ERR;
-         if (varid) ERR;
+            /* Create var. */
+            if (nc_def_var(ncid, CXX_VAR_NAME, NC_FLOAT, VAR_DIMS,
+                           var_dimids, &varid)) ERR;
+            if (varid) ERR;
 
-         if (nc_put_att(ncid, varid, LONG_NAME, NC_CHAR, strlen(long_name) + 1,
-                        long_name)) ERR;
-         if (nc_put_att(ncid, varid, UNITS, NC_CHAR, strlen(UNITS) + 1,
-                        UNITS)) ERR;
+            if (nc_put_att(ncid, varid, LONG_NAME, NC_CHAR, strlen(long_name) + 1,
+                           long_name)) ERR;
+            if (nc_put_att(ncid, varid, UNITS, NC_CHAR, strlen(UNITS) + 1,
+                           UNITS)) ERR;
 
-         /* Check to ensure the atts have their expected attnums. */
-         if (nc_inq_attid(ncid, 0, LONG_NAME, &attnum_in)) ERR;
-         if (attnum_in != 0) ERR;
-         if (nc_inq_attid(ncid, 0, UNITS, &attnum_in)) ERR;
-         if (attnum_in != 1) ERR;
+            /* Check to ensure the atts have their expected attnums. */
+            if (nc_inq_attid(ncid, 0, LONG_NAME, &attnum_in)) ERR;
+            if (attnum_in != 0) ERR;
+            if (nc_inq_attid(ncid, 0, UNITS, &attnum_in)) ERR;
+            if (attnum_in != 1) ERR;
 
-         /* Now add a fill value. This will acutually cause HDF5 to
-          * destroy the dataset and recreate it, recreating also the
-          * three attributes that are attached to it. */
-         if (nc_put_att(ncid, varid, _FillValue, NC_FLOAT,
-                        1, &fill_value)) ERR;
+            /* Now add a fill value. This will acutually cause HDF5 to
+             * destroy the dataset and recreate it, recreating also the
+             * three attributes that are attached to it. */
+            if (nc_put_att(ncid, varid, _FillValue, NC_FLOAT,
+                           1, &fill_value)) ERR;
 
-         /* Check to ensure the atts have their expected attnums. */
-         if (nc_inq_attid(ncid, 0, LONG_NAME, &attnum_in)) ERR;
-         if (attnum_in != 0) ERR;
-         if (nc_inq_attid(ncid, 0, UNITS, &attnum_in)) ERR;
-         if (attnum_in != 1) ERR;
+            /* Check to ensure the atts have their expected attnums. */
+            if (nc_inq_attid(ncid, 0, LONG_NAME, &attnum_in)) ERR;
+            if (attnum_in != 0) ERR;
+            if (nc_inq_attid(ncid, 0, UNITS, &attnum_in)) ERR;
+            if (attnum_in != 1) ERR;
 
-         if (nc_close(ncid)) ERR;
+            if (nc_close(ncid)) ERR;
 
-         /* Open the file and check. */
-         if (nc_open(FILE_NAME, 0, &ncid)) ERR;
-         if (nc_inq_attid(ncid, 0, LONG_NAME, &attnum_in)) ERR;
-         if (attnum_in != 0) ERR;
-         if (nc_inq_attid(ncid, 0, UNITS, &attnum_in)) ERR;
-         if (attnum_in != 1) ERR;
-         if (nc_inq_attid(ncid, 0, _FillValue, &attnum_in)) ERR;
-         if (attnum_in != 2) ERR;
+            /* Open the file and check. */
+            if (nc_open(FILE_NAME, 0, &ncid)) ERR;
+            if (nc_inq_attid(ncid, 0, LONG_NAME, &attnum_in)) ERR;
+            if (attnum_in != 0) ERR;
+            if (nc_inq_attid(ncid, 0, UNITS, &attnum_in)) ERR;
+            if (attnum_in != 1) ERR;
+            if (nc_inq_attid(ncid, 0, _FillValue, &attnum_in)) ERR;
+            if (attnum_in != 2) ERR;
 
-         if (nc_close(ncid)) ERR;
-      }
-      SUMMARIZE_ERR;
+            if (nc_close(ncid)) ERR;
+        }
+        SUMMARIZE_ERR;
 
 #ifndef NO_NETCDF_2
-      /* The following test is an attempt to recreate a problem occurring
-         in the cxx tests. The file is created in c++ in nctsts.cpp. */
-      printf("**** testing fill value with example from cxx tests in v2 api...");
-      {
+        /* The following test is an attempt to recreate a problem occurring
+           in the cxx tests. The file is created in c++ in nctsts.cpp. */
+        printf("**** testing fill value with example from cxx tests in v2 api...");
+        {
 /* Dims stuff. */
 #define NDIMS_1 4
 #define VAR_DIMS 3
@@ -351,421 +351,421 @@ main(int argc, char **argv)
 #define LONG_NAME "long_name"
 #define UNITS "units"
 
-         int dimid[NDIMS_1], var_dimids[VAR_DIMS] = {2, 0, 1};
-         float fill_value = -9999.0f;
-         char long_name[] = PRES_MAX_WIND;
-         int i;
+            int dimid[NDIMS_1], var_dimids[VAR_DIMS] = {2, 0, 1};
+            float fill_value = -9999.0f;
+            char long_name[] = PRES_MAX_WIND;
+            int i;
 
-         ncid = nccreate(FILE_NAME, NC_NETCDF4);
+            ncid = nccreate(FILE_NAME, NC_NETCDF4);
 
-         /* Create dims. */
-         dimid[0] = ncdimdef(ncid, LAT, LAT_LEN);
-         dimid[1] = ncdimdef(ncid, LON, LON_LEN);
-         dimid[2] = ncdimdef(ncid, FRTIMED, FRTIMED_LEN);
-         dimid[3] = ncdimdef(ncid, TIMELEN, TIMELEN_LEN);
+            /* Create dims. */
+            dimid[0] = ncdimdef(ncid, LAT, LAT_LEN);
+            dimid[1] = ncdimdef(ncid, LON, LON_LEN);
+            dimid[2] = ncdimdef(ncid, FRTIMED, FRTIMED_LEN);
+            dimid[3] = ncdimdef(ncid, TIMELEN, TIMELEN_LEN);
 
-         /* Just check our dimids to see that they are correct. */
-         for (i = 0; i < NDIMS_1; i++)
-            if (dimid[i] != i) ERR;
+            /* Just check our dimids to see that they are correct. */
+            for (i = 0; i < NDIMS_1; i++)
+                if (dimid[i] != i) ERR;
 
-         /* Create var. */
-         varid = ncvardef(ncid, CXX_VAR_NAME, NC_FLOAT, VAR_DIMS, var_dimids);
-         if (varid) ERR;
+            /* Create var. */
+            varid = ncvardef(ncid, CXX_VAR_NAME, NC_FLOAT, VAR_DIMS, var_dimids);
+            if (varid) ERR;
 
-         /* Add three atts to the var, long_name, units, and
-          * valid_range. */
-         if (nc_put_att(ncid, varid, LONG_NAME, NC_CHAR, strlen(long_name) + 1,
-                        long_name)) ERR;
-         if (nc_put_att(ncid, varid, UNITS, NC_CHAR, strlen(UNITS) + 1,
-                        UNITS)) ERR;
+            /* Add three atts to the var, long_name, units, and
+             * valid_range. */
+            if (nc_put_att(ncid, varid, LONG_NAME, NC_CHAR, strlen(long_name) + 1,
+                           long_name)) ERR;
+            if (nc_put_att(ncid, varid, UNITS, NC_CHAR, strlen(UNITS) + 1,
+                           UNITS)) ERR;
 
-         /* Check to ensure the atts have their expected attnums. */
-         if (nc_inq_attid(ncid, 0, LONG_NAME, &attnum_in)) ERR;
-         if (attnum_in != 0) ERR;
-         if (nc_inq_attid(ncid, 0, UNITS, &attnum_in)) ERR;
-         if (attnum_in != 1) ERR;
+            /* Check to ensure the atts have their expected attnums. */
+            if (nc_inq_attid(ncid, 0, LONG_NAME, &attnum_in)) ERR;
+            if (attnum_in != 0) ERR;
+            if (nc_inq_attid(ncid, 0, UNITS, &attnum_in)) ERR;
+            if (attnum_in != 1) ERR;
 
-         /* Now add a fill value. This will acutually cause HDF5 to
-          * destroy the dataset and recreate it, recreating also the
-          * three attributes that are attached to it. */
-	 ncattput(ncid, varid, _FillValue, NC_FLOAT, 1, &fill_value);
+            /* Now add a fill value. This will acutually cause HDF5 to
+             * destroy the dataset and recreate it, recreating also the
+             * three attributes that are attached to it. */
+            ncattput(ncid, varid, _FillValue, NC_FLOAT, 1, &fill_value);
 
-         /* Check to ensure the atts have their expected attnums. */
-         if (nc_inq_attid(ncid, 0, LONG_NAME, &attnum_in)) ERR;
-         if (attnum_in != 0) ERR;
-         if (nc_inq_attid(ncid, 0, UNITS, &attnum_in)) ERR;
-         if (attnum_in != 1) ERR;
-         if (nc_inq_attid(ncid, 0, _FillValue, &attnum_in)) ERR;
-         if (attnum_in != 2) ERR;
+            /* Check to ensure the atts have their expected attnums. */
+            if (nc_inq_attid(ncid, 0, LONG_NAME, &attnum_in)) ERR;
+            if (attnum_in != 0) ERR;
+            if (nc_inq_attid(ncid, 0, UNITS, &attnum_in)) ERR;
+            if (attnum_in != 1) ERR;
+            if (nc_inq_attid(ncid, 0, _FillValue, &attnum_in)) ERR;
+            if (attnum_in != 2) ERR;
 
-         ncclose(ncid);
+            ncclose(ncid);
 
-         /* Open the file and check. */
-         ncid = ncopen(FILE_NAME, 0);
-         if (nc_inq_attid(ncid, 0, LONG_NAME, &attnum_in)) ERR;
-         if (attnum_in != 0) ERR;
-         if (nc_inq_attid(ncid, 0, UNITS, &attnum_in)) ERR;
-         if (attnum_in != 1) ERR;
-         if (nc_inq_attid(ncid, 0, _FillValue, &attnum_in)) ERR;
-         if (attnum_in != 2) ERR;
-         ncclose(ncid);
-      }
-      SUMMARIZE_ERR;
+            /* Open the file and check. */
+            ncid = ncopen(FILE_NAME, 0);
+            if (nc_inq_attid(ncid, 0, LONG_NAME, &attnum_in)) ERR;
+            if (attnum_in != 0) ERR;
+            if (nc_inq_attid(ncid, 0, UNITS, &attnum_in)) ERR;
+            if (attnum_in != 1) ERR;
+            if (nc_inq_attid(ncid, 0, _FillValue, &attnum_in)) ERR;
+            if (attnum_in != 2) ERR;
+            ncclose(ncid);
+        }
+        SUMMARIZE_ERR;
 #endif /* NO_NETCDF_2 */
-   }
+    }
 
-   printf("**** testing create order varids...");
+    printf("**** testing create order varids...");
 
 #define UNITS "units"
 #define DIMNAME "x"
 #define VARNAME "data"
-   {
-      /* This test contributed by Jeff Whitaker of NOAA - Thanks Jeff! */
-      int ncid, dimid, varid, xvarid;
-      char units[] = "zlotys";
+    {
+        /* This test contributed by Jeff Whitaker of NOAA - Thanks Jeff! */
+        int ncid, dimid, varid, xvarid;
+        char units[] = "zlotys";
 
-      if (nc_create(FILE_NAME, NC_NETCDF4|NC_CLASSIC_MODEL, &ncid)) ERR;
-      if (nc_def_dim(ncid, DIMNAME, 1, &dimid)) ERR;
-      if (nc_enddef(ncid)) ERR;
-      if (nc_redef(ncid)) ERR;
+        if (nc_create(FILE_NAME, NC_NETCDF4|NC_CLASSIC_MODEL, &ncid)) ERR;
+        if (nc_def_dim(ncid, DIMNAME, 1, &dimid)) ERR;
+        if (nc_enddef(ncid)) ERR;
+        if (nc_redef(ncid)) ERR;
 
-      /* Check that these netCDF-4 things will fail on this classic
-       * model file. */
-      if (nc_def_var(ncid, DIMNAME, NC_UINT, 1, &dimid, &xvarid) != NC_ESTRICTNC3) ERR;
-      if (nc_def_var(ncid, DIMNAME, NC_INT, NC_MAX_VAR_DIMS + 1, &dimid,
-                     &xvarid) != NC_EMAXDIMS) ERR;
-      if (nc_enddef(ncid)) ERR;
-      if (nc_def_var(ncid, DIMNAME, NC_INT, 1, &dimid, &xvarid) != NC_ENOTINDEFINE) ERR;
-      if (nc_redef(ncid)) ERR;
+        /* Check that these netCDF-4 things will fail on this classic
+         * model file. */
+        if (nc_def_var(ncid, DIMNAME, NC_UINT, 1, &dimid, &xvarid) != NC_ESTRICTNC3) ERR;
+        if (nc_def_var(ncid, DIMNAME, NC_INT, NC_MAX_VAR_DIMS + 1, &dimid,
+                       &xvarid) != NC_EMAXDIMS) ERR;
+        if (nc_enddef(ncid)) ERR;
+        if (nc_def_var(ncid, DIMNAME, NC_INT, 1, &dimid, &xvarid) != NC_ENOTINDEFINE) ERR;
+        if (nc_redef(ncid)) ERR;
 
-      /* Define the variable for the test. */
-      if (nc_def_var(ncid, DIMNAME, NC_INT, 1, &dimid, &xvarid)) ERR;
-      if (nc_put_att_text(ncid, xvarid, UNITS, strlen(units), units)) ERR;
-      if (nc_def_var(ncid, VARNAME, NC_INT, 1, &dimid, &varid)) ERR;
-      if (nc_close(ncid)) ERR;
+        /* Define the variable for the test. */
+        if (nc_def_var(ncid, DIMNAME, NC_INT, 1, &dimid, &xvarid)) ERR;
+        if (nc_put_att_text(ncid, xvarid, UNITS, strlen(units), units)) ERR;
+        if (nc_def_var(ncid, VARNAME, NC_INT, 1, &dimid, &varid)) ERR;
+        if (nc_close(ncid)) ERR;
 
-      if (nc_open(FILE_NAME, 0, &ncid)) ERR;
-      if (nc_close(ncid)) ERR;
-   }
+        if (nc_open(FILE_NAME, 0, &ncid)) ERR;
+        if (nc_close(ncid)) ERR;
+    }
 
-   SUMMARIZE_ERR;
+    SUMMARIZE_ERR;
 #define RANK_wind 1
-   printf("**** testing simple variable renaming...");
-   {
-      /* This test contributed by Jeff Whitaker of NOAA - Thanks Jeff! */
-      int  ncid, lat_dim, time_dim, lon_dim, wind_id;
-      size_t lat_len = 73, time_len = 10, lon_len = 145;
-      int cdf_goober[1];
+    printf("**** testing simple variable renaming...");
+    {
+        /* This test contributed by Jeff Whitaker of NOAA - Thanks Jeff! */
+        int  ncid, lat_dim, time_dim, lon_dim, wind_id;
+        size_t lat_len = 73, time_len = 10, lon_len = 145;
+        int cdf_goober[1];
 
 /*      if (nc_set_default_format(NC_FORMAT_NETCDF4, NULL)) ERR;*/
-      if (nc_create(FILE_NAME, NC_NETCDF4, &ncid)) ERR;
+        if (nc_create(FILE_NAME, NC_NETCDF4, &ncid)) ERR;
 
-      /* define dimensions */
-      if (nc_def_dim(ncid, "a", lon_len, &lon_dim)) ERR;
-      if (nc_def_dim(ncid, "b", lat_len, &lat_dim)) ERR;
-      if (nc_def_dim(ncid, "c", time_len, &time_dim)) ERR;
+        /* define dimensions */
+        if (nc_def_dim(ncid, "a", lon_len, &lon_dim)) ERR;
+        if (nc_def_dim(ncid, "b", lat_len, &lat_dim)) ERR;
+        if (nc_def_dim(ncid, "c", time_len, &time_dim)) ERR;
 
-      if (nc_put_att_text(ncid, NC_GLOBAL, "a", 3, "bar")) ERR;
-      cdf_goober[0] = 2;
-      if (nc_put_att_int(ncid, NC_GLOBAL, "b", NC_INT, 1, cdf_goober)) ERR;
+        if (nc_put_att_text(ncid, NC_GLOBAL, "a", 3, "bar")) ERR;
+        cdf_goober[0] = 2;
+        if (nc_put_att_int(ncid, NC_GLOBAL, "b", NC_INT, 1, cdf_goober)) ERR;
 
-      /* define variables */
-      if (nc_def_var(ncid, "aa", NC_FLOAT, RANK_wind, &lon_dim, &wind_id)) ERR;
-      if (nc_close(ncid)) ERR;
+        /* define variables */
+        if (nc_def_var(ncid, "aa", NC_FLOAT, RANK_wind, &lon_dim, &wind_id)) ERR;
+        if (nc_close(ncid)) ERR;
 
-      if (nc_open(FILE_NAME, NC_WRITE, &ncid)) ERR;
+        if (nc_open(FILE_NAME, NC_WRITE, &ncid)) ERR;
 
-      /* These won't work. */
-      if (nc_rename_var(ncid + TEST_VAL_42, 0, "az") != NC_EBADID) ERR;
-      if (nc_rename_var(ncid + MILLION, 0, "az") != NC_EBADID) ERR;
+        /* These won't work. */
+        if (nc_rename_var(ncid + TEST_VAL_42, 0, "az") != NC_EBADID) ERR;
+        if (nc_rename_var(ncid + MILLION, 0, "az") != NC_EBADID) ERR;
 
-      /* Rename the var. */
-      if (nc_rename_var(ncid, 0, "az")) ERR;
-      if (nc_close(ncid)) ERR;
-   }
+        /* Rename the var. */
+        if (nc_rename_var(ncid, 0, "az")) ERR;
+        if (nc_close(ncid)) ERR;
+    }
 
-   SUMMARIZE_ERR;
-   printf("**** testing dimension and variable renaming...");
-   {
-      /* This test based on code contributed by Jeff Whitaker of NOAA
-       * - Thanks Jeff! */
-      int  ncid, lat_dim, time_dim, lon_dim, wind_id, temp2_id;
-      size_t lat_len = 73, time_len = 10, lon_len = 145;
-      int wind_dims[RANK_wind], wind_slobber[1], cdf_goober[1];
+    SUMMARIZE_ERR;
+    printf("**** testing dimension and variable renaming...");
+    {
+        /* This test based on code contributed by Jeff Whitaker of NOAA
+         * - Thanks Jeff! */
+        int  ncid, lat_dim, time_dim, lon_dim, wind_id, temp2_id;
+        size_t lat_len = 73, time_len = 10, lon_len = 145;
+        int wind_dims[RANK_wind], wind_slobber[1], cdf_goober[1];
 
-      if (nc_create(FILE_NAME, NC_NETCDF4|NC_CLASSIC_MODEL, &ncid)) ERR;
+        if (nc_create(FILE_NAME, NC_NETCDF4|NC_CLASSIC_MODEL, &ncid)) ERR;
 
-      /* define dimensions */
-      if (nc_def_dim(ncid, "lon", lon_len, &lon_dim)) ERR;
-      if (nc_def_dim(ncid, "lat", lat_len, &lat_dim)) ERR;
-      if (nc_def_dim(ncid, "time", time_len, &time_dim)) ERR;
+        /* define dimensions */
+        if (nc_def_dim(ncid, "lon", lon_len, &lon_dim)) ERR;
+        if (nc_def_dim(ncid, "lat", lat_len, &lat_dim)) ERR;
+        if (nc_def_dim(ncid, "time", time_len, &time_dim)) ERR;
 
-      if (nc_put_att_text(ncid, NC_GLOBAL, "foo", 3, "bar")) ERR;
-      cdf_goober[0] = 2;
-      if (nc_put_att_int(ncid, NC_GLOBAL, "goober", NC_INT, 1, cdf_goober)) ERR;
+        if (nc_put_att_text(ncid, NC_GLOBAL, "foo", 3, "bar")) ERR;
+        cdf_goober[0] = 2;
+        if (nc_put_att_int(ncid, NC_GLOBAL, "goober", NC_INT, 1, cdf_goober)) ERR;
 
-      /* define variables */
-      wind_dims[0] = lon_dim;
-      if (nc_def_var(ncid, "temp", NC_FLOAT, RANK_wind, wind_dims, &wind_id)) ERR;
-      if (nc_def_var(ncid, "temp2", NC_FLOAT, RANK_wind, wind_dims, &temp2_id)) ERR;
+        /* define variables */
+        wind_dims[0] = lon_dim;
+        if (nc_def_var(ncid, "temp", NC_FLOAT, RANK_wind, wind_dims, &wind_id)) ERR;
+        if (nc_def_var(ncid, "temp2", NC_FLOAT, RANK_wind, wind_dims, &temp2_id)) ERR;
 
-      if (nc_put_att_text(ncid, wind_id, "bar", 3, "foo")) ERR;
-      wind_slobber[0] = 3;
-      if (nc_put_att_int(ncid, wind_id, "slobber", NC_INT, 1, wind_slobber)) ERR;
-      if (nc_close(ncid)) ERR;
+        if (nc_put_att_text(ncid, wind_id, "bar", 3, "foo")) ERR;
+        wind_slobber[0] = 3;
+        if (nc_put_att_int(ncid, wind_id, "slobber", NC_INT, 1, wind_slobber)) ERR;
+        if (nc_close(ncid)) ERR;
 
-      /* re-open dataset*/
-      if (nc_open(FILE_NAME, NC_WRITE, &ncid)) ERR;
-      if (nc_inq_dimid(ncid, "lon", &lon_dim)) ERR;
+        /* re-open dataset*/
+        if (nc_open(FILE_NAME, NC_WRITE, &ncid)) ERR;
+        if (nc_inq_dimid(ncid, "lon", &lon_dim)) ERR;
 
-      /* THese won't work due to bad params. */
-      if (nc_rename_dim(ncid + MILLION, lon_dim, "longitude") != NC_EBADID) ERR;
-      if (nc_rename_dim(ncid + TEST_VAL_42, lon_dim, "longitude") != NC_EBADID) ERR;
-      if (nc_rename_dim(ncid, lon_dim, NULL) != NC_EINVAL) ERR;
+        /* THese won't work due to bad params. */
+        if (nc_rename_dim(ncid + MILLION, lon_dim, "longitude") != NC_EBADID) ERR;
+        if (nc_rename_dim(ncid + TEST_VAL_42, lon_dim, "longitude") != NC_EBADID) ERR;
+        if (nc_rename_dim(ncid, lon_dim, NULL) != NC_EINVAL) ERR;
 
-      /* rename dimension */
-      if (nc_rename_dim(ncid, lon_dim, "longitude")) ERR;
+        /* rename dimension */
+        if (nc_rename_dim(ncid, lon_dim, "longitude")) ERR;
 
-      /* These will fail due to bad params. */
-      if (nc_inq_varid(ncid + MILLION, "temp", &wind_id) != NC_EBADID) ERR;
-      if (nc_inq_varid(ncid + TEST_VAL_42, "temp", &wind_id) != NC_EBADID) ERR;
-      if (nc_inq_varid(ncid, NULL, &wind_id) != NC_EINVAL) ERR;
-      if (nc_inq_varid(ncid, "not_a_real_name", &wind_id) != NC_ENOTVAR) ERR;
-      if (nc_inq_varid(ncid, BAD_NAME, &wind_id) != NC_ENOTVAR) ERR;
-      if (nc_inq_varid(ncid, too_long_name, &wind_id) != NC_EMAXNAME) ERR;
+        /* These will fail due to bad params. */
+        if (nc_inq_varid(ncid + MILLION, "temp", &wind_id) != NC_EBADID) ERR;
+        if (nc_inq_varid(ncid + TEST_VAL_42, "temp", &wind_id) != NC_EBADID) ERR;
+        if (nc_inq_varid(ncid, NULL, &wind_id) != NC_EINVAL) ERR;
+        if (nc_inq_varid(ncid, "not_a_real_name", &wind_id) != NC_ENOTVAR) ERR;
+        if (nc_inq_varid(ncid, BAD_NAME, &wind_id) != NC_ENOTVAR) ERR;
+        if (nc_inq_varid(ncid, too_long_name, &wind_id) != NC_EMAXNAME) ERR;
 
-      /* Now get the variable ID. */
-      if (nc_inq_varid(ncid, "temp", &wind_id)) ERR;
+        /* Now get the variable ID. */
+        if (nc_inq_varid(ncid, "temp", &wind_id)) ERR;
 
-      /* THis also works, pointlessly. */
-      if (nc_inq_varid(ncid, "temp", NULL)) ERR;
+        /* THis also works, pointlessly. */
+        if (nc_inq_varid(ncid, "temp", NULL)) ERR;
 
-      /* These won't work due to bad parameters. */
-      if (nc_rename_var(ncid + MILLION, wind_id, "wind") != NC_EBADID) ERR;
-      if (nc_rename_var(ncid, wind_id + TEST_VAL_42, "wind") != NC_ENOTVAR) ERR;
-      if (nc_rename_var(ncid, -TEST_VAL_42, "wind") != NC_ENOTVAR) ERR;
-      if (nc_rename_var(ncid, wind_id, BAD_NAME) != NC_EBADNAME) ERR;
-      if (nc_rename_var(ncid, wind_id, too_long_name) != NC_EMAXNAME) ERR;
-      if (nc_rename_var(ncid, wind_id, "temp2") != NC_ENAMEINUSE) ERR;
-      if (nc_rename_var(ncid, wind_id, "windy") != NC_ENOTINDEFINE) ERR;
-      if (nc_rename_var(ncid, wind_id, NULL) != NC_EINVAL) ERR;
+        /* These won't work due to bad parameters. */
+        if (nc_rename_var(ncid + MILLION, wind_id, "wind") != NC_EBADID) ERR;
+        if (nc_rename_var(ncid, wind_id + TEST_VAL_42, "wind") != NC_ENOTVAR) ERR;
+        if (nc_rename_var(ncid, -TEST_VAL_42, "wind") != NC_ENOTVAR) ERR;
+        if (nc_rename_var(ncid, wind_id, BAD_NAME) != NC_EBADNAME) ERR;
+        if (nc_rename_var(ncid, wind_id, too_long_name) != NC_EMAXNAME) ERR;
+        if (nc_rename_var(ncid, wind_id, "temp2") != NC_ENAMEINUSE) ERR;
+        if (nc_rename_var(ncid, wind_id, "windy") != NC_ENOTINDEFINE) ERR;
+        if (nc_rename_var(ncid, wind_id, NULL) != NC_EINVAL) ERR;
 
-      /* rename variable */
-      if (nc_rename_var(ncid, wind_id, "wind")) ERR;
+        /* rename variable */
+        if (nc_rename_var(ncid, wind_id, "wind")) ERR;
 
-      /* Enter define mode and rename it to something longer. */
-      if (nc_redef(ncid)) ERR;
-      if (nc_rename_var(ncid, wind_id, "windy")) ERR;
-      if (nc_inq_varid(ncid, "windy", &wind_id)) ERR;
-      if (nc_close(ncid)) ERR;
+        /* Enter define mode and rename it to something longer. */
+        if (nc_redef(ncid)) ERR;
+        if (nc_rename_var(ncid, wind_id, "windy")) ERR;
+        if (nc_inq_varid(ncid, "windy", &wind_id)) ERR;
+        if (nc_close(ncid)) ERR;
 
-      /* Try again without classic. */
-      if (nc_create(FILE_NAME, NC_NETCDF4, &ncid)) ERR;
+        /* Try again without classic. */
+        if (nc_create(FILE_NAME, NC_NETCDF4, &ncid)) ERR;
 
-      /* define dimension */
-      if (nc_def_dim(ncid, "lon", lon_len, &lon_dim)) ERR;
+        /* define dimension */
+        if (nc_def_dim(ncid, "lon", lon_len, &lon_dim)) ERR;
 
-      /* define variable */
-      wind_dims[0] = lon_dim;
-      if (nc_def_var(ncid, "temp", NC_FLOAT, RANK_wind, wind_dims, &wind_id)) ERR;
-      if (nc_enddef(ncid)) ERR;
-      if (nc_rename_var(ncid, wind_id, "windy")) ERR;
-      if (nc_close(ncid)) ERR;
+        /* define variable */
+        wind_dims[0] = lon_dim;
+        if (nc_def_var(ncid, "temp", NC_FLOAT, RANK_wind, wind_dims, &wind_id)) ERR;
+        if (nc_enddef(ncid)) ERR;
+        if (nc_rename_var(ncid, wind_id, "windy")) ERR;
+        if (nc_close(ncid)) ERR;
 
-   }
-   SUMMARIZE_ERR;
+    }
+    SUMMARIZE_ERR;
 
 #ifndef NO_NETCDF_2
 #define VAR_DIMS2 2
-   printf("*** testing 2D array of NC_FLOAT with v2 API...");
-   {
-      int dimid[VAR_DIMS2];
-      int ndims, nvars, natts, recdim;
+    printf("*** testing 2D array of NC_FLOAT with v2 API...");
+    {
+        int dimid[VAR_DIMS2];
+        int ndims, nvars, natts, recdim;
 
-      ncid = nccreate(FILE_NAME, NC_NETCDF4);
+        ncid = nccreate(FILE_NAME, NC_NETCDF4);
 
-      /* Create dims. */
-      dimid[0] = ncdimdef(ncid, LAT, LAT_LEN);
-      dimid[1] = ncdimdef(ncid, LON, LON_LEN);
+        /* Create dims. */
+        dimid[0] = ncdimdef(ncid, LAT, LAT_LEN);
+        dimid[1] = ncdimdef(ncid, LON, LON_LEN);
 
-      /* Create var. */
-      varid = ncvardef(ncid, CXX_VAR_NAME, NC_FLOAT, VAR_DIMS2, dimid);
-      if (varid != 0) ERR;
+        /* Create var. */
+        varid = ncvardef(ncid, CXX_VAR_NAME, NC_FLOAT, VAR_DIMS2, dimid);
+        if (varid != 0) ERR;
 
-      ncclose(ncid);
+        ncclose(ncid);
 
-      /* Open the file and check. */
-      ncid = ncopen(FILE_NAME, 0);
-      ncinquire (ncid, &ndims, &nvars, &natts, &recdim);
-      if (nvars != 1 || ndims != 2 || natts != 0 || recdim != -1) ERR;
-      ncclose(ncid);
-   }
-   SUMMARIZE_ERR;
+        /* Open the file and check. */
+        ncid = ncopen(FILE_NAME, 0);
+        ncinquire (ncid, &ndims, &nvars, &natts, &recdim);
+        if (nvars != 1 || ndims != 2 || natts != 0 || recdim != -1) ERR;
+        ncclose(ncid);
+    }
+    SUMMARIZE_ERR;
 #endif /* NO_NETCDF_2 */
 
 #define NDIMS 3
 #define NNAMES 4
 #define NLINES 13
-   printf("**** testing funny names for netCDF-4...");
-   {
-      int  ncid, wind_id;
-      size_t len[NDIMS] = {7, 3, 1};
-      int dimids[NDIMS], dimids_in[NDIMS], ndims_in;
-      char funny_name[NNAMES][NC_MAX_NAME] = {"\a\t", "\f\n", "\r\v", "\b"};
-      char serious_name[NNAMES][NC_MAX_NAME] = {"name1", "name2", "name3", "name4"};
-      char name_in[NC_MAX_NAME + 1];
-      char *speech[NLINES] = {"who would fardels bear, ",
-			      "To grunt and sweat under a weary life, ",
-			      "But that the dread of something after death, ",
-			      "The undiscover'd country from whose bourn ",
-			      "No traveller returns, puzzles the will ",
-			      "And makes us rather bear those ills we have ",
-			      "Than fly to others that we know not of? ",
-			      "Thus conscience does make cowards of us all; ",
-			      "And thus the native hue of resolution ",
-			      "Is sicklied o'er with the pale cast of thought, ",
-			      "And enterprises of great pith and moment ",
-			      "With this regard their currents turn awry, ",
-			      "And lose the name of action."};
-      char *speech_in[NLINES];
-      int i;
-      unsigned short nlines = NLINES;
-      unsigned int nlines_in;
+    printf("**** testing funny names for netCDF-4...");
+    {
+        int  ncid, wind_id;
+        size_t len[NDIMS] = {7, 3, 1};
+        int dimids[NDIMS], dimids_in[NDIMS], ndims_in;
+        char funny_name[NNAMES][NC_MAX_NAME] = {"\a\t", "\f\n", "\r\v", "\b"};
+        char serious_name[NNAMES][NC_MAX_NAME] = {"name1", "name2", "name3", "name4"};
+        char name_in[NC_MAX_NAME + 1];
+        char *speech[NLINES] = {"who would fardels bear, ",
+                                "To grunt and sweat under a weary life, ",
+                                "But that the dread of something after death, ",
+                                "The undiscover'd country from whose bourn ",
+                                "No traveller returns, puzzles the will ",
+                                "And makes us rather bear those ills we have ",
+                                "Than fly to others that we know not of? ",
+                                "Thus conscience does make cowards of us all; ",
+                                "And thus the native hue of resolution ",
+                                "Is sicklied o'er with the pale cast of thought, ",
+                                "And enterprises of great pith and moment ",
+                                "With this regard their currents turn awry, ",
+                                "And lose the name of action."};
+        char *speech_in[NLINES];
+        int i;
+        unsigned short nlines = NLINES;
+        unsigned int nlines_in;
 
-      if (nc_create(FILE_NAME, NC_NETCDF4, &ncid)) ERR;
+        if (nc_create(FILE_NAME, NC_NETCDF4, &ncid)) ERR;
 
-      /* Define dimensions. Funny names are rejected, serious names work. */
-      for (i = 0; i < NDIMS; i++)
-      	 if (nc_def_dim(ncid, funny_name[i], len[i], &dimids[i]) != NC_EBADNAME) ERR;
-      for (i = 0; i < NDIMS; i++)
-      	 if (nc_def_dim(ncid, serious_name[i], len[i], &dimids[i])) ERR;
+        /* Define dimensions. Funny names are rejected, serious names work. */
+        for (i = 0; i < NDIMS; i++)
+            if (nc_def_dim(ncid, funny_name[i], len[i], &dimids[i]) != NC_EBADNAME) ERR;
+        for (i = 0; i < NDIMS; i++)
+            if (nc_def_dim(ncid, serious_name[i], len[i], &dimids[i])) ERR;
 
-      /* Write some global atts. Funny names are rejected, serious names work. */
-      if (nc_put_att_string(ncid, NC_GLOBAL, funny_name[0], NLINES,
-			    (const char **)speech) != NC_EBADNAME) ERR;
-      if (nc_put_att_ushort(ncid, NC_GLOBAL, funny_name[1], NC_UINT, 1, &nlines) != NC_EBADNAME) ERR;
-      if (nc_put_att_string(ncid, NC_GLOBAL, serious_name[0], NLINES,
-			    (const char **)speech)) ERR;
-      if (nc_put_att_ushort(ncid, NC_GLOBAL, serious_name[1], NC_UINT, 1, &nlines)) ERR;
+        /* Write some global atts. Funny names are rejected, serious names work. */
+        if (nc_put_att_string(ncid, NC_GLOBAL, funny_name[0], NLINES,
+                              (const char **)speech) != NC_EBADNAME) ERR;
+        if (nc_put_att_ushort(ncid, NC_GLOBAL, funny_name[1], NC_UINT, 1, &nlines) != NC_EBADNAME) ERR;
+        if (nc_put_att_string(ncid, NC_GLOBAL, serious_name[0], NLINES,
+                              (const char **)speech)) ERR;
+        if (nc_put_att_ushort(ncid, NC_GLOBAL, serious_name[1], NC_UINT, 1, &nlines)) ERR;
 
-      /* Define variables. Funny name fails, seriousness wins the day! */
-      if (nc_def_var(ncid, funny_name[3], NC_INT64, NDIMS, dimids, &wind_id) != NC_EBADNAME) ERR;
-      if (nc_def_var(ncid, serious_name[3], NC_INT64, NDIMS, dimids, &wind_id)) ERR;
+        /* Define variables. Funny name fails, seriousness wins the day! */
+        if (nc_def_var(ncid, funny_name[3], NC_INT64, NDIMS, dimids, &wind_id) != NC_EBADNAME) ERR;
+        if (nc_def_var(ncid, serious_name[3], NC_INT64, NDIMS, dimids, &wind_id)) ERR;
 
-      if (nc_close(ncid)) ERR;
+        if (nc_close(ncid)) ERR;
 
-      /* Open the file and check. */
-      if (nc_open(FILE_NAME, NC_WRITE, &ncid)) ERR;
-      if (nc_inq_dimids(ncid, &ndims_in, dimids_in, 0)) ERR;
-      if (ndims_in != NDIMS) ERR;
-      for (i = 0; i < NDIMS; i++)
-      {
-      	 if (dimids_in[i] != i) ERR;
-      	 if (nc_inq_dimname(ncid, i, name_in)) ERR;
-      	 if (strcmp(name_in, serious_name[i])) ERR;
-      }
+        /* Open the file and check. */
+        if (nc_open(FILE_NAME, NC_WRITE, &ncid)) ERR;
+        if (nc_inq_dimids(ncid, &ndims_in, dimids_in, 0)) ERR;
+        if (ndims_in != NDIMS) ERR;
+        for (i = 0; i < NDIMS; i++)
+        {
+            if (dimids_in[i] != i) ERR;
+            if (nc_inq_dimname(ncid, i, name_in)) ERR;
+            if (strcmp(name_in, serious_name[i])) ERR;
+        }
 
-      if (nc_get_att_string(ncid, NC_GLOBAL, serious_name[0], (char **)speech_in)) ERR;
-      for (i = 0; i < NLINES; i++)
-      	 if (strcmp(speech_in[i], speech[i])) ERR;
-      if (nc_get_att_uint(ncid, NC_GLOBAL, serious_name[1], &nlines_in)) ERR;
-      if (nlines_in != NLINES) ERR;
-      if (nc_free_string(NLINES, (char **)speech_in)) ERR;
-      if (nc_inq_varname(ncid, 0, name_in)) ERR;
-      if (strcmp(name_in, serious_name[3])) ERR;
-      if (nc_close(ncid)) ERR;
-   }
-   SUMMARIZE_ERR;
-   printf("**** testing endianness...");
+        if (nc_get_att_string(ncid, NC_GLOBAL, serious_name[0], (char **)speech_in)) ERR;
+        for (i = 0; i < NLINES; i++)
+            if (strcmp(speech_in[i], speech[i])) ERR;
+        if (nc_get_att_uint(ncid, NC_GLOBAL, serious_name[1], &nlines_in)) ERR;
+        if (nlines_in != NLINES) ERR;
+        if (nc_free_string(NLINES, (char **)speech_in)) ERR;
+        if (nc_inq_varname(ncid, 0, name_in)) ERR;
+        if (strcmp(name_in, serious_name[3])) ERR;
+        if (nc_close(ncid)) ERR;
+    }
+    SUMMARIZE_ERR;
+    printf("**** testing endianness...");
 
 #define NDIMS4 1
 #define DIM4_NAME "Joe"
 #define VAR_NAME4 "Ed"
 #define DIM4_LEN 10
-   {
-      int dimids[NDIMS4], dimids_in[NDIMS4];
-      int varid, varid1;
-      int ndims, nvars, natts, unlimdimid;
-      nc_type xtype_in;
-      char name_in[NC_MAX_NAME + 1];
-      int data[DIM4_LEN], data_in[DIM4_LEN];
-      int endian_in;
-      int i;
+    {
+        int dimids[NDIMS4], dimids_in[NDIMS4];
+        int varid, varid1;
+        int ndims, nvars, natts, unlimdimid;
+        nc_type xtype_in;
+        char name_in[NC_MAX_NAME + 1];
+        int data[DIM4_LEN], data_in[DIM4_LEN];
+        int endian_in;
+        int i;
 
-      for (i = 0; i < DIM4_LEN; i++)
-         data[i] = i;
+        for (i = 0; i < DIM4_LEN; i++)
+            data[i] = i;
 
-      /* Create a netcdf-4 file with one dim and one var. */
-      if (nc_create(FILE_NAME, NC_NETCDF4, &ncid)) ERR;
-      if (nc_def_dim(ncid, DIM4_NAME, DIM4_LEN, &dimids[0])) ERR;
-      if (dimids[0] != 0) ERR;
-      if (nc_def_var(ncid, VAR_NAME4, NC_INT, NDIMS4, dimids, &varid)) ERR;
-      if (nc_def_var_endian(ncid, varid, NC_ENDIAN_BIG)) ERR;
-      if (varid != 0) ERR;
-      if (nc_put_var_int(ncid, varid, data)) ERR;
+        /* Create a netcdf-4 file with one dim and one var. */
+        if (nc_create(FILE_NAME, NC_NETCDF4, &ncid)) ERR;
+        if (nc_def_dim(ncid, DIM4_NAME, DIM4_LEN, &dimids[0])) ERR;
+        if (dimids[0] != 0) ERR;
+        if (nc_def_var(ncid, VAR_NAME4, NC_INT, NDIMS4, dimids, &varid)) ERR;
+        if (nc_def_var_endian(ncid, varid, NC_ENDIAN_BIG)) ERR;
+        if (varid != 0) ERR;
+        if (nc_put_var_int(ncid, varid, data)) ERR;
 
-      /* Check stuff. */
-      if (nc_inq(ncid, &ndims, &nvars, &natts, &unlimdimid)) ERR;
-      if (ndims != NDIMS4 || nvars != 1 || natts != 0 ||
-          unlimdimid != -1) ERR;
-      if (nc_inq_varids(ncid, &nvars, varids_in)) ERR;
-      if (nvars != 1) ERR;
-      if (varids_in[0] != 0) ERR;
+        /* Check stuff. */
+        if (nc_inq(ncid, &ndims, &nvars, &natts, &unlimdimid)) ERR;
+        if (ndims != NDIMS4 || nvars != 1 || natts != 0 ||
+            unlimdimid != -1) ERR;
+        if (nc_inq_varids(ncid, &nvars, varids_in)) ERR;
+        if (nvars != 1) ERR;
+        if (varids_in[0] != 0) ERR;
 
-      /* Test some bad parameter values. */
-      if (nc_inq_var(ncid + MILLION, 0, name_in, &xtype_in, &ndims,
-                     dimids_in, &natts) != NC_EBADID) ERR;
-      if (nc_inq_var(ncid + TEST_VAL_42, 0, name_in, &xtype_in, &ndims,
-                     dimids_in, &natts) != NC_EBADID) ERR;
-      if (nc_inq_var(ncid, -TEST_VAL_42, name_in, &xtype_in, &ndims,
-                     dimids_in, &natts) != NC_ENOTVAR) ERR;
-      if (nc_inq_var(ncid, 1, name_in, &xtype_in, &ndims,
-                     dimids_in, &natts) != NC_ENOTVAR) ERR;
-      if (nc_inq_var(ncid, TEST_VAL_42, name_in, &xtype_in, &ndims,
-                     dimids_in, &natts) != NC_ENOTVAR) ERR;
+        /* Test some bad parameter values. */
+        if (nc_inq_var(ncid + MILLION, 0, name_in, &xtype_in, &ndims,
+                       dimids_in, &natts) != NC_EBADID) ERR;
+        if (nc_inq_var(ncid + TEST_VAL_42, 0, name_in, &xtype_in, &ndims,
+                       dimids_in, &natts) != NC_EBADID) ERR;
+        if (nc_inq_var(ncid, -TEST_VAL_42, name_in, &xtype_in, &ndims,
+                       dimids_in, &natts) != NC_ENOTVAR) ERR;
+        if (nc_inq_var(ncid, 1, name_in, &xtype_in, &ndims,
+                       dimids_in, &natts) != NC_ENOTVAR) ERR;
+        if (nc_inq_var(ncid, TEST_VAL_42, name_in, &xtype_in, &ndims,
+                       dimids_in, &natts) != NC_ENOTVAR) ERR;
 
-      /* Now pass correct parameters. */
-      if (nc_inq_var(ncid, 0, name_in, &xtype_in, &ndims,
-                     dimids_in, &natts)) ERR;
-      if (strcmp(name_in, VAR_NAME4) || xtype_in != NC_INT ||
-          ndims != 1 || natts != 0 || dimids_in[0] != 0) ERR;
-      if (nc_inq_var_endian(ncid, 0, &endian_in)) ERR;
-      if (endian_in != NC_ENDIAN_BIG) ERR;
+        /* Now pass correct parameters. */
+        if (nc_inq_var(ncid, 0, name_in, &xtype_in, &ndims,
+                       dimids_in, &natts)) ERR;
+        if (strcmp(name_in, VAR_NAME4) || xtype_in != NC_INT ||
+            ndims != 1 || natts != 0 || dimids_in[0] != 0) ERR;
+        if (nc_inq_var_endian(ncid, 0, &endian_in)) ERR;
+        if (endian_in != NC_ENDIAN_BIG) ERR;
 
-      /* This also works, uselessly. */
-      if (nc_inq_var(ncid, 0, name_in, NULL, NULL, NULL, NULL)) ERR;
+        /* This also works, uselessly. */
+        if (nc_inq_var(ncid, 0, name_in, NULL, NULL, NULL, NULL)) ERR;
 
-      if (nc_close(ncid)) ERR;
+        if (nc_close(ncid)) ERR;
 
-      /* Open the file and check the same stuff. */
-      if (nc_open(FILE_NAME, NC_NOWRITE, &ncid)) ERR;
+        /* Open the file and check the same stuff. */
+        if (nc_open(FILE_NAME, NC_NOWRITE, &ncid)) ERR;
 
-      /* This won't work. */
-      if (nc_def_var(ncid, "this_wont_work", NC_BYTE, NDIMS4, dimids,
-                     &varid1) != NC_EPERM) ERR;
+        /* This won't work. */
+        if (nc_def_var(ncid, "this_wont_work", NC_BYTE, NDIMS4, dimids,
+                       &varid1) != NC_EPERM) ERR;
 
-      if (nc_inq(ncid, &ndims, &nvars, &natts, &unlimdimid)) ERR;
-      if (ndims != NDIMS4 || nvars != 1 || natts != 0 ||
-          unlimdimid != -1) ERR;
-      if (nc_inq_varids(ncid, &nvars, varids_in)) ERR;
-      if (nvars != 1) ERR;
-      if (varids_in[0] != 0) ERR;
-      if (nc_inq_var(ncid, 0, name_in, &xtype_in, &ndims,
-                     dimids_in, &natts)) ERR;
-      if (strcmp(name_in, VAR_NAME4) || xtype_in != NC_INT ||
-          ndims != 1 || natts != 0 || dimids_in[0] != 0) ERR;
-      if (nc_inq_var_endian(ncid, 0, &endian_in)) ERR;
-      if (endian_in != NC_ENDIAN_BIG) ERR;
-      if (nc_get_var_int(ncid, varid, data_in)) ERR;
-      for (i = 0; i < DIM4_LEN; i++)
-	 if (data[i] != data_in[i]) ERR;
+        if (nc_inq(ncid, &ndims, &nvars, &natts, &unlimdimid)) ERR;
+        if (ndims != NDIMS4 || nvars != 1 || natts != 0 ||
+            unlimdimid != -1) ERR;
+        if (nc_inq_varids(ncid, &nvars, varids_in)) ERR;
+        if (nvars != 1) ERR;
+        if (varids_in[0] != 0) ERR;
+        if (nc_inq_var(ncid, 0, name_in, &xtype_in, &ndims,
+                       dimids_in, &natts)) ERR;
+        if (strcmp(name_in, VAR_NAME4) || xtype_in != NC_INT ||
+            ndims != 1 || natts != 0 || dimids_in[0] != 0) ERR;
+        if (nc_inq_var_endian(ncid, 0, &endian_in)) ERR;
+        if (endian_in != NC_ENDIAN_BIG) ERR;
+        if (nc_get_var_int(ncid, varid, data_in)) ERR;
+        for (i = 0; i < DIM4_LEN; i++)
+            if (data[i] != data_in[i]) ERR;
 
-      if (nc_close(ncid)) ERR;
-   }
+        if (nc_close(ncid)) ERR;
+    }
 
-   SUMMARIZE_ERR;
-   printf("**** testing chunking and the chunk cache...");
-   {
+    SUMMARIZE_ERR;
+    printf("**** testing chunking and the chunk cache...");
+    {
 #define NDIMS5 1
 #define DIM5_NAME "D5"
 #define VAR_NAME5 "V5"
@@ -782,543 +782,543 @@ main(int argc, char **argv)
 #define CACHE_PREEMPTION2 .50
 #define NVAR4 5
 
-      int dimids[NDIMS5], dimids_in[NDIMS5];
-      int varid, varid1, varid2, varid3, varid4;
-      int varids_in4[NVAR4];
-      int ndims, nvars, natts, unlimdimid;
-      nc_type xtype_in;
-      char name_in[NC_MAX_NAME + 1];
-      int data[DIM5_LEN], data_in[DIM5_LEN];
-      size_t chunksize[NDIMS5] = {5};
-      size_t bad_chunksize[NDIMS5] = {-5}; /* Converted to large pos number since size_t is unsigned. */
-      size_t large_chunksize[NDIMS5] = {(size_t)NC_MAX_INT + (size_t)1}; /* Too big for inq_var_chunking_ints(). */
-      size_t chunksize_in[NDIMS5];
-      int chunksize_int[NDIMS5];
-      int chunksize_int_in[NDIMS5];
-      int storage_in;
-      size_t cache_size_in, cache_nelems_in;
-      float cache_preemption_in;
-      int cache_size_int_in, cache_nelems_int_in;
-      int cache_preemption_int_in;
-      int cache_size_int_default, cache_nelems_int_default;
-      int cache_preemption_int_default;
-      int i, d;
+        int dimids[NDIMS5], dimids_in[NDIMS5];
+        int varid, varid1, varid2, varid3, varid4;
+        int varids_in4[NVAR4];
+        int ndims, nvars, natts, unlimdimid;
+        nc_type xtype_in;
+        char name_in[NC_MAX_NAME + 1];
+        int data[DIM5_LEN], data_in[DIM5_LEN];
+        size_t chunksize[NDIMS5] = {5};
+        size_t bad_chunksize[NDIMS5] = {-5}; /* Converted to large pos number since size_t is unsigned. */
+        size_t large_chunksize[NDIMS5] = {(size_t)NC_MAX_INT + (size_t)1}; /* Too big for inq_var_chunking_ints(). */
+        size_t chunksize_in[NDIMS5];
+        int chunksize_int[NDIMS5];
+        int chunksize_int_in[NDIMS5];
+        int storage_in;
+        size_t cache_size_in, cache_nelems_in;
+        float cache_preemption_in;
+        int cache_size_int_in, cache_nelems_int_in;
+        int cache_preemption_int_in;
+        int cache_size_int_default, cache_nelems_int_default;
+        int cache_preemption_int_default;
+        int i, d;
 
-      for (i = 0; i < DIM5_LEN; i++)
-         data[i] = i;
+        for (i = 0; i < DIM5_LEN; i++)
+            data[i] = i;
 
-      /* Create a netcdf-4 file with one dim and one var. */
-      if (nc_create(FILE_NAME, NC_NETCDF4, &ncid)) ERR;
-      if (nc_def_dim(ncid, DIM5_NAME, DIM5_LEN, &dimids[0])) ERR;
-      if (dimids[0] != 0) ERR;
+        /* Create a netcdf-4 file with one dim and one var. */
+        if (nc_create(FILE_NAME, NC_NETCDF4, &ncid)) ERR;
+        if (nc_def_dim(ncid, DIM5_NAME, DIM5_LEN, &dimids[0])) ERR;
+        if (dimids[0] != 0) ERR;
 
-      /* Define the variable. */
-      if (nc_def_var(ncid, VAR_NAME5, NC_INT, NDIMS5, dimids, &varid)) ERR;
+        /* Define the variable. */
+        if (nc_def_var(ncid, VAR_NAME5, NC_INT, NDIMS5, dimids, &varid)) ERR;
 
-      /* These will fail due to bad parameters. */
-      if (nc_def_var_chunking(ncid + MILLION, varid, NC_CHUNKED,
-                              chunksize) != NC_EBADID) ERR;
-      if (nc_def_var_chunking(ncid + TEST_VAL_42, varid, NC_CHUNKED,
-                              chunksize) != NC_EBADID) ERR;
-      if (nc_def_var_chunking(ncid, varid + TEST_VAL_42, NC_CHUNKED,
-                              chunksize) != NC_ENOTVAR) ERR;
-      if (nc_def_var_chunking(ncid, varid + 1, NC_CHUNKED,
-                              chunksize) != NC_ENOTVAR) ERR;
-      if (nc_def_var_chunking(ncid, -1, NC_CHUNKED,
-                              chunksize) != NC_ENOTVAR) ERR;
-      if (nc_def_var_chunking(ncid, varid, NC_CHUNKED, bad_chunksize) !=
-          NC_EBADCHUNK) ERR;
+        /* These will fail due to bad parameters. */
+        if (nc_def_var_chunking(ncid + MILLION, varid, NC_CHUNKED,
+                                chunksize) != NC_EBADID) ERR;
+        if (nc_def_var_chunking(ncid + TEST_VAL_42, varid, NC_CHUNKED,
+                                chunksize) != NC_EBADID) ERR;
+        if (nc_def_var_chunking(ncid, varid + TEST_VAL_42, NC_CHUNKED,
+                                chunksize) != NC_ENOTVAR) ERR;
+        if (nc_def_var_chunking(ncid, varid + 1, NC_CHUNKED,
+                                chunksize) != NC_ENOTVAR) ERR;
+        if (nc_def_var_chunking(ncid, -1, NC_CHUNKED,
+                                chunksize) != NC_ENOTVAR) ERR;
+        if (nc_def_var_chunking(ncid, varid, NC_CHUNKED, bad_chunksize) !=
+            NC_EBADCHUNK) ERR;
 
-      /* Define the chunking. */
-      if (nc_def_var_chunking(ncid, varid, NC_CHUNKED, chunksize)) ERR;
+        /* Define the chunking. */
+        if (nc_def_var_chunking(ncid, varid, NC_CHUNKED, chunksize)) ERR;
 
-      /* Try to set var cache with bad parameters. They will be
-       * rejected. */
-      if (nc_set_var_chunk_cache(ncid + MILLION, varid, CACHE_SIZE, CACHE_NELEMS,
-                                 CACHE_PREEMPTION) != NC_EBADID) ERR;
-      if (nc_set_var_chunk_cache(ncid + 1, varid, CACHE_SIZE, CACHE_NELEMS,
-                                 CACHE_PREEMPTION) != NC_EBADID) ERR;
-      if (nc_set_var_chunk_cache(ncid, varid + TEST_VAL_42, CACHE_SIZE, CACHE_NELEMS,
-                                 CACHE_PREEMPTION) != NC_ENOTVAR) ERR;
-      if (nc_set_var_chunk_cache(ncid, -TEST_VAL_42, CACHE_SIZE, CACHE_NELEMS,
-                                 CACHE_PREEMPTION) != NC_ENOTVAR) ERR;
-      if (nc_set_var_chunk_cache(ncid, varid + 1, CACHE_SIZE, CACHE_NELEMS,
-                                 CACHE_PREEMPTION) != NC_ENOTVAR) ERR;
-      if (nc_set_var_chunk_cache(ncid, varid, CACHE_SIZE, CACHE_NELEMS,
-                                 CACHE_PREEMPTION + TEST_VAL_42) != NC_EINVAL) ERR;
-      if (nc_set_var_chunk_cache(ncid, varid, CACHE_SIZE, CACHE_NELEMS,
-                                 CACHE_PREEMPTION - TEST_VAL_42) != NC_EINVAL) ERR;
+        /* Try to set var cache with bad parameters. They will be
+         * rejected. */
+        if (nc_set_var_chunk_cache(ncid + MILLION, varid, CACHE_SIZE, CACHE_NELEMS,
+                                   CACHE_PREEMPTION) != NC_EBADID) ERR;
+        if (nc_set_var_chunk_cache(ncid + 1, varid, CACHE_SIZE, CACHE_NELEMS,
+                                   CACHE_PREEMPTION) != NC_EBADID) ERR;
+        if (nc_set_var_chunk_cache(ncid, varid + TEST_VAL_42, CACHE_SIZE, CACHE_NELEMS,
+                                   CACHE_PREEMPTION) != NC_ENOTVAR) ERR;
+        if (nc_set_var_chunk_cache(ncid, -TEST_VAL_42, CACHE_SIZE, CACHE_NELEMS,
+                                   CACHE_PREEMPTION) != NC_ENOTVAR) ERR;
+        if (nc_set_var_chunk_cache(ncid, varid + 1, CACHE_SIZE, CACHE_NELEMS,
+                                   CACHE_PREEMPTION) != NC_ENOTVAR) ERR;
+        if (nc_set_var_chunk_cache(ncid, varid, CACHE_SIZE, CACHE_NELEMS,
+                                   CACHE_PREEMPTION + TEST_VAL_42) != NC_EINVAL) ERR;
+        if (nc_set_var_chunk_cache(ncid, varid, CACHE_SIZE, CACHE_NELEMS,
+                                   CACHE_PREEMPTION - TEST_VAL_42) != NC_EINVAL) ERR;
 
-      /* Set the cache. */
-      if (nc_set_var_chunk_cache(ncid, varid, CACHE_SIZE, CACHE_NELEMS, CACHE_PREEMPTION)) ERR;
-      if (nc_put_var_int(ncid, varid, data)) ERR;
+        /* Set the cache. */
+        if (nc_set_var_chunk_cache(ncid, varid, CACHE_SIZE, CACHE_NELEMS, CACHE_PREEMPTION)) ERR;
+        if (nc_put_var_int(ncid, varid, data)) ERR;
 
-      /* Check stuff. */
-      if (nc_inq(ncid, &ndims, &nvars, &natts, &unlimdimid)) ERR;
-      if (ndims != NDIMS5 || nvars != 1 || natts != 0 ||
-          unlimdimid != -1) ERR;
-      if (nc_inq_varids(ncid, &nvars, varids_in4)) ERR;
-      if (nvars != 1) ERR;
-      if (varids_in4[0] != 0) ERR;
-      if (nc_inq_var(ncid, 0, name_in, &xtype_in, &ndims, dimids_in, &natts)) ERR;
-      if (strcmp(name_in, VAR_NAME5) || xtype_in != NC_INT || ndims != 1 || natts != 0 ||
-	  dimids_in[0] != 0) ERR;
-      if (nc_inq_var_chunking(ncid, 0, &storage_in, chunksize_in)) ERR;
-      for (d = 0; d < NDIMS5; d++)
-	 if (chunksize[d] != chunksize_in[d]) ERR;
-      if (storage_in != NC_CHUNKED) ERR;
-      if (nc_get_var_int(ncid, varid, data_in)) ERR;
-      for (i = 0; i < DIM5_LEN; i++)
-         if (data[i] != data_in[i])
-	    ERR_RET;
+        /* Check stuff. */
+        if (nc_inq(ncid, &ndims, &nvars, &natts, &unlimdimid)) ERR;
+        if (ndims != NDIMS5 || nvars != 1 || natts != 0 ||
+            unlimdimid != -1) ERR;
+        if (nc_inq_varids(ncid, &nvars, varids_in4)) ERR;
+        if (nvars != 1) ERR;
+        if (varids_in4[0] != 0) ERR;
+        if (nc_inq_var(ncid, 0, name_in, &xtype_in, &ndims, dimids_in, &natts)) ERR;
+        if (strcmp(name_in, VAR_NAME5) || xtype_in != NC_INT || ndims != 1 || natts != 0 ||
+            dimids_in[0] != 0) ERR;
+        if (nc_inq_var_chunking(ncid, 0, &storage_in, chunksize_in)) ERR;
+        for (d = 0; d < NDIMS5; d++)
+            if (chunksize[d] != chunksize_in[d]) ERR;
+        if (storage_in != NC_CHUNKED) ERR;
+        if (nc_get_var_int(ncid, varid, data_in)) ERR;
+        for (i = 0; i < DIM5_LEN; i++)
+            if (data[i] != data_in[i])
+                ERR_RET;
 
-      /* These will not work due to bad parameters. */
-      if (nc_inq_var_chunking_ints(ncid + MILLION, 0, &storage_in,
-                                   chunksize_int_in) != NC_EBADID) ERR;
-      if (nc_inq_var_chunking_ints(ncid + TEST_VAL_42, 0, &storage_in,
-                                   chunksize_int_in) != NC_EBADID) ERR;
-      if (nc_inq_var_chunking_ints(ncid, -1, &storage_in,
-                                   chunksize_int_in) != NC_ENOTVAR) ERR;
-      if (nc_inq_var_chunking_ints(ncid, varid + 1, &storage_in,
-                                   chunksize_int_in) != NC_ENOTVAR) ERR;
-      if (nc_inq_var_chunking_ints(ncid, varid + TEST_VAL_42, &storage_in,
-                                   chunksize_int_in) != NC_ENOTVAR) ERR;
+        /* These will not work due to bad parameters. */
+        if (nc_inq_var_chunking_ints(ncid + MILLION, 0, &storage_in,
+                                     chunksize_int_in) != NC_EBADID) ERR;
+        if (nc_inq_var_chunking_ints(ncid + TEST_VAL_42, 0, &storage_in,
+                                     chunksize_int_in) != NC_EBADID) ERR;
+        if (nc_inq_var_chunking_ints(ncid, -1, &storage_in,
+                                     chunksize_int_in) != NC_ENOTVAR) ERR;
+        if (nc_inq_var_chunking_ints(ncid, varid + 1, &storage_in,
+                                     chunksize_int_in) != NC_ENOTVAR) ERR;
+        if (nc_inq_var_chunking_ints(ncid, varid + TEST_VAL_42, &storage_in,
+                                     chunksize_int_in) != NC_ENOTVAR) ERR;
 
-      /* Now check with the fortran versions of the var_chunking. */
-      if (nc_inq_var_chunking_ints(ncid, 0, &storage_in, chunksize_int_in)) ERR;
-      if (storage_in != NC_CHUNKED) ERR;
-      for (d = 0; d < NDIMS5; d++)
-	 if (chunksize_int_in[d] != chunksize[d]) ERR;
-      for (d = 0; d < NDIMS5; d++)
-         chunksize_int[d] = chunksize[d] * 2;
-      if (nc_inq_var_chunking_ints(ncid, 0, &storage_in, NULL)) ERR;
-      if (storage_in != NC_CHUNKED) ERR;
+        /* Now check with the fortran versions of the var_chunking. */
+        if (nc_inq_var_chunking_ints(ncid, 0, &storage_in, chunksize_int_in)) ERR;
+        if (storage_in != NC_CHUNKED) ERR;
+        for (d = 0; d < NDIMS5; d++)
+            if (chunksize_int_in[d] != chunksize[d]) ERR;
+        for (d = 0; d < NDIMS5; d++)
+            chunksize_int[d] = chunksize[d] * 2;
+        if (nc_inq_var_chunking_ints(ncid, 0, &storage_in, NULL)) ERR;
+        if (storage_in != NC_CHUNKED) ERR;
 
-      /* Check that some bad parameter values are rejected properly. */
-      if (nc_def_var_chunking_ints(ncid + MILLION, varid, NC_CHUNKED,
-                                   chunksize_int) != NC_EBADID) ERR;
-      if (nc_def_var_chunking_ints(ncid + TEST_VAL_42, varid, NC_CHUNKED,
-                                   chunksize_int) != NC_EBADID) ERR;
-      if (nc_def_var_chunking_ints(ncid, -1, NC_CHUNKED,
-                                   chunksize_int) != NC_ENOTVAR) ERR;
-      if (nc_def_var_chunking_ints(ncid, varid + 1, NC_CHUNKED,
-                                   chunksize_int) != NC_ENOTVAR) ERR;
-      if (nc_def_var_chunking_ints(ncid, varid + TEST_VAL_42, NC_CHUNKED,
-                                   chunksize_int) != NC_ENOTVAR) ERR;
+        /* Check that some bad parameter values are rejected properly. */
+        if (nc_def_var_chunking_ints(ncid + MILLION, varid, NC_CHUNKED,
+                                     chunksize_int) != NC_EBADID) ERR;
+        if (nc_def_var_chunking_ints(ncid + TEST_VAL_42, varid, NC_CHUNKED,
+                                     chunksize_int) != NC_EBADID) ERR;
+        if (nc_def_var_chunking_ints(ncid, -1, NC_CHUNKED,
+                                     chunksize_int) != NC_ENOTVAR) ERR;
+        if (nc_def_var_chunking_ints(ncid, varid + 1, NC_CHUNKED,
+                                     chunksize_int) != NC_ENOTVAR) ERR;
+        if (nc_def_var_chunking_ints(ncid, varid + TEST_VAL_42, NC_CHUNKED,
+                                     chunksize_int) != NC_ENOTVAR) ERR;
 
-      if (nc_def_var_chunking_ints(ncid, varid, NC_CHUNKED, chunksize_int) != NC_ELATEDEF) ERR;
-      if (nc_redef(ncid)) ERR;
-      if (nc_def_var(ncid, VAR_NAME5_1, NC_INT, NDIMS5, dimids, &varid1)) ERR;
-      if (nc_def_var(ncid, VAR_NAME5_2, NC_INT, 0, NULL, &varid2)) ERR;
-      if (nc_def_var(ncid, VAR_NAME5_3, NC_INT, 0, NULL, &varid3)) ERR;
-      if (nc_def_var(ncid, VAR_NAME5_4, NC_INT, NDIMS5, dimids, &varid4)) ERR;
-      if (nc_def_var_chunking(ncid, varid2, NC_CHUNKED, chunksize)) ERR;
-      if (nc_def_var_chunking(ncid, varid3, NC_CONTIGUOUS, NULL)) ERR;
-      if (nc_def_var_chunking(ncid, varid4, NC_CHUNKED, large_chunksize) != NC_EBADCHUNK) ERR;
-      if (nc_def_var_chunking_ints(ncid, varid2, NC_CHUNKED, chunksize_int)) ERR;
-      if (nc_def_var_chunking_ints(ncid, varid1, NC_CHUNKED, chunksize_int)) ERR;
-      if (nc_inq_var_chunking_ints(ncid, varid2, NULL, chunksize_int_in)) ERR;
-      if (nc_inq_var_chunking_ints(ncid, varid1, NULL, chunksize_int_in)) ERR;
-      for (d = 0; d < NDIMS5; d++)
-	 if (chunksize_int_in[d] != chunksize[d] * 2) ERR;
-      if (nc_inq_var_chunking_ints(ncid, varid1, &storage_in, NULL)) ERR;
-      if (storage_in != NC_CHUNKED) ERR;
-      if (nc_inq_var_chunking_ints(ncid, varid2, NULL, chunksize_int_in)) ERR;
-      if (nc_inq_var_chunking_ints(ncid, varid3, &storage_in, NULL)) ERR;
-      if (storage_in != NC_CONTIGUOUS) ERR;
-      if (nc_inq_var_chunking_ints(ncid, varid3, &storage_in, chunksize_int_in)) ERR;
-      if (storage_in != NC_CONTIGUOUS) ERR;
+        if (nc_def_var_chunking_ints(ncid, varid, NC_CHUNKED, chunksize_int) != NC_ELATEDEF) ERR;
+        if (nc_redef(ncid)) ERR;
+        if (nc_def_var(ncid, VAR_NAME5_1, NC_INT, NDIMS5, dimids, &varid1)) ERR;
+        if (nc_def_var(ncid, VAR_NAME5_2, NC_INT, 0, NULL, &varid2)) ERR;
+        if (nc_def_var(ncid, VAR_NAME5_3, NC_INT, 0, NULL, &varid3)) ERR;
+        if (nc_def_var(ncid, VAR_NAME5_4, NC_INT, NDIMS5, dimids, &varid4)) ERR;
+        if (nc_def_var_chunking(ncid, varid2, NC_CHUNKED, chunksize)) ERR;
+        if (nc_def_var_chunking(ncid, varid3, NC_CONTIGUOUS, NULL)) ERR;
+        if (nc_def_var_chunking(ncid, varid4, NC_CHUNKED, large_chunksize) != NC_EBADCHUNK) ERR;
+        if (nc_def_var_chunking_ints(ncid, varid2, NC_CHUNKED, chunksize_int)) ERR;
+        if (nc_def_var_chunking_ints(ncid, varid1, NC_CHUNKED, chunksize_int)) ERR;
+        if (nc_inq_var_chunking_ints(ncid, varid2, NULL, chunksize_int_in)) ERR;
+        if (nc_inq_var_chunking_ints(ncid, varid1, NULL, chunksize_int_in)) ERR;
+        for (d = 0; d < NDIMS5; d++)
+            if (chunksize_int_in[d] != chunksize[d] * 2) ERR;
+        if (nc_inq_var_chunking_ints(ncid, varid1, &storage_in, NULL)) ERR;
+        if (storage_in != NC_CHUNKED) ERR;
+        if (nc_inq_var_chunking_ints(ncid, varid2, NULL, chunksize_int_in)) ERR;
+        if (nc_inq_var_chunking_ints(ncid, varid3, &storage_in, NULL)) ERR;
+        if (storage_in != NC_CONTIGUOUS) ERR;
+        if (nc_inq_var_chunking_ints(ncid, varid3, &storage_in, chunksize_int_in)) ERR;
+        if (storage_in != NC_CONTIGUOUS) ERR;
 
-      /* Check that some bad parameter values are rejected properly. */
-      if (nc_get_var_chunk_cache(ncid + MILLION, varid, &cache_size_in, &cache_nelems_in,
-				 &cache_preemption_in) != NC_EBADID) ERR;
-      if (nc_get_var_chunk_cache(ncid + 1, -TEST_VAL_42, &cache_size_in, &cache_nelems_in,
-				 &cache_preemption_in) != NC_EBADID) ERR;
-      if (nc_get_var_chunk_cache(ncid, varid + TEST_VAL_42, &cache_size_in, &cache_nelems_in,
-				 &cache_preemption_in) != NC_ENOTVAR) ERR;
-      if (nc_get_var_chunk_cache(ncid, varid4 + 1, &cache_size_in, &cache_nelems_in,
-				 &cache_preemption_in) != NC_ENOTVAR) ERR;
-      if (nc_get_var_chunk_cache(ncid, -TEST_VAL_42, &cache_size_in, &cache_nelems_in,
-				 &cache_preemption_in) != NC_ENOTVAR) ERR;
+        /* Check that some bad parameter values are rejected properly. */
+        if (nc_get_var_chunk_cache(ncid + MILLION, varid, &cache_size_in, &cache_nelems_in,
+                                   &cache_preemption_in) != NC_EBADID) ERR;
+        if (nc_get_var_chunk_cache(ncid + 1, -TEST_VAL_42, &cache_size_in, &cache_nelems_in,
+                                   &cache_preemption_in) != NC_EBADID) ERR;
+        if (nc_get_var_chunk_cache(ncid, varid + TEST_VAL_42, &cache_size_in, &cache_nelems_in,
+                                   &cache_preemption_in) != NC_ENOTVAR) ERR;
+        if (nc_get_var_chunk_cache(ncid, varid4 + 1, &cache_size_in, &cache_nelems_in,
+                                   &cache_preemption_in) != NC_ENOTVAR) ERR;
+        if (nc_get_var_chunk_cache(ncid, -TEST_VAL_42, &cache_size_in, &cache_nelems_in,
+                                   &cache_preemption_in) != NC_ENOTVAR) ERR;
 
-      /* Get the var chunk cache settings. */
-      if (nc_get_var_chunk_cache(ncid, varid, &cache_size_in, &cache_nelems_in,
-				 &cache_preemption_in)) ERR;
-      if (cache_size_in != CACHE_SIZE || cache_nelems_in != CACHE_NELEMS ||
-	  cache_preemption_in != CACHE_PREEMPTION) ERR;
-      /* THis should also work, pointlessly. */
-      if (nc_get_var_chunk_cache(ncid, varid, NULL, NULL, NULL)) ERR;
+        /* Get the var chunk cache settings. */
+        if (nc_get_var_chunk_cache(ncid, varid, &cache_size_in, &cache_nelems_in,
+                                   &cache_preemption_in)) ERR;
+        if (cache_size_in != CACHE_SIZE || cache_nelems_in != CACHE_NELEMS ||
+            cache_preemption_in != CACHE_PREEMPTION) ERR;
+        /* THis should also work, pointlessly. */
+        if (nc_get_var_chunk_cache(ncid, varid, NULL, NULL, NULL)) ERR;
 
-      /* Check the _int version of this function, used by the F77 API. */
-      if (nc_get_var_chunk_cache_ints(ncid, varid, &cache_size_int_in, &cache_nelems_int_in,
-                                      &cache_preemption_int_in)) ERR;
-      if (cache_size_int_in != CACHE_SIZE / MEGABYTE) ERR;
-      if (cache_nelems_int_in != CACHE_NELEMS) ERR;
-      if (cache_preemption_int_in != (int)(CACHE_PREEMPTION * 100)) ERR;
-      /* THis should also work, pointlessly. */
-      if (nc_get_var_chunk_cache_ints(ncid, varid, NULL, NULL, NULL)) ERR;
+        /* Check the _int version of this function, used by the F77 API. */
+        if (nc_get_var_chunk_cache_ints(ncid, varid, &cache_size_int_in, &cache_nelems_int_in,
+                                        &cache_preemption_int_in)) ERR;
+        if (cache_size_int_in != CACHE_SIZE / MEGABYTE) ERR;
+        if (cache_nelems_int_in != CACHE_NELEMS) ERR;
+        if (cache_preemption_int_in != (int)(CACHE_PREEMPTION * 100)) ERR;
+        /* THis should also work, pointlessly. */
+        if (nc_get_var_chunk_cache_ints(ncid, varid, NULL, NULL, NULL)) ERR;
 
-      if (nc_close(ncid)) ERR;
+        if (nc_close(ncid)) ERR;
 
-      /* Open the file and check the same stuff. */
-      if (nc_open(FILE_NAME, NC_NOWRITE, &ncid)) ERR;
+        /* Open the file and check the same stuff. */
+        if (nc_open(FILE_NAME, NC_NOWRITE, &ncid)) ERR;
 
-      /* Check stuff. */
-      if (nc_inq(ncid, &ndims, &nvars, &natts, &unlimdimid)) ERR;
-      if (ndims != NDIMS5 || nvars != NVAR4 || natts != 0 ||
-          unlimdimid != -1) ERR;
-      if (nc_inq_varids(ncid, &nvars, varids_in4)) ERR;
-      if (nvars != NVAR4) ERR;
-      if (varids_in4[0] != 0 || varids_in4[1] != 1) ERR;
-      if (nc_inq_var(ncid, 0, name_in, &xtype_in, &ndims, dimids_in, &natts)) ERR;
-      if (strcmp(name_in, VAR_NAME5) || xtype_in != NC_INT || ndims != 1 || natts != 0 ||
-	  dimids_in[0] != 0) ERR;
-      if (nc_inq_var_chunking(ncid, 0, &storage_in, chunksize_in)) ERR;
-      for (d = 0; d < NDIMS5; d++)
-	 if (chunksize[d] != chunksize_in[d]) ERR;
-      if (storage_in != NC_CHUNKED) ERR;
-      if (nc_get_var_int(ncid, varid, data_in)) ERR;
-      for (i = 0; i < DIM5_LEN; i++)
-         if (data[i] != data_in[i])
-	    ERR_RET;
+        /* Check stuff. */
+        if (nc_inq(ncid, &ndims, &nvars, &natts, &unlimdimid)) ERR;
+        if (ndims != NDIMS5 || nvars != NVAR4 || natts != 0 ||
+            unlimdimid != -1) ERR;
+        if (nc_inq_varids(ncid, &nvars, varids_in4)) ERR;
+        if (nvars != NVAR4) ERR;
+        if (varids_in4[0] != 0 || varids_in4[1] != 1) ERR;
+        if (nc_inq_var(ncid, 0, name_in, &xtype_in, &ndims, dimids_in, &natts)) ERR;
+        if (strcmp(name_in, VAR_NAME5) || xtype_in != NC_INT || ndims != 1 || natts != 0 ||
+            dimids_in[0] != 0) ERR;
+        if (nc_inq_var_chunking(ncid, 0, &storage_in, chunksize_in)) ERR;
+        for (d = 0; d < NDIMS5; d++)
+            if (chunksize[d] != chunksize_in[d]) ERR;
+        if (storage_in != NC_CHUNKED) ERR;
+        if (nc_get_var_int(ncid, varid, data_in)) ERR;
+        for (i = 0; i < DIM5_LEN; i++)
+            if (data[i] != data_in[i])
+                ERR_RET;
 
-      /* Use the _int function to change the var chunk cache settings. */
-      if (nc_set_var_chunk_cache_ints(ncid, varid, CACHE_SIZE2 / MEGABYTE, CACHE_NELEMS2,
-                                      (int)(CACHE_PREEMPTION2 * 100))) ERR;
+        /* Use the _int function to change the var chunk cache settings. */
+        if (nc_set_var_chunk_cache_ints(ncid, varid, CACHE_SIZE2 / MEGABYTE, CACHE_NELEMS2,
+                                        (int)(CACHE_PREEMPTION2 * 100))) ERR;
 
-      /* These will fail due to bad ncid and group ID. */
-      if (nc_get_var_chunk_cache_ints(ncid + MILLION, varid, &cache_size_int_in, &cache_nelems_int_in,
-                                      &cache_preemption_int_in) != NC_EBADID) ERR;
-      if (nc_get_var_chunk_cache_ints(ncid + TEST_VAL_42, varid, &cache_size_int_in, &cache_nelems_int_in,
-                                      &cache_preemption_int_in) != NC_EBADID) ERR;
+        /* These will fail due to bad ncid and group ID. */
+        if (nc_get_var_chunk_cache_ints(ncid + MILLION, varid, &cache_size_int_in, &cache_nelems_int_in,
+                                        &cache_preemption_int_in) != NC_EBADID) ERR;
+        if (nc_get_var_chunk_cache_ints(ncid + TEST_VAL_42, varid, &cache_size_int_in, &cache_nelems_int_in,
+                                        &cache_preemption_int_in) != NC_EBADID) ERR;
 
-      /* Now get the settings. */
-      if (nc_get_var_chunk_cache_ints(ncid, varid, &cache_size_int_in, &cache_nelems_int_in,
-                                      &cache_preemption_int_in)) ERR;
-      if (cache_size_int_in != CACHE_SIZE2 / MEGABYTE || cache_nelems_int_in != CACHE_NELEMS2 ||
-          cache_preemption_int_in != (int)(CACHE_PREEMPTION2 * 100)) ERR;
+        /* Now get the settings. */
+        if (nc_get_var_chunk_cache_ints(ncid, varid, &cache_size_int_in, &cache_nelems_int_in,
+                                        &cache_preemption_int_in)) ERR;
+        if (cache_size_int_in != CACHE_SIZE2 / MEGABYTE || cache_nelems_int_in != CACHE_NELEMS2 ||
+            cache_preemption_int_in != (int)(CACHE_PREEMPTION2 * 100)) ERR;
 
-      /* Passing negative values to the _int function causes them to
-       * be ignored and a default setting used. Set all to negative to
-       * get defaults.. */
-      if (nc_set_var_chunk_cache_ints(ncid, varid, -CACHE_SIZE / MEGABYTE, -CACHE_NELEMS2,
-                                      -(int)(CACHE_PREEMPTION2 * 100))) ERR;
-      if (nc_get_var_chunk_cache_ints(ncid, varid, &cache_size_int_default, &cache_nelems_int_default,
-                                      &cache_preemption_int_default)) ERR;
+        /* Passing negative values to the _int function causes them to
+         * be ignored and a default setting used. Set all to negative to
+         * get defaults.. */
+        if (nc_set_var_chunk_cache_ints(ncid, varid, -CACHE_SIZE / MEGABYTE, -CACHE_NELEMS2,
+                                        -(int)(CACHE_PREEMPTION2 * 100))) ERR;
+        if (nc_get_var_chunk_cache_ints(ncid, varid, &cache_size_int_default, &cache_nelems_int_default,
+                                        &cache_preemption_int_default)) ERR;
 
-      /* Now set the size only. */
-      if (nc_set_var_chunk_cache_ints(ncid, varid, CACHE_SIZE / MEGABYTE, -CACHE_NELEMS2,
-                                      -(int)(CACHE_PREEMPTION2 * 100))) ERR;
-      if (nc_get_var_chunk_cache_ints(ncid, varid, &cache_size_int_in, &cache_nelems_int_in,
-                                      &cache_preemption_int_in)) ERR;
-      if (cache_size_int_in != CACHE_SIZE / MEGABYTE || cache_nelems_int_in != cache_nelems_int_default ||
-          cache_preemption_int_in != cache_preemption_int_default) ERR;
-      /* Now set the nelems only. */
-      if (nc_set_var_chunk_cache_ints(ncid, varid, -CACHE_SIZE / MEGABYTE, CACHE_NELEMS,
-                                      -(int)(CACHE_PREEMPTION2 * 100))) ERR;
-      if (nc_get_var_chunk_cache_ints(ncid, varid, &cache_size_int_in, &cache_nelems_int_in,
-                                      &cache_preemption_int_in)) ERR;
-      if (cache_size_int_in != cache_size_int_default || cache_nelems_int_in != CACHE_NELEMS ||
-          cache_preemption_int_in != cache_preemption_int_default) ERR;
-      /* Now set the preemption only. */
-      if (nc_set_var_chunk_cache_ints(ncid, varid, -CACHE_SIZE / MEGABYTE, -CACHE_NELEMS,
-                                      (int)(CACHE_PREEMPTION2 * 100))) ERR;
-      if (nc_get_var_chunk_cache_ints(ncid, varid, &cache_size_int_in, &cache_nelems_int_in,
-                                      &cache_preemption_int_in)) ERR;
-      if (cache_size_int_in != cache_size_int_default || cache_nelems_int_in != cache_nelems_int_default ||
-          cache_preemption_int_in != (int)(CACHE_PREEMPTION2 * 100)) ERR;
+        /* Now set the size only. */
+        if (nc_set_var_chunk_cache_ints(ncid, varid, CACHE_SIZE / MEGABYTE, -CACHE_NELEMS2,
+                                        -(int)(CACHE_PREEMPTION2 * 100))) ERR;
+        if (nc_get_var_chunk_cache_ints(ncid, varid, &cache_size_int_in, &cache_nelems_int_in,
+                                        &cache_preemption_int_in)) ERR;
+        if (cache_size_int_in != CACHE_SIZE / MEGABYTE || cache_nelems_int_in != cache_nelems_int_default ||
+            cache_preemption_int_in != cache_preemption_int_default) ERR;
+        /* Now set the nelems only. */
+        if (nc_set_var_chunk_cache_ints(ncid, varid, -CACHE_SIZE / MEGABYTE, CACHE_NELEMS,
+                                        -(int)(CACHE_PREEMPTION2 * 100))) ERR;
+        if (nc_get_var_chunk_cache_ints(ncid, varid, &cache_size_int_in, &cache_nelems_int_in,
+                                        &cache_preemption_int_in)) ERR;
+        if (cache_size_int_in != cache_size_int_default || cache_nelems_int_in != CACHE_NELEMS ||
+            cache_preemption_int_in != cache_preemption_int_default) ERR;
+        /* Now set the preemption only. */
+        if (nc_set_var_chunk_cache_ints(ncid, varid, -CACHE_SIZE / MEGABYTE, -CACHE_NELEMS,
+                                        (int)(CACHE_PREEMPTION2 * 100))) ERR;
+        if (nc_get_var_chunk_cache_ints(ncid, varid, &cache_size_int_in, &cache_nelems_int_in,
+                                        &cache_preemption_int_in)) ERR;
+        if (cache_size_int_in != cache_size_int_default || cache_nelems_int_in != cache_nelems_int_default ||
+            cache_preemption_int_in != (int)(CACHE_PREEMPTION2 * 100)) ERR;
 
-      if (nc_close(ncid)) ERR;
-   }
+        if (nc_close(ncid)) ERR;
+    }
 
-   SUMMARIZE_ERR;
-   printf("**** testing netCDF-4 functions on netCDF-3 files...");
-   {
-      int dimids[NDIMS5], dimids_in[NDIMS5];
-      int varid;
-      int ndims, nvars, natts, unlimdimid;
-      nc_type xtype_in;
-      char name_in[NC_MAX_NAME + 1];
-      int data[DIM5_LEN], data_in[DIM5_LEN];
-      size_t chunksize[NDIMS5] = {5};
-      size_t chunksize_in[NDIMS5];
-      int storage_in;
-      size_t cache_size_in, cache_nelems_in;
-      float cache_preemption_in;
-      int i;
+    SUMMARIZE_ERR;
+    printf("**** testing netCDF-4 functions on netCDF-3 files...");
+    {
+        int dimids[NDIMS5], dimids_in[NDIMS5];
+        int varid;
+        int ndims, nvars, natts, unlimdimid;
+        nc_type xtype_in;
+        char name_in[NC_MAX_NAME + 1];
+        int data[DIM5_LEN], data_in[DIM5_LEN];
+        size_t chunksize[NDIMS5] = {5};
+        size_t chunksize_in[NDIMS5];
+        int storage_in;
+        size_t cache_size_in, cache_nelems_in;
+        float cache_preemption_in;
+        int i;
 
-      for (i = 0; i < DIM5_LEN; i++)
-         data[i] = i;
+        for (i = 0; i < DIM5_LEN; i++)
+            data[i] = i;
 
-      /* Create a netcdf classic file with one dim and one var. */
-      if (nc_create(FILE_NAME, 0, &ncid)) ERR;
-      if (nc_def_dim(ncid, DIM5_NAME, DIM5_LEN, &dimids[0])) ERR;
-      if (dimids[0] != 0) ERR;
-      if (nc_def_var(ncid, VAR_NAME5, NC_INT, NDIMS5, dimids, &varid)) ERR;
+        /* Create a netcdf classic file with one dim and one var. */
+        if (nc_create(FILE_NAME, 0, &ncid)) ERR;
+        if (nc_def_dim(ncid, DIM5_NAME, DIM5_LEN, &dimids[0])) ERR;
+        if (dimids[0] != 0) ERR;
+        if (nc_def_var(ncid, VAR_NAME5, NC_INT, NDIMS5, dimids, &varid)) ERR;
 
-      /* These will return error. */
-      if (nc_def_var_chunking(ncid, varid, NC_CHUNKED, chunksize) != NC_ENOTNC4) ERR;
-      if (nc_set_var_chunk_cache(ncid, varid, CACHE_SIZE, CACHE_NELEMS,
-                                 CACHE_PREEMPTION) != NC_ENOTNC4) ERR;
+        /* These will return error. */
+        if (nc_def_var_chunking(ncid, varid, NC_CHUNKED, chunksize) != NC_ENOTNC4) ERR;
+        if (nc_set_var_chunk_cache(ncid, varid, CACHE_SIZE, CACHE_NELEMS,
+                                   CACHE_PREEMPTION) != NC_ENOTNC4) ERR;
 
-      if (nc_enddef(ncid)) ERR;
-      if (nc_put_var_int(ncid, varid, data)) ERR;
+        if (nc_enddef(ncid)) ERR;
+        if (nc_put_var_int(ncid, varid, data)) ERR;
 
-      /* Check stuff. */
-      if (nc_inq(ncid, &ndims, &nvars, &natts, &unlimdimid)) ERR;
-      if (ndims != NDIMS5 || nvars != 1 || natts != 0 ||
-          unlimdimid != -1) ERR;
-      if (nc_inq_varids(ncid, &nvars, varids_in)) ERR;
-      if (nvars != 1) ERR;
-      if (varids_in[0] != 0) ERR;
-      if (nc_inq_var(ncid, 0, name_in, &xtype_in, &ndims, dimids_in, &natts)) ERR;
-      if (strcmp(name_in, VAR_NAME5) || xtype_in != NC_INT || ndims != 1 || natts != 0 ||
-	  dimids_in[0] != 0) ERR;
+        /* Check stuff. */
+        if (nc_inq(ncid, &ndims, &nvars, &natts, &unlimdimid)) ERR;
+        if (ndims != NDIMS5 || nvars != 1 || natts != 0 ||
+            unlimdimid != -1) ERR;
+        if (nc_inq_varids(ncid, &nvars, varids_in)) ERR;
+        if (nvars != 1) ERR;
+        if (varids_in[0] != 0) ERR;
+        if (nc_inq_var(ncid, 0, name_in, &xtype_in, &ndims, dimids_in, &natts)) ERR;
+        if (strcmp(name_in, VAR_NAME5) || xtype_in != NC_INT || ndims != 1 || natts != 0 ||
+            dimids_in[0] != 0) ERR;
 
-      /* This call fails. */
-      if (nc_get_var_chunk_cache(ncid, varid, &cache_size_in, &cache_nelems_in,
-				 &cache_preemption_in) != NC_ENOTNC4) ERR;
+        /* This call fails. */
+        if (nc_get_var_chunk_cache(ncid, varid, &cache_size_in, &cache_nelems_in,
+                                   &cache_preemption_in) != NC_ENOTNC4) ERR;
 
-      /* This call passes but does nothing. */
-      if (nc_inq_var_chunking(ncid, 0, &storage_in, chunksize_in)) ERR;
+        /* This call passes but does nothing. */
+        if (nc_inq_var_chunking(ncid, 0, &storage_in, chunksize_in)) ERR;
 
-      if (nc_get_var_int(ncid, varid, data_in)) ERR;
-      for (i = 0; i < DIM5_LEN; i++)
-         if (data[i] != data_in[i])
-	    ERR_RET;
+        if (nc_get_var_int(ncid, varid, data_in)) ERR;
+        for (i = 0; i < DIM5_LEN; i++)
+            if (data[i] != data_in[i])
+                ERR_RET;
 
-      if (nc_close(ncid)) ERR;
+        if (nc_close(ncid)) ERR;
 
-      /* Open the file and check the same stuff. */
-      if (nc_open(FILE_NAME, NC_NOWRITE, &ncid)) ERR;
+        /* Open the file and check the same stuff. */
+        if (nc_open(FILE_NAME, NC_NOWRITE, &ncid)) ERR;
 
-      /* Check stuff. */
-      if (nc_inq(ncid, &ndims, &nvars, &natts, &unlimdimid)) ERR;
-      if (ndims != NDIMS5 || nvars != 1 || natts != 0 ||
-          unlimdimid != -1) ERR;
-      if (nc_inq_varids(ncid, &nvars, varids_in)) ERR;
-      if (nvars != 1) ERR;
-      if (varids_in[0] != 0) ERR;
-      if (nc_inq_var(ncid, 0, name_in, &xtype_in, &ndims, dimids_in, &natts)) ERR;
-      if (strcmp(name_in, VAR_NAME5) || xtype_in != NC_INT || ndims != 1 || natts != 0 ||
-	  dimids_in[0] != 0) ERR;
+        /* Check stuff. */
+        if (nc_inq(ncid, &ndims, &nvars, &natts, &unlimdimid)) ERR;
+        if (ndims != NDIMS5 || nvars != 1 || natts != 0 ||
+            unlimdimid != -1) ERR;
+        if (nc_inq_varids(ncid, &nvars, varids_in)) ERR;
+        if (nvars != 1) ERR;
+        if (varids_in[0] != 0) ERR;
+        if (nc_inq_var(ncid, 0, name_in, &xtype_in, &ndims, dimids_in, &natts)) ERR;
+        if (strcmp(name_in, VAR_NAME5) || xtype_in != NC_INT || ndims != 1 || natts != 0 ||
+            dimids_in[0] != 0) ERR;
 
-      /* This call fails. */
-      if (nc_get_var_chunk_cache(ncid, varid, &cache_size_in, &cache_nelems_in,
-				 &cache_preemption_in) != NC_ENOTNC4) ERR;
+        /* This call fails. */
+        if (nc_get_var_chunk_cache(ncid, varid, &cache_size_in, &cache_nelems_in,
+                                   &cache_preemption_in) != NC_ENOTNC4) ERR;
 
-      /* This call passes but does nothing. */
-      if (nc_inq_var_chunking(ncid, 0, &storage_in, chunksize_in)) ERR;
+        /* This call passes but does nothing. */
+        if (nc_inq_var_chunking(ncid, 0, &storage_in, chunksize_in)) ERR;
 
-      if (nc_get_var_int(ncid, varid, data_in)) ERR;
-      for (i = 0; i < DIM5_LEN; i++)
-         if (data[i] != data_in[i])
-	    ERR_RET;
-      if (nc_close(ncid)) ERR;
-   }
+        if (nc_get_var_int(ncid, varid, data_in)) ERR;
+        for (i = 0; i < DIM5_LEN; i++)
+            if (data[i] != data_in[i])
+                ERR_RET;
+        if (nc_close(ncid)) ERR;
+    }
 
-   SUMMARIZE_ERR;
-   printf("**** testing contiguous storage...");
-   {
+    SUMMARIZE_ERR;
+    printf("**** testing contiguous storage...");
+    {
 #define DIM6_NAME "D5"
 #define VAR_NAME6 "V5"
 #define DIM6_LEN 100
 
-      int dimids[NDIMS1], dimids_in[NDIMS1];
-      int varid;
-      int ndims, nvars, natts, unlimdimid;
-      nc_type xtype_in;
-      char name_in[NC_MAX_NAME + 1];
-      int data[DIM6_LEN], data_in[DIM6_LEN];
-      size_t chunksize_in[NDIMS1];
-      int storage_in;
-      int i;
+        int dimids[NDIMS1], dimids_in[NDIMS1];
+        int varid;
+        int ndims, nvars, natts, unlimdimid;
+        nc_type xtype_in;
+        char name_in[NC_MAX_NAME + 1];
+        int data[DIM6_LEN], data_in[DIM6_LEN];
+        size_t chunksize_in[NDIMS1];
+        int storage_in;
+        int i;
 
-      for (i = 0; i < DIM6_LEN; i++)
-         data[i] = i;
+        for (i = 0; i < DIM6_LEN; i++)
+            data[i] = i;
 
-      /* Create a netcdf-4 file with one dim and one var. */
-      if (nc_create(FILE_NAME, NC_NETCDF4, &ncid)) ERR;
-      if (nc_def_dim(ncid, DIM6_NAME, DIM6_LEN, &dimids[0])) ERR;
-      if (dimids[0] != 0) ERR;
-      if (nc_def_var(ncid, VAR_NAME6, NC_INT, NDIMS1, dimids, &varid)) ERR;
-      if (nc_def_var_chunking(ncid, varid, NC_CONTIGUOUS, NULL)) ERR;
-      if (nc_put_var_int(ncid, varid, data)) ERR;
+        /* Create a netcdf-4 file with one dim and one var. */
+        if (nc_create(FILE_NAME, NC_NETCDF4, &ncid)) ERR;
+        if (nc_def_dim(ncid, DIM6_NAME, DIM6_LEN, &dimids[0])) ERR;
+        if (dimids[0] != 0) ERR;
+        if (nc_def_var(ncid, VAR_NAME6, NC_INT, NDIMS1, dimids, &varid)) ERR;
+        if (nc_def_var_chunking(ncid, varid, NC_CONTIGUOUS, NULL)) ERR;
+        if (nc_put_var_int(ncid, varid, data)) ERR;
 
-      /* Check stuff. */
-      if (nc_inq(ncid, &ndims, &nvars, &natts, &unlimdimid)) ERR;
-      if (ndims != NDIMS1 || nvars != 1 || natts != 0 ||
-          unlimdimid != -1) ERR;
-      if (nc_inq_varids(ncid, &nvars, varids_in)) ERR;
-      if (nvars != 1) ERR;
-      if (varids_in[0] != 0) ERR;
-      if (nc_inq_var(ncid, 0, name_in, &xtype_in, &ndims, dimids_in, &natts)) ERR;
-      if (strcmp(name_in, VAR_NAME6) || xtype_in != NC_INT || ndims != 1 || natts != 0 ||
-	  dimids_in[0] != 0) ERR;
-      if (nc_inq_var_chunking(ncid, 0, &storage_in, chunksize_in)) ERR;
-      if (storage_in != NC_CONTIGUOUS) ERR;
-      if (nc_get_var_int(ncid, varid, data_in)) ERR;
-      for (i = 0; i < DIM6_LEN; i++)
-         if (data_in[i] != data[i])
-	    ERR_RET;
-      if (nc_close(ncid)) ERR;
+        /* Check stuff. */
+        if (nc_inq(ncid, &ndims, &nvars, &natts, &unlimdimid)) ERR;
+        if (ndims != NDIMS1 || nvars != 1 || natts != 0 ||
+            unlimdimid != -1) ERR;
+        if (nc_inq_varids(ncid, &nvars, varids_in)) ERR;
+        if (nvars != 1) ERR;
+        if (varids_in[0] != 0) ERR;
+        if (nc_inq_var(ncid, 0, name_in, &xtype_in, &ndims, dimids_in, &natts)) ERR;
+        if (strcmp(name_in, VAR_NAME6) || xtype_in != NC_INT || ndims != 1 || natts != 0 ||
+            dimids_in[0] != 0) ERR;
+        if (nc_inq_var_chunking(ncid, 0, &storage_in, chunksize_in)) ERR;
+        if (storage_in != NC_CONTIGUOUS) ERR;
+        if (nc_get_var_int(ncid, varid, data_in)) ERR;
+        for (i = 0; i < DIM6_LEN; i++)
+            if (data_in[i] != data[i])
+                ERR_RET;
+        if (nc_close(ncid)) ERR;
 
-      /* Open the file and check the same stuff. */
-      if (nc_open(FILE_NAME, NC_NOWRITE, &ncid)) ERR;
+        /* Open the file and check the same stuff. */
+        if (nc_open(FILE_NAME, NC_NOWRITE, &ncid)) ERR;
 
-      /* Check stuff. */
-      if (nc_inq(ncid, &ndims, &nvars, &natts, &unlimdimid)) ERR;
-      if (ndims != NDIMS1 || nvars != 1 || natts != 0 ||
-          unlimdimid != -1) ERR;
-      if (nc_inq_varids(ncid, &nvars, varids_in)) ERR;
-      if (nvars != 1) ERR;
-      if (varids_in[0] != 0) ERR;
-      if (nc_inq_var(ncid, 0, name_in, &xtype_in, &ndims, dimids_in, &natts)) ERR;
-      if (strcmp(name_in, VAR_NAME6) || xtype_in != NC_INT || ndims != 1 || natts != 0 ||
-	  dimids_in[0] != 0) ERR;
-      if (nc_inq_var_chunking(ncid, 0, &storage_in, chunksize_in)) ERR;
-      if (storage_in != NC_CONTIGUOUS) ERR;
-      if (nc_get_var_int(ncid, varid, data_in)) ERR;
-      for (i = 0; i < DIM6_LEN; i++)
-         if (data[i] != data_in[i])
-	    ERR_RET;
-      if (nc_close(ncid)) ERR;
-   }
+        /* Check stuff. */
+        if (nc_inq(ncid, &ndims, &nvars, &natts, &unlimdimid)) ERR;
+        if (ndims != NDIMS1 || nvars != 1 || natts != 0 ||
+            unlimdimid != -1) ERR;
+        if (nc_inq_varids(ncid, &nvars, varids_in)) ERR;
+        if (nvars != 1) ERR;
+        if (varids_in[0] != 0) ERR;
+        if (nc_inq_var(ncid, 0, name_in, &xtype_in, &ndims, dimids_in, &natts)) ERR;
+        if (strcmp(name_in, VAR_NAME6) || xtype_in != NC_INT || ndims != 1 || natts != 0 ||
+            dimids_in[0] != 0) ERR;
+        if (nc_inq_var_chunking(ncid, 0, &storage_in, chunksize_in)) ERR;
+        if (storage_in != NC_CONTIGUOUS) ERR;
+        if (nc_get_var_int(ncid, varid, data_in)) ERR;
+        for (i = 0; i < DIM6_LEN; i++)
+            if (data[i] != data_in[i])
+                ERR_RET;
+        if (nc_close(ncid)) ERR;
+    }
 
-   SUMMARIZE_ERR;
-   printf("**** testing extreme numbers dude...");
-   {
+    SUMMARIZE_ERR;
+    printf("**** testing extreme numbers dude...");
+    {
 #define VAR_NAME7 "V5"
 #define DIM6_LEN 100
 
-      int varid;
-      int ndims, nvars, natts, unlimdimid;
-      nc_type xtype_in;
-      char name_in[NC_MAX_NAME + 1];
+        int varid;
+        int ndims, nvars, natts, unlimdimid;
+        nc_type xtype_in;
+        char name_in[NC_MAX_NAME + 1];
 /*      unsigned long long data = 9223372036854775807ull, data_in;*/
-      unsigned long long data = 9223372036854775817ull, data_in;
+        unsigned long long data = 9223372036854775817ull, data_in;
 
-      /* Create a netcdf-4 file with scalar var. */
-      if (nc_create(FILE_NAME, NC_NETCDF4, &ncid)) ERR;
-      if (nc_def_var(ncid, VAR_NAME7, NC_UINT64, 0, NULL, &varid)) ERR;
-      if (nc_put_var_ulonglong(ncid, varid, &data)) ERR;
+        /* Create a netcdf-4 file with scalar var. */
+        if (nc_create(FILE_NAME, NC_NETCDF4, &ncid)) ERR;
+        if (nc_def_var(ncid, VAR_NAME7, NC_UINT64, 0, NULL, &varid)) ERR;
+        if (nc_put_var_ulonglong(ncid, varid, &data)) ERR;
 
-      /* Check stuff. */
-      if (nc_inq(ncid, &ndims, &nvars, &natts, &unlimdimid)) ERR;
-      if (ndims != 0 || nvars != 1 || natts != 0 || unlimdimid != -1) ERR;
-      if (nc_inq_varids(ncid, &nvars, varids_in)) ERR;
-      if (nvars != 1 || varids_in[0] != 0) ERR;
-      if (nc_inq_var(ncid, 0, name_in, &xtype_in, &ndims, NULL, &natts)) ERR;
-      if (strcmp(name_in, VAR_NAME7) || xtype_in != NC_UINT64 || ndims != 0 || natts != 0) ERR;
-      if (nc_get_var_ulonglong(ncid, varid, &data_in)) ERR;
-      if (data_in != data) ERR;
-      if (nc_close(ncid)) ERR;
+        /* Check stuff. */
+        if (nc_inq(ncid, &ndims, &nvars, &natts, &unlimdimid)) ERR;
+        if (ndims != 0 || nvars != 1 || natts != 0 || unlimdimid != -1) ERR;
+        if (nc_inq_varids(ncid, &nvars, varids_in)) ERR;
+        if (nvars != 1 || varids_in[0] != 0) ERR;
+        if (nc_inq_var(ncid, 0, name_in, &xtype_in, &ndims, NULL, &natts)) ERR;
+        if (strcmp(name_in, VAR_NAME7) || xtype_in != NC_UINT64 || ndims != 0 || natts != 0) ERR;
+        if (nc_get_var_ulonglong(ncid, varid, &data_in)) ERR;
+        if (data_in != data) ERR;
+        if (nc_close(ncid)) ERR;
 
-      /* Open the file and check the same stuff. */
-      if (nc_open(FILE_NAME, NC_NOWRITE, &ncid)) ERR;
-      if (nc_inq(ncid, &ndims, &nvars, &natts, &unlimdimid)) ERR;
-      if (ndims != 0 || nvars != 1 || natts != 0 || unlimdimid != -1) ERR;
-      if (nc_inq_varids(ncid, &nvars, varids_in)) ERR;
-      if (nvars != 1 || varids_in[0] != 0) ERR;
-      if (nc_inq_var(ncid, 0, name_in, &xtype_in, &ndims, NULL, &natts)) ERR;
-      if (strcmp(name_in, VAR_NAME7) || xtype_in != NC_UINT64 || ndims != 0 || natts != 0) ERR;
-      if (nc_get_var_ulonglong(ncid, varid, &data_in)) ERR;
-      if (data_in != data) ERR;
-      if (nc_close(ncid)) ERR;
-   }
+        /* Open the file and check the same stuff. */
+        if (nc_open(FILE_NAME, NC_NOWRITE, &ncid)) ERR;
+        if (nc_inq(ncid, &ndims, &nvars, &natts, &unlimdimid)) ERR;
+        if (ndims != 0 || nvars != 1 || natts != 0 || unlimdimid != -1) ERR;
+        if (nc_inq_varids(ncid, &nvars, varids_in)) ERR;
+        if (nvars != 1 || varids_in[0] != 0) ERR;
+        if (nc_inq_var(ncid, 0, name_in, &xtype_in, &ndims, NULL, &natts)) ERR;
+        if (strcmp(name_in, VAR_NAME7) || xtype_in != NC_UINT64 || ndims != 0 || natts != 0) ERR;
+        if (nc_get_var_ulonglong(ncid, varid, &data_in)) ERR;
+        if (data_in != data) ERR;
+        if (nc_close(ncid)) ERR;
+    }
 
-   SUMMARIZE_ERR;
-   printf("**** testing error codes for name clashes...");
-   {
+    SUMMARIZE_ERR;
+    printf("**** testing error codes for name clashes...");
+    {
 #define GENERIC_NAME "bob"
-      int ncid, varid, numgrps, ntypes;
+        int ncid, varid, numgrps, ntypes;
 
-      /* Create a netcdf-4 file with one var. */
-      if (nc_create(FILE_NAME, NC_NETCDF4, &ncid)) ERR;
-      if (nc_def_var(ncid, GENERIC_NAME, NC_BYTE, 0, NULL, &varid)) ERR;
+        /* Create a netcdf-4 file with one var. */
+        if (nc_create(FILE_NAME, NC_NETCDF4, &ncid)) ERR;
+        if (nc_def_var(ncid, GENERIC_NAME, NC_BYTE, 0, NULL, &varid)) ERR;
 
-      /* These don'e work, because the name is already in use. Make
-       * sure the correct error is returned. */
-      if (nc_def_grp(ncid, GENERIC_NAME, NULL) != NC_ENAMEINUSE) ERR;
-      if (nc_def_opaque(ncid, 1, GENERIC_NAME, NULL) != NC_ENAMEINUSE) ERR;
+        /* These don'e work, because the name is already in use. Make
+         * sure the correct error is returned. */
+        if (nc_def_grp(ncid, GENERIC_NAME, NULL) != NC_ENAMEINUSE) ERR;
+        if (nc_def_opaque(ncid, 1, GENERIC_NAME, NULL) != NC_ENAMEINUSE) ERR;
 
-      /* Close it. */
-      if (nc_close(ncid)) ERR;
+        /* Close it. */
+        if (nc_close(ncid)) ERR;
 
-      /* Open the file and check. */
-      if (nc_open(FILE_NAME, NC_WRITE, &ncid)) ERR;
-      if (nc_inq_varids(ncid, &nvars_in, varids_in)) ERR;
-      if (nvars_in != 1 || varids_in[0] != 0) ERR;
-      if (nc_inq_varname(ncid, 0, name_in)) ERR;
-      if (strcmp(name_in, GENERIC_NAME)) ERR;
-      if (nc_inq_grps(ncid, &numgrps, NULL)) ERR;
-      if (numgrps) ERR;
-      if (nc_inq_typeids(ncid, &ntypes, NULL)) ERR;
-      if (ntypes) ERR;
-      if (nc_close(ncid)) ERR;
-   }
+        /* Open the file and check. */
+        if (nc_open(FILE_NAME, NC_WRITE, &ncid)) ERR;
+        if (nc_inq_varids(ncid, &nvars_in, varids_in)) ERR;
+        if (nvars_in != 1 || varids_in[0] != 0) ERR;
+        if (nc_inq_varname(ncid, 0, name_in)) ERR;
+        if (strcmp(name_in, GENERIC_NAME)) ERR;
+        if (nc_inq_grps(ncid, &numgrps, NULL)) ERR;
+        if (numgrps) ERR;
+        if (nc_inq_typeids(ncid, &ntypes, NULL)) ERR;
+        if (ntypes) ERR;
+        if (nc_close(ncid)) ERR;
+    }
 
-   SUMMARIZE_ERR;
-   printf("**** testing error codes for name clashes some more...");
+    SUMMARIZE_ERR;
+    printf("**** testing error codes for name clashes some more...");
 
-   {
+    {
 #define GENERIC_NAME "bob"
-      int ncid, varid, numgrps, ntypes;
+        int ncid, varid, numgrps, ntypes;
 
-      /* Create a netcdf-4 file with one type. */
-      if (nc_create(FILE_NAME, NC_NETCDF4, &ncid)) ERR;
-      if (nc_def_opaque(ncid, 1, GENERIC_NAME, NULL)) ERR;
+        /* Create a netcdf-4 file with one type. */
+        if (nc_create(FILE_NAME, NC_NETCDF4, &ncid)) ERR;
+        if (nc_def_opaque(ncid, 1, GENERIC_NAME, NULL)) ERR;
 
-      /* These don'e work, because the name is already in use. Make
-       * sure the correct error is returned. */
-      if (nc_def_grp(ncid, GENERIC_NAME, NULL) != NC_ENAMEINUSE) ERR;
-      if (nc_def_var(ncid, GENERIC_NAME, NC_BYTE, 0, NULL, &varid) != NC_ENAMEINUSE) ERR;
+        /* These don'e work, because the name is already in use. Make
+         * sure the correct error is returned. */
+        if (nc_def_grp(ncid, GENERIC_NAME, NULL) != NC_ENAMEINUSE) ERR;
+        if (nc_def_var(ncid, GENERIC_NAME, NC_BYTE, 0, NULL, &varid) != NC_ENAMEINUSE) ERR;
 
-      /* Close it. */
-      if (nc_close(ncid)) ERR;
+        /* Close it. */
+        if (nc_close(ncid)) ERR;
 
-      /* Open the file and check. */
-      if (nc_open(FILE_NAME, NC_WRITE, &ncid)) ERR;
-      if (nc_inq_varids(ncid, &nvars_in, varids_in)) ERR;
-      if (nvars_in) ERR;
-      if (nc_inq_grps(ncid, &numgrps, NULL)) ERR;
-      if (numgrps) ERR;
-      if (nc_inq_typeids(ncid, &ntypes, NULL)) ERR;
-      if (ntypes != 1) ERR;
-      if (nc_close(ncid)) ERR;
-   }
-   SUMMARIZE_ERR;
-   printf("**** testing error codes for name clashes even more...");
+        /* Open the file and check. */
+        if (nc_open(FILE_NAME, NC_WRITE, &ncid)) ERR;
+        if (nc_inq_varids(ncid, &nvars_in, varids_in)) ERR;
+        if (nvars_in) ERR;
+        if (nc_inq_grps(ncid, &numgrps, NULL)) ERR;
+        if (numgrps) ERR;
+        if (nc_inq_typeids(ncid, &ntypes, NULL)) ERR;
+        if (ntypes != 1) ERR;
+        if (nc_close(ncid)) ERR;
+    }
+    SUMMARIZE_ERR;
+    printf("**** testing error codes for name clashes even more...");
 
-   {
+    {
 #define GENERIC_NAME "bob"
-      int ncid, varid, numgrps, ntypes;
+        int ncid, varid, numgrps, ntypes;
 
-      /* Create a netcdf-4 file with one group. */
-      if (nc_create(FILE_NAME, NC_NETCDF4, &ncid)) ERR;
-      if (nc_def_grp(ncid, GENERIC_NAME, NULL)) ERR;
+        /* Create a netcdf-4 file with one group. */
+        if (nc_create(FILE_NAME, NC_NETCDF4, &ncid)) ERR;
+        if (nc_def_grp(ncid, GENERIC_NAME, NULL)) ERR;
 
-      /* These don'e work, because the name is already in use. Make
-       * sure the correct error is returned. */
-      if (nc_def_opaque(ncid, 1, GENERIC_NAME, NULL) != NC_ENAMEINUSE) ERR;
-      if (nc_def_var(ncid, GENERIC_NAME, NC_BYTE, 0, NULL, &varid) != NC_ENAMEINUSE) ERR;
+        /* These don'e work, because the name is already in use. Make
+         * sure the correct error is returned. */
+        if (nc_def_opaque(ncid, 1, GENERIC_NAME, NULL) != NC_ENAMEINUSE) ERR;
+        if (nc_def_var(ncid, GENERIC_NAME, NC_BYTE, 0, NULL, &varid) != NC_ENAMEINUSE) ERR;
 
-      /* Close it. */
-      if (nc_close(ncid)) ERR;
+        /* Close it. */
+        if (nc_close(ncid)) ERR;
 
-      /* Open the file and check. */
-      if (nc_open(FILE_NAME, NC_WRITE, &ncid)) ERR;
-      if (nc_inq_varids(ncid, &nvars_in, varids_in)) ERR;
-      if (nvars_in) ERR;
-      if (nc_inq_grps(ncid, &numgrps, NULL)) ERR;
-      if (numgrps != 1) ERR;
-      if (nc_inq_typeids(ncid, &ntypes, NULL)) ERR;
-      if (ntypes) ERR;
-      if (nc_close(ncid)) ERR;
-   }
-   SUMMARIZE_ERR;
-   printf("**** testing error code for too-large chunks...");
-   {
+        /* Open the file and check. */
+        if (nc_open(FILE_NAME, NC_WRITE, &ncid)) ERR;
+        if (nc_inq_varids(ncid, &nvars_in, varids_in)) ERR;
+        if (nvars_in) ERR;
+        if (nc_inq_grps(ncid, &numgrps, NULL)) ERR;
+        if (numgrps != 1) ERR;
+        if (nc_inq_typeids(ncid, &ntypes, NULL)) ERR;
+        if (ntypes) ERR;
+        if (nc_close(ncid)) ERR;
+    }
+    SUMMARIZE_ERR;
+    printf("**** testing error code for too-large chunks...");
+    {
 #define NDIMS17 2
 #define DIM17_NAME "personality"
 #define DIM17_NAME_2 "good_looks"
@@ -1326,257 +1326,257 @@ main(int argc, char **argv)
 #define DIM17_LEN 2147483644 /* max dimension size - 2GB - 4. */
 #define DIM17_2_LEN 1000
 
-      int dimids[NDIMS17], dimids_in[NDIMS17];
-      int varid;
-      int ndims, nvars, natts, unlimdimid;
-      nc_type xtype_in;
-      char name_in[NC_MAX_NAME + 1];
-      size_t chunksize[NDIMS17] = {5, 5};
-      size_t bad_chunksize[NDIMS17] = {5, DIM17_LEN};
-      size_t chunksize_in[NDIMS17];
-      int storage_in;
-      int d;
+        int dimids[NDIMS17], dimids_in[NDIMS17];
+        int varid;
+        int ndims, nvars, natts, unlimdimid;
+        nc_type xtype_in;
+        char name_in[NC_MAX_NAME + 1];
+        size_t chunksize[NDIMS17] = {5, 5};
+        size_t bad_chunksize[NDIMS17] = {5, DIM17_LEN};
+        size_t chunksize_in[NDIMS17];
+        int storage_in;
+        int d;
 
-      /* Create a netcdf-4 file with two dims and one var. */
-      if (nc_create(FILE_NAME, NC_NETCDF4, &ncid)) ERR;
-      if (nc_def_dim(ncid, DIM17_NAME, DIM17_LEN, &dimids[0])) ERR;
-      if (nc_def_dim(ncid, DIM17_NAME_2, DIM17_2_LEN, &dimids[1])) ERR;
-      if (dimids[0] != 0 || dimids[1] != 1) ERR;
-      if (nc_def_var(ncid, VAR_NAME17, NC_UINT64, NDIMS17, dimids, &varid)) ERR;
-      if (nc_def_var_chunking(ncid, varid, NC_CHUNKED, bad_chunksize) != NC_EBADCHUNK) ERR;
-      if (nc_def_var_chunking(ncid, varid, NC_CHUNKED, chunksize)) ERR;
+        /* Create a netcdf-4 file with two dims and one var. */
+        if (nc_create(FILE_NAME, NC_NETCDF4, &ncid)) ERR;
+        if (nc_def_dim(ncid, DIM17_NAME, DIM17_LEN, &dimids[0])) ERR;
+        if (nc_def_dim(ncid, DIM17_NAME_2, DIM17_2_LEN, &dimids[1])) ERR;
+        if (dimids[0] != 0 || dimids[1] != 1) ERR;
+        if (nc_def_var(ncid, VAR_NAME17, NC_UINT64, NDIMS17, dimids, &varid)) ERR;
+        if (nc_def_var_chunking(ncid, varid, NC_CHUNKED, bad_chunksize) != NC_EBADCHUNK) ERR;
+        if (nc_def_var_chunking(ncid, varid, NC_CHUNKED, chunksize)) ERR;
 
-      /* Check stuff. */
-      if (nc_inq(ncid, &ndims, &nvars, &natts, &unlimdimid)) ERR;
-      if (ndims != NDIMS17 || nvars != 1 || natts != 0 ||
-          unlimdimid != -1) ERR;
-      if (nc_inq_varids(ncid, &nvars, varids_in)) ERR;
-      if (nvars != 1) ERR;
-      if (varids_in[0] != 0) ERR;
-      if (nc_inq_var(ncid, 0, name_in, &xtype_in, &ndims, dimids_in, &natts)) ERR;
-      if (strcmp(name_in, VAR_NAME17) || xtype_in != NC_UINT64 || ndims != 2 || natts != 0 ||
-	  dimids_in[0] != 0 || dimids_in[1] != 1) ERR;
-      if (nc_inq_var_chunking(ncid, 0, &storage_in, chunksize_in)) ERR;
-      for (d = 0; d < NDIMS17; d++)
-	 if (chunksize[d] != chunksize_in[d]) ERR;
-      if (storage_in != NC_CHUNKED) ERR;
-      if (nc_close(ncid)) ERR;
+        /* Check stuff. */
+        if (nc_inq(ncid, &ndims, &nvars, &natts, &unlimdimid)) ERR;
+        if (ndims != NDIMS17 || nvars != 1 || natts != 0 ||
+            unlimdimid != -1) ERR;
+        if (nc_inq_varids(ncid, &nvars, varids_in)) ERR;
+        if (nvars != 1) ERR;
+        if (varids_in[0] != 0) ERR;
+        if (nc_inq_var(ncid, 0, name_in, &xtype_in, &ndims, dimids_in, &natts)) ERR;
+        if (strcmp(name_in, VAR_NAME17) || xtype_in != NC_UINT64 || ndims != 2 || natts != 0 ||
+            dimids_in[0] != 0 || dimids_in[1] != 1) ERR;
+        if (nc_inq_var_chunking(ncid, 0, &storage_in, chunksize_in)) ERR;
+        for (d = 0; d < NDIMS17; d++)
+            if (chunksize[d] != chunksize_in[d]) ERR;
+        if (storage_in != NC_CHUNKED) ERR;
+        if (nc_close(ncid)) ERR;
 
-      /* Open the file and check the same stuff. */
-      if (nc_open(FILE_NAME, NC_NOWRITE, &ncid)) ERR;
+        /* Open the file and check the same stuff. */
+        if (nc_open(FILE_NAME, NC_NOWRITE, &ncid)) ERR;
 
-      /* Check stuff. */
-      if (nc_inq(ncid, &ndims, &nvars, &natts, &unlimdimid)) ERR;
-      if (ndims != NDIMS17 || nvars != 1 || natts != 0 ||
-          unlimdimid != -1) ERR;
-      if (nc_inq_varids(ncid, &nvars, varids_in)) ERR;
-      if (nvars != 1) ERR;
-      if (varids_in[0] != 0) ERR;
-      if (nc_inq_var(ncid, 0, name_in, &xtype_in, &ndims, dimids_in, &natts)) ERR;
-      if (strcmp(name_in, VAR_NAME17) || xtype_in != NC_UINT64 || ndims != 2 || natts != 0 ||
-	  dimids_in[0] != 0 || dimids_in[1] != 1) ERR;
-      if (nc_inq_var_chunking(ncid, 0, &storage_in, chunksize_in)) ERR;
-      for (d = 0; d < NDIMS17; d++)
-	 if (chunksize[d] != chunksize_in[d]) ERR;
-      if (storage_in != NC_CHUNKED) ERR;
-      if (nc_close(ncid)) ERR;
-   }
-   SUMMARIZE_ERR;
+        /* Check stuff. */
+        if (nc_inq(ncid, &ndims, &nvars, &natts, &unlimdimid)) ERR;
+        if (ndims != NDIMS17 || nvars != 1 || natts != 0 ||
+            unlimdimid != -1) ERR;
+        if (nc_inq_varids(ncid, &nvars, varids_in)) ERR;
+        if (nvars != 1) ERR;
+        if (varids_in[0] != 0) ERR;
+        if (nc_inq_var(ncid, 0, name_in, &xtype_in, &ndims, dimids_in, &natts)) ERR;
+        if (strcmp(name_in, VAR_NAME17) || xtype_in != NC_UINT64 || ndims != 2 || natts != 0 ||
+            dimids_in[0] != 0 || dimids_in[1] != 1) ERR;
+        if (nc_inq_var_chunking(ncid, 0, &storage_in, chunksize_in)) ERR;
+        for (d = 0; d < NDIMS17; d++)
+            if (chunksize[d] != chunksize_in[d]) ERR;
+        if (storage_in != NC_CHUNKED) ERR;
+        if (nc_close(ncid)) ERR;
+    }
+    SUMMARIZE_ERR;
 #define DIM8_NAME "num_monkeys"
 #define DIM9_NAME "num_coconuts"
 #define DIM9_LEN 10
 #define VAR_NAME8 "John_Clayton"
 #define VAR_NAME9 "Lord_Greystoke"
 #define VAR_NAME10 "Jane_Porter"
-   printf("**** testing that contiguous storage can't be turned on for vars with unlimited dims or filters...");
-   {
-      int ncid;
-      int dimids[NDIMS1];
-      int varid, varid2;
-      size_t chunksize_in[NDIMS1];
-      int storage_in;
+    printf("**** testing that contiguous storage can't be turned on for vars with unlimited dims or filters...");
+    {
+        int ncid;
+        int dimids[NDIMS1];
+        int varid, varid2;
+        size_t chunksize_in[NDIMS1];
+        int storage_in;
 
-      /* Create a netcdf-4 file with one dim and some vars. */
-      if (nc_create(FILE_NAME, NC_NETCDF4, &ncid)) ERR;
-      if (nc_def_dim(ncid, DIM8_NAME, NC_UNLIMITED, &dimids[0])) ERR;
-      if (nc_def_var(ncid, VAR_NAME8, NC_INT, NDIMS1, dimids, &varid)) ERR;
-      if (nc_def_dim(ncid, DIM9_NAME, DIM9_LEN, &dimids[0])) ERR;
-      if (nc_def_var(ncid, VAR_NAME9, NC_INT, NDIMS1, dimids, &varid2)) ERR;
+        /* Create a netcdf-4 file with one dim and some vars. */
+        if (nc_create(FILE_NAME, NC_NETCDF4, &ncid)) ERR;
+        if (nc_def_dim(ncid, DIM8_NAME, NC_UNLIMITED, &dimids[0])) ERR;
+        if (nc_def_var(ncid, VAR_NAME8, NC_INT, NDIMS1, dimids, &varid)) ERR;
+        if (nc_def_dim(ncid, DIM9_NAME, DIM9_LEN, &dimids[0])) ERR;
+        if (nc_def_var(ncid, VAR_NAME9, NC_INT, NDIMS1, dimids, &varid2)) ERR;
 
-      /* These will fail due to bad parameters. */
-      if (nc_def_var_deflate(ncid, varid2, 0, 1,
-                             NC_MIN_DEFLATE_LEVEL - 1) != NC_EINVAL) ERR;
-      if (nc_def_var_deflate(ncid, varid2, 0, 1,
-                             NC_MAX_DEFLATE_LEVEL + 1) != NC_EINVAL) ERR;
+        /* These will fail due to bad parameters. */
+        if (nc_def_var_deflate(ncid, varid2, 0, 1,
+                               NC_MIN_DEFLATE_LEVEL - 1) != NC_EINVAL) ERR;
+        if (nc_def_var_deflate(ncid, varid2, 0, 1,
+                               NC_MAX_DEFLATE_LEVEL + 1) != NC_EINVAL) ERR;
 
-      /* This will work. */
-      if (nc_def_var_deflate(ncid, varid2, 0, 1, 4)) ERR;
+        /* This will work. */
+        if (nc_def_var_deflate(ncid, varid2, 0, 1, 4)) ERR;
 
-      /* This won't work because of the umlimited dimension. */
-      if (nc_def_var_chunking(ncid, varid, NC_CONTIGUOUS, NULL) != NC_EINVAL) ERR;
+        /* This won't work because of the umlimited dimension. */
+        if (nc_def_var_chunking(ncid, varid, NC_CONTIGUOUS, NULL) != NC_EINVAL) ERR;
 
-      /* This won't work because of the deflate filter. */
-      if (nc_def_var_chunking(ncid, varid2, NC_CONTIGUOUS, NULL) != NC_EINVAL) ERR;
+        /* This won't work because of the deflate filter. */
+        if (nc_def_var_chunking(ncid, varid2, NC_CONTIGUOUS, NULL) != NC_EINVAL) ERR;
 
-      /* Storage must be chunked because of unlimited dimension and
-       * the deflate filter. */
-      if (nc_inq_var_chunking(ncid, varid, &storage_in, chunksize_in)) ERR;
-      if (storage_in != NC_CHUNKED) ERR;
-      if (nc_inq_var_chunking(ncid, varid2, &storage_in, chunksize_in)) ERR;
-      if (storage_in != NC_CHUNKED) ERR;
-      if (nc_close(ncid)) ERR;
+        /* Storage must be chunked because of unlimited dimension and
+         * the deflate filter. */
+        if (nc_inq_var_chunking(ncid, varid, &storage_in, chunksize_in)) ERR;
+        if (storage_in != NC_CHUNKED) ERR;
+        if (nc_inq_var_chunking(ncid, varid2, &storage_in, chunksize_in)) ERR;
+        if (storage_in != NC_CHUNKED) ERR;
+        if (nc_close(ncid)) ERR;
 
-   }
-   SUMMARIZE_ERR;
-   printf("**** testing error conditions on nc_def_var functions...");
-   {
-      int ncid;
-      int dimids[NDIMS1];
-      int bad_dimids[NDIMS1] = {42};
-      int varid;
-      int varid_scalar;
-      int num_models = 2;
-      int m;
-      int mode = NC_NETCDF4;
+    }
+    SUMMARIZE_ERR;
+    printf("**** testing error conditions on nc_def_var functions...");
+    {
+        int ncid;
+        int dimids[NDIMS1];
+        int bad_dimids[NDIMS1] = {42};
+        int varid;
+        int varid_scalar;
+        int num_models = 2;
+        int m;
+        int mode = NC_NETCDF4;
 
-      /* Test without and with classic model. */
-      for (m = 0; m < num_models; m++)
-      {
-         int contiguous_in;
-         size_t chunksizes_in[NDIMS1];
-         int shuffle_in, deflate_in, deflate_level_in;
+        /* Test without and with classic model. */
+        for (m = 0; m < num_models; m++)
+        {
+            int contiguous_in;
+            size_t chunksizes_in[NDIMS1];
+            int shuffle_in, deflate_in, deflate_level_in;
 
-         if (m)
-            mode |= NC_CLASSIC_MODEL;
+            if (m)
+                mode |= NC_CLASSIC_MODEL;
 
-         /* Create a netcdf-4 file. */
-         if (nc_create(FILE_NAME, mode, &ncid)) ERR;
-         if (nc_def_dim(ncid, DIM8_NAME, TEST_VAL_42, &dimids[0])) ERR;
+            /* Create a netcdf-4 file. */
+            if (nc_create(FILE_NAME, mode, &ncid)) ERR;
+            if (nc_def_dim(ncid, DIM8_NAME, TEST_VAL_42, &dimids[0])) ERR;
 
-         /* This won't work. */
-         if (nc_def_var(ncid, VAR_NAME8, NC_INT, NDIMS1, bad_dimids,
-                        &varid) != NC_EBADDIM) ERR;
+            /* This won't work. */
+            if (nc_def_var(ncid, VAR_NAME8, NC_INT, NDIMS1, bad_dimids,
+                           &varid) != NC_EBADDIM) ERR;
 
-         /* This will work. */
-         if (nc_def_var(ncid, VAR_NAME8, NC_INT, NDIMS1, dimids, &varid)) ERR;
-         if (nc_def_var(ncid, VAR_NAME10, NC_INT, 0, NULL, &varid_scalar)) ERR;
+            /* This will work. */
+            if (nc_def_var(ncid, VAR_NAME8, NC_INT, NDIMS1, dimids, &varid)) ERR;
+            if (nc_def_var(ncid, VAR_NAME10, NC_INT, 0, NULL, &varid_scalar)) ERR;
 
-         /* Set the var to contiguous. */
-         if (nc_def_var_chunking(ncid, varid, NC_CONTIGUOUS, NULL)) ERR;
+            /* Set the var to contiguous. */
+            if (nc_def_var_chunking(ncid, varid, NC_CONTIGUOUS, NULL)) ERR;
 
-         /* Now defalte will change the var to chunked. */
-         if (nc_def_var_deflate(ncid, varid, 0, 1, 4)) ERR;
-         if (nc_inq_var_chunking(ncid, varid, &contiguous_in, chunksizes_in)) ERR;
-         if (contiguous_in) ERR;
+            /* Now defalte will change the var to chunked. */
+            if (nc_def_var_deflate(ncid, varid, 0, 1, 4)) ERR;
+            if (nc_inq_var_chunking(ncid, varid, &contiguous_in, chunksizes_in)) ERR;
+            if (contiguous_in) ERR;
 
-         /* Now I can't turn contiguous on, because deflate is on. */
-         if (nc_def_var_chunking(ncid, varid, NC_CONTIGUOUS, NULL) != NC_EINVAL) ERR;
+            /* Now I can't turn contiguous on, because deflate is on. */
+            if (nc_def_var_chunking(ncid, varid, NC_CONTIGUOUS, NULL) != NC_EINVAL) ERR;
 
-         /* Turn off deflation. */
-         if (nc_def_var_deflate(ncid, varid, 0, 0, 0)) ERR;
-         if (nc_inq_var_deflate(ncid, varid, &shuffle_in, &deflate_in, &deflate_level_in)) ERR;
-         if (shuffle_in || deflate_in) ERR;
-         if (nc_inq_var_deflate(ncid, varid, NULL, NULL, NULL)) ERR;
+            /* Turn off deflation. */
+            if (nc_def_var_deflate(ncid, varid, 0, 0, 0)) ERR;
+            if (nc_inq_var_deflate(ncid, varid, &shuffle_in, &deflate_in, &deflate_level_in)) ERR;
+            if (shuffle_in || deflate_in) ERR;
+            if (nc_inq_var_deflate(ncid, varid, NULL, NULL, NULL)) ERR;
 
-         /* Deflate is ignored for scalar. */
-         if (nc_def_var_deflate(ncid, varid_scalar, 0, 1, 4)) ERR;
-         if (nc_inq_var_deflate(ncid, varid, &shuffle_in, &deflate_in, &deflate_level_in)) ERR;
-         if (shuffle_in || deflate_in) ERR;
+            /* Deflate is ignored for scalar. */
+            if (nc_def_var_deflate(ncid, varid_scalar, 0, 1, 4)) ERR;
+            if (nc_inq_var_deflate(ncid, varid, &shuffle_in, &deflate_in, &deflate_level_in)) ERR;
+            if (shuffle_in || deflate_in) ERR;
 
-         /* Turn on shuffle. */
-         if (nc_def_var_deflate(ncid, varid, 1, 0, 0)) ERR;
+            /* Turn on shuffle. */
+            if (nc_def_var_deflate(ncid, varid, 1, 0, 0)) ERR;
 
-         /* Now I can't turn contiguous on, because shuffle is on. */
-         if (nc_def_var_chunking(ncid, varid, NC_CONTIGUOUS, NULL) != NC_EINVAL) ERR;
+            /* Now I can't turn contiguous on, because shuffle is on. */
+            if (nc_def_var_chunking(ncid, varid, NC_CONTIGUOUS, NULL) != NC_EINVAL) ERR;
 
-         /* Turn off shuffle. */
-         if (nc_def_var_deflate(ncid, varid, 0, 0, 0)) ERR;
+            /* Turn off shuffle. */
+            if (nc_def_var_deflate(ncid, varid, 0, 0, 0)) ERR;
 
-         /* Turn on fletcher32. */
-         if (nc_def_var_fletcher32(ncid, varid, 1)) ERR;
+            /* Turn on fletcher32. */
+            if (nc_def_var_fletcher32(ncid, varid, 1)) ERR;
 
-         /* Now I can't turn contiguous on, because fletcher32 is on. */
-         if (nc_def_var_chunking(ncid, varid, NC_CONTIGUOUS, NULL) != NC_EINVAL) ERR;
+            /* Now I can't turn contiguous on, because fletcher32 is on. */
+            if (nc_def_var_chunking(ncid, varid, NC_CONTIGUOUS, NULL) != NC_EINVAL) ERR;
 
-         /* Turn off fletcher32. */
-         if (nc_def_var_fletcher32(ncid, varid, 0)) ERR;
+            /* Turn off fletcher32. */
+            if (nc_def_var_fletcher32(ncid, varid, 0)) ERR;
 
-         /* Now I can make it contiguous again. */
-         if (nc_def_var_chunking(ncid, varid, NC_CONTIGUOUS, NULL)) ERR;
-         if (nc_close(ncid)) ERR;
-      }
-   }
-   SUMMARIZE_ERR;
+            /* Now I can make it contiguous again. */
+            if (nc_def_var_chunking(ncid, varid, NC_CONTIGUOUS, NULL)) ERR;
+            if (nc_close(ncid)) ERR;
+        }
+    }
+    SUMMARIZE_ERR;
 #define DIM8_NAME "num_monkeys"
 #define DIM9_NAME "num_coconuts"
 #define DIM9_LEN 10
 #define VAR_NAME8 "John_Clayton"
 #define VAR_NAME9 "Lord_Greystoke"
-   printf("**** testing that contiguous storage can't be turned on for vars with unlimited dims or filters...");
-   {
-      int ncid;
-      int dimids[NDIMS1];
-      int varid, varid2;
-      size_t chunksize_in[NDIMS1];
-      int storage_in;
+    printf("**** testing that contiguous storage can't be turned on for vars with unlimited dims or filters...");
+    {
+        int ncid;
+        int dimids[NDIMS1];
+        int varid, varid2;
+        size_t chunksize_in[NDIMS1];
+        int storage_in;
 
-      /* Create a netcdf-4 file with one dim and some vars. */
-      if (nc_create(FILE_NAME, NC_NETCDF4, &ncid)) ERR;
-      if (nc_def_dim(ncid, DIM8_NAME, NC_UNLIMITED, &dimids[0])) ERR;
-      if (nc_def_var(ncid, VAR_NAME8, NC_INT, NDIMS1, dimids, &varid)) ERR;
-      if (nc_def_dim(ncid, DIM9_NAME, DIM9_LEN, &dimids[0])) ERR;
-      if (nc_def_var(ncid, VAR_NAME9, NC_INT, NDIMS1, dimids, &varid2)) ERR;
-      if (nc_def_var_deflate(ncid, varid2, 0, 1, 4)) ERR;
+        /* Create a netcdf-4 file with one dim and some vars. */
+        if (nc_create(FILE_NAME, NC_NETCDF4, &ncid)) ERR;
+        if (nc_def_dim(ncid, DIM8_NAME, NC_UNLIMITED, &dimids[0])) ERR;
+        if (nc_def_var(ncid, VAR_NAME8, NC_INT, NDIMS1, dimids, &varid)) ERR;
+        if (nc_def_dim(ncid, DIM9_NAME, DIM9_LEN, &dimids[0])) ERR;
+        if (nc_def_var(ncid, VAR_NAME9, NC_INT, NDIMS1, dimids, &varid2)) ERR;
+        if (nc_def_var_deflate(ncid, varid2, 0, 1, 4)) ERR;
 
-      /* This won't work because of the umlimited dimension. */
-      if (nc_def_var_chunking(ncid, varid, NC_CONTIGUOUS, NULL) != NC_EINVAL) ERR;
+        /* This won't work because of the umlimited dimension. */
+        if (nc_def_var_chunking(ncid, varid, NC_CONTIGUOUS, NULL) != NC_EINVAL) ERR;
 
-      /* This won't work because of the deflate filter. */
-      if (nc_def_var_chunking(ncid, varid2, NC_CONTIGUOUS, NULL) != NC_EINVAL) ERR;
+        /* This won't work because of the deflate filter. */
+        if (nc_def_var_chunking(ncid, varid2, NC_CONTIGUOUS, NULL) != NC_EINVAL) ERR;
 
-      /* Storage must be chunked because of unlimited dimension and
-       * the deflate filter. */
-      if (nc_inq_var_chunking(ncid, varid, &storage_in, chunksize_in)) ERR;
-      if (storage_in != NC_CHUNKED) ERR;
-      if (nc_inq_var_chunking(ncid, varid2, &storage_in, chunksize_in)) ERR;
-      if (storage_in != NC_CHUNKED) ERR;
-      if (nc_close(ncid)) ERR;
+        /* Storage must be chunked because of unlimited dimension and
+         * the deflate filter. */
+        if (nc_inq_var_chunking(ncid, varid, &storage_in, chunksize_in)) ERR;
+        if (storage_in != NC_CHUNKED) ERR;
+        if (nc_inq_var_chunking(ncid, varid2, &storage_in, chunksize_in)) ERR;
+        if (storage_in != NC_CHUNKED) ERR;
+        if (nc_close(ncid)) ERR;
 
-   }
-   SUMMARIZE_ERR;
+    }
+    SUMMARIZE_ERR;
 #define DIM10_NAME "num_monkeys"
 #define DIM11_NAME "num_hats"
 #define VAR_NAME11 "Silly_Sally"
 #define NDIM2 2
-   printf("**** testing very large chunksizes...");
-   {
-      int ncid;
-      int dimid[NDIM2];
-      int varid;
-      size_t chunksize[NDIM2] = {1, (size_t)NC_MAX_INT + (size_t)1};
-      size_t chunksize_in[NDIM2];
-      int chunksize_int_in[NDIM2];
-      int storage_in;
+    printf("**** testing very large chunksizes...");
+    {
+        int ncid;
+        int dimid[NDIM2];
+        int varid;
+        size_t chunksize[NDIM2] = {1, (size_t)NC_MAX_INT + (size_t)1};
+        size_t chunksize_in[NDIM2];
+        int chunksize_int_in[NDIM2];
+        int storage_in;
 
-      /* Create a netcdf-4 file. */
-      if (nc_create(FILE_NAME, NC_NETCDF4, &ncid)) ERR;
-      if (nc_def_dim(ncid, DIM10_NAME, NC_UNLIMITED, &dimid[0])) ERR;
-      if (nc_def_dim(ncid, DIM11_NAME, NC_UNLIMITED, &dimid[1])) ERR;
-      if (nc_def_var(ncid, VAR_NAME11, NC_BYTE, NDIM2, dimid, &varid)) ERR;
-      if (nc_inq_var_chunking(ncid, varid, &storage_in, chunksize_in)) ERR;
-      if (storage_in != NC_CHUNKED) ERR;
+        /* Create a netcdf-4 file. */
+        if (nc_create(FILE_NAME, NC_NETCDF4, &ncid)) ERR;
+        if (nc_def_dim(ncid, DIM10_NAME, NC_UNLIMITED, &dimid[0])) ERR;
+        if (nc_def_dim(ncid, DIM11_NAME, NC_UNLIMITED, &dimid[1])) ERR;
+        if (nc_def_var(ncid, VAR_NAME11, NC_BYTE, NDIM2, dimid, &varid)) ERR;
+        if (nc_inq_var_chunking(ncid, varid, &storage_in, chunksize_in)) ERR;
+        if (storage_in != NC_CHUNKED) ERR;
 
-      /* Set a large chunksize. */
-      if (nc_def_var_chunking(ncid, varid, NC_CHUNKED, chunksize)) ERR;
-      if (nc_inq_var_chunking(ncid, varid, &storage_in, chunksize_in)) ERR;
-      if (storage_in != NC_CHUNKED) ERR;
-      if (chunksize_in[0] != chunksize[0] || chunksize_in[1] != chunksize[1]) ERR;
-      if (nc_inq_var_chunking_ints(ncid, varid, &storage_in, chunksize_int_in) != NC_ERANGE) ERR;
+        /* Set a large chunksize. */
+        if (nc_def_var_chunking(ncid, varid, NC_CHUNKED, chunksize)) ERR;
+        if (nc_inq_var_chunking(ncid, varid, &storage_in, chunksize_in)) ERR;
+        if (storage_in != NC_CHUNKED) ERR;
+        if (chunksize_in[0] != chunksize[0] || chunksize_in[1] != chunksize[1]) ERR;
+        if (nc_inq_var_chunking_ints(ncid, varid, &storage_in, chunksize_int_in) != NC_ERANGE) ERR;
 
-      /* Close the file. */
-      if (nc_close(ncid)) ERR;
+        /* Close the file. */
+        if (nc_close(ncid)) ERR;
 
-   }
-   SUMMARIZE_ERR;
-   FINAL_RESULTS;
+    }
+    SUMMARIZE_ERR;
+    FINAL_RESULTS;
 }

--- a/nc_test4/tst_vars2.c
+++ b/nc_test4/tst_vars2.c
@@ -1585,6 +1585,7 @@ main(int argc, char **argv)
     {
         int ncid, varid, dimid;
         float data[SZIP_DIM_LEN];
+        int options_mask;
         int i;
 
         /* Create data. */
@@ -1595,13 +1596,19 @@ main(int argc, char **argv)
         if (nc_create(FILE_NAME, NC_NETCDF4, &ncid)) ERR;
         if (nc_def_dim(ncid, SZIP_DIM_NAME, SZIP_DIM_LEN, &dimid)) ERR;
         if (nc_def_var(ncid, SZIP_VAR_NAME, NC_FLOAT, 1, &dimid, &varid)) ERR;
+
+        /* Works but does nothing. */
+        if (nc_inq_var_szip(ncid, 0, NULL, NULL)) ERR;
+
+        /* Allows us to tell that szip is not on. */
+        if (nc_inq_var_szip(ncid, 0, &options_mask, NULL)) ERR;
+        if (options_mask != 0) ERR;
+
         if (nc_enddef(ncid)) ERR;
         if (nc_put_var(ncid, varid, data)) ERR;
         if (nc_close(ncid)) ERR;
 
         {
-            int options_mask;
-
             /* Open the file and check. */
             if (nc_open(FILE_NAME2, NC_WRITE, &ncid)) ERR;
 

--- a/nc_test4/tst_vars2.c
+++ b/nc_test4/tst_vars2.c
@@ -1584,10 +1584,7 @@ main(int argc, char **argv)
     printf("**** testing szip inq functions (but szip not required for these tests) ...");
     {
         int ncid, varid, dimid;
-        int cmode = 0;
         float data[SZIP_DIM_LEN];
-        size_t index[1] = {0};
-        int dimid;
         int i;
 
         /* Create data. */

--- a/nc_test4/tst_vars2.c
+++ b/nc_test4/tst_vars2.c
@@ -1599,17 +1599,20 @@ main(int argc, char **argv)
         if (nc_put_var(ncid, varid, data)) ERR;
         if (nc_close(ncid)) ERR;
 
-        /* Open the file and check. */
-        if (nc_open(FILE_NAME2, NC_WRITE, &ncid)) ERR;
-        /* if (nc_inq_varids(ncid, &nvars_in, varids_in)) ERR; */
-        /* if (nvars_in != 1 || varids_in[0] != 0) ERR; */
-        /* if (nc_inq_varname(ncid, 0, name_in)) ERR; */
-        /* if (strcmp(name_in, VAR_NAME)) ERR; */
-        /* if (nc_inq_att(ncid, varid, _FillValue, &xtype_in, &len_in)) ERR; */
-        /* if (xtype_in != NC_BYTE || len_in != 1) ERR; */
-        /* if (nc_get_att(ncid, varid, _FillValue, &fill_value_in)) ERR; */
-        /* if (fill_value_in != fill_value) ERR; */
-        if (nc_close(ncid)) ERR;
+        {
+            int options_mask;
+
+            /* Open the file and check. */
+            if (nc_open(FILE_NAME2, NC_WRITE, &ncid)) ERR;
+
+            /* Works but does nothing. */
+            if (nc_inq_var_szip(ncid, 0, NULL, NULL)) ERR;
+
+            /* Allows us to tell that szip is not on. */
+            if (nc_inq_var_szip(ncid, 0, &options_mask, NULL)) ERR;
+            if (options_mask != 0) ERR;
+            if (nc_close(ncid)) ERR;
+        }
     }
     SUMMARIZE_ERR;
     FINAL_RESULTS;

--- a/nc_test4/tst_vars2.c
+++ b/nc_test4/tst_vars2.c
@@ -1578,45 +1578,40 @@ main(int argc, char **argv)
 
     }
     SUMMARIZE_ERR;
-    printf("**** testing szip inq functions...");
+#define SZIP_DIM_LEN 50
+#define SZIP_DIM_NAME "szip_dim_name"
+#define SZIP_VAR_NAME "szip_var_name"
+    printf("**** testing szip inq functions (but szip not required for these tests) ...");
     {
+        int ncid, varid, dimid;
         int cmode = 0;
-        int schar_data = 0;
+        float data[SZIP_DIM_LEN];
         size_t index[1] = {0};
-        int expected_ret;
         int dimid;
+        int i;
 
-        /* Determined the expected result of setting fill value
-         * late. For historical reasons this is allowed for classic
-         * and 64-bit offset formats, but should never be done. */
-        if (cmode == 0 || cmode == NC_64BIT_OFFSET)
-            expected_ret = NC_NOERR;
-        else
-            expected_ret = NC_ELATEFILL;
+        /* Create data. */
+        for (i = 0; i < SZIP_DIM_LEN; i++)
+            data[i] = i;
 
-        /* Create a netcdf-4 file with one scalar var. Add fill
-         * value. */
-        if (nc_create(FILE_NAME2, cmode, &ncid)) ERR;
-        if (nc_def_dim(ncid, VAR_NAME, TEST_VAL_42, &dimid)) ERR;
-        if (nc_def_var(ncid, VAR_NAME, NC_BYTE, 1, &dimid, &varid)) ERR;
-        if (nc_put_att_schar(ncid, varid, _FillValue, NC_BYTE, 1, &fill_value)) ERR;
+        /* Create a netcdf-4 file with one dim and one var. */
+        if (nc_create(FILE_NAME, NC_NETCDF4, &ncid)) ERR;
+        if (nc_def_dim(ncid, SZIP_DIM_NAME, SZIP_DIM_LEN, &dimid)) ERR;
+        if (nc_def_var(ncid, SZIP_VAR_NAME, NC_FLOAT, 1, &dimid, &varid)) ERR;
         if (nc_enddef(ncid)) ERR;
-        if (nc_put_var1(ncid, varid, index, &schar_data)) ERR;
-        if (nc_redef(ncid)) ERR;
-        if (nc_put_att_schar(ncid, varid, _FillValue, NC_BYTE, 1,
-                             &fill_value) != expected_ret) ERR;
+        if (nc_put_var(ncid, varid, data)) ERR;
         if (nc_close(ncid)) ERR;
 
         /* Open the file and check. */
         if (nc_open(FILE_NAME2, NC_WRITE, &ncid)) ERR;
-        if (nc_inq_varids(ncid, &nvars_in, varids_in)) ERR;
-        if (nvars_in != 1 || varids_in[0] != 0) ERR;
-        if (nc_inq_varname(ncid, 0, name_in)) ERR;
-        if (strcmp(name_in, VAR_NAME)) ERR;
-        if (nc_inq_att(ncid, varid, _FillValue, &xtype_in, &len_in)) ERR;
-        if (xtype_in != NC_BYTE || len_in != 1) ERR;
-        if (nc_get_att(ncid, varid, _FillValue, &fill_value_in)) ERR;
-        if (fill_value_in != fill_value) ERR;
+        /* if (nc_inq_varids(ncid, &nvars_in, varids_in)) ERR; */
+        /* if (nvars_in != 1 || varids_in[0] != 0) ERR; */
+        /* if (nc_inq_varname(ncid, 0, name_in)) ERR; */
+        /* if (strcmp(name_in, VAR_NAME)) ERR; */
+        /* if (nc_inq_att(ncid, varid, _FillValue, &xtype_in, &len_in)) ERR; */
+        /* if (xtype_in != NC_BYTE || len_in != 1) ERR; */
+        /* if (nc_get_att(ncid, varid, _FillValue, &fill_value_in)) ERR; */
+        /* if (fill_value_in != fill_value) ERR; */
         if (nc_close(ncid)) ERR;
     }
     SUMMARIZE_ERR;

--- a/nc_test4/tst_vars3.c
+++ b/nc_test4/tst_vars3.c
@@ -1,5 +1,5 @@
 /* This is part of the netCDF package.
-   Copyright 2018 University Corporation for Atmospheric Research/Unidata
+   Copyright 2020 University Corporation for Atmospheric Research/Unidata
    See COPYRIGHT file for conditions of use.
 
    Test netcdf-4 variables.
@@ -621,5 +621,29 @@ main(int argc, char **argv)
     }
     SUMMARIZE_ERR;
 #endif /* USE_SZIP */
+#ifndef USE_SZIP
+    /* This code is run if szip is not present in HDF5. It checks that
+     * nc_def_var_szip() returns NC_EFILTER in that case. */
+    printf("**** testing szip filter when szip is not built into HDF5...");
+    {
+        int ncid;
+        int dimid;
+        int varid;
+        int options_mask = NC_SZIP_NN_OPTION_MASK;
+        int bits_per_pixel = NC_SZIP_EC_BPP_IN;
+
+        /* Create a netcdf-4 file with one dimensions. */
+        if (nc_create(FILE_NAME, NC_NETCDF4, &ncid)) ERR;
+        if (nc_def_dim(ncid, DIM_NAME_1, DIM_LEN_1, &dimid)) ERR;
+
+        /* Add a var. Turn on szip filter. */
+        if (nc_def_var(ncid, V_SMALL, NC_INT64, NDIMS1, &dimid, &varid)) ERR;
+        if (nc_def_var_chunking(ncid, varid, NC_CHUNKED, NULL)) ERR;
+        if (nc_def_var_szip(ncid, varid, options_mask,
+                            bits_per_pixel) != NC_EFILTER) ERR;
+        if (nc_close(ncid)) ERR;
+    }
+    SUMMARIZE_ERR;
+#endif /* not USE_SZIP */
     FINAL_RESULTS;
 }


### PR DESCRIPTION
Fixes #1618

Also added some documentation to nc_inq_var_szip() docs, and some additional tests, including tests that run when szip is not present in the build.