### PR TITLE
Fix XGetopt.h inclusion for Windows/MinGW again

### DIFF
--- a/ncdump/ncvalidator.c
+++ b/ncdump/ncvalidator.c
@@ -73,7 +73,7 @@ THIS SOFTWARE.
 #include <unistd.h>     /* read() getopt() */
 #endif
 
-#ifdef _WIN32
+#ifdef _MSC_VER
 #include <io.h>
 #define snprintf _snprintf
 #include "XGetopt.h"


### PR DESCRIPTION
Same problem as #1447. 

MinGW fails to build the project unless _WIN32 is replaced with _MSC_VER.
