### PR TITLE
Correcting a formatting error for scalars when dumping with ncdump -f

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,7 @@ This file contains a high-level description of this package's evolution. Release
 
 ## 4.8.0 - TBD
 
+* [Bug Fix] Fixed a scalar annotation error when scalar == 0; see [Github #1707](https://github.com/Unidata/netcdf-c/issues/1707) for more information.
 * [Bug Fix] Use proper CURLOPT values for VERIFYHOST and VERIFYPEER; the semantics for VERIFYHOST in particular changed. Documented in NUG/DAP2.md. See  [https://github.com/Unidata/netcdf-c/issues/1684].
 * [Bug Fix][cmake] Correct an issue with parallel filter test logic in CMake-based builds.
 * [Bug Fix] Now allow nc_inq_var_deflate()/nc_inq_var_szip() to be called for all formats, not just HDF5. Non-HDF5 files return NC_NOERR and report no compression in use. This reverts behavior that was changed in the 4.7.4 release. See [https://github.com/Unidata/netcdf-c/issues/1691].

--- a/ncdump/vardata.c
+++ b/ncdump/vardata.c
@@ -506,12 +506,12 @@ print_rows(
             }
 	}
 	if (formatting_specs.full_data_cmnts) {
-            for (j = 0; j < marks_pending; j++) {
+      for (j = 0; j < marks_pending; j++) {
 		sbuf_cat(sb, RBRACE);
-            }
-            printf("%s", sbuf_str(sb));
-            lastdelim (0, lastrow);
-            annotate (vp, cor, d0-1);
+      }
+      printf("%s", sbuf_str(sb));
+      lastdelim (0, lastrow);
+      annotate (vp, cor, (d0 > 0 ? d0-1 : d0));
 	} else {
             for (j = 0; j < marks_pending; j++) {
 		sbuf_cat(sb, RBRACE);


### PR DESCRIPTION
* Fixes #1706.  