### PR TITLE
Force error report when DAP gets error response.

### DIFF
--- a/libdap4/d4parser.c
+++ b/libdap4/d4parser.c
@@ -211,6 +211,12 @@ traverse(NCD4parser* parser, ezxml_t dom)
     /* See if we have an <Error> or <Dataset> */
     if(strcmp(dom->name,"Error")==0) {
 	ret=parseError(parser,dom);
+        /* Report the error */
+	fprintf(stderr,"DAP4 Error: http-code=%d message=\"%s\" context=\"%s\"\n",
+		parser->metadata->error.httpcode,
+		parser->metadata->error.message,
+		parser->metadata->error.context);
+	fflush(stderr);
 	ret=NC_EDMR;
 	goto done;
     } else if(strcmp(dom->name,"Dataset")==0) {

--- a/oc2/ocinternal.c
+++ b/oc2/ocinternal.c
@@ -229,7 +229,7 @@ ocfetch(OCstate* state, const char* constraint, OCdxd kind, OCflags flags,
     stat = DAPparse(state,tree,tree->text);
     /* Check and report on an error return from the server */
     if(stat == OC_EDAPSVC  && state->error.code != NULL) {
-	nclog(NCLOGERR,"oc_open: server error retrieving url: code=%s message=\"%s\"",
+	fprintf(stderr,"oc_open: server error retrieving url: code=%s message=\"%s\"",
 		  state->error.code,
 		  (state->error.message?state->error.message:""));
     }
@@ -286,7 +286,7 @@ fprintf(stderr,"ocfetch.datadds.memory: datasize=%lu bod=%lu\n",
          */
 	if(dataError(tree->data.xdrs,state)) {
 	    stat = OC_EDATADDS;
-	    nclog(NCLOGERR,"oc_open: server error retrieving url: code=%s message=\"%s\"",
+	    fprintf(stderr,"oc_open: server error retrieving url: code=%s message=\"%s\"",
 		  state->error.code,
 		  (state->error.message?state->error.message:""));
 	    goto fail;


### PR DESCRIPTION
* Fixes https://github.com/Unidata/netcdf-c/issues/1667

Make DAP (2 and 4) forcibly report an error message
when an error response is received from the DAP servlet.