### PR TITLE
Make plugin noop1 be distcleaned

### DIFF
--- a/plugins/Makefile.am
+++ b/plugins/Makefile.am
@@ -36,7 +36,7 @@ libnoop1_la_SOURCES = H5Znoop1.c H5Zutil.c h5noop.h
 endif #ENABLE_FILTER_TESTING
 
 BUILT_SOURCES = H5Znoop1.c
-CLEANFILES = H5Znoop1.c
+DISTCLEANFILES = H5Znoop1.c
 H5Znoop1.c: Makefile H5Znoop.c
 	echo '#define NOOP_INSTANCE 1' > $@
 	cat ${srcdir}/H5Znoop.c >> $@


### PR DESCRIPTION
Convert plugins/Makefile.am to remove H5Znoop1.c
using distclean instead of clean.