### PR TITLE
Fix open/create of UTF8 names

### DIFF
--- a/libdispatch/dfile.c
+++ b/libdispatch/dfile.c
@@ -1851,8 +1851,8 @@ NC_create(const char *path0, int cmode, size_t initialsz,
 
     {
         /* Skip past any leading whitespace in path */
-        const char* p;
-        for(p=(char*)path0;*p;p++) {if(*p > ' ') break;}
+        const unsigned char* p;
+        for(p=(const unsigned char*)path0;*p;p++) {if(*p > ' ') break;}
 #ifdef WINPATH
         /* Need to do path conversion */
         path = NCpathcvt(p);
@@ -1999,8 +1999,8 @@ NC_open(const char *path0, int omode, int basepe, size_t *chunksizehintp,
 
     {
         /* Skip past any leading whitespace in path */
-        const char* p;
-        for(p=(char*)path0;*p;p++) {if(*p > ' ') break;}
+        const unsigned char* p;
+        for(p=(const unsigned char*)path0;*p;p++) {if(*p > ' ') break;}
 #ifdef WINPATH
         /* Need to do path conversion */
         path = NCpathcvt(p);


### PR DESCRIPTION
* Fixes https://github.com/Unidata/netcdf-c/issues/1666

The code in NC_open and NC_create (in dfile.c)
was using improper testing for leading whitespace chars.
It was treating UTF-8 as whitespace.

Fix is to do tests using unsigned char.