### PR TITLE
more compact storage tests, plus update of nc_inq_var_chunking() to explain nc_compact

### DIFF
--- a/libdispatch/dvarinq.c
+++ b/libdispatch/dvarinq.c
@@ -358,32 +358,33 @@ nc_inq_var_fletcher32(int ncid, int varid, int *fletcher32p)
       );
 }
 
-/** \ingroup variables
-
-This is a wrapper for nc_inq_var_all().
-
-\param ncid NetCDF or group ID, from a previous call to nc_open(),
-nc_create(), nc_def_grp(), or associated inquiry functions such as
-nc_inq_ncid().
-
-\param varid Variable ID
-
-\param storagep Address of returned storage property, returned as
-::NC_CONTIGUOUS if this variable uses contiguous storage, or
-::NC_CHUNKED if it uses chunked storage. \ref ignored_if_null.
-
-\param chunksizesp The chunksizes will be copied here. \ref
-ignored_if_null.
-
-\returns ::NC_NOERR No error.
-\returns ::NC_EBADID Bad ncid.
-\returns ::NC_ENOTNC4 Not a netCDF-4 file.
-\returns ::NC_ENOTVAR Invalid variable ID.
-
-
-\section nc_inq_var_chunking_example Example
-
-\code
+/**
+ * @ingroup variables
+ *
+ * Get the storage and (for chunked variables) the chunksizes of a
+ * variable. See nc_def_var_chunking() for explanation of storage.
+ *
+ * @param ncid NetCDF or group ID, from a previous call to nc_open(),
+ * nc_create(), nc_def_grp(), or associated inquiry functions such as
+ * nc_inq_ncid().
+ * @param varid Variable ID
+ * @param storagep Address of returned storage property, returned as
+ * ::NC_CONTIGUOUS if this variable uses contiguous storage,
+ * ::NC_CHUNKED if it uses chunked storage, or ::NC_COMPACT for
+ * compact storage. \ref ignored_if_null.
+ * @param chunksizesp The chunksizes will be copied here. \ref
+ * ignored_if_null.
+ *
+ * @return ::NC_NOERR No error.
+ * @return ::NC_EBADID Bad ncid.
+ * @return ::NC_ENOTNC4 Not a netCDF-4 file.
+ * @return ::NC_ENOTVAR Invalid variable ID.
+ *
+ * @author Ed Hartnett
+ *
+ * @section nc_inq_var_chunking_example Example
+ *
+ * @code
         printf("**** testing contiguous storage...");
         {
      #define NDIMS6 1
@@ -415,8 +416,8 @@ ignored_if_null.
 
            if (nc_inq_var_chunking(ncid, 0, &storage_in, chunksize_in)) ERR;
            if (storage_in != NC_CONTIGUOUS) ERR;
-\endcode
-
+@endcode
+*
 */
 int
 nc_inq_var_chunking(int ncid, int varid, int *storagep, size_t *chunksizesp)

--- a/nc_test4/tst_vars4.c
+++ b/nc_test4/tst_vars4.c
@@ -231,6 +231,7 @@ main(int argc, char **argv)
     {
         int ncid, dimid[NDIM2], varid, varid2;
         int data[XDIM_LEN];
+        int storage_in;
         int x;
 
         /* Create some data. */
@@ -247,6 +248,8 @@ main(int argc, char **argv)
         /* Define vars. */
         if (nc_def_var(ncid, Y_NAME, NC_INT, 1, dimid, &varid)) ERR;
         if (nc_def_var_chunking(ncid, varid, NC_COMPACT, NULL)) ERR;
+        if (nc_inq_var_chunking(ncid, varid, &storage_in, NULL)) ERR;
+        if (storage_in != NC_COMPACT) ERR;
         if (nc_def_var(ncid, CLAIR, NC_INT, NDIM2, dimid, &varid2)) ERR;
         /* This won't work, the var is too big for compact! */
         if (nc_def_var_chunking(ncid, varid2, NC_COMPACT, NULL) != NC_EVARSIZE) ERR;

--- a/nc_test4/tst_vars4.c
+++ b/nc_test4/tst_vars4.c
@@ -229,7 +229,7 @@ main(int argc, char **argv)
     SUMMARIZE_ERR;
     printf("**** testing compact storage...");
     {
-        int ncid, dimid[NDIM2], varid, varid2;
+        int ncid, dimid[NDIM2], varid, varid2, varid3;
         int data[XDIM_LEN];
         int storage_in;
         int x;
@@ -253,6 +253,7 @@ main(int argc, char **argv)
         if (nc_def_var(ncid, CLAIR, NC_INT, NDIM2, dimid, &varid2)) ERR;
         /* This won't work, the var is too big for compact! */
         if (nc_def_var_chunking(ncid, varid2, NC_COMPACT, NULL) != NC_EVARSIZE) ERR;
+        if (nc_def_var(ncid, JAMIE, NC_INT, 0, NULL, &varid3)) ERR;
 
         /* Write data. */
         if (nc_put_var_int(ncid, varid, data)) ERR;
@@ -267,7 +268,7 @@ main(int argc, char **argv)
 
             if (nc_open(FILE_NAME, NC_NOWRITE, &ncid)) ERR;
             if (nc_inq(ncid, &ndims, &nvars, NULL, NULL)) ERR;
-            if (ndims != 2 || nvars != 2) ERR;
+            if (ndims != 2 || nvars != 3) ERR;
             if (nc_inq_var_chunking(ncid, varid, &storage_in, NULL)) ERR;
             if (storage_in != NC_COMPACT) ERR;
             if (nc_inq_var_chunking(ncid, varid2, &storage_in, NULL)) ERR;


### PR DESCRIPTION
Part of #1568 

I have already documented compact storage in nc_def_var_chunking(), but nc_inq_var_chunking() needed to be updated.

Also I noticed I was not testing nc_inq_var_chunking() before enddef. This is of course an important thing to test. I have added the test, and it passes fine.