### PR TITLE
refactor storage in NC_VAR_INFO_T

### DIFF
--- a/h5_test/tst_h_vars2.c
+++ b/h5_test/tst_h_vars2.c
@@ -29,71 +29,71 @@ main()
 #define MAX_SYMBOL_LEN 2
 #define ELEMENTS_NAME "Elements"
     {
-        hid_t did[NUM_ELEMENTS], fapl_id, fcpl_id, gcpl_id;
-        hsize_t num_obj;
-        hid_t fileid, grpid, spaceid;
-        int i;
-        H5O_info_t obj_info;
-        char names[NUM_ELEMENTS][MAX_SYMBOL_LEN + 1] = {"H", "He", "Li", "Be", "B", "C"};
-        char name[MAX_SYMBOL_LEN + 1];
-        ssize_t size;
+	hid_t did[NUM_ELEMENTS], fapl_id, fcpl_id, gcpl_id;
+	hsize_t num_obj;
+	hid_t fileid, grpid, spaceid;
+	int i;
+	H5O_info_t obj_info;
+	char names[NUM_ELEMENTS][MAX_SYMBOL_LEN + 1] = {"H", "He", "Li", "Be", "B", "C"};
+	char name[MAX_SYMBOL_LEN + 1];
+	ssize_t size;
 
-        /* Create file, setting latest_format in access propertly list
-         * and H5P_CRT_ORDER_TRACKED in the creation property list. */
-        if ((fapl_id = H5Pcreate(H5P_FILE_ACCESS)) < 0) ERR;
-        if (H5Pset_libver_bounds(fapl_id, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0) ERR;
-        if ((fcpl_id = H5Pcreate(H5P_FILE_CREATE)) < 0) ERR;
-        if (H5Pset_link_creation_order(fcpl_id, H5P_CRT_ORDER_TRACKED|H5P_CRT_ORDER_INDEXED) < 0) ERR;
-        if ((fileid = H5Fcreate(FILE_NAME, H5F_ACC_TRUNC, fcpl_id, fapl_id)) < 0) ERR;
+	/* Create file, setting latest_format in access propertly list
+	 * and H5P_CRT_ORDER_TRACKED in the creation property list. */
+	if ((fapl_id = H5Pcreate(H5P_FILE_ACCESS)) < 0) ERR;
+	if (H5Pset_libver_bounds(fapl_id, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0) ERR;
+	if ((fcpl_id = H5Pcreate(H5P_FILE_CREATE)) < 0) ERR;
+	if (H5Pset_link_creation_order(fcpl_id, H5P_CRT_ORDER_TRACKED|H5P_CRT_ORDER_INDEXED) < 0) ERR;
+	if ((fileid = H5Fcreate(FILE_NAME, H5F_ACC_TRUNC, fcpl_id, fapl_id)) < 0) ERR;
 
-        /* Create group, with link_creation_order set in the group
-         * creation property list. */
-        if ((gcpl_id = H5Pcreate(H5P_GROUP_CREATE)) < 0) ERR;
-        if (H5Pset_link_creation_order(gcpl_id, H5P_CRT_ORDER_TRACKED|H5P_CRT_ORDER_INDEXED) < 0) ERR;
-        if ((grpid = H5Gcreate_anon(fileid, gcpl_id, H5P_DEFAULT)) < 0) ERR;
-        if ((H5Olink(grpid, fileid, ELEMENTS_NAME, H5P_DEFAULT, H5P_DEFAULT)) < 0) ERR;
+	/* Create group, with link_creation_order set in the group
+	 * creation property list. */
+	if ((gcpl_id = H5Pcreate(H5P_GROUP_CREATE)) < 0) ERR;
+	if (H5Pset_link_creation_order(gcpl_id, H5P_CRT_ORDER_TRACKED|H5P_CRT_ORDER_INDEXED) < 0) ERR;
+	if ((grpid = H5Gcreate_anon(fileid, gcpl_id, H5P_DEFAULT)) < 0) ERR;
+	if ((H5Olink(grpid, fileid, ELEMENTS_NAME, H5P_DEFAULT, H5P_DEFAULT)) < 0) ERR;
 
-        /* Create a scalar space. */
-        if ((spaceid = H5Screate(H5S_SCALAR)) < 0) ERR;
+	/* Create a scalar space. */
+	if ((spaceid = H5Screate(H5S_SCALAR)) < 0) ERR;
 
-        /* Create the variables, one per element. */
-        for (i = 0; i < NUM_ELEMENTS; i++)
-        {
-            if ((did[i] = H5Dcreate(grpid, names[i], H5T_NATIVE_INT,
-                                    spaceid, H5P_DEFAULT)) < 0) ERR;
-            if (H5Dclose(did[i]) < 0) ERR;
-        }
+	/* Create the variables, one per element. */
+	for (i = 0; i < NUM_ELEMENTS; i++)
+	{
+	    if ((did[i] = H5Dcreate(grpid, names[i], H5T_NATIVE_INT,
+				    spaceid, H5P_DEFAULT)) < 0) ERR;
+	    if (H5Dclose(did[i]) < 0) ERR;
+	}
 
-        if (H5Pclose(fapl_id) < 0 ||
-            H5Pclose(gcpl_id) < 0 ||
-            H5Sclose(spaceid) < 0 ||
-            H5Gclose(grpid) < 0 ||
-            H5Fclose(fileid) < 0)
-            ERR;
+	if (H5Pclose(fapl_id) < 0 ||
+	    H5Pclose(gcpl_id) < 0 ||
+	    H5Sclose(spaceid) < 0 ||
+	    H5Gclose(grpid) < 0 ||
+	    H5Fclose(fileid) < 0)
+	    ERR;
 
-        /* Now reopen the file and check the order. */
-        if ((fapl_id = H5Pcreate(H5P_FILE_ACCESS)) < 0) ERR;
-        if (H5Pset_libver_bounds(fapl_id, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0) ERR;
-        if ((fileid = H5Fopen(FILE_NAME, H5F_ACC_RDONLY, fapl_id)) < 0) ERR;
-        if ((grpid = H5Gopen(fileid, ELEMENTS_NAME)) < 0) ERR;
+	/* Now reopen the file and check the order. */
+	if ((fapl_id = H5Pcreate(H5P_FILE_ACCESS)) < 0) ERR;
+	if (H5Pset_libver_bounds(fapl_id, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0) ERR;
+	if ((fileid = H5Fopen(FILE_NAME, H5F_ACC_RDONLY, fapl_id)) < 0) ERR;
+	if ((grpid = H5Gopen(fileid, ELEMENTS_NAME)) < 0) ERR;
 
-        if (H5Gget_num_objs(grpid, &num_obj) < 0) ERR;
-        if (num_obj != NUM_ELEMENTS) ERR;
-        for (i = 0; i < num_obj; i++)
-        {
-            if (H5Oget_info_by_idx(grpid, ".", H5_INDEX_CRT_ORDER, H5_ITER_INC,
-                                   i, &obj_info, H5P_DEFAULT) < 0) ERR;
-            if (obj_info.type != H5O_TYPE_DATASET) ERR;
-            if ((size = H5Lget_name_by_idx(grpid, ".", H5_INDEX_CRT_ORDER, H5_ITER_INC, i,
-                                           NULL, 0, H5P_DEFAULT)) < 0) ERR;
-            H5Lget_name_by_idx(grpid, ".", H5_INDEX_CRT_ORDER, H5_ITER_INC, i,
-                               name, size+1, H5P_DEFAULT);
-            if (strcmp(name, names[i])) ERR;
-        }
-        if (H5Pclose(fapl_id) < 0 ||
-            H5Gclose(grpid) < 0 ||
-            H5Fclose(fileid) < 0)
-            ERR;
+	if (H5Gget_num_objs(grpid, &num_obj) < 0) ERR;
+	if (num_obj != NUM_ELEMENTS) ERR;
+	for (i = 0; i < num_obj; i++)
+	{
+	    if (H5Oget_info_by_idx(grpid, ".", H5_INDEX_CRT_ORDER, H5_ITER_INC,
+				   i, &obj_info, H5P_DEFAULT) < 0) ERR;
+	    if (obj_info.type != H5O_TYPE_DATASET) ERR;
+	    if ((size = H5Lget_name_by_idx(grpid, ".", H5_INDEX_CRT_ORDER, H5_ITER_INC, i,
+					   NULL, 0, H5P_DEFAULT)) < 0) ERR;
+	    H5Lget_name_by_idx(grpid, ".", H5_INDEX_CRT_ORDER, H5_ITER_INC, i,
+			       name, size+1, H5P_DEFAULT);
+	    if (strcmp(name, names[i])) ERR;
+	}
+	if (H5Pclose(fapl_id) < 0 ||
+	    H5Gclose(grpid) < 0 ||
+	    H5Fclose(fileid) < 0)
+	    ERR;
     }
     SUMMARIZE_ERR;
     printf("*** Checking HDF5 variable ordering in root group...");
@@ -104,69 +104,69 @@ main()
 #define DIMSCALE_NAME "Joe"
 #define NAME_ATTRIBUTE "short"
     {
-        hid_t fapl_id, fcpl_id;
-        hid_t fileid, grpid;
-        hsize_t num_obj;
-        int i;
-        H5O_info_t obj_info;
-        char names[NUM_DIMSCALES][MAX_SYMBOL_LEN + 1] = {"b", "a"};
-        char name[MAX_SYMBOL_LEN + 1];
-        hid_t dimscaleid;
-        hid_t dimscale_spaceid;
-        hsize_t dimscale_dims[1] = {DIM1_LEN};
-        ssize_t size;
+	hid_t fapl_id, fcpl_id;
+	hid_t fileid, grpid;
+	hsize_t num_obj;
+	int i;
+	H5O_info_t obj_info;
+	char names[NUM_DIMSCALES][MAX_SYMBOL_LEN + 1] = {"b", "a"};
+	char name[MAX_SYMBOL_LEN + 1];
+	hid_t dimscaleid;
+	hid_t dimscale_spaceid;
+	hsize_t dimscale_dims[1] = {DIM1_LEN};
+	ssize_t size;
 
-        /* Create file, setting latest_format in access propertly list
-         * and H5P_CRT_ORDER_TRACKED in the creation property list. */
-        if ((fapl_id = H5Pcreate(H5P_FILE_ACCESS)) < 0) ERR;
-        if (H5Pset_libver_bounds(fapl_id, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0) ERR;
-        if ((fcpl_id = H5Pcreate(H5P_FILE_CREATE)) < 0) ERR;
-        if (H5Pset_link_creation_order(fcpl_id, H5P_CRT_ORDER_TRACKED|H5P_CRT_ORDER_INDEXED) < 0) ERR;
-        if ((fileid = H5Fcreate(FILE_NAME, H5F_ACC_TRUNC, fcpl_id, fapl_id)) < 0) ERR;
+	/* Create file, setting latest_format in access propertly list
+	 * and H5P_CRT_ORDER_TRACKED in the creation property list. */
+	if ((fapl_id = H5Pcreate(H5P_FILE_ACCESS)) < 0) ERR;
+	if (H5Pset_libver_bounds(fapl_id, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0) ERR;
+	if ((fcpl_id = H5Pcreate(H5P_FILE_CREATE)) < 0) ERR;
+	if (H5Pset_link_creation_order(fcpl_id, H5P_CRT_ORDER_TRACKED|H5P_CRT_ORDER_INDEXED) < 0) ERR;
+	if ((fileid = H5Fcreate(FILE_NAME, H5F_ACC_TRUNC, fcpl_id, fapl_id)) < 0) ERR;
 
-        if ((dimscale_spaceid = H5Screate_simple(1, dimscale_dims,
-                                                 dimscale_dims)) < 0) ERR;
-        /* Create the variables, one per element. */
-        for (i = 0; i < NUM_DIMSCALES; i++)
-        {
-            /* Create our dimension scale. Use the built-in NAME attribute
-             * on the dimscale. */
-            if ((dimscaleid = H5Dcreate(fileid, names[i], H5T_NATIVE_INT,
-                                        dimscale_spaceid, H5P_DEFAULT)) < 0) ERR;
-            if (H5DSset_scale(dimscaleid, NAME_ATTRIBUTE) < 0) ERR;
+	if ((dimscale_spaceid = H5Screate_simple(1, dimscale_dims,
+						 dimscale_dims)) < 0) ERR;
+	/* Create the variables, one per element. */
+	for (i = 0; i < NUM_DIMSCALES; i++)
+	{
+	    /* Create our dimension scale. Use the built-in NAME attribute
+	     * on the dimscale. */
+	    if ((dimscaleid = H5Dcreate(fileid, names[i], H5T_NATIVE_INT,
+					dimscale_spaceid, H5P_DEFAULT)) < 0) ERR;
+	    if (H5DSset_scale(dimscaleid, NAME_ATTRIBUTE) < 0) ERR;
 
-            if (H5Dclose(dimscaleid) < 0) ERR;
-        }
+	    if (H5Dclose(dimscaleid) < 0) ERR;
+	}
 
-        if (H5Pclose(fapl_id) < 0 ||
-            H5Pclose(fcpl_id) < 0 ||
-            H5Sclose(dimscale_spaceid) < 0 ||
-            H5Fclose(fileid) < 0)
-            ERR;
+	if (H5Pclose(fapl_id) < 0 ||
+	    H5Pclose(fcpl_id) < 0 ||
+	    H5Sclose(dimscale_spaceid) < 0 ||
+	    H5Fclose(fileid) < 0)
+	    ERR;
 
-        /* Now reopen the file and check the order. */
-        if ((fapl_id = H5Pcreate(H5P_FILE_ACCESS)) < 0) ERR;
-        if (H5Pset_libver_bounds(fapl_id, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0) ERR;
-        if ((fileid = H5Fopen(FILE_NAME, H5F_ACC_RDONLY, fapl_id)) < 0) ERR;
-        if ((grpid = H5Gopen(fileid, "/")) < 0) ERR;
+	/* Now reopen the file and check the order. */
+	if ((fapl_id = H5Pcreate(H5P_FILE_ACCESS)) < 0) ERR;
+	if (H5Pset_libver_bounds(fapl_id, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0) ERR;
+	if ((fileid = H5Fopen(FILE_NAME, H5F_ACC_RDONLY, fapl_id)) < 0) ERR;
+	if ((grpid = H5Gopen(fileid, "/")) < 0) ERR;
 
-        if (H5Gget_num_objs(grpid, &num_obj) < 0) ERR;
-        if (num_obj != NUM_DIMSCALES) ERR;
-        for (i = 0; i < num_obj; i++)
-        {
-            if (H5Oget_info_by_idx(grpid, ".", H5_INDEX_CRT_ORDER, H5_ITER_INC,
-                                   i, &obj_info, H5P_DEFAULT) < 0) ERR;
-            if (obj_info.type != H5O_TYPE_DATASET) ERR;
-            if ((size = H5Lget_name_by_idx(grpid, ".", H5_INDEX_CRT_ORDER, H5_ITER_INC, i,
-                                           NULL, 0, H5P_DEFAULT)) < 0) ERR;
-            if (H5Lget_name_by_idx(grpid, ".", H5_INDEX_CRT_ORDER, H5_ITER_INC, i,
-                                   name, size+1, H5P_DEFAULT) < 0) ERR;
-            if (strcmp(name, names[i])) ERR;
-        }
-        if (H5Pclose(fapl_id) < 0 ||
-            H5Gclose(grpid) < 0 ||
-            H5Fclose(fileid) < 0)
-            ERR;
+	if (H5Gget_num_objs(grpid, &num_obj) < 0) ERR;
+	if (num_obj != NUM_DIMSCALES) ERR;
+	for (i = 0; i < num_obj; i++)
+	{
+	    if (H5Oget_info_by_idx(grpid, ".", H5_INDEX_CRT_ORDER, H5_ITER_INC,
+				   i, &obj_info, H5P_DEFAULT) < 0) ERR;
+	    if (obj_info.type != H5O_TYPE_DATASET) ERR;
+	    if ((size = H5Lget_name_by_idx(grpid, ".", H5_INDEX_CRT_ORDER, H5_ITER_INC, i,
+					   NULL, 0, H5P_DEFAULT)) < 0) ERR;
+	    if (H5Lget_name_by_idx(grpid, ".", H5_INDEX_CRT_ORDER, H5_ITER_INC, i,
+				   name, size+1, H5P_DEFAULT) < 0) ERR;
+	    if (strcmp(name, names[i])) ERR;
+	}
+	if (H5Pclose(fapl_id) < 0 ||
+	    H5Gclose(grpid) < 0 ||
+	    H5Fclose(fileid) < 0)
+	    ERR;
     }
     SUMMARIZE_ERR;
     printf("*** Checking HDF5 variable ordering flags with redef-type situations...");
@@ -176,82 +176,82 @@ main()
 #define ELEMENTS_NAME "Elements"
 #define VAR_NAME "Sears_Zemansky_and_Young"
     {
-        hid_t did, fapl_id, fcpl_id, gcpl_id, attid;
-        hsize_t num_obj;
-        hid_t fileid, grpid, spaceid;
-        float val = 3.1495;
-        H5O_info_t obj_info;
-        char name[MAX_NAME_LEN + 1];
-        ssize_t size;
+	hid_t did, fapl_id, fcpl_id, gcpl_id, attid;
+	hsize_t num_obj;
+	hid_t fileid, grpid, spaceid;
+	float val = 3.1495;
+	H5O_info_t obj_info;
+	char name[MAX_NAME_LEN + 1];
+	ssize_t size;
 
-        /* Create file, setting latest_format in access propertly list
-         * and H5P_CRT_ORDER_TRACKED in the creation property list. */
-        if ((fapl_id = H5Pcreate(H5P_FILE_ACCESS)) < 0) ERR;
-        if (H5Pset_libver_bounds(fapl_id, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0) ERR;
-        if ((fcpl_id = H5Pcreate(H5P_FILE_CREATE)) < 0) ERR;
-        if (H5Pset_link_creation_order(fcpl_id, H5P_CRT_ORDER_TRACKED|H5P_CRT_ORDER_INDEXED) < 0) ERR;
-        if ((fileid = H5Fcreate(FILE_NAME, H5F_ACC_TRUNC, fcpl_id, fapl_id)) < 0) ERR;
+	/* Create file, setting latest_format in access propertly list
+	 * and H5P_CRT_ORDER_TRACKED in the creation property list. */
+	if ((fapl_id = H5Pcreate(H5P_FILE_ACCESS)) < 0) ERR;
+	if (H5Pset_libver_bounds(fapl_id, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0) ERR;
+	if ((fcpl_id = H5Pcreate(H5P_FILE_CREATE)) < 0) ERR;
+	if (H5Pset_link_creation_order(fcpl_id, H5P_CRT_ORDER_TRACKED|H5P_CRT_ORDER_INDEXED) < 0) ERR;
+	if ((fileid = H5Fcreate(FILE_NAME, H5F_ACC_TRUNC, fcpl_id, fapl_id)) < 0) ERR;
 
-        /* Create group, with link_creation_order set in the group
-         * creation property list. */
-        if ((gcpl_id = H5Pcreate(H5P_GROUP_CREATE)) < 0) ERR;
-        if (H5Pset_link_creation_order(gcpl_id, H5P_CRT_ORDER_TRACKED|H5P_CRT_ORDER_INDEXED) < 0) ERR;
-        if ((grpid = H5Gcreate_anon(fileid, gcpl_id, H5P_DEFAULT)) < 0) ERR;
-        if ((H5Olink(grpid, fileid, ELEMENTS_NAME, H5P_DEFAULT, H5P_DEFAULT)) < 0) ERR;
+	/* Create group, with link_creation_order set in the group
+	 * creation property list. */
+	if ((gcpl_id = H5Pcreate(H5P_GROUP_CREATE)) < 0) ERR;
+	if (H5Pset_link_creation_order(gcpl_id, H5P_CRT_ORDER_TRACKED|H5P_CRT_ORDER_INDEXED) < 0) ERR;
+	if ((grpid = H5Gcreate_anon(fileid, gcpl_id, H5P_DEFAULT)) < 0) ERR;
+	if ((H5Olink(grpid, fileid, ELEMENTS_NAME, H5P_DEFAULT, H5P_DEFAULT)) < 0) ERR;
 
-        /* Create a scalar space. */
-        if ((spaceid = H5Screate(H5S_SCALAR)) < 0) ERR;
+	/* Create a scalar space. */
+	if ((spaceid = H5Screate(H5S_SCALAR)) < 0) ERR;
 
-        /* Create a scalar variable. */
-        if ((did = H5Dcreate(grpid, VAR_NAME, H5T_NATIVE_INT,
-                             spaceid, H5P_DEFAULT)) < 0) ERR;
-        if (H5Dclose(did) < 0) ERR;
+	/* Create a scalar variable. */
+	if ((did = H5Dcreate(grpid, VAR_NAME, H5T_NATIVE_INT,
+			     spaceid, H5P_DEFAULT)) < 0) ERR;
+	if (H5Dclose(did) < 0) ERR;
 
-        /* Flush the HDF5 buffers. */
-        H5Fflush(fileid, H5F_SCOPE_GLOBAL);
+	/* Flush the HDF5 buffers. */
+	H5Fflush(fileid, H5F_SCOPE_GLOBAL);
 
-        /* Delete the variable. Just to be mean. */
-        if (H5Gunlink(grpid, VAR_NAME) < 0) ERR;
+	/* Delete the variable. Just to be mean. */
+	if (H5Gunlink(grpid, VAR_NAME) < 0) ERR;
 
-        /* Re-reate the scalar variable. */
-        if ((did = H5Dcreate(grpid, VAR_NAME, H5T_NATIVE_INT,
-                             spaceid, H5P_DEFAULT)) < 0) ERR;
+	/* Re-reate the scalar variable. */
+	if ((did = H5Dcreate(grpid, VAR_NAME, H5T_NATIVE_INT,
+			     spaceid, H5P_DEFAULT)) < 0) ERR;
 
-        /* Add an attribute. */
-        if ((attid = H5Acreate(did, "Some_Attribute", H5T_NATIVE_FLOAT, spaceid,
-                               H5P_DEFAULT)) < 0) ERR;
-        if (H5Awrite(attid, H5T_NATIVE_FLOAT, &val) < 0) ERR;
+	/* Add an attribute. */
+	if ((attid = H5Acreate(did, "Some_Attribute", H5T_NATIVE_FLOAT, spaceid,
+			       H5P_DEFAULT)) < 0) ERR;
+	if (H5Awrite(attid, H5T_NATIVE_FLOAT, &val) < 0) ERR;
 
-        if (H5Aclose(attid) < 0) ERR;
-        if (H5Dclose(did) < 0) ERR;
+	if (H5Aclose(attid) < 0) ERR;
+	if (H5Dclose(did) < 0) ERR;
 
-        if (H5Pclose(fapl_id) < 0 ||
-            H5Pclose(gcpl_id) < 0 ||
-            H5Sclose(spaceid) < 0 ||
-            H5Gclose(grpid) < 0 ||
-            H5Fclose(fileid) < 0)
-            ERR;
+	if (H5Pclose(fapl_id) < 0 ||
+	    H5Pclose(gcpl_id) < 0 ||
+	    H5Sclose(spaceid) < 0 ||
+	    H5Gclose(grpid) < 0 ||
+	    H5Fclose(fileid) < 0)
+	    ERR;
 
-        /* Now reopen the file and check the order. */
-        if ((fapl_id = H5Pcreate(H5P_FILE_ACCESS)) < 0) ERR;
-        if (H5Pset_libver_bounds(fapl_id, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0) ERR;
-        if ((fileid = H5Fopen(FILE_NAME, H5F_ACC_RDONLY, fapl_id)) < 0) ERR;
-        if ((grpid = H5Gopen(fileid, ELEMENTS_NAME)) < 0) ERR;
+	/* Now reopen the file and check the order. */
+	if ((fapl_id = H5Pcreate(H5P_FILE_ACCESS)) < 0) ERR;
+	if (H5Pset_libver_bounds(fapl_id, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0) ERR;
+	if ((fileid = H5Fopen(FILE_NAME, H5F_ACC_RDONLY, fapl_id)) < 0) ERR;
+	if ((grpid = H5Gopen(fileid, ELEMENTS_NAME)) < 0) ERR;
 
-        if (H5Gget_num_objs(grpid, &num_obj) < 0) ERR;
-        if (num_obj != 1) ERR;
-        if (H5Oget_info_by_idx(grpid, ".", H5_INDEX_CRT_ORDER, H5_ITER_INC,
-                               0, &obj_info, H5P_DEFAULT) < 0) ERR;
-        if (obj_info.type != H5O_TYPE_DATASET) ERR;
-        if ((size = H5Lget_name_by_idx(grpid, ".", H5_INDEX_CRT_ORDER, H5_ITER_INC, 0,
-                                       NULL, 0, H5P_DEFAULT)) < 0) ERR;
-        H5Lget_name_by_idx(grpid, ".", H5_INDEX_CRT_ORDER, H5_ITER_INC, 0,
-                           name, size+1, H5P_DEFAULT);
-        if (strcmp(name, VAR_NAME)) ERR;
-        if (H5Pclose(fapl_id) < 0 ||
-            H5Gclose(grpid) < 0 ||
-            H5Fclose(fileid) < 0)
-            ERR;
+	if (H5Gget_num_objs(grpid, &num_obj) < 0) ERR;
+	if (num_obj != 1) ERR;
+	if (H5Oget_info_by_idx(grpid, ".", H5_INDEX_CRT_ORDER, H5_ITER_INC,
+			       0, &obj_info, H5P_DEFAULT) < 0) ERR;
+	if (obj_info.type != H5O_TYPE_DATASET) ERR;
+	if ((size = H5Lget_name_by_idx(grpid, ".", H5_INDEX_CRT_ORDER, H5_ITER_INC, 0,
+				       NULL, 0, H5P_DEFAULT)) < 0) ERR;
+	H5Lget_name_by_idx(grpid, ".", H5_INDEX_CRT_ORDER, H5_ITER_INC, 0,
+			   name, size+1, H5P_DEFAULT);
+	if (strcmp(name, VAR_NAME)) ERR;
+	if (H5Pclose(fapl_id) < 0 ||
+	    H5Gclose(grpid) < 0 ||
+	    H5Fclose(fileid) < 0)
+	    ERR;
     }
     SUMMARIZE_ERR;
     printf("*** Checking HDF5 variable compession and filters...");
@@ -266,82 +266,82 @@ main()
 #define DEFLATE_LEVEL 3
 #define SIMPLE_VAR_NAME "data"
 
-        hid_t fapl_id, fcpl_id;
-        hid_t datasetid;
-        hid_t fileid, grpid, spaceid, plistid;
-        int data_in[NX][NY], data_out[NX][NY];
-        hsize_t fdims[NDIMS], fmaxdims[NDIMS];
-        hsize_t chunksize[NDIMS], dimsize[NDIMS], maxdimsize[NDIMS];
-        int x, y;
+	hid_t fapl_id, fcpl_id;
+	hid_t datasetid;
+	hid_t fileid, grpid, spaceid, plistid;
+	int data_in[NX][NY], data_out[NX][NY];
+	hsize_t fdims[NDIMS], fmaxdims[NDIMS];
+	hsize_t chunksize[NDIMS], dimsize[NDIMS], maxdimsize[NDIMS];
+	int x, y;
 
-        /* Create some data to write. */
-        for (x = 0; x < NX; x++)
-            for (y = 0; y < NY; y++)
-                data_out[x][y] = x * NY + y;
+	/* Create some data to write. */
+	for (x = 0; x < NX; x++)
+	    for (y = 0; y < NY; y++)
+		data_out[x][y] = x * NY + y;
 
-        /* Create file, setting latest_format in access propertly list
-         * and H5P_CRT_ORDER_TRACKED in the creation property list. */
-        if ((fapl_id = H5Pcreate(H5P_FILE_ACCESS)) < 0) ERR;
-        if (H5Pset_libver_bounds(fapl_id, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0) ERR;
-        if ((fcpl_id = H5Pcreate(H5P_FILE_CREATE)) < 0) ERR;
-        if (H5Pset_link_creation_order(fcpl_id, H5P_CRT_ORDER_TRACKED|H5P_CRT_ORDER_INDEXED) < 0) ERR;
-        if ((fileid = H5Fcreate(FILE_NAME, H5F_ACC_TRUNC, fcpl_id, fapl_id)) < 0) ERR;
+	/* Create file, setting latest_format in access propertly list
+	 * and H5P_CRT_ORDER_TRACKED in the creation property list. */
+	if ((fapl_id = H5Pcreate(H5P_FILE_ACCESS)) < 0) ERR;
+	if (H5Pset_libver_bounds(fapl_id, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0) ERR;
+	if ((fcpl_id = H5Pcreate(H5P_FILE_CREATE)) < 0) ERR;
+	if (H5Pset_link_creation_order(fcpl_id, H5P_CRT_ORDER_TRACKED|H5P_CRT_ORDER_INDEXED) < 0) ERR;
+	if ((fileid = H5Fcreate(FILE_NAME, H5F_ACC_TRUNC, fcpl_id, fapl_id)) < 0) ERR;
 
-        if ((grpid = H5Gopen(fileid, "/")) < 0) ERR;
+	if ((grpid = H5Gopen(fileid, "/")) < 0) ERR;
 
-        dimsize[0] = maxdimsize[0] = NX;
-        dimsize[1] = maxdimsize[1] = NY;
-        if ((spaceid = H5Screate_simple(NDIMS, dimsize, maxdimsize)) < 0) ERR;
+	dimsize[0] = maxdimsize[0] = NX;
+	dimsize[1] = maxdimsize[1] = NY;
+	if ((spaceid = H5Screate_simple(NDIMS, dimsize, maxdimsize)) < 0) ERR;
 
-        /* Create property lust. */
-        if ((plistid = H5Pcreate(H5P_DATASET_CREATE)) < 0) ERR;
+	/* Create property lust. */
+	if ((plistid = H5Pcreate(H5P_DATASET_CREATE)) < 0) ERR;
 
-        /* Set up chunksizes. */
-        chunksize[0] = NX;
-        chunksize[1] = NY;
-        if (H5Pset_chunk(plistid, NDIMS, chunksize) < 0)ERR;
+	/* Set up chunksizes. */
+	chunksize[0] = NX;
+	chunksize[1] = NY;
+	if (H5Pset_chunk(plistid, NDIMS, chunksize) < 0)ERR;
 
-        /* Set up compression. */
-        if (H5Pset_deflate(plistid, DEFLATE_LEVEL) < 0) ERR;
+	/* Set up compression. */
+	if (H5Pset_deflate(plistid, DEFLATE_LEVEL) < 0) ERR;
 
-        /* Create the variable. */
-        if ((datasetid = H5Dcreate(grpid, SIMPLE_VAR_NAME, H5T_NATIVE_INT,
-                                   spaceid, plistid)) < 0) ERR;
+	/* Create the variable. */
+	if ((datasetid = H5Dcreate(grpid, SIMPLE_VAR_NAME, H5T_NATIVE_INT,
+				   spaceid, plistid)) < 0) ERR;
 
-        /* Write the data. */
-        if (H5Dwrite(datasetid, H5T_NATIVE_INT, H5S_ALL, H5S_ALL,
-                     H5P_DEFAULT, data_out) < 0) ERR;
+	/* Write the data. */
+	if (H5Dwrite(datasetid, H5T_NATIVE_INT, H5S_ALL, H5S_ALL,
+		     H5P_DEFAULT, data_out) < 0) ERR;
 
-        if (H5Dclose(datasetid) < 0) ERR;
-        if (H5Pclose(fapl_id) < 0 ||
-            H5Sclose(spaceid) < 0 ||
-            H5Gclose(grpid) < 0 ||
-            H5Fclose(fileid) < 0)
-            ERR;
+	if (H5Dclose(datasetid) < 0) ERR;
+	if (H5Pclose(fapl_id) < 0 ||
+	    H5Sclose(spaceid) < 0 ||
+	    H5Gclose(grpid) < 0 ||
+	    H5Fclose(fileid) < 0)
+	    ERR;
 
-        /* Now reopen the file and check the order. */
-        if ((fapl_id = H5Pcreate(H5P_FILE_ACCESS)) < 0) ERR;
-        if (H5Pset_libver_bounds(fapl_id, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0) ERR;
-        if ((fileid = H5Fopen(FILE_NAME, H5F_ACC_RDONLY, fapl_id)) < 0) ERR;
-        if ((grpid = H5Gopen(fileid, "/")) < 0) ERR;
+	/* Now reopen the file and check the order. */
+	if ((fapl_id = H5Pcreate(H5P_FILE_ACCESS)) < 0) ERR;
+	if (H5Pset_libver_bounds(fapl_id, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0) ERR;
+	if ((fileid = H5Fopen(FILE_NAME, H5F_ACC_RDONLY, fapl_id)) < 0) ERR;
+	if ((grpid = H5Gopen(fileid, "/")) < 0) ERR;
 
-        if ((datasetid = H5Dopen1(grpid, SIMPLE_VAR_NAME)) < 0) ERR;
-        if ((spaceid = H5Dget_space(datasetid)) < 0)
-            if (H5Sget_simple_extent_dims(spaceid, fdims, fmaxdims) > 0) ERR;
-        if (H5Dread(datasetid, H5T_NATIVE_INT, H5S_ALL,
-                    spaceid, H5P_DEFAULT, data_in) < 0) ERR;
+	if ((datasetid = H5Dopen1(grpid, SIMPLE_VAR_NAME)) < 0) ERR;
+	if ((spaceid = H5Dget_space(datasetid)) < 0)
+	    if (H5Sget_simple_extent_dims(spaceid, fdims, fmaxdims) > 0) ERR;
+	if (H5Dread(datasetid, H5T_NATIVE_INT, H5S_ALL,
+		    spaceid, H5P_DEFAULT, data_in) < 0) ERR;
 
-        /* Check the data. */
-        for (x = 0; x < NX; x++)
-            for (y = 0; y < NY; y++)
-                if (data_in[x][y] != data_out[x][y]) ERR_RET;
+	/* Check the data. */
+	for (x = 0; x < NX; x++)
+	    for (y = 0; y < NY; y++)
+		if (data_in[x][y] != data_out[x][y]) ERR_RET;
 
-        if (H5Pclose(fapl_id) < 0 ||
-            H5Dclose(datasetid) < 0 ||
-            H5Sclose(spaceid) < 0 ||
-            H5Gclose(grpid) < 0 ||
-            H5Fclose(fileid) < 0)
-            ERR;
+	if (H5Pclose(fapl_id) < 0 ||
+	    H5Dclose(datasetid) < 0 ||
+	    H5Sclose(spaceid) < 0 ||
+	    H5Gclose(grpid) < 0 ||
+	    H5Fclose(fileid) < 0)
+	    ERR;
     }
     SUMMARIZE_ERR;
     printf("*** Checking fill value of compound type...");
@@ -351,60 +351,60 @@ main()
 #define REF_FILE "ref_tst_compounds.nc"
 #define ATT_NAME "_FillValue"
 
-        typedef struct obs_t {
-            char day ;
-            short elev;
-            int count;
-            float relhum;
-            double time;
-        } obs_t ;
+	typedef struct obs_t {
+	    char day ;
+	    short elev;
+	    int count;
+	    float relhum;
+	    double time;
+	} obs_t ;
 
-        obs_t f1, f2;
-        obs_t m = {-99, -99, -99, -99, -99};
-        hid_t fileid, grpid, attid, typeid, datasetid, native_typeid, propid;
-        H5D_fill_value_t fill_status;
-        char file_in[STR_LEN * 2];
-        size_t type_size;
+	obs_t f1, f2;
+	obs_t m = {-99, -99, -99, -99, -99};
+	hid_t fileid, grpid, attid, typeid, datasetid, native_typeid, propid;
+	H5D_fill_value_t fill_status;
+	char file_in[STR_LEN * 2];
+	size_t type_size;
 
-        if (getenv("srcdir"))
-        {
-            strcpy(file_in, getenv("srcdir"));
-            strcat(file_in, "/");
-            strcat(file_in, REF_FILE);
-        }
-        else
-            strcpy(file_in, REF_FILE);
+	if (getenv("srcdir"))
+	{
+	    strcpy(file_in, getenv("srcdir"));
+	    strcat(file_in, "/");
+	    strcat(file_in, REF_FILE);
+	}
+	else
+	    strcpy(file_in, REF_FILE);
 
-        /* Open file and read fill value of the variable. */
-        if ((fileid = H5Fopen(file_in, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0) ERR;
-        if ((grpid = H5Gopen(fileid, "/")) < 0) ERR;
-        if ((datasetid = H5Dopen1(grpid, VAR_NAME2)) < 0) ERR;
-        if ((propid = H5Dget_create_plist(datasetid)) < 0) ERR;
-        if (H5Pfill_value_defined(propid, &fill_status) < 0) ERR;
-        if (fill_status != H5D_FILL_VALUE_USER_DEFINED) ERR;
-        if ((typeid = H5Dget_type(datasetid)) < 0) ERR;
-        if ((native_typeid = H5Tget_native_type(typeid, H5T_DIR_DEFAULT)) < 0) ERR;
-        if (!(type_size = H5Tget_size(native_typeid))) ERR;
-        if (type_size != sizeof(obs_t)) ERR;
-        if (H5Pget_fill_value(propid, native_typeid, &f1) < 0) ERR;
-        if (f1.day != m.day || f1.elev != m.elev || f1.count != m.count ||
-            f1.relhum != m.relhum || f1.time != m.time) ERR;
+	/* Open file and read fill value of the variable. */
+	if ((fileid = H5Fopen(file_in, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0) ERR;
+	if ((grpid = H5Gopen(fileid, "/")) < 0) ERR;
+	if ((datasetid = H5Dopen1(grpid, VAR_NAME2)) < 0) ERR;
+	if ((propid = H5Dget_create_plist(datasetid)) < 0) ERR;
+	if (H5Pfill_value_defined(propid, &fill_status) < 0) ERR;
+	if (fill_status != H5D_FILL_VALUE_USER_DEFINED) ERR;
+	if ((typeid = H5Dget_type(datasetid)) < 0) ERR;
+	if ((native_typeid = H5Tget_native_type(typeid, H5T_DIR_DEFAULT)) < 0) ERR;
+	if (!(type_size = H5Tget_size(native_typeid))) ERR;
+	if (type_size != sizeof(obs_t)) ERR;
+	if (H5Pget_fill_value(propid, native_typeid, &f1) < 0) ERR;
+	if (f1.day != m.day || f1.elev != m.elev || f1.count != m.count ||
+	    f1.relhum != m.relhum || f1.time != m.time) ERR;
 
-        /* It's also in an attribute, netCDF style. */
-        if ((attid = H5Aopen_name(datasetid, ATT_NAME)) < 0) ERR;
-        if ((typeid = H5Aget_type(attid)) < 0) ERR;
-        if ((native_typeid = H5Tget_native_type(typeid, H5T_DIR_DEFAULT)) < 0) ERR;
-        if (H5Aread(attid, native_typeid, &f2) < 0) ERR;
-        if (f2.day != m.day || f2.elev != m.elev || f2.count != m.count ||
-            f2.relhum != m.relhum || f2.time != m.time) ERR;
+	/* It's also in an attribute, netCDF style. */
+	if ((attid = H5Aopen_name(datasetid, ATT_NAME)) < 0) ERR;
+	if ((typeid = H5Aget_type(attid)) < 0) ERR;
+	if ((native_typeid = H5Tget_native_type(typeid, H5T_DIR_DEFAULT)) < 0) ERR;
+	if (H5Aread(attid, native_typeid, &f2) < 0) ERR;
+	if (f2.day != m.day || f2.elev != m.elev || f2.count != m.count ||
+	    f2.relhum != m.relhum || f2.time != m.time) ERR;
 
-        if (H5Dclose(datasetid) < 0 ||
-            H5Aclose(attid) < 0 ||
-            H5Tclose(native_typeid) < 0 ||
-            H5Tclose(typeid) < 0 ||
-            H5Pclose(propid) < 0 ||
-            H5Gclose(grpid) < 0 ||
-            H5Fclose(fileid) < 0) ERR;
+	if (H5Dclose(datasetid) < 0 ||
+	    H5Aclose(attid) < 0 ||
+	    H5Tclose(native_typeid) < 0 ||
+	    H5Tclose(typeid) < 0 ||
+	    H5Pclose(propid) < 0 ||
+	    H5Gclose(grpid) < 0 ||
+	    H5Fclose(fileid) < 0) ERR;
 
     }
     SUMMARIZE_ERR;
@@ -414,79 +414,66 @@ main()
 #define NUM_DATASETS 10000
 #define CHUNKSIZE 1
 
-        hid_t fapl_id, fcpl_id;
-        hid_t datasetid[NUM_DATASETS];
-        hid_t fileid, grpid, spaceid, plistid;
-        hsize_t chunksize[NDIMS1], dimsize[NDIMS1], maxdimsize[NDIMS1];
-        char var_name[STR_LEN + 1];
-        int v;
+	hid_t fapl_id, fcpl_id;
+	hid_t datasetid[NUM_DATASETS];
+	hid_t fileid, grpid, spaceid, plistid;
+	hsize_t chunksize[NDIMS1], dimsize[NDIMS1], maxdimsize[NDIMS1];
+	char var_name[STR_LEN + 1];
+	int v;
 
-        /* Create file, setting latest_format in access propertly list
-         * and H5P_CRT_ORDER_TRACKED in the creation property list. */
-        if ((fapl_id = H5Pcreate(H5P_FILE_ACCESS)) < 0) ERR;
-        if (H5Pset_libver_bounds(fapl_id, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0) ERR;
-        if ((fcpl_id = H5Pcreate(H5P_FILE_CREATE)) < 0) ERR;
-        if (H5Pset_link_creation_order(fcpl_id, H5P_CRT_ORDER_TRACKED|H5P_CRT_ORDER_INDEXED) < 0) ERR;
-        if ((fileid = H5Fcreate(FILE_NAME, H5F_ACC_TRUNC, fcpl_id, fapl_id)) < 0) ERR;
+	/* Create file, setting latest_format in access propertly list
+	 * and H5P_CRT_ORDER_TRACKED in the creation property list. */
+	if ((fapl_id = H5Pcreate(H5P_FILE_ACCESS)) < 0) ERR;
+	if (H5Pset_libver_bounds(fapl_id, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0) ERR;
+	if ((fcpl_id = H5Pcreate(H5P_FILE_CREATE)) < 0) ERR;
+	if (H5Pset_link_creation_order(fcpl_id, H5P_CRT_ORDER_TRACKED|H5P_CRT_ORDER_INDEXED) < 0) ERR;
+	if ((fileid = H5Fcreate(FILE_NAME, H5F_ACC_TRUNC, fcpl_id, fapl_id)) < 0) ERR;
 
-        /* Open root group. */
-        if ((grpid = H5Gopen(fileid, "/")) < 0) ERR;
+	/* Open root group. */
+	if ((grpid = H5Gopen(fileid, "/")) < 0) ERR;
 
-        /* Create 1 D data space with unlimited dimension. */
-        dimsize[0] = 0;
-        maxdimsize[0] = H5S_UNLIMITED;
-        if ((spaceid = H5Screate_simple(NDIMS1, dimsize, maxdimsize)) < 0) ERR;
+	/* Create 1 D data space with unlimited dimension. */
+	dimsize[0] = 0;
+	maxdimsize[0] = H5S_UNLIMITED;
+	if ((spaceid = H5Screate_simple(NDIMS1, dimsize, maxdimsize)) < 0) ERR;
 
-        /* Create property list. */
-        if ((plistid = H5Pcreate(H5P_DATASET_CREATE)) < 0) ERR;
+	/* Create property list. */
+	if ((plistid = H5Pcreate(H5P_DATASET_CREATE)) < 0) ERR;
 
-        /* Set up chunksizes. */
-        chunksize[0] = CHUNKSIZE;
-        if (H5Pset_chunk(plistid, NDIMS1, chunksize) < 0)ERR;
+	/* Set up chunksizes. */
+	chunksize[0] = CHUNKSIZE;
+	if (H5Pset_chunk(plistid, NDIMS1, chunksize) < 0)ERR;
 
-        /* Create the variables. */
-        for (v = 0; v < NUM_DATASETS; v++)
-        {
-            sprintf(var_name, "var_%d", v);
-/*       printf("creating var %s\n", var_name);*/
-            if ((datasetid[v] = H5Dcreate(grpid, var_name, H5T_NATIVE_INT,
-                                          spaceid, plistid)) < 0) ERR_RET;
-        }
+	/* Create the variables. */
+	for (v = 0; v < NUM_DATASETS; v++)
+	{
+	    sprintf(var_name, "var_%d", v);
+	    /*       printf("creating var %s\n", var_name);*/
+	    if ((datasetid[v] = H5Dcreate(grpid, var_name, H5T_NATIVE_INT,
+					  spaceid, plistid)) < 0) ERR_RET;
+	}
 
-        /* Close the datasets. */
-        for (v = 0; v < NUM_DATASETS; v++)
-            if (H5Dclose(datasetid[v]) < 0) ERR_RET;
+	/* Close the datasets. */
+	for (v = 0; v < NUM_DATASETS; v++)
+	    if (H5Dclose(datasetid[v]) < 0) ERR_RET;
 
-        /* Close everything. */
-        if (H5Pclose(fapl_id) < 0 ||
-            H5Sclose(spaceid) < 0 ||
-            H5Gclose(grpid) < 0 ||
-            H5Fclose(fileid) < 0)
-            ERR;
+	/* Close everything. */
+	if (H5Pclose(fapl_id) < 0 ||
+	    H5Sclose(spaceid) < 0 ||
+	    H5Gclose(grpid) < 0 ||
+	    H5Fclose(fileid) < 0)
+	    ERR;
 
-        /* Now reopen the file and check. */
-        if ((fapl_id = H5Pcreate(H5P_FILE_ACCESS)) < 0) ERR;
-        if (H5Pset_libver_bounds(fapl_id, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0) ERR;
-        if ((fileid = H5Fopen(FILE_NAME, H5F_ACC_RDONLY, fapl_id)) < 0) ERR;
-        if ((grpid = H5Gopen(fileid, "/")) < 0) ERR;
+	/* Now reopen the file and check. */
+	if ((fapl_id = H5Pcreate(H5P_FILE_ACCESS)) < 0) ERR;
+	if (H5Pset_libver_bounds(fapl_id, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0) ERR;
+	if ((fileid = H5Fopen(FILE_NAME, H5F_ACC_RDONLY, fapl_id)) < 0) ERR;
+	if ((grpid = H5Gopen(fileid, "/")) < 0) ERR;
 
-/*       if ((datasetid = H5Dopen1(grpid, SIMPLE_VAR_NAME)) < 0) ERR; */
-/*       if ((spaceid = H5Dget_space(datasetid)) < 0) */
-/*       if (H5Sget_simple_extent_dims(spaceid, fdims, fmaxdims) > 0) ERR; */
-/*       if (H5Dread(datasetid, H5T_NATIVE_INT, H5S_ALL, */
-/*                spaceid, H5P_DEFAULT, data_in) < 0) ERR; */
-
-/*       /\* Check the data. *\/ */
-/*       for (x = 0; x < NX; x++) */
-/*       for (y = 0; y < NY; y++) */
-/*          if (data_in[x][y] != data_out[x][y]) ERR_RET; */
-
-        if (H5Pclose(fapl_id) < 0 ||
-/*        H5Dclose(datasetid) < 0 ||
-          H5Sclose(spaceid) < 0 ||*/
-            H5Gclose(grpid) < 0 ||
-            H5Fclose(fileid) < 0)
-            ERR;
+	if (H5Pclose(fapl_id) < 0 ||
+	    H5Gclose(grpid) < 0 ||
+	    H5Fclose(fileid) < 0)
+	    ERR;
     }
     SUMMARIZE_ERR;
     printf("*** Checking that HDF5 does not allow scalar variable compession...");
@@ -494,165 +481,165 @@ main()
 #define DEFLATE_LEVEL 3
 #define SIMPLE_VAR_NAME1 "punches"
     {
-        hid_t fapl_id, fcpl_id;
-        hid_t datasetid;
-        hid_t fileid, grpid, spaceid, plistid;
-        hsize_t chunksize = 1;
+	hid_t fapl_id, fcpl_id;
+	hid_t datasetid;
+	hid_t fileid, grpid, spaceid, plistid;
+	hsize_t chunksize = 1;
 
-        /* Create file, setting latest_format in access propertly list
-         * and H5P_CRT_ORDER_TRACKED in the creation property list. */
-        if ((fapl_id = H5Pcreate(H5P_FILE_ACCESS)) < 0) ERR;
-        if (H5Pset_libver_bounds(fapl_id, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0) ERR;
-        if ((fcpl_id = H5Pcreate(H5P_FILE_CREATE)) < 0) ERR;
-        if (H5Pset_link_creation_order(fcpl_id, H5P_CRT_ORDER_TRACKED|H5P_CRT_ORDER_INDEXED) < 0) ERR;
-        if ((fileid = H5Fcreate(FILE_NAME, H5F_ACC_TRUNC, fcpl_id, fapl_id)) < 0) ERR;
+	/* Create file, setting latest_format in access propertly list
+	 * and H5P_CRT_ORDER_TRACKED in the creation property list. */
+	if ((fapl_id = H5Pcreate(H5P_FILE_ACCESS)) < 0) ERR;
+	if (H5Pset_libver_bounds(fapl_id, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0) ERR;
+	if ((fcpl_id = H5Pcreate(H5P_FILE_CREATE)) < 0) ERR;
+	if (H5Pset_link_creation_order(fcpl_id, H5P_CRT_ORDER_TRACKED|H5P_CRT_ORDER_INDEXED) < 0) ERR;
+	if ((fileid = H5Fcreate(FILE_NAME, H5F_ACC_TRUNC, fcpl_id, fapl_id)) < 0) ERR;
 
-        if ((grpid = H5Gopen(fileid, "/")) < 0) ERR;
+	if ((grpid = H5Gopen(fileid, "/")) < 0) ERR;
 
-        if ((spaceid = H5Screate(H5S_SCALAR)) < 0) ERR;
+	if ((spaceid = H5Screate(H5S_SCALAR)) < 0) ERR;
 
-        /* Create property list. */
-        if ((plistid = H5Pcreate(H5P_DATASET_CREATE)) < 0) ERR;
+	/* Create property list. */
+	if ((plistid = H5Pcreate(H5P_DATASET_CREATE)) < 0) ERR;
 
-        /* Set chunking. */
-        if (H5Pset_chunk(plistid, 1, &chunksize) < 0)ERR;
+	/* Set chunking. */
+	if (H5Pset_chunk(plistid, 1, &chunksize) < 0)ERR;
 
-        /* Set up compression. */
-        if (H5Pset_deflate(plistid, DEFLATE_LEVEL) < 0) ERR;
+	/* Set up compression. */
+	if (H5Pset_deflate(plistid, DEFLATE_LEVEL) < 0) ERR;
 
-        /* Turn off error messages. The next call will generate a
-         * bunch of error messages on the console. */
-        H5Eset_auto2(H5E_DEFAULT, NULL, NULL);
+	/* Turn off error messages. The next call will generate a
+	 * bunch of error messages on the console. */
+	H5Eset_auto2(H5E_DEFAULT, NULL, NULL);
 
-        /* Create the variable. This will not work, because only
-         * chunked datasets can use filters, and scalars can't be
-         * chunked. The H5Dcreate() call will fail. */
-        if ((datasetid = H5Dcreate(grpid, SIMPLE_VAR_NAME1, H5T_NATIVE_INT,
-                                   spaceid, plistid)) > 0) ERR;
+	/* Create the variable. This will not work, because only
+	 * chunked datasets can use filters, and scalars can't be
+	 * chunked. The H5Dcreate() call will fail. */
+	if ((datasetid = H5Dcreate(grpid, SIMPLE_VAR_NAME1, H5T_NATIVE_INT,
+				   spaceid, plistid)) > 0) ERR;
 
-        /* Turn on error messages back on. */
-        H5Eset_auto2(H5E_DEFAULT, (H5E_auto2_t)&H5Eprint, stderr);
+	/* Turn on error messages back on. */
+	H5Eset_auto2(H5E_DEFAULT, (H5E_auto2_t)&H5Eprint, stderr);
 
-        if (H5Pclose(fapl_id) < 0 ||
-            H5Sclose(spaceid) < 0 ||
-            H5Gclose(grpid) < 0 ||
-            H5Fclose(fileid) < 0)
-            ERR;
+	if (H5Pclose(fapl_id) < 0 ||
+	    H5Sclose(spaceid) < 0 ||
+	    H5Gclose(grpid) < 0 ||
+	    H5Fclose(fileid) < 0)
+	    ERR;
 
     }
     SUMMARIZE_ERR;
     printf("*** Checking HDF5 scalar compact dataset...");
     {
-        hid_t fapl_id, fcpl_id;
-        hid_t datasetid;
-        hid_t fileid, grpid, spaceid, plistid;
-        hid_t propid;
-        int data_in, data_out = 42;
-        H5D_layout_t layout;
+	hid_t fapl_id, fcpl_id;
+	hid_t datasetid;
+	hid_t fileid, grpid, spaceid, plistid;
+	hid_t propid;
+	int data_in, data_out = 42;
+	H5D_layout_t layout;
 
-        /* Create file, setting latest_format in access propertly list
-         * and H5P_CRT_ORDER_TRACKED in the creation property list. */
-        if ((fapl_id = H5Pcreate(H5P_FILE_ACCESS)) < 0) ERR;
-        if (H5Pset_libver_bounds(fapl_id, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0) ERR;
-        if ((fcpl_id = H5Pcreate(H5P_FILE_CREATE)) < 0) ERR;
-        if (H5Pset_link_creation_order(fcpl_id, H5P_CRT_ORDER_TRACKED|H5P_CRT_ORDER_INDEXED) < 0) ERR;
-        if ((fileid = H5Fcreate(FILE_NAME, H5F_ACC_TRUNC, fcpl_id, fapl_id)) < 0) ERR;
+	/* Create file, setting latest_format in access propertly list
+	 * and H5P_CRT_ORDER_TRACKED in the creation property list. */
+	if ((fapl_id = H5Pcreate(H5P_FILE_ACCESS)) < 0) ERR;
+	if (H5Pset_libver_bounds(fapl_id, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0) ERR;
+	if ((fcpl_id = H5Pcreate(H5P_FILE_CREATE)) < 0) ERR;
+	if (H5Pset_link_creation_order(fcpl_id, H5P_CRT_ORDER_TRACKED|H5P_CRT_ORDER_INDEXED) < 0) ERR;
+	if ((fileid = H5Fcreate(FILE_NAME, H5F_ACC_TRUNC, fcpl_id, fapl_id)) < 0) ERR;
 
-        if ((grpid = H5Gopen(fileid, "/")) < 0) ERR;
+	if ((grpid = H5Gopen(fileid, "/")) < 0) ERR;
 
-        if ((spaceid = H5Screate(H5S_SCALAR)) < 0) ERR;
+	if ((spaceid = H5Screate(H5S_SCALAR)) < 0) ERR;
 
-        /* Create property lust. */
-        if ((plistid = H5Pcreate(H5P_DATASET_CREATE)) < 0) ERR;
+	/* Create property lust. */
+	if ((plistid = H5Pcreate(H5P_DATASET_CREATE)) < 0) ERR;
 
-        if (H5Pset_layout(plistid, H5D_COMPACT) < 0)ERR;
+	if (H5Pset_layout(plistid, H5D_COMPACT) < 0)ERR;
 
-        /* Create the variable. */
-        if ((datasetid = H5Dcreate(grpid, SIMPLE_VAR_NAME1, H5T_NATIVE_INT,
-                                   spaceid, plistid)) < 0) ERR;
+	/* Create the variable. */
+	if ((datasetid = H5Dcreate(grpid, SIMPLE_VAR_NAME1, H5T_NATIVE_INT,
+				   spaceid, plistid)) < 0) ERR;
 
-        /* Write the data. */
-        if (H5Dwrite(datasetid, H5T_NATIVE_INT, spaceid, spaceid,
-                     H5P_DEFAULT, &data_out) < 0) ERR;
+	/* Write the data. */
+	if (H5Dwrite(datasetid, H5T_NATIVE_INT, spaceid, spaceid,
+		     H5P_DEFAULT, &data_out) < 0) ERR;
 
-        if ((layout = H5Pget_layout(plistid)) < 0) ERR;
-        if (layout != H5D_COMPACT) ERR;
+	if ((layout = H5Pget_layout(plistid)) < 0) ERR;
+	if (layout != H5D_COMPACT) ERR;
 
-        if (H5Pclose(fapl_id) < 0 ||
-            H5Dclose(datasetid) < 0 ||
-            H5Sclose(spaceid) < 0 ||
-            H5Gclose(grpid) < 0 ||
-            H5Fclose(fileid) < 0)
-            ERR;
+	if (H5Pclose(fapl_id) < 0 ||
+	    H5Dclose(datasetid) < 0 ||
+	    H5Sclose(spaceid) < 0 ||
+	    H5Gclose(grpid) < 0 ||
+	    H5Fclose(fileid) < 0)
+	    ERR;
 
-        /* Now reopen the file and check. */
-        if ((fapl_id = H5Pcreate(H5P_FILE_ACCESS)) < 0) ERR;
-        if (H5Pset_libver_bounds(fapl_id, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0) ERR;
-        if ((fileid = H5Fopen(FILE_NAME, H5F_ACC_RDONLY, fapl_id)) < 0) ERR;
-        if ((grpid = H5Gopen(fileid, "/")) < 0) ERR;
+	/* Now reopen the file and check. */
+	if ((fapl_id = H5Pcreate(H5P_FILE_ACCESS)) < 0) ERR;
+	if (H5Pset_libver_bounds(fapl_id, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0) ERR;
+	if ((fileid = H5Fopen(FILE_NAME, H5F_ACC_RDONLY, fapl_id)) < 0) ERR;
+	if ((grpid = H5Gopen(fileid, "/")) < 0) ERR;
 
-        if ((datasetid = H5Dopen1(grpid, SIMPLE_VAR_NAME1)) < 0) ERR;
-        if ((spaceid = H5Dget_space(datasetid)) < 0) ERR;
-        if ((propid = H5Dget_create_plist(datasetid)) < 0) ERR;
-        if ((layout = H5Pget_layout(propid)) < 0) ERR;
-        if (layout != H5D_COMPACT) ERR;
-        if (H5Dread(datasetid, H5T_NATIVE_INT, H5S_ALL,
-                    spaceid, H5P_DEFAULT, &data_in) < 0) ERR;
+	if ((datasetid = H5Dopen1(grpid, SIMPLE_VAR_NAME1)) < 0) ERR;
+	if ((spaceid = H5Dget_space(datasetid)) < 0) ERR;
+	if ((propid = H5Dget_create_plist(datasetid)) < 0) ERR;
+	if ((layout = H5Pget_layout(propid)) < 0) ERR;
+	if (layout != H5D_COMPACT) ERR;
+	if (H5Dread(datasetid, H5T_NATIVE_INT, H5S_ALL,
+		    spaceid, H5P_DEFAULT, &data_in) < 0) ERR;
 
-        /* Check the data. */
-        if (data_in != data_out) ERR;
+	/* Check the data. */
+	if (data_in != data_out) ERR;
 
-        if (H5Pclose(fapl_id) < 0 ||
-            H5Dclose(datasetid) < 0 ||
-            H5Pclose(propid) < 0 ||
-            H5Gclose(grpid) < 0 ||
-            H5Fclose(fileid) < 0)
-            ERR;
+	if (H5Pclose(fapl_id) < 0 ||
+	    H5Dclose(datasetid) < 0 ||
+	    H5Pclose(propid) < 0 ||
+	    H5Gclose(grpid) < 0 ||
+	    H5Fclose(fileid) < 0)
+	    ERR;
     }
     SUMMARIZE_ERR;
     printf("*** Checking that HDF5 does not allow chunked, scalar datasets...");
     {
-        hid_t fapl_id, fcpl_id;
-        hid_t datasetid;
-        hid_t fileid, grpid, spaceid, plistid;
-        hsize_t chunksize = 1;
+	hid_t fapl_id, fcpl_id;
+	hid_t datasetid;
+	hid_t fileid, grpid, spaceid, plistid;
+	hsize_t chunksize = 1;
 
-        /* Create file, setting latest_format in access propertly list
-         * and H5P_CRT_ORDER_TRACKED in the creation property list. */
-        if ((fapl_id = H5Pcreate(H5P_FILE_ACCESS)) < 0) ERR;
-        if (H5Pset_libver_bounds(fapl_id, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0) ERR;
-        if ((fcpl_id = H5Pcreate(H5P_FILE_CREATE)) < 0) ERR;
-        if (H5Pset_link_creation_order(fcpl_id, H5P_CRT_ORDER_TRACKED|H5P_CRT_ORDER_INDEXED) < 0) ERR;
-        if ((fileid = H5Fcreate(FILE_NAME, H5F_ACC_TRUNC, fcpl_id, fapl_id)) < 0) ERR;
+	/* Create file, setting latest_format in access propertly list
+	 * and H5P_CRT_ORDER_TRACKED in the creation property list. */
+	if ((fapl_id = H5Pcreate(H5P_FILE_ACCESS)) < 0) ERR;
+	if (H5Pset_libver_bounds(fapl_id, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0) ERR;
+	if ((fcpl_id = H5Pcreate(H5P_FILE_CREATE)) < 0) ERR;
+	if (H5Pset_link_creation_order(fcpl_id, H5P_CRT_ORDER_TRACKED|H5P_CRT_ORDER_INDEXED) < 0) ERR;
+	if ((fileid = H5Fcreate(FILE_NAME, H5F_ACC_TRUNC, fcpl_id, fapl_id)) < 0) ERR;
 
-        if ((grpid = H5Gopen(fileid, "/")) < 0) ERR;
+	if ((grpid = H5Gopen(fileid, "/")) < 0) ERR;
 
-        if ((spaceid = H5Screate(H5S_SCALAR)) < 0) ERR;
+	if ((spaceid = H5Screate(H5S_SCALAR)) < 0) ERR;
 
-        /* Create property list. */
-        if ((plistid = H5Pcreate(H5P_DATASET_CREATE)) < 0) ERR;
+	/* Create property list. */
+	if ((plistid = H5Pcreate(H5P_DATASET_CREATE)) < 0) ERR;
 
-        /* Set chunking. */
-        if (H5Pset_chunk(plistid, 1, &chunksize) < 0)ERR;
+	/* Set chunking. */
+	if (H5Pset_chunk(plistid, 1, &chunksize) < 0)ERR;
 
-        /* Turn off error messages. The next call will generate a
-         * bunch of error messages on the console. */
-        H5Eset_auto2(H5E_DEFAULT, NULL, NULL);
+	/* Turn off error messages. The next call will generate a
+	 * bunch of error messages on the console. */
+	H5Eset_auto2(H5E_DEFAULT, NULL, NULL);
 
-        /* Create the variable. This will not work, because only
-         * chunked datasets can use filters, and scalars can't be
-         * chunked. The H5Dcreate() call will fail. */
-        if ((datasetid = H5Dcreate(grpid, SIMPLE_VAR_NAME1, H5T_NATIVE_INT,
-                                   spaceid, plistid)) > 0) ERR;
+	/* Create the variable. This will not work, because only
+	 * chunked datasets can use filters, and scalars can't be
+	 * chunked. The H5Dcreate() call will fail. */
+	if ((datasetid = H5Dcreate(grpid, SIMPLE_VAR_NAME1, H5T_NATIVE_INT,
+				   spaceid, plistid)) > 0) ERR;
 
-        /* Turn on error messages back on. */
-        H5Eset_auto2(H5E_DEFAULT, (H5E_auto2_t)&H5Eprint, stderr);
+	/* Turn on error messages back on. */
+	H5Eset_auto2(H5E_DEFAULT, (H5E_auto2_t)&H5Eprint, stderr);
 
-        if (H5Pclose(fapl_id) < 0 ||
-            H5Sclose(spaceid) < 0 ||
-            H5Gclose(grpid) < 0 ||
-            H5Fclose(fileid) < 0)
-            ERR;
+	if (H5Pclose(fapl_id) < 0 ||
+	    H5Sclose(spaceid) < 0 ||
+	    H5Gclose(grpid) < 0 ||
+	    H5Fclose(fileid) < 0)
+	    ERR;
 
     }
     SUMMARIZE_ERR;

--- a/include/nc4internal.h
+++ b/include/nc4internal.h
@@ -210,6 +210,7 @@ typedef struct NC_VAR_INFO
     size_t *chunksizes;          /**< For chunked storage, an array (size ndims) of chunksizes. */
     nc_bool_t contiguous;        /**< True if variable is stored contiguously in HDF5 file. */
     nc_bool_t compact;           /**< True if variable is in comact storage in HDF5 file. */
+    int storage;                 /**< Storage of this var, compact, contiguous, or chunked. */
     int parallel_access;         /**< Type of parallel access for I/O on variable (collective or independent). */
     nc_bool_t dimscale;          /**< True if var is a dimscale. */
     nc_bool_t *dimscale_attached;  /**< Array of flags that are true if dimscale is attached for that dim index. */

--- a/include/nc4internal.h
+++ b/include/nc4internal.h
@@ -208,8 +208,6 @@ typedef struct NC_VAR_INFO
     nc_bool_t no_fill;           /**< True if no fill value is defined for var. */
     void *fill_value;            /**< Pointer to fill value, or NULL. */
     size_t *chunksizes;          /**< For chunked storage, an array (size ndims) of chunksizes. */
-    nc_bool_t contiguous;        /**< True if variable is stored contiguously in HDF5 file. */
-    nc_bool_t compact;           /**< True if variable is in comact storage in HDF5 file. */
     int storage;                 /**< Storage of this var, compact, contiguous, or chunked. */
     int parallel_access;         /**< Type of parallel access for I/O on variable (collective or independent). */
     nc_bool_t dimscale;          /**< True if var is a dimscale. */

--- a/libhdf4/hdf4file.c
+++ b/libhdf4/hdf4file.c
@@ -435,7 +435,10 @@ nc4_var_list_add_full(NC_GRP_INFO_T* grp, const char* name, int ndims, nc_type x
     }
 
     /* Var contiguous or chunked? */
-    (*var)->contiguous = contiguous;
+    if (contiguous)
+	(*var)->storage = NC_CONTIGUOUS;
+    else
+	(*var)->storage = NC_CHUNKED;
 
     /* Were chunksizes provided? */
     if (chunksizes)

--- a/libhdf5/hdf5filter.c
+++ b/libhdf5/hdf5filter.c
@@ -278,6 +278,7 @@ NC4_filter_actions(int ncid, int varid, int op, NC_Filterobject* args)
 #endif
         /* Filter => chunking */
         var->contiguous = NC_FALSE;
+	var->storage = NC_CHUNKED;
         /* Determine default chunksizes for this variable unless already specified */
         if(var->chunksizes && !var->chunksizes[0]) {
 	    /* Should this throw error? */

--- a/libhdf5/hdf5filter.c
+++ b/libhdf5/hdf5filter.c
@@ -277,7 +277,6 @@ NC4_filter_actions(int ncid, int varid, int op, NC_Filterobject* args)
             return THROW(NC_EFILTER); /* Not allowed */
 #endif
         /* Filter => chunking */
-        var->contiguous = NC_FALSE;
 	var->storage = NC_CHUNKED;
         /* Determine default chunksizes for this variable unless already specified */
         if(var->chunksizes && !var->chunksizes[0]) {

--- a/libhdf5/hdf5open.c
+++ b/libhdf5/hdf5open.c
@@ -1096,6 +1096,7 @@ get_chunking_info(hid_t propid, NC_VAR_INFO_T *var)
     /* Remember the layout and, if chunked, the chunksizes. */
     if (layout == H5D_CHUNKED)
     {
+	var->storage = NC_CHUNKED;
         if (H5Pget_chunk(propid, H5S_MAX_RANK, chunksize) < 0)
             return NC_EHDFERR;
         if (!(var->chunksizes = malloc(var->ndims * sizeof(size_t))))
@@ -1104,9 +1105,15 @@ get_chunking_info(hid_t propid, NC_VAR_INFO_T *var)
             var->chunksizes[d] = chunksize[d];
     }
     else if (layout == H5D_CONTIGUOUS)
+    {
+	var->storage = NC_CONTIGUOUS;
         var->contiguous = NC_TRUE;
+    }
     else if (layout == H5D_COMPACT)
+    {
+	var->storage = NC_COMPACT;
         var->compact = NC_TRUE;
+    }
 
     return NC_NOERR;
 }

--- a/libhdf5/hdf5open.c
+++ b/libhdf5/hdf5open.c
@@ -1107,12 +1107,10 @@ get_chunking_info(hid_t propid, NC_VAR_INFO_T *var)
     else if (layout == H5D_CONTIGUOUS)
     {
 	var->storage = NC_CONTIGUOUS;
-        var->contiguous = NC_TRUE;
     }
     else if (layout == H5D_COMPACT)
     {
 	var->storage = NC_COMPACT;
-        var->compact = NC_TRUE;
     }
 
     return NC_NOERR;

--- a/libhdf5/hdf5var.c
+++ b/libhdf5/hdf5var.c
@@ -174,8 +174,8 @@ nc4_find_default_chunksizes2(NC_GRP_INFO_T *grp, NC_VAR_INFO_T *var)
 #endif
 
     if(var->chunksizes == NULL) {
-	if((var->chunksizes = calloc(1,sizeof(size_t)*var->ndims)) == NULL)
-	    return NC_ENOMEM;
+        if((var->chunksizes = calloc(1,sizeof(size_t)*var->ndims)) == NULL)
+            return NC_ENOMEM;
     }
 
     /* How many values in the variable (or one record, if there are
@@ -550,11 +550,11 @@ NC4_def_var(int ncid, const char *name, nc_type xtype, int ndims,
         }
 
         /* Check for unlimited dimension. If present, we must use
-	 * chunked storage. */
+         * chunked storage. */
         if (dim->unlimited)
-	{
-	    var->storage = NC_CHUNKED;
-	}
+        {
+            var->storage = NC_CHUNKED;
+        }
 
         /* Track dimensions for variable */
         var->dimids[d] = dimidsp[d];
@@ -573,7 +573,7 @@ NC4_def_var(int ncid, const char *name, nc_type xtype, int ndims,
         /* Is this a variable with a chunksize greater than the current
          * cache size? */
         if ((retval = nc4_adjust_var_cache(grp, var)))
-           BAIL(retval);
+            BAIL(retval);
     }
 
     /* If the user names this variable the same as a dimension, but
@@ -681,24 +681,24 @@ nc_def_var_extra(int ncid, int varid, int *shuffle, int *unused1,
 
     /* Cannot set filters of any sort on scalars */
     if(var->ndims == 0) {
-	if(shuffle && *shuffle)
-	    return NC_EINVAL;
-	if(fletcher32 && *fletcher32)
-	    return NC_EINVAL;
+        if(shuffle && *shuffle)
+            return NC_EINVAL;
+        if(fletcher32 && *fletcher32)
+            return NC_EINVAL;
     }
 
     /* Shuffle filter? */
     if (shuffle)
     {
         var->shuffle = *shuffle;
-	var->storage = NC_CHUNKED;
+        var->storage = NC_CHUNKED;
     }
 
     /* Fletcher32 checksum error protection? */
     if (fletcher32)
     {
         var->fletcher32 = *fletcher32;
-	var->storage = NC_CHUNKED;
+        var->storage = NC_CHUNKED;
     }
 
 #ifdef USE_PARALLEL
@@ -732,12 +732,12 @@ nc_def_var_extra(int ncid, int varid, int *shuffle, int *unused1,
         /* Handle chunked storage settings. */
         if (*storage == NC_CHUNKED && var->ndims == 0)
         {
-	    /* Chunked not allowed for scalar vars. */
+            /* Chunked not allowed for scalar vars. */
             return NC_EINVAL;
         }
-	else if (*storage == NC_CHUNKED)
+        else if (*storage == NC_CHUNKED)
         {
-	    var->storage = NC_CHUNKED;
+            var->storage = NC_CHUNKED;
 
             /* If the user provided chunksizes, check that they are not too
              * big, and that their total size of chunk is less than 4 GB. */
@@ -760,7 +760,7 @@ nc_def_var_extra(int ncid, int varid, int *shuffle, int *unused1,
         }
         else if (*storage == NC_CONTIGUOUS)
         {
-	    var->storage = NC_CONTIGUOUS;
+            var->storage = NC_CONTIGUOUS;
         }
         else if (*storage == NC_COMPACT)
         {
@@ -775,7 +775,7 @@ nc_def_var_extra(int ncid, int varid, int *shuffle, int *unused1,
             if (ndata * var->type_info->size > SIXTY_FOUR_KB)
                 return NC_EVARSIZE;
 
-	    var->storage = NC_COMPACT;
+            var->storage = NC_COMPACT;
         }
     }
 

--- a/libhdf5/hdf5var.c
+++ b/libhdf5/hdf5var.c
@@ -509,7 +509,6 @@ NC4_def_var(int ncid, const char *name, nc_type xtype, int ndims,
      * same name as one of its dimensions. If it is a coordinate var,
      * is it a coordinate var in the same group as the dim? Also, check
      * whether we should use contiguous or chunked storage. */
-    var->contiguous = NC_TRUE;
     var->storage = NC_CONTIGUOUS;
     for (d = 0; d < ndims; d++)
     {
@@ -554,7 +553,6 @@ NC4_def_var(int ncid, const char *name, nc_type xtype, int ndims,
 	 * chunked storage. */
         if (dim->unlimited)
 	{
-            var->contiguous = NC_FALSE;
 	    var->storage = NC_CHUNKED;
 	}
 
@@ -693,8 +691,6 @@ nc_def_var_extra(int ncid, int varid, int *shuffle, int *unused1,
     if (shuffle)
     {
         var->shuffle = *shuffle;
-        var->contiguous = NC_FALSE;
-        var->compact = NC_FALSE;
 	var->storage = NC_CHUNKED;
     }
 
@@ -702,8 +698,6 @@ nc_def_var_extra(int ncid, int varid, int *shuffle, int *unused1,
     if (fletcher32)
     {
         var->fletcher32 = *fletcher32;
-        var->contiguous = NC_FALSE;
-        var->compact = NC_FALSE;
 	var->storage = NC_CHUNKED;
     }
 
@@ -743,8 +737,6 @@ nc_def_var_extra(int ncid, int varid, int *shuffle, int *unused1,
         }
 	else if (*storage == NC_CHUNKED)
         {
-            var->contiguous = NC_FALSE;
-            var->compact = NC_FALSE;
 	    var->storage = NC_CHUNKED;
 
             /* If the user provided chunksizes, check that they are not too
@@ -768,8 +760,6 @@ nc_def_var_extra(int ncid, int varid, int *shuffle, int *unused1,
         }
         else if (*storage == NC_CONTIGUOUS)
         {
-            var->contiguous = NC_TRUE;
-            var->compact = NC_FALSE;
 	    var->storage = NC_CONTIGUOUS;
         }
         else if (*storage == NC_COMPACT)
@@ -785,8 +775,6 @@ nc_def_var_extra(int ncid, int varid, int *shuffle, int *unused1,
             if (ndata * var->type_info->size > SIXTY_FOUR_KB)
                 return NC_EVARSIZE;
 
-            var->contiguous = NC_FALSE;
-            var->compact = NC_TRUE;
 	    var->storage = NC_COMPACT;
         }
     }

--- a/libhdf5/hdf5var.c
+++ b/libhdf5/hdf5var.c
@@ -793,7 +793,7 @@ nc_def_var_extra(int ncid, int varid, int *shuffle, int *unused1,
 
     /* Is this a variable with a chunksize greater than the current
      * cache size? */
-    if (!var->contiguous && !var->compact)
+    if (var->storage == NC_CHUNKED)
     {
         /* Determine default chunksizes for this variable (do nothing
          * for scalar vars). */

--- a/libhdf5/nc4hdf.c
+++ b/libhdf5/nc4hdf.c
@@ -970,10 +970,7 @@ var_create_dataset(NC_GRP_INFO_T *grp, NC_VAR_INFO_T *var, nc_bool_t write_dimid
          * better performance. */
         if (!var->shuffle && !var->fletcher32 && nclistlength(var->filters) == 0 &&
             (var->chunksizes == NULL || !var->chunksizes[0]) && !unlimdim)
-	{
-            var->contiguous = NC_TRUE;
 	    var->storage = NC_CONTIGUOUS;
-	}
 
         /* Gather current & maximum dimension sizes, along with chunk
          * sizes. */

--- a/libhdf5/nc4hdf.c
+++ b/libhdf5/nc4hdf.c
@@ -970,7 +970,10 @@ var_create_dataset(NC_GRP_INFO_T *grp, NC_VAR_INFO_T *var, nc_bool_t write_dimid
          * better performance. */
         if (!var->shuffle && !var->fletcher32 && nclistlength(var->filters) == 0 &&
             (var->chunksizes == NULL || !var->chunksizes[0]) && !unlimdim)
+	{
             var->contiguous = NC_TRUE;
+	    var->storage = NC_CONTIGUOUS;
+	}
 
         /* Gather current & maximum dimension sizes, along with chunk
          * sizes. */

--- a/libsrc4/nc4internal.c
+++ b/libsrc4/nc4internal.c
@@ -1696,9 +1696,9 @@ rec_print_metadata(NC_GRP_INFO_T *grp, int tab_count)
         }
         if (!var->meta_read)
             strcat(storage_str, "unknown");
-        else if (var->contiguous)
+        else if (var->storage == NC_CONTIGUOUS)
             strcat(storage_str, "contiguous");
-        else if (var->compact)
+        else if (var->storage == NC_COMPACT)
             strcat(storage_str, "compact");
         else
             strcat(storage_str, "chunked");

--- a/libsrc4/nc4var.c
+++ b/libsrc4/nc4var.c
@@ -123,7 +123,7 @@ nc_get_var_chunk_cache_ints(int ncid, int varid, int *sizep,
  * @param deflatep Gets deflate setting.
  * @param deflate_levelp Gets deflate level.
  * @param fletcher32p Gets fletcher32 setting.
- * @param storagep Gets contiguous setting.
+ * @param storagep Gets storage setting.
  * @param chunksizesp Gets chunksizes.
  * @param no_fill Gets fill mode.
  * @param fill_valuep Gets fill value.
@@ -188,7 +188,7 @@ NC4_inq_var_all(int ncid, int varid, char *name, nc_type *xtypep,
         *nattsp = ncindexcount(var->att);
 
     /* Did the user want the chunksizes? */
-    if (!var->contiguous && !var->compact && chunksizesp)
+    if (var->storage == NC_CHUNKED && chunksizesp)
     {
         for (d = 0; d < var->ndims; d++)
         {
@@ -199,14 +199,7 @@ NC4_inq_var_all(int ncid, int varid, char *name, nc_type *xtypep,
 
     /* Did the user inquire about the storage? */
     if (storagep)
-    {
-        if (var->contiguous)
-            *storagep = NC_CONTIGUOUS;
-        else if (var->compact)
-            *storagep = NC_COMPACT;
-        else
-            *storagep = NC_CHUNKED;
-    }
+	*storagep = var->storage;
 
     /* Filter stuff. */
     if (shufflep)

--- a/libsrc4/nc4var.c
+++ b/libsrc4/nc4var.c
@@ -323,7 +323,7 @@ nc_inq_var_chunking_ints(int ncid, int varid, int *storagep, int *chunksizesp)
                              NULL, NULL, NULL, NULL, NULL);
 
     /* Copy from size_t array. */
-    if (!retval && chunksizesp && var->contiguous == NC_CHUNKED)
+    if (!retval && chunksizesp && var->storage == NC_CHUNKED)
     {
         for (i = 0; i < var->ndims; i++)
         {


### PR DESCRIPTION
Fixes #1649 

This PR changes from using two fields (contiguous and compact) to hold storage info in NC_VAR_INFO_T, and instead uses one new field (storage) to hold the storage info.

