### PR TITLE
Fix reclamation of the ->format_XXX_info fields

### DIFF
--- a/include/hdf5internal.h
+++ b/include/hdf5internal.h
@@ -140,6 +140,7 @@ int nc4_get_hdf_typeid(NC_FILE_INFO_T *h5, nc_type xtype,
 int nc4_close_hdf5_file(NC_FILE_INFO_T *h5, int abort, NC_memio *memio);
 int nc4_rec_grp_HDF5_del(NC_GRP_INFO_T *grp);
 int nc4_enddef_netcdf4_file(NC_FILE_INFO_T *h5);
+void nc_hdf5_formatfree(NC_OBJ* arg);
 
 /* Break & reform coordinate variables */
 int nc4_break_coord_var(NC_GRP_INFO_T *grp, NC_VAR_INFO_T *coord_var, NC_DIM_INFO_T *dim);

--- a/libhdf4/hdf4file.c
+++ b/libhdf4/hdf4file.c
@@ -35,6 +35,8 @@ nc_type_size_g[NUM_TYPES] = {sizeof(char), sizeof(char), sizeof(short),
                              sizeof(unsigned int), sizeof(long long),
                              sizeof(unsigned long long), sizeof(char *)};
 
+static void nc_hdf4_formatfree(NC_OBJ* arg);
+
 /**
  * @internal Recursively delete the data for a group (and everything
  * it contains) in our internal metadata store.
@@ -724,8 +726,25 @@ NC_HDF4_close(int ncid, void *ignore)
     free(hdf4_file);
 
     /* Free the NC_FILE_INFO_T struct. */
-    if ((retval = nc4_nc4f_list_del(h5)))
+    if ((retval = nc4_nc4f_list_del(h5,nc_hdf4_formatfree)))
         return retval;
 
     return NC_NOERR;
+}
+
+static void
+nc_hdf4_formatfree(NC_OBJ* arg)
+{
+
+    if(arg == NULL) return;
+    switch (arg->sort) {
+    case NCVAR: nullfree(((NC_VAR_INFO_T*)arg)->format_var_info); break;
+    case NCDIM: nullfree(((NC_DIM_INFO_T*)arg)->format_dim_info); break;
+    case NCATT: nullfree(((NC_ATT_INFO_T*)arg)->format_att_info); break;
+    case NCTYP: nullfree(((NC_TYPE_INFO_T*)arg)->format_type_info); break;
+    case NCFLD: nullfree(((NC_FIELD_INFO_T*)arg)->format_field_info); break;
+    case NCGRP: nullfree(((NC_GRP_INFO_T*)arg)->format_grp_info); break;
+    case NCFIL: nullfree(((NC_FILE_INFO_T*)arg)->format_file_info); break;
+    default: abort();
+    }
 }

--- a/libhdf5/hdf5attr.c
+++ b/libhdf5/hdf5attr.c
@@ -325,7 +325,7 @@ NC4_HDF5_del_att(int ncid, int varid, const char *name)
     deletedid = att->hdr.id;
 
     /* Remove this attribute in this list */
-    if ((retval = nc4_att_list_del(attlist, att)))
+    if ((retval = nc4_att_list_del(attlist, att, nc_hdf5_formatfree)))
         return retval;
 
     /* Renumber all attributes with higher indices. */

--- a/libhdf5/hdf5open.c
+++ b/libhdf5/hdf5open.c
@@ -213,6 +213,7 @@ get_type_info2(NC_FILE_INFO_T *h5, hid_t datasetid, NC_TYPE_INFO_T **type_info)
             else
                 (*type_info)->nc_type_class = NC_FLOAT;
         }
+	(*type_info)->hdr.sort = NCTYP;
         (*type_info)->hdr.id = nc_type_constant_g[t];
         (*type_info)->size = nc_type_size_g[t];
         if (!((*type_info)->hdr.name = strdup(nc_type_name_g[t])))
@@ -1409,7 +1410,7 @@ exit:
         if (incr_id_rc && H5Idec_ref(datasetid) < 0)
             BAIL2(NC_EHDFERR);
         if (var)
-            nc4_var_list_del(grp, var);
+            nc4_var_list_del(grp, var, nc_hdf5_formatfree);
     }
 
     return retval;
@@ -2130,7 +2131,7 @@ exit:
     {
         /* NC_EBADTYPID will be normally converted to NC_NOERR so that
            the parent iterator does not fail. */
-        retval = nc4_att_list_del(list, att);
+        retval = nc4_att_list_del(list, att, nc_hdf5_formatfree);
         att = NULL;
     }
     if (attid > 0 && H5Aclose(attid) < 0)
@@ -2313,7 +2314,7 @@ exit:
     if (retval && dimscale_created)
     {
         /* free the dimension */
-        if ((retval = nc4_dim_list_del(grp, new_dim)))
+        if ((retval = nc4_dim_list_del(grp, new_dim, nc_hdf5_formatfree)))
             BAIL2(retval);
 
         /* Reset the group's information */

--- a/libhdf5/hdf5var.c
+++ b/libhdf5/hdf5var.c
@@ -601,7 +601,7 @@ NC4_def_var(int ncid, const char *name, nc_type xtype, int ndims,
 
 exit:
     if (type)
-        if ((retval = nc4_type_free(type)))
+        if ((retval = nc4_type_free(type, nc_hdf5_formatfree)))
             BAIL2(retval);
 
     return retval;
@@ -2290,7 +2290,7 @@ nc_set_var_chunk_cache_ints(int ncid, int varid, int size, int nelems,
     float real_preemption = CHUNK_CACHE_PREEMPTION;
 
     LOG((1, "%s: ncid 0x%x varid %d size %d nelems %d preemption %d",
-	 __func__, ncid, varid, size, nelems, preemptions));
+	 __func__, ncid, varid, size, nelems, preemption));
     
     if (size >= 0)
         real_size = ((size_t) size) * MEGABYTE;

--- a/libsrc4/nc4internal.c
+++ b/libsrc4/nc4internal.c
@@ -1565,6 +1565,7 @@ nc4_nc4f_list_del(NC_FILE_INFO_T *h5, NCformatfree formatfree)
     nclistfree(h5->alltypes);
 
     /* Free the NC_FILE_INFO_T struct. */
+    nullfree(h5->hdr.name);
     free(h5);
 
     return NC_NOERR;

--- a/unit_test/tst_nc4internal.c
+++ b/unit_test/tst_nc4internal.c
@@ -26,6 +26,11 @@
 #define FIELD_NAME "Britany_Spears"
 #define FIELD_OFFSET 9
 
+static void
+formatfree(NC_OBJ* o)
+{
+}
+
 int
 main(int argc, char **argv)
 {
@@ -65,10 +70,10 @@ main(int argc, char **argv)
         if (mode_in != mode) ERR;
 
         /* This won't work. */
-        if (nc4_file_list_del(TEST_VAL_42) != NC_EBADID) ERR;
+        if (nc4_file_list_del(TEST_VAL_42,formatfree) != NC_EBADID) ERR;
 
         /* Delete the NC_FILE_INFO_T and related storage. */
-        if (nc4_file_list_del(ncp->ext_ncid)) ERR;
+        if (nc4_file_list_del(ncp->ext_ncid,formatfree)) ERR;
 
         /* Delete the ncp from the list. (In fact, just null out its
          * entry in the array of file slots.) */
@@ -136,7 +141,7 @@ main(int argc, char **argv)
         if (grp2->nc4_info->controller->ext_ncid != ncp->ext_ncid) ERR;
 
         /* Delete the NC_FILE_INFO_T and related storage. */
-        if (nc4_file_list_del(ncp->ext_ncid)) ERR;
+        if (nc4_file_list_del(ncp->ext_ncid,formatfree)) ERR;
 
         /* Delete the ncp from the list. (In fact, just null out its
          * entry in the array of file slots.) */
@@ -186,7 +191,7 @@ main(int argc, char **argv)
 
         /* Delete the NC_FILE_INFO_T and related storage, including
          * all vars, dims, types, etc. */
-        if (nc4_file_list_del(ncp->ext_ncid)) ERR;
+        if (nc4_file_list_del(ncp->ext_ncid,formatfree)) ERR;
 
         /* Delete the ncp from the list. (In fact, just null out its
          * entry in the array of file slots.) */
@@ -221,7 +226,7 @@ main(int argc, char **argv)
         if (strcmp(dim_in->hdr.name, dim->hdr.name)) ERR;
 
         /* Release resources. */
-        if (nc4_file_list_del(ncp->ext_ncid)) ERR;
+        if (nc4_file_list_del(ncp->ext_ncid,formatfree)) ERR;
         del_from_NCList(ncp);
         free_NC(ncp);
     }
@@ -252,7 +257,7 @@ main(int argc, char **argv)
         if (strcmp(type_in->hdr.name, type->hdr.name)) ERR;
 
         /* Release resources. */
-        if (nc4_file_list_del(ncp->ext_ncid)) ERR;
+        if (nc4_file_list_del(ncp->ext_ncid,formatfree)) ERR;
         del_from_NCList(ncp);
         free_NC(ncp);
     }
@@ -279,7 +284,7 @@ main(int argc, char **argv)
         if (nc4_find_nc_grp_h5(old_ncid, NULL, NULL, NULL) != NC_EBADID) ERR;
 
         /* Delete it. */
-        if (nc4_file_list_del(ncp->ext_ncid)) ERR;
+        if (nc4_file_list_del(ncp->ext_ncid,formatfree)) ERR;
         del_from_NCList(ncp); /* Will free empty list. */
         free_NC(ncp);
 
@@ -290,3 +295,4 @@ main(int argc, char **argv)
     SUMMARIZE_ERR;
     FINAL_RESULTS;
 }
+


### PR DESCRIPTION
Currently, the code assumes that all the values assigned
to the format_XXX_info fields (e.g. format_file_info)
are assigned by libhdf5 or libhdf4. But now nczarr is using that field
and requires nczarr specific free'ing of the format_XXX_info fields.

This solution is to pass a function that can free any of the
format_XXX_info fields. This is primarily passed to the
nc4_XXX_list_del functions.