### PR TITLE
Return error on attempt to set chunking on scalar var

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,7 +7,7 @@ This file contains a high-level description of this package's evolution. Release
 
 ## 4.7.4 - TBD
 
-* [Bug Fix] Attempts to set chunking on scalar vars will now return NC_EINVAL. Scalar vars cannot be chunked. Previously the library ignored these attempts and scalar vars were always stored as contiguous. See [https://github.com/Unidata/netcdf-c/issues/1644].
+* [Bug Fix] Attempts to set filters or chunked storage on scalar vars will now return NC_EINVAL. Scalar vars cannot be chunked, and only chunked vars can have filters. Previously the library ignored these attempts, and always storing scalars as contiguous storage. See [https://github.com/Unidata/netcdf-c/issues/1644].
 * [Enhancement] Support has been added for multiple filters per variable.  See [https://github.com/Unidata/netcdf-c/issues/1584].
 * [Enhancement] Now nc_inq_var_szip retuns 0 for parameter values if szip is not in use for var. See [https://github.com/Unidata/netcdf-c/issues/1618].
 * [Enhancement] Now allow parallel I/O with filters, for HDF5-1.10.3 and later. See [https://github.com/Unidata/netcdf-c/issues/1473].

--- a/libdispatch/dfilter.c
+++ b/libdispatch/dfilter.c
@@ -580,13 +580,16 @@ nc_inq_var_filter(int ncid, int varid, unsigned int* idp, size_t* nparamsp, unsi
 /**
    Define a new variable hdf5 filter.
 
+   Only variables with chunked storage can use filters.
+
    @param ncid File and group ID.
    @param varid Variable ID.
-   @param id
+   @param id Filter ID.
    @param nparams Number of filter parameters.
    @param parms Filter parameters.
 
    @return ::NC_NOERR No error.
+   @return ::NC_EINVAL Variable must be chunked.
    @return ::NC_EBADID Bad ID.
    @author Dennis Heimbigner
 */

--- a/libdispatch/dvar.c
+++ b/libdispatch/dvar.c
@@ -327,7 +327,8 @@ nc_def_var_fill(int ncid, int varid, int no_fill, const void *fill_value)
    to chunked data, with default chunksizes. Use nc_def_var_chunking()
    to tune performance with user-defined chunksizes.
 
-   If this function is called on a scalar variable, it is ignored.
+   If this function is called on a scalar variable, ::NC_EINVAL is
+   returned. Only chunked variables may use filters.
 
    If this function is called on a variable which already has szip
    compression turned on, ::NC_EINVAL is returned.

--- a/libhdf5/hdf5var.c
+++ b/libhdf5/hdf5var.c
@@ -731,8 +731,6 @@ nc_def_var_extra(int ncid, int varid, int *shuffle, int *unused1,
         if (*storage == NC_CHUNKED && var->ndims == 0)
         {
             return NC_EINVAL;
-                /* var->contiguous = NC_TRUE; */
-		/* var->compact = NC_FALSE; */
         } else if (*storage == NC_CHUNKED)
         {
             var->contiguous = NC_FALSE;

--- a/libhdf5/hdf5var.c
+++ b/libhdf5/hdf5var.c
@@ -728,9 +728,11 @@ nc_def_var_extra(int ncid, int varid, int *shuffle, int *unused1,
         }
 
         /* Handle chunked storage settings. */
-        if (*storage == NC_CHUNKED && var->ndims == 0) {
-                var->contiguous = NC_TRUE;
-		var->compact = NC_FALSE;
+        if (*storage == NC_CHUNKED && var->ndims == 0)
+        {
+            return NC_EINVAL;
+                /* var->contiguous = NC_TRUE; */
+		/* var->compact = NC_FALSE; */
         } else if (*storage == NC_CHUNKED)
         {
             var->contiguous = NC_FALSE;

--- a/nc_test4/tst_vars2.c
+++ b/nc_test4/tst_vars2.c
@@ -912,18 +912,18 @@ main(int argc, char **argv)
         if (nc_def_var(ncid, VAR_NAME5_2, NC_INT, 0, NULL, &varid2)) ERR;
         if (nc_def_var(ncid, VAR_NAME5_3, NC_INT, 0, NULL, &varid3)) ERR;
         if (nc_def_var(ncid, VAR_NAME5_4, NC_INT, NDIMS5, dimids, &varid4)) ERR;
-        if (nc_def_var_chunking(ncid, varid2, NC_CHUNKED, chunksize)) ERR;
+        if (nc_def_var_chunking(ncid, varid2, NC_CHUNKED, chunksize) != NC_EINVAL) ERR;
         if (nc_def_var_chunking(ncid, varid3, NC_CONTIGUOUS, NULL)) ERR;
         if (nc_def_var_chunking(ncid, varid4, NC_CHUNKED, large_chunksize) != NC_EBADCHUNK) ERR;
-        if (nc_def_var_chunking_ints(ncid, varid2, NC_CHUNKED, chunksize_int)) ERR;
+        if (nc_def_var_chunking_ints(ncid, varid2, NC_CHUNKED, chunksize_int) != NC_EINVAL) ERR;
         if (nc_def_var_chunking_ints(ncid, varid1, NC_CHUNKED, chunksize_int)) ERR;
-        if (nc_inq_var_chunking_ints(ncid, varid2, NULL, chunksize_int_in)) ERR;
+        if (nc_inq_var_chunking_ints(ncid, varid2, &storage_in, NULL)) ERR;
+        if (storage_in != NC_CONTIGUOUS) ERR;
         if (nc_inq_var_chunking_ints(ncid, varid1, NULL, chunksize_int_in)) ERR;
         for (d = 0; d < NDIMS5; d++)
             if (chunksize_int_in[d] != chunksize[d] * 2) ERR;
         if (nc_inq_var_chunking_ints(ncid, varid1, &storage_in, NULL)) ERR;
         if (storage_in != NC_CHUNKED) ERR;
-        if (nc_inq_var_chunking_ints(ncid, varid2, NULL, chunksize_int_in)) ERR;
         if (nc_inq_var_chunking_ints(ncid, varid3, &storage_in, NULL)) ERR;
         if (storage_in != NC_CONTIGUOUS) ERR;
         if (nc_inq_var_chunking_ints(ncid, varid3, &storage_in, chunksize_int_in)) ERR;


### PR DESCRIPTION
Fixes #1644 

Also updated documentation to note that nc_def_var_deflate, nc_def_var_filter cannot be used on scalar vars.