### PR TITLE
bypass NcML non-classic model abort and turn into a warning

### DIFF
--- a/ncdump/ncdump.c
+++ b/ncdump/ncdump.c
@@ -2412,12 +2412,14 @@ main(int argc, char *argv[])
 			goto fail;
 		}
 		if (xml_out) {
-                   if(!ignore_classic_limit) {
-                       if(formatting_specs.nc_kind == NC_FORMAT_NETCDF4) {
+		    if(formatting_specs.nc_kind == NC_FORMAT_NETCDF4) {
+			if(ignore_classic_limit) {
+			    //fprintf(stderr,"Warning: Ignoring NcML classic model limit for XML output generation.");
+                        } else {
 			    snprintf(errmsg,sizeof(errmsg),"NcML output (-x) currently only permitted for netCDF classic model");
-                            goto fail;
-                       }
-                   }
+			    goto fail;
+			}
+		    }
 		    do_ncdumpx(ncid, path);
 		} else {
 		    do_ncdump(ncid, path);

--- a/ncdump/ncdump.c
+++ b/ncdump/ncdump.c
@@ -134,7 +134,7 @@ usage(void)
   file             Name of netCDF file (or URL if DAP access enabled)\n"
 
     (void) fprintf(stderr,
-		   "%s [-c|-h] [-v ...] [[-b|-f] [c|f]] [-l len] [-n name] [-p n[,n]] [-k] [-x] [-s] [-t|-i] [-g ...] [-w] [-Ln] file\n%s",
+		   "%s [-c|-h] [-v ...] [[-b|-f] [c|f]] [-l len] [-n name] [-p n[,n]] [-k] [-x] [-Z] [-s] [-t|-i] [-g ...] [-w] [-Ln] file\n%s",
 		   progname,
 		   USAGE);
 
@@ -2208,7 +2208,7 @@ main(int argc, char *argv[])
        exit(EXIT_SUCCESS);
     }
 
-    while ((c = getopt(argc, argv, "b:cd:f:g:hikl:n:p:stv:xwKL:X:")) != EOF)
+    while ((c = getopt(argc, argv, "b:cd:f:g:hikl:n:p:stv:xZwKL:X:")) != EOF)
       switch(c) {
 	case 'h':		/* dump header only, no data */
 	  formatting_specs.header_only = true;

--- a/ncdump/ncdump.c
+++ b/ncdump/ncdump.c
@@ -128,6 +128,7 @@ usage(void)
   [-g grp1[,...]]  Data and metadata for group(s) <grp1>,... only\n\
   [-w]             With client-side caching of variables for DAP URLs\n\
   [-x]             Output XML (NcML) instead of CDL\n\
+  [-Z]             Ignore XML (NcML) classic model limit\n\
   [-Xp]            Unconditionally suppress output of the properties attribute\n\
   [-Ln]            Set log level to n (>= 0); ignore if logging not enabled.\n\
   file             Name of netCDF file (or URL if DAP access enabled)\n"
@@ -2179,6 +2180,7 @@ main(int argc, char *argv[])
     int max_len = 80;		/* default maximum line length */
     int nameopt = 0;
     bool_t xml_out = false;    /* if true, output NcML instead of CDL */
+    bool_t ignore_classic_limit = false; /* if true, ignore NcML classic model limits */
     bool_t kind_out = false;	/* if true, just output kind of netCDF file */
     bool_t kind_out_extended = false;	/* output inq_format vs inq_format_extended */
     int Xp_flag = 0;    /* indicate that -Xp flag was set */
@@ -2273,6 +2275,9 @@ main(int argc, char *argv[])
 	  break;
         case 'x':		/* XML output (NcML) */
 	  xml_out = true;
+	  break;
+        case 'Z':		/* ignore XML (NcML) classic model limit */
+	  ignore_classic_limit = true;
 	  break;
         case 'k':	        /* just output what kind of netCDF file */
 	  kind_out = true;
@@ -2407,10 +2412,12 @@ main(int argc, char *argv[])
 			goto fail;
 		}
 		if (xml_out) {
-		    if(formatting_specs.nc_kind == NC_FORMAT_NETCDF4) {
-			snprintf(errmsg,sizeof(errmsg),"NcML output (-x) currently only permitted for netCDF classic model");
-			goto fail;
-		    }
+                   if(!ignore_classic_limit) {
+                       if(formatting_specs.nc_kind == NC_FORMAT_NETCDF4) {
+			    snprintf(errmsg,sizeof(errmsg),"NcML output (-x) currently only permitted for netCDF classic model");
+                            goto fail;
+                       }
+                   }
 		    do_ncdumpx(ncid, path);
 		} else {
 		    do_ncdump(ncid, path);

--- a/ncdump/ncdump.c
+++ b/ncdump/ncdump.c
@@ -2414,7 +2414,7 @@ main(int argc, char *argv[])
 		if (xml_out) {
 		    if(formatting_specs.nc_kind == NC_FORMAT_NETCDF4) {
 			if(ignore_classic_limit) {
-			    //fprintf(stderr,"Warning: Ignoring NcML classic model limit for XML output generation.");
+			    fprintf(stderr,"<!-- Warning: Ignoring NcML classic model limit for XML output generation. -->");
                         } else {
 			    snprintf(errmsg,sizeof(errmsg),"NcML output (-x) currently only permitted for netCDF classic model");
 			    goto fail;


### PR DESCRIPTION
I am working with a bunch of GOES-R ABI satellite imagery which uses a non-classic NcML schema which trips an abort in ncdump when generating XML metadata output for versions greater than netcdf-4.1.3.  To facilitate an update I have added a command line switch which bypasses the abort code when attempting to dump non-classic model NcML data, and turns it into a warning.  This can be verified by downloading any GOES-R ABI imagery and running "ncdump -x <image>" using both version 4.1.3 and anything newer.

I am requesting that this patch be reviewed for inclusion as others may be interested in dumping XML metadata from the GOES-R satellite imagery using newer versions of NetCDF.

Please note, that I have spot checked the XML output for imagery using an offline version of netcdf-4.7.3 containing this modification against what is generated on the Ground System using netcdf-4.1.3 and found them to be consistent.  I will be reviewing the NcML documentation to see if the schema will trigger any known bugs, but any changes at that level will take a very long time to update.