### PR TITLE
Improve ncdump handling of time units

### DIFF
--- a/config.h.cmake.in
+++ b/config.h.cmake.in
@@ -60,6 +60,10 @@ are set when opening a binary file on Windows. */
       #define strcasecmp _stricmp
     #endif
 
+    #ifndef strincasecmp
+      #define strncasecmp _strnicmp
+    #endif
+
     #ifndef snprintf
      #if _MSC_VER<1900
        #define snprintf _snprintf
@@ -595,10 +599,14 @@ with zip */
 /* Define to `unsigned long if <sys/types.h> does not define. */
 #cmakedefine uintptr_t unsigned long
 
-/* Define strcasecmp, snprintf on Win32 systems. */
+/* Define strcasecmp, strncasecmp, snprintf on Win32 systems. */
 #ifdef _WIN32
     #ifndef HAVE_STRCASECMP
 	 #define strcasecmp _stricmp
+    #endif
+
+    #ifndef HAVE_STRNCASECMP
+	 #define strncasecmp _strnicmp
     #endif
 
     #ifndef HAVE_SNPRINTF

--- a/configure.ac
+++ b/configure.ac
@@ -846,7 +846,8 @@ AC_CHECK_HEADERS([ftw.h])
 AC_CHECK_FUNCS([strlcat snprintf strcasecmp fileno \
                 strdup strtoll strtoull \
 		mkstemp mktemp random \
-		getrlimit gettimeofday fsync MPI_Comm_f2c MPI_Info_f2c])
+		getrlimit gettimeofday fsync MPI_Comm_f2c MPI_Info_f2c \
+		strncasecmp])
 
 # disable dap4 if netcdf-4 is disabled
 #if test "x$enable_netcdf_4" = "xno" ; then
@@ -1468,9 +1469,10 @@ AC_SUBST([HAS_PAR_FILTERS], [$hdf5_supports_par_filters])
 # Include some specifics for netcdf on windows.
 #AH_VERBATIM([_WIN32_STRICMP],
 AH_BOTTOM(
-[/* Define strcasecmp, snprintf on Win32 systems. */
+[/* Define strcasecmp, strncasecmp, snprintf on Win32 systems. */
 #ifdef _WIN32
 	#define strcasecmp _stricmp
+	#define strncasecmp _strnicmp
 	#define snprintf _snprintf
 #endif])
 

--- a/libdispatch/nctime.c
+++ b/libdispatch/nctime.c
@@ -338,28 +338,28 @@ cdParseRelunits(cdCalenType timetype, char* relunits, cdUnitTime* unit, cdCompTi
 	}
 					     /* Get the units */
 	cdTrim(charunits,CD_MAX_RELUNITS);
-	if(!strncmp(charunits,"sec",3) || !strcmp(charunits,"s")){
+	if(!strncasecmp(charunits,"sec",3) || !strcasecmp(charunits,"s")){
 		*unit = cdSecond;
 	}
-	else if(!strncmp(charunits,"min",3) || !strcmp(charunits,"mn")){
+	else if(!strncasecmp(charunits,"min",3) || !strcasecmp(charunits,"mn")){
 		*unit = cdMinute;
 	}
-	else if(!strncmp(charunits,"hour",4) || !strcmp(charunits,"hr")){
+	else if(!strncasecmp(charunits,"hour",4) || !strcasecmp(charunits,"hr")){
 		*unit = cdHour;
 	}
-	else if(!strncmp(charunits,"day",3) || !strcmp(charunits,"dy")){
+	else if(!strncasecmp(charunits,"day",3) || !strcasecmp(charunits,"dy")){
 		*unit = cdDay;
 	}
-	else if(!strncmp(charunits,"week",4) || !strcmp(charunits,"wk")){
+	else if(!strncasecmp(charunits,"week",4) || !strcasecmp(charunits,"wk")){
 		*unit = cdWeek;
 	}
-	else if(!strncmp(charunits,"month",5) || !strcmp(charunits,"mo")){
+	else if(!strncasecmp(charunits,"month",5) || !strcasecmp(charunits,"mo")){
 		*unit = cdMonth;
 	}
-	else if(!strncmp(charunits,"season",6)){
+	else if(!strncasecmp(charunits,"season",6)){
 		*unit = cdSeason;
 	}
-	else if(!strncmp(charunits,"year",4) || !strcmp(charunits,"yr")){
+	else if(!strncasecmp(charunits,"year",4) || !strcasecmp(charunits,"yr")){
 		if(!(timetype & cdStandardCal)){
 			cdError("Error on relative units conversion: climatological units cannot be 'years'.\n");
 			return 1;

--- a/ncdump/nctime0.c
+++ b/ncdump/nctime0.c
@@ -85,7 +85,7 @@ calendar_type(int ncid, int varid) {
 	NC_CHECK(nc_get_att(ncid, varid, CF_CAL_ATT_NAME, calstr));	
 	calstr[catt.len] = '\0';
 	for(itype = 0; itype < ncals; itype++) {
-	    if(strncmp(calstr, calmap[itype].attname, catt.len) == 0) {
+	    if(strncasecmp(calstr, calmap[itype].attname, catt.len) == 0) {
 		ctype = calmap[itype].type;
 		break;
 	    }
@@ -128,28 +128,28 @@ is_valid_time_unit(const char *units) {
 	    return false;
 	/* Check for unit compatible with cdtime library, no attempt
 	 * to enforce CF-compliance or udunits compliance here ... */
-	if(!strncmp(charunits,"sec",3) || !strcmp(charunits,"s")){
+	if(!strncasecmp(charunits,"sec",3) || !strcasecmp(charunits,"s")){
 	    okunit = true;
 	}
-	else if(!strncmp(charunits,"min",3) || !strcmp(charunits,"mn")){
+	else if(!strncasecmp(charunits,"min",3) || !strcasecmp(charunits,"mn")){
 	    okunit = true;
 	}
-	else if(!strncmp(charunits,"hour",4) || !strcmp(charunits,"hr")){
+	else if(!strncasecmp(charunits,"hour",4) || !strcasecmp(charunits,"hr")){
 	    okunit = true;
 	}
-	else if(!strncmp(charunits,"day",3) || !strcmp(charunits,"dy")){
+	else if(!strncasecmp(charunits,"day",3) || !strcasecmp(charunits,"dy")){
 	    okunit = true;
 	}
-	else if(!strncmp(charunits,"week",4) || !strcmp(charunits,"wk")){
+	else if(!strncasecmp(charunits,"week",4) || !strcasecmp(charunits,"wk")){
 	    okunit = true;
 	}
-	else if(!strncmp(charunits,"month",5) || !strcmp(charunits,"mo")){
+	else if(!strncasecmp(charunits,"month",5) || !strcasecmp(charunits,"mo")){
 	    okunit = true;
 	}
-	else if(!strncmp(charunits,"season",6)){
+	else if(!strncasecmp(charunits,"season",6)){
 	    okunit = true;
 	}
-	else if(!strncmp(charunits,"year",4) || !strcmp(charunits,"yr")){
+	else if(!strncasecmp(charunits,"year",4) || !strcasecmp(charunits,"yr")){
 	    okunit = true;
 	}
 	if (!okunit)

--- a/ncdump/ref_times.cdl
+++ b/ncdump/ref_times.cdl
@@ -6,6 +6,8 @@ dimensions:
 variables:
 	double t1_days(time) ;
 		t1_days:units = "days since 1500-1-1" ;
+	double t1_days_case(time) ;
+		t1_days_case:units = "DaYs since 1500-1-1" ;
 	double t1_st_days(time) ;
 		t1_st_days:calendar = "standard" ;
 		t1_st_days:units = "days since 1500-01-01 00:00:00" ;
@@ -90,6 +92,8 @@ variables:
 data:
 
  t1_days = "2009-01-01" ;
+
+ t1_days_case = "2009-01-01" ;
 
  t1_st_days = "2009-01-01" ;
 

--- a/ncdump/tst_calendars.cdl
+++ b/ncdump/tst_calendars.cdl
@@ -6,6 +6,8 @@ dimensions:
 variables:
   double t1_days(time);
      t1_days:units = "days since 1500-1-1";
+  double t1_days_case(time);
+     t1_days_case:units = "DaYs since 1500-1-1";
   double t1_st_days(time);
      t1_st_days:calendar = "standard" ; // mixed julian-gregorian
      t1_st_days:units = "days since 1500-01-01 00:00:00";
@@ -96,6 +98,7 @@ variables:
 data:
    // Should all represent 2009-01-01 00:00:00
 	t1_days = 185900;
+	t1_days_case = 185900;
 	t1_st_days = 185900;
 	t1_gr_days = 185900;
 	t1_pg_days = 185909;


### PR DESCRIPTION
This PR changes the `strcmp` and `strncmp` calls to `strcasecmp` and `strncasecmp` calls in `nctime.c`, `nctime0.c` to account for the case-insensitive nature of UDUNITS unit names, and adds a test by piggybacking on the calendar focused test in `ncdump/`.