### PR TITLE
fixed for parallel build, largefile build, parallel szip build

### DIFF
--- a/h5_test/tst_h_files.c
+++ b/h5_test/tst_h_files.c
@@ -361,12 +361,6 @@ main()
         if (H5Gclose(grpid) < 0) ERR;
         if (H5Fclose(fileid) < 0) ERR;
 
-        /* Reopen the file and check it. */
-        if ((fileid = H5Fopen(file_name, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) ERR;
-        if (H5Gget_num_objs(fileid, &num_obj) < 0) ERR;
-        if (num_obj) ERR;
-        if (H5Fclose(fileid) < 0) ERR;
-
         /* Delete the huge data file we created. */
         (void) remove(file_name);
     }

--- a/libdispatch/dparallel.c
+++ b/libdispatch/dparallel.c
@@ -289,42 +289,48 @@ nc_open_par_fortran(const char *path, int omode, int comm,
 #endif
 }
 
-/**\ingroup datasets
+/**
+@ingroup datasets
 
 This function will change the parallel access of a variable from independent to
-collective and vice versa. Note when file is opened/created to use PnetCDF
-library to perform parallel I/O underneath, argument varid is ignored and the
-mode changed by this function applies to all variables. This is because PnetCDF
-does not support access mode change for individual variables. In this case,
-users may use NC_GLOBAL in varid argument for better program readability. This
-function is collective, i.e. must be called by all MPI processes defined in the
-MPI communicator used in nc_create_par() or nc_open_par(). In addition, values
-of arguments of this function must be the same among all MPI processes.
+collective and vice versa.
+
+This function is collective, i.e. must be called by all MPI processes
+defined in the MPI communicator used in nc_create_par() or
+nc_open_par(). In addition, values of arguments of this function must
+be the same among all MPI processes.
 
 To obtain a good I/O performance, users are recommended to use collective mode.
 In addition, switching between collective and independent I/O mode can be
 expensive.
 
-In netcdf-c-4.7.4 or later, using hdf5-1.10.2 or later, the zlib and
-fletcher32 filters may be used when writing data with parallel
-I/O. The use of these filters require collective access. Turning on
-the zlib (deflate) or fletcher32 filter for a variable will
-automatically set its access to collective. Attempts to set access to
-independent will return ::NC_EINVAL.
+In netcdf-c-4.7.4 or later, using hdf5-1.10.2 or later, the zlib,
+shuffle, fletcher32 and other filters may be used when writing data
+with parallel I/O. The use of any filters require collective
+access. Turning on any filter for a variable will automatically set
+its access to collective. Attempts to set access to independent will
+return ::NC_EINVAL.
 
-\param ncid NetCDF or group ID, from a previous call to nc_open_par(),
+Note when file is opened/created to use PnetCDF library to perform
+parallel I/O underneath, argument varid is ignored and the mode
+changed by this function applies to all variables. This is because
+PnetCDF does not support access mode change for individual
+variables. In this case, users may use NC_GLOBAL in varid argument for
+better program readability.
+
+@param ncid NetCDF or group ID, from a previous call to nc_open_par(),
 nc_create_par(), nc_def_grp(), or associated inquiry functions such as
 nc_inq_ncid().
 
-\param varid Variable ID
+@param varid Variable ID
 
-\param par_access NC_COLLECTIVE or NC_INDEPENDENT.
+@param par_access NC_COLLECTIVE or NC_INDEPENDENT.
 
-\returns ::NC_NOERR No error.
-\returns ::NC_EBADID Invalid ncid passed.
-\returns ::NC_ENOTVAR Invalid varid passed.
-\returns ::NC_ENOPAR File was not opened with nc_open_par/nc_create_var.
-\returns ::NC_EINVAL Invalid par_access specified, or attempt to set
+@return ::NC_NOERR No error.
+@return ::NC_EBADID Invalid ncid passed.
+@return ::NC_ENOTVAR Invalid varid passed.
+@return ::NC_ENOPAR File was not opened with nc_open_par/nc_create_var.
+@return ::NC_EINVAL Invalid par_access specified, or attempt to set
 filtered variable to independent access.
 
 <h1>Example</h1>
@@ -332,7 +338,7 @@ filtered variable to independent access.
 Here is an example from examples/C/parallel_vara.c which changes the
 parallel access of a variable and then writes to it.
 
-\code
+@code
 #define NY 10
 #define NX 4
 
@@ -366,9 +372,8 @@ parallel access of a variable and then writes to it.
 
     err = nc_put_vara_int(ncid, varid, start, count, &buf[0][0]); ERR
 
-\endcode
-\author Ed Hartnett, Dennis Heimbigner
-\ingroup datasets
+@endcode
+@author Ed Hartnett, Dennis Heimbigner
  */
 int
 nc_var_par_access(int ncid, int varid, int par_access)

--- a/libsrc4/nc4var.c
+++ b/libsrc4/nc4var.c
@@ -446,7 +446,7 @@ NC4_var_par_access(int ncid, int varid, int par_access)
     /* If zlib, shuffle, or fletcher32 filters are in use, then access
      * must be collective. Fail an attempt to set such a variable to
      * independent access. */
-    if ((var->deflate || var->shuffle || var->fletcher32) &&
+    if ((nclistlength(var->filters) || var->shuffle || var->fletcher32) &&
         par_access == NC_INDEPENDENT)
         return NC_EINVAL;
 

--- a/libsrc4/nc4var.c
+++ b/libsrc4/nc4var.c
@@ -443,8 +443,8 @@ NC4_var_par_access(int ncid, int varid, int par_access)
     if (!var) return NC_ENOTVAR;
     assert(var->hdr.id == varid);
 
-    /* If zlib, shuffle, or fletcher32 filters are in use, then access
-     * must be collective. Fail an attempt to set such a variable to
+    /* If any filters filters are in use, then access must be
+     * collective. Fail an attempt to set such a variable to
      * independent access. */
     if ((nclistlength(var->filters) || var->shuffle || var->fletcher32) &&
         par_access == NC_INDEPENDENT)

--- a/nc_test4/tst_parallel5.c
+++ b/nc_test4/tst_parallel5.c
@@ -336,7 +336,7 @@ main(int argc, char **argv)
                           &ncid)) ERR;
         if (nc_def_dim(ncid, SZIP_DIM_NAME, SZIP_DIM_LEN, &dimid)) ERR;
         if (nc_def_var(ncid, SZIP_VAR_NAME, NC_FLOAT, NDIMS1, &dimid, &varid)) ERR;
-        if (nc_def_var_szip(ncid, varid, NC_SZIP_NN, SZIP_PIXELS_PER_BLOCK)) ERR;
+        if (nc_def_var_szip(ncid, varid, H5_SZIP_NN_OPTION_MASK, SZIP_PIXELS_PER_BLOCK)) ERR;
         if (nc_enddef(ncid)) ERR;
         start[0] = mpi_rank * elements_per_pe;
         count[0] = elements_per_pe;


### PR DESCRIPTION
Part of #1639 
Fixes #1652 
Fixes #1653

This fixes compiles of parallel builds.

Also update the documentation for nc_var_par_access() to describe collective vs. independent access with respect to filters.