### PR TITLE
Condition XGetOpt on MSC_VER not WIN32

### DIFF
--- a/ncdump/ncvalidator.c
+++ b/ncdump/ncvalidator.c
@@ -73,10 +73,10 @@ THIS SOFTWARE.
 #include <unistd.h>     /* read() getopt() */
 #endif
 
-#ifdef _WIN32
+#ifdef _MSC_VER
+#include "XGetopt.h"
 #include <io.h>
 #define snprintf _snprintf
-#include "XGetopt.h"
 #endif
 
 #define X_ALIGN         4


### PR DESCRIPTION
re: Issue https://github.com/Unidata/netcdf-c/issues/1737
Fix one last case of wrapping XGetOpt.h in WIN32 when it should be _MSC_VER.
