### PR TITLE
Fix missing forward declarations

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,6 +8,7 @@ This file contains a high-level description of this package's evolution. Release
 ## 4.8.0 - TBD
 
 * [Bug Fix][cmake] Correct an issue with parallel filter test logic in CMake-based builds.
+* [Bug Fix] Compiling on a big-endian machine exposes some missing forward delcarations in dfilter.c.
 
 ## 4.7.4 - March 27, 2020
 

--- a/libdispatch/dfilter.c
+++ b/libdispatch/dfilter.c
@@ -40,6 +40,10 @@ Unified filter related code
 
 /* Forward */
 static int gettype(const int q0, const int q1, int* unsignedp);
+#ifdef WORDS_BIGENDIAN
+static void byteswap8(unsigned char* mem);
+static void byteswap4(unsigned char* mem);
+#endif
 
 const struct LegalFormat {
     const char* tag;

--- a/nc_test4/tst_filterparser.c
+++ b/nc_test4/tst_filterparser.c
@@ -122,6 +122,11 @@ static const char* spectype[] = {"i", "b", "ub", "s", "us", "i", "ui", "i", "i",
 
 static int nerrs = 0;
 
+#ifdef WORDS_BIGENDIAN
+static void byteswap8(unsigned char* mem);
+static void byteswap4(unsigned char* mem);
+#endif
+
 static void
 mismatch(size_t i, unsigned int *params, const char* tag)
 {

--- a/plugins/H5Zutil.c
+++ b/plugins/H5Zutil.c
@@ -4,6 +4,7 @@
  */
 
 
+#include "config.h"
 #include <hdf5.h>
 
 /*


### PR DESCRIPTION
* Fixes issue https://github.com/Unidata/netcdf-c/issues/1687

static functions are being used before decl and it causes
errors. Only occurs when BIG_ENDIAN is defined.
Solution is to add the forward declarations.