### PR TITLE
fixed LDFLAFS in plugins Makefile.am, also fixed warning in tst_h_vars.c, restore NC_NOTNC3_get|put_varm() functions

### DIFF
--- a/h5_test/tst_h_vars.c
+++ b/h5_test/tst_h_vars.c
@@ -511,7 +511,7 @@ main()
         /* Run test 4 times. */
         for (f = 0; f < NUM_FILE; f++)
         {
-            char file_name[MAX_STR + 1];
+            char file_name[MAX_STR * 2 + 1];
             char desc[NUM_FILE][MAX_STR + 1] = {"uncompressed", "zlib",
                                                 "szip", "zlib_and_szip",
                                                 "szip_and_zlib"};

--- a/include/netcdf_dispatch.h
+++ b/include/netcdf_dispatch.h
@@ -230,6 +230,17 @@ extern "C" {
      */
     EXTERNL int NC_NOOP_filter_actions(int, int, int, struct NC_Filterobject*);
 
+    /* These functions are for dispatch layers that don't want to
+     * implement the deprecated varm functions. They return
+     * NC_ENOTNC3. */
+    EXTERNL int NC_NOTNC3_get_varm(int ncid, int varid, const size_t *start,
+				   const size_t *edges, const ptrdiff_t *stride,
+				   const ptrdiff_t *imapp, void *value0, nc_type memtype);
+    EXTERNL int NC_NOTNC3_put_varm(int ncid, int varid, const size_t * start,
+				   const size_t *edges, const ptrdiff_t *stride,
+				   const ptrdiff_t *imapp, const void *value0,
+				   nc_type memtype);
+
 #if defined(__cplusplus)
 }
 #endif

--- a/libdispatch/Makefile.am
+++ b/libdispatch/Makefile.am
@@ -18,9 +18,9 @@ libdispatch_la_CPPFLAGS = ${AM_CPPFLAGS}
 libdispatch_la_SOURCES = dparallel.c dcopy.c dfile.c ddim.c datt.c	\
 dattinq.c dattput.c dattget.c derror.c dvar.c dvarget.c dvarput.c	\
 dvarinq.c dinternal.c ddispatch.c dutf8.c nclog.c dstring.c ncuri.c	\
-nclist.c ncbytes.c nchashmap.c nctime.c nc.c nclistmgr.c		\
-dauth.c doffsets.c dwinpath.c dutil.c dreadonly.c dnotnc4.c \
-crc32.c crc32.h daux.c dinfermodel.c
+nclist.c ncbytes.c nchashmap.c nctime.c nc.c nclistmgr.c dauth.c	\
+doffsets.c dwinpath.c dutil.c dreadonly.c dnotnc4.c dnotnc3.c crc32.c	\
+crc32.h daux.c dinfermodel.c
 
 # Add the utf8 codebase
 libdispatch_la_SOURCES += utf8proc.c utf8proc.h

--- a/plugins/Makefile.am
+++ b/plugins/Makefile.am
@@ -37,7 +37,7 @@ libnoop1_la_SOURCES = H5Znoop1.c H5Zutil.c h5noop.h
 endif #ENABLE_FILTER_TESTING
 
 BUILT_SOURCES = H5Znoop1.c
-CLEANFILES = H5Znoop1.c
+MOSTLYCLEANFILES = H5Znoop1.c
 H5Znoop1.c: Makefile H5Znoop.c
 	echo '#define NOOP_INSTANCE 1' > $@
 	cat ${srcdir}/H5Znoop.c >> $@

--- a/plugins/Makefile.am
+++ b/plugins/Makefile.am
@@ -37,7 +37,7 @@ libnoop1_la_SOURCES = H5Znoop1.c H5Zutil.c h5noop.h
 endif #ENABLE_FILTER_TESTING
 
 BUILT_SOURCES = H5Znoop1.c
-MOSTLYCLEANFILES = H5Znoop1.c
+DISTCLEANFILES = H5Znoop1.c
 H5Znoop1.c: Makefile H5Znoop.c
 	echo '#define NOOP_INSTANCE 1' > $@
 	cat ${srcdir}/H5Znoop.c >> $@

--- a/plugins/Makefile.am
+++ b/plugins/Makefile.am
@@ -4,20 +4,21 @@
 # Put Together AM_CPPFLAGS and AM_LDFLAGS
 include $(top_srcdir)/lib_flags.am
 
-LDFLAGS = -module -avoid-version -shared -export-dynamic -no-undefined -rpath ${abs_builddir}
+AM_LDFLAGS = -module -avoid-version -shared -export-dynamic	\
+-no-undefined -rpath ${abs_builddir}
 
-BZIP2HDRS=bzlib.h bzlib_private.h
-BZIP2SRC= blocksort.c huffman.c crctable.c randtable.c compress.c decompress.c bzlib.c
+BZIP2HDRS = bzlib.h bzlib_private.h
+BZIP2SRC = blocksort.c huffman.c crctable.c randtable.c compress.c decompress.c bzlib.c
 
-PLUGINSRC=H5Zbzip2.c
-PLUGINHDRS=h5bzip2.h
+PLUGINSRC = H5Zbzip2.c
+PLUGINHDRS = h5bzip2.h
 
-EXTRA_DIST=${PLUGINSRC} ${BZIP2SRC} ${PLUGINHDRS} ${BZIP2HDRS} \
-		H5Ztemplate.c H5Zmisc.c H5Zutil.c H5Znoop.c h5noop.h CMakeLists.txt
+EXTRA_DIST = ${PLUGINSRC} ${BZIP2SRC} ${PLUGINHDRS} ${BZIP2HDRS}	\
+H5Ztemplate.c H5Zmisc.c H5Zutil.c H5Znoop.c h5noop.h CMakeLists.txt
 
 # WARNING: This list must be kept consistent with the corresponding
 # AC_CONFIG_LINK commands near the end of configure.ac.
-HDF5PLUGINSRC=${PLUGINSRC} ${BZIP2SRC} ${PLUGINHDRS} ${BZIP2HDRS}
+HDF5PLUGINSRC = ${PLUGINSRC} ${BZIP2SRC} ${PLUGINHDRS} ${BZIP2HDRS}
 
 if ENABLE_FILTER_TESTING
 


### PR DESCRIPTION
Fixes #1746 
Fixes #1745 
Fixed #1749