### PR TITLE
m4 check in cmake provide a clear error when required but not available.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1492,20 +1492,27 @@ ENDIF()
 
 MACRO(GEN_m4 filename)
 
+  # If m4 isn't present, and the generated file doesn't exist,
+  # it cannot be generated and an error should be thrown.
+  IF(NOT HAVE_M4)
+    IF(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${filename.c})
+      MESSAGE(FATAL_ERROR "m4 is required to generate ${filename}.c. Please install m4 so that it is on the PATH and try again.")
+    ENDIF()
+  ENDIF(NOT HAVE_M4)
+
   IF(HAVE_M4)
+    # If m4 is available, remove generated file if it exists.
+    IF(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${filename}.c)
+      FILE(REMOVE ${CMAKE_CURRENT_SOURCE_DIR}/${filename}.c)
+    ENDIF()
 
-  # If m4 is available, remove generated file if it exists.
-  IF(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${filename}.c)
-    FILE(REMOVE ${CMAKE_CURRENT_SOURCE_DIR}/${filename}.c)
-  ENDIF()
-
-  ADD_CUSTOM_COMMAND(
-    OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/${filename}.c
-    COMMAND ${NC_M4}
-    ARGS ${M4FLAGS} ${CMAKE_CURRENT_SOURCE_DIR}/${filename}.m4 > ${CMAKE_CURRENT_SOURCE_DIR}/${filename}.c
-    VERBATIM
-    )
-ENDIF(HAVE_M4)
+    ADD_CUSTOM_COMMAND(
+      OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/${filename}.c
+      COMMAND ${NC_M4}
+      ARGS ${M4FLAGS} ${CMAKE_CURRENT_SOURCE_DIR}/${filename}.m4 > ${CMAKE_CURRENT_SOURCE_DIR}/${filename}.c
+      VERBATIM
+      )
+  ENDIF(HAVE_M4)
 ENDMACRO(GEN_m4)
 
 # Binary tests, but ones which depend on value of 'TEMP_LARGE' being defined.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1488,6 +1488,7 @@ IF(NC_M4)
   SET(HAVE_M4 TRUE)
 ELSE()
   MESSAGE(STATUS "m4 not found.")
+  SET(HAVE_M4 FALSE)
 ENDIF()
 
 MACRO(GEN_m4 filename)

--- a/libsrc/CMakeLists.txt
+++ b/libsrc/CMakeLists.txt
@@ -4,9 +4,10 @@
 # Process these files with m4.
 SET(m4_SOURCES attr ncx putget t_ncxx)
 foreach (f ${m4_SOURCES})
-  IF(HAVE_M4)
     GEN_m4(${f})
-  ENDIF()
+    IF(NOT EXISTS ${f}.c)
+      MESSAGE(FATAL_ERROR "m4 is required to generate ${f}.c. Please install m4 on the PATH and try again.")
+    ENDIF()
 endforeach(f)
 
 SET(libsrc_SOURCES v1hpg.c putget.c attr.c nc3dispatch.c


### PR DESCRIPTION
* Fixes #1739 