### PR TITLE
Remove duplicate references to error4.c

### DIFF
--- a/libsrc4/CMakeLists.txt
+++ b/libsrc4/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright 1993, 1994, 1995, 1996, 1997, 1998, 1999, 2000, 2001, 2002,
 # 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014,
-# 2015, 2016, 2017, 2018
+# 2015, 2016, 2017, 2018, 2019, 2020
 # University Corporation for Atmospheric Research/Unidata.
 
 # See netcdf-c/COPYRIGHT file for more info.
@@ -10,15 +10,11 @@ SET(libsrc4_SOURCES nc4dispatch.c nc4attr.c nc4dim.c nc4grp.c
 nc4internal.c nc4type.c nc4var.c ncfunc.c error4.c nc4printer.c
 ncindex.c)
 
-IF(LOGGING)
-  SET(libsrc4_SOURCES ${libsrc4_SOURCES} error4.c)
-ENDIF()
-
 add_library(netcdf4 OBJECT ${libsrc4_SOURCES})
 
 # Files for make dist
 FILE(GLOB libsrc4_HEADERS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/*.h ${CMAKE_CURRENT_SOURCE_DIR}/*.sh)
-SET(CUR_EXTRA_DIST error4.c CMakeLists.txt Makefile.am)
+SET(CUR_EXTRA_DIST CMakeLists.txt Makefile.am)
 ADD_EXTRA_DIST("${libsrc4_SOURCES}")
 ADD_EXTRA_DIST("${libsrc4_HEADERS}")
 ADD_EXTRA_DIST("${CUR_EXTRA_DIST}")


### PR DESCRIPTION
The `error4.c` file is already listed in `libsrc4_SOURCES`, so does not need to be added again later.  The file's contents are only compiled if `LOGGING` is defined, so is ok to always compile.