### PR TITLE
Fix wrong header include in testing HDF5 for zlib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -770,7 +770,7 @@ IF(USE_HDF5 OR ENABLE_NETCDF_4)
 
   # Check to ensure that HDF5 was built with zlib.
   set (CMAKE_REQUIRED_INCLUDES ${HAVE_HDF5_H})
-  CHECK_C_SOURCE_COMPILES("#include <H5pubconf.h>
+  CHECK_C_SOURCE_COMPILES("#include <H5public.h>
    #if !H5_HAVE_ZLIB_H
    #error
    #endif


### PR DESCRIPTION
Fedora renames the installed `H5pubconf.h` to allow for multi-arch installations. `H5public.h` will always be correct and include the correct version of `H5pubconf`.