### PR TITLE
Fix some memory leaks in libdap4

### DIFF
--- a/libdap4/d4meta.c
+++ b/libdap4/d4meta.c
@@ -130,6 +130,7 @@ NCD4_reclaimMeta(NCD4meta* dataset)
     nullfree(dataset->error.otherinfo);
     nullfree(dataset->serial.errdata);
     nclistfree(dataset->groupbyid);
+    nclistfree(dataset->atomictypes);
 #if 0
     for(i=0;i<nclistlength(dataset->blobs);i++) {
 	void* p = nclistget(dataset->blobs,i);


### PR DESCRIPTION
Discovered that there were some remaining memory leaks
in the dap4 code as a result of PR https://github.com/Unidata/netcdf-c/pull/1743.
Found and fixed.