### PR TITLE
Fix reclamation of the ->format_XXX_info fields

### DIFF
--- a/debug/cf
+++ b/debug/cf
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 #NB=1
 #DB=1
 #X=-x

--- a/include/hdf5internal.h
+++ b/include/hdf5internal.h
@@ -92,6 +92,8 @@ typedef struct NC_HDF5_VAR_INFO
 {
     hid_t hdf_datasetid;
     HDF5_OBJID_T *dimscale_hdf5_objids;
+    nc_bool_t dimscale;          /**< True if var is a dimscale. */
+    nc_bool_t *dimscale_attached;  /**< Array of flags that are true if dimscale is attached for that dim index. */
 } NC_HDF5_VAR_INFO_T;
 
 /* Struct to hold HDF5-specific info for a field. */
@@ -140,6 +142,7 @@ int nc4_get_hdf_typeid(NC_FILE_INFO_T *h5, nc_type xtype,
 int nc4_close_hdf5_file(NC_FILE_INFO_T *h5, int abort, NC_memio *memio);
 int nc4_rec_grp_HDF5_del(NC_GRP_INFO_T *grp);
 int nc4_enddef_netcdf4_file(NC_FILE_INFO_T *h5);
+int nc4_HDF5_close_type(NC_TYPE_INFO_T* type);
 
 /* Break & reform coordinate variables */
 int nc4_break_coord_var(NC_GRP_INFO_T *grp, NC_VAR_INFO_T *coord_var, NC_DIM_INFO_T *dim);
@@ -168,6 +171,8 @@ int nc4_hdf5_find_grp_var_att(int ncid, int varid, const char *name, int attnum,
 /* Find var, doing lazy var metadata read if needed. */
 int nc4_hdf5_find_grp_h5_var(int ncid, int varid, NC_FILE_INFO_T **h5,
                              NC_GRP_INFO_T **grp, NC_VAR_INFO_T **var);
+
+int nc4_HDF5_close_att(NC_ATT_INFO_T *att);
 
 /* Perform lazy read of the rest of the metadata for a var. */
 int nc4_get_var_meta(NC_VAR_INFO_T *var);

--- a/include/nc4internal.h
+++ b/include/nc4internal.h
@@ -18,7 +18,6 @@
 #include <ctype.h>
 #include <string.h>
 
-#include "ncdimscale.h"
 #include "nc_logging.h"
 #include "ncindex.h"
 #include "nc_provenance.h"
@@ -45,7 +44,7 @@
 
 /* typedef enum {GET, PUT} NC_PG_T; */
 /** These are the different objects that can be in our hash-lists. */
-typedef enum {NCNAT, NCVAR, NCDIM, NCATT, NCTYP, NCFLD, NCGRP} NC_SORT;
+typedef enum {NCNAT, NCVAR, NCDIM, NCATT, NCTYP, NCFLD, NCGRP, NCFIL} NC_SORT;
 
 /** The netCDF V2 error code. */
 #define NC_V2_ERR (-1)
@@ -188,7 +187,7 @@ typedef struct NC_ATT_INFO
 typedef struct NC_VAR_INFO
 {
     NC_OBJ hdr;                  /**< The hdr contains the name and ID. */
-    char *hdf5_name;             /**< Used if name in HDF5 must be different from name. */
+    char *alt_name;              /**< Used if name in dispatcher must be different from hdr.name. */
     struct NC_GRP_INFO *container; /**< Pointer to containing group. */
     size_t ndims;                /**< Number of dims. */
     int *dimids;                 /**< Dim IDs. */
@@ -210,8 +209,6 @@ typedef struct NC_VAR_INFO
     size_t *chunksizes;          /**< For chunked storage, an array (size ndims) of chunksizes. */
     int storage;                 /**< Storage of this var, compact, contiguous, or chunked. */
     int parallel_access;         /**< Type of parallel access for I/O on variable (collective or independent). */
-    nc_bool_t dimscale;          /**< True if var is a dimscale. */
-    nc_bool_t *dimscale_attached;  /**< Array of flags that are true if dimscale is attached for that dim index. */
     nc_bool_t shuffle;           /**< True if var has shuffle filter applied. */
     nc_bool_t fletcher32;        /**< True if var has fletcher32 filter applied. */
     size_t chunk_cache_size;     /**< Size in bytes of the var chunk chache. */
@@ -298,6 +295,7 @@ typedef struct NC_GRP_INFO
  * netcdf-4/HDF5 file. */
 typedef struct  NC_FILE_INFO
 {
+    NC_OBJ hdr;
     NC *controller; /**< Pointer to containing NC. */
 #ifdef USE_PARALLEL4
     MPI_Comm comm;  /**< Copy of MPI Communicator used to open the file. */
@@ -417,6 +415,7 @@ int nc4_build_root_grp(NC_FILE_INFO_T *h5);
 int nc4_rec_grp_del(NC_GRP_INFO_T *grp);
 int nc4_enum_member_add(NC_TYPE_INFO_T *type, size_t size, const char *name,
                         const void *value);
+int nc4_att_free(NC_ATT_INFO_T *att);
 
 /* Check and normalize names. */
 int NC_check_name(const char *name);

--- a/libhdf4/hdf4file.c
+++ b/libhdf4/hdf4file.c
@@ -69,6 +69,8 @@ hdf4_rec_grp_del(NC_GRP_INFO_T *grp)
          * scale. */
         if (hdf4_var->sdsid && SDendaccess(hdf4_var->sdsid) < 0)
             return NC_EHDFERR;
+
+        nullfree(hdf4_var);
     }
 
     return NC_NOERR;

--- a/libhdf5/hdf5attr.c
+++ b/libhdf5/hdf5attr.c
@@ -325,6 +325,7 @@ NC4_HDF5_del_att(int ncid, int varid, const char *name)
     deletedid = att->hdr.id;
 
     /* Remove this attribute in this list */
+    if((retval=nc4_HDF5_close_att(att))) return retval;
     if ((retval = nc4_att_list_del(attlist, att)))
         return retval;
 
@@ -523,7 +524,6 @@ nc4_put_att(NC_GRP_INFO_T* grp, int varid, const char *name, nc_type file_type,
         if (!(att->format_att_info = calloc(1, sizeof(NC_HDF5_ATT_INFO_T))))
             BAIL(NC_ENOMEM);
     }
-
     /* Now fill in the metadata. */
     att->dirty = NC_TRUE;
     att->nc_typeid = file_type;
@@ -559,16 +559,16 @@ nc4_put_att(NC_GRP_INFO_T* grp, int varid, const char *name, nc_type file_type,
         if (att->nc_typeid != var->type_info->hdr.id)
             return NC_EBADTYPE;
         if (att->len != 1)
-            return NC_EINVAL;
+            BAIL(NC_EINVAL);
 
         /* If we already wrote to the dataset, then return an error. */
         if (var->written_to)
-            return NC_ELATEFILL;
+           BAIL(NC_ELATEFILL);
 
         /* Get the length of the veriable data type. */
         if ((retval = nc4_get_typelen_mem(grp->nc4_info, var->type_info->hdr.id,
                                           &type_size)))
-            return retval;
+            BAIL(retval);
 
         /* Already set a fill value? Now I'll have to free the old
          * one. Make up your damn mind, would you? */
@@ -577,7 +577,7 @@ nc4_put_att(NC_GRP_INFO_T* grp, int varid, const char *name, nc_type file_type,
             if (var->type_info->nc_type_class == NC_VLEN)
             {
                 if ((retval = nc_free_vlen(var->fill_value)))
-                    return retval;
+                    BAIL(retval);
             }
             else if (var->type_info->nc_type_class == NC_STRING)
             {
@@ -597,7 +597,7 @@ nc4_put_att(NC_GRP_INFO_T* grp, int varid, const char *name, nc_type file_type,
 
         /* Allocate space for the fill value. */
         if (!(var->fill_value = calloc(1, size)))
-            return NC_ENOMEM;
+            BAIL(NC_ENOMEM);
 
         /* Copy the fill_value. */
         LOG((4, "Copying fill value into metadata for variable %s", var->hdr.name));
@@ -610,11 +610,11 @@ nc4_put_att(NC_GRP_INFO_T* grp, int varid, const char *name, nc_type file_type,
             /* get the basetype and its size */
             basetype = var->type_info;
             if ((retval = nc4_get_typelen_mem(grp->nc4_info, basetype->hdr.id, &basetypesize)))
-                return retval;
+                BAIL(retval);
             /* shallow clone the content of the vlen; shallow because it has only a temporary existence */
             fv_vlen->len = in_vlen->len;
             if (!(fv_vlen->p = malloc(basetypesize * in_vlen->len)))
-                return NC_ENOMEM;
+                BAIL(NC_ENOMEM);
             memcpy(fv_vlen->p, in_vlen->p, in_vlen->len * basetypesize);
         }
         else if (var->type_info->nc_type_class == NC_STRING)
@@ -622,7 +622,7 @@ nc4_put_att(NC_GRP_INFO_T* grp, int varid, const char *name, nc_type file_type,
             if (*(char **)data)
             {
                 if (!(*(char **)(var->fill_value) = malloc(strlen(*(char **)data) + 1)))
-                    return NC_ENOMEM;
+                    BAIL(NC_ENOMEM);
                 strcpy(*(char **)var->fill_value, *(char **)data);
             }
             else
@@ -645,7 +645,7 @@ nc4_put_att(NC_GRP_INFO_T* grp, int varid, const char *name, nc_type file_type,
 
         /* Get class for this type. */
         if ((retval = nc4_get_typeclass(h5, file_type, &type_class)))
-            return retval;
+            BAIL(retval);
 
         assert(data);
         if (type_class == NC_VLEN)

--- a/libhdf5/hdf5debug.c
+++ b/libhdf5/hdf5debug.c
@@ -15,7 +15,9 @@
 
 #define STSIZE 1000
 
+#if !defined _WIN32 && !defined __CYGWIN__
 static void* stacktrace[STSIZE];
+#endif
 
 int
 nch5breakpoint(int err)

--- a/libhdf5/hdf5var.c
+++ b/libhdf5/hdf5var.c
@@ -9,9 +9,7 @@
  */
 
 #include "config.h"
-#ifdef USE_HDF5
 #include <hdf5internal.h>
-#endif
 #include <math.h> /* For pow() used below. */
 
 #include "netcdf.h"
@@ -291,11 +289,11 @@ give_var_secret_name(NC_VAR_INFO_T *var, const char *name)
      * clash. */
     if (strlen(name) + strlen(NON_COORD_PREPEND) > NC_MAX_NAME)
         return NC_EMAXNAME;
-    if (!(var->hdf5_name = malloc((strlen(NON_COORD_PREPEND) +
+    if (!(var->alt_name = malloc((strlen(NON_COORD_PREPEND) +
                                    strlen(name) + 1) * sizeof(char))))
         return NC_ENOMEM;
 
-    sprintf(var->hdf5_name, "%s%s", NON_COORD_PREPEND, name);
+    sprintf(var->alt_name, "%s%s", NON_COORD_PREPEND, name);
 
     return NC_NOERR;
 }
@@ -342,6 +340,7 @@ NC4_def_var(int ncid, const char *name, nc_type xtype, int ndims,
     NC_TYPE_INFO_T *type = NULL;
     NC_HDF5_TYPE_INFO_T *hdf5_type;
     NC_HDF5_GRP_INFO_T *hdf5_grp;
+    NC_HDF5_VAR_INFO_T* hdf5_var;
     char norm_name[NC_MAX_NAME + 1];
     int d;
     int retval;
@@ -488,6 +487,8 @@ NC4_def_var(int ncid, const char *name, nc_type xtype, int ndims,
     if (!(var->format_var_info = calloc(1, sizeof(NC_HDF5_VAR_INFO_T))))
         BAIL(NC_ENOMEM);
 
+    hdf5_var = (NC_HDF5_VAR_INFO_T*)var->format_var_info;
+
     /* Set these state flags for the var. */
     var->is_new_var = NC_TRUE;
     var->meta_read = NC_TRUE;
@@ -524,7 +525,7 @@ NC4_def_var(int ncid, const char *name, nc_type xtype, int ndims,
         /* Check for dim index 0 having the same name, in the same group */
         if (d == 0 && dim_grp == grp && strcmp(dim->hdr.name, norm_name) == 0)
         {
-            var->dimscale = NC_TRUE;
+            hdf5_var->dimscale = NC_TRUE;
             dim->coord_var = var;
 
             /* Use variable's dataset ID for the dimscale ID. So delete
@@ -590,8 +591,8 @@ NC4_def_var(int ncid, const char *name, nc_type xtype, int ndims,
      * scale. (We found dim above.) Otherwise, allocate space to
      * remember whether dimension scales have been attached to each
      * dimension. */
-    if (!var->dimscale && ndims)
-        if (!(var->dimscale_attached = calloc(ndims, sizeof(nc_bool_t))))
+    if (!hdf5_var->dimscale && ndims)
+        if (!(hdf5_var->dimscale_attached = calloc(ndims, sizeof(nc_bool_t))))
             BAIL(NC_ENOMEM);
 
     /* Return the varid. */
@@ -1126,6 +1127,7 @@ NC4_rename_var(int ncid, int varid, const char *name)
     NC_HDF5_GRP_INFO_T *hdf5_grp;
     NC_FILE_INFO_T *h5;
     NC_VAR_INFO_T *var;
+    NC_HDF5_VAR_INFO_T *hdf5_var;
     NC_DIM_INFO_T *other_dim;
     int use_secret_name = 0;
     int retval = NC_NOERR;
@@ -1190,13 +1192,16 @@ NC4_rename_var(int ncid, int varid, const char *name)
         use_secret_name++;
     }
 
+    hdf5_var = (NC_HDF5_VAR_INFO_T*)var->format_var_info;
+    assert(hdf5_var != NULL);
+
     /* Change the HDF5 file, if this var has already been created
        there. */
     if (var->created)
     {
         int v;
         char *hdf5_name; /* Dataset will be renamed to this. */
-        hdf5_name = use_secret_name ? var->hdf5_name: (char *)name;
+        hdf5_name = use_secret_name ? var->alt_name: (char *)name;
 
         /* Do we need to read var metadata? */
         if (!var->meta_read)
@@ -1261,7 +1266,7 @@ NC4_rename_var(int ncid, int varid, const char *name)
 
     /* Check if this was a coordinate variable previously, but names
      * are different now */
-    if (var->dimscale && strcmp(var->hdr.name, var->dim[0]->hdr.name))
+    if (hdf5_var->dimscale && strcmp(var->hdr.name, var->dim[0]->hdr.name))
     {
         /* Break up the coordinate variable */
         if ((retval = nc4_break_coord_var(grp, var, var->dim[0])))
@@ -1269,7 +1274,7 @@ NC4_rename_var(int ncid, int varid, const char *name)
     }
 
     /* Check if this should become a coordinate variable. */
-    if (!var->dimscale)
+    if (!hdf5_var->dimscale)
     {
         /* Only variables with >0 dimensions can become coordinate
          * variables. */
@@ -2290,7 +2295,7 @@ nc_set_var_chunk_cache_ints(int ncid, int varid, int size, int nelems,
     float real_preemption = CHUNK_CACHE_PREEMPTION;
 
     LOG((1, "%s: ncid 0x%x varid %d size %d nelems %d preemption %d",
-	 __func__, ncid, varid, size, nelems, preemptions));
+	 __func__, ncid, varid, size, nelems, preemption));
     
     if (size >= 0)
         real_size = ((size_t) size) * MEGABYTE;


### PR DESCRIPTION
nc4internal.c contains code to free the format_XXX_info
fields. Since these are format specific, this code
was moved to the dispatch code (libhdf5 and libhdf4
in the current case).

Additionally, there are some fields in nc4internal.h (e.g.
dimscale fields) that are specific to HDF5 and have been moved
to the corresponding HDF5 data structures and code.

Misc. other changes:
1. NC_VAR_INFO_T->hdf5_name renamed to alt_name to avoid
   implying it is necessarily HDF5 specific.
2. prefix NC_FILE_INFO_T with an instance of NC_OBJ for consistency.
   this also requires wrapping move_in_NCList() to keep
   hdr.id consistent.