### PR TITLE
Allow use of type keywords as identifiers in some formats

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,7 @@ This file contains a high-level description of this package's evolution. Release
 
 ## 4.8.0 - TBD
 
+* [Enhancement] Modify ncgen to allow type keywords not used in some particular format to be used as identifiers when compiling to that format. For example, when compiling a netcdf-3 .cdl file, allow the use of "string" as a dimension name [https://github.com/Unidata/netcdf-c/issues/1750].
 * [Bug Fix] Fix some protocol bugs/differences between the netcdf-c library and the OPeNDAP Hyrax server. Also cleanup checksum handling [https://github.com/Unidata/netcdf-c/issues/1712].
 * [Bug Fix] Add necessary __declspec declarations to allow compilation
 of netcdf library without causing errors or (_declspec related)

--- a/ncdump/CMakeLists.txt
+++ b/ncdump/CMakeLists.txt
@@ -268,6 +268,10 @@ ENDIF(MSVC)
 
   add_sh_test(ncdump tst_ctests)
 
+  IF(USE_CDF5)
+  add_sh_test(ncdump test_keywords)
+  ENDIF()
+  
 ENDIF()
 
 ENDIF()

--- a/ncdump/Makefile.am
+++ b/ncdump/Makefile.am
@@ -4,7 +4,6 @@
 
 # Ed Hartnett, Dennis Heimbigner, Ward Fisher
 
-
 #SH_LOG_DRIVER = $(SHELL) $(top_srcdir)/test-driver-verbose
 #sh_LOG_DRIVER = $(SHELL) $(top_srcdir)/test-driver-verbose
 #LOG_DRIVER = $(SHELL) $(top_srcdir)/test-driver-verbose
@@ -112,6 +111,11 @@ if USE_HDF5
 TESTS += tst_ctests.sh
 endif
 
+if ENABLE_CDF5
+# Test for keywords as identifiers
+TESTS += test_keywords.sh
+endif
+
 endif BUILD_TESTSETS
 
 # These files all have to be included with the distribution.
@@ -150,8 +154,8 @@ tst_ncgen4_cycle.sh tst_null_byte_padding.sh				\
 ref_null_byte_padding_test.nc ref_tst_irish_rover.nc ref_provenance_v1.nc \
 ref_tst_radix.cdl tst_radix.cdl test_radix.sh                           \
 ref_nccopy_w.cdl tst_nccopy_w3.sh tst_nccopy_w4.sh ref_no_ncproperty.nc \
-test_unicode_directory.sh
-
+test_unicode_directory.sh                                               \
+test_keywords.sh ref_keyword1.cdl ref_keyword2.cdl
 
 # The L512.bin file is file containing exactly 512 bytes each of value 0.
 # It is used for creating hdf5 files with varying offsets for testing.
@@ -186,4 +190,5 @@ tst_compound_datasize_test.cdl tst_compound_datasize_test2.cdl		\
 tst_ncf199.cdl tst_tst_gattenum.cdl tst_tst_usuffix.cdl ctest.c		\
 ctest64.c nccopy3_subset_out.nc camrun.c tst_ncf213.cdl tst_ncf213.nc   \
 tst_radix.nc tmp_radix.cdl ctest_small_3.c ctest_small_4.c              \
-ctest_special_atts_4.c
+ctest_special_atts_4.c                                                  \
+keyword1.nc keyword2.nc tmp_keyword1.cdl tmp_keyword2.cdl

--- a/ncdump/nccopy.c
+++ b/ncdump/nccopy.c
@@ -32,6 +32,7 @@
 #include "list.h"
 
 #undef DEBUGFILTER
+#undef DEBUGCHUNK
 
 /* default bytes of memory we are willing to allocate for variable
  * values during copy */
@@ -1462,6 +1463,7 @@ copy_vars(int igrp, int ogrp)
     return stat;
 }
 
+#ifdef DEBUGCHUNK
 static void
 report(int rank, size_t* start, size_t* count, void* buf)
 {
@@ -1482,7 +1484,7 @@ report(int rank, size_t* start, size_t* count, void* buf)
     fprintf(stderr,"\n");
     fflush(stderr);
 }
-
+#endif /*DEBUGCHUNK*/
 
 /* Copy the schema in a group and all its subgroups, recursively, from
  * group igrp in input to parent group ogrp in destination.  Use
@@ -1636,7 +1638,9 @@ copy_var_data(int igrp, int varid, int ogrp) {
      * subsequent calls. */
     while((ntoget = nc_next_iter(iterp, start, count)) > 0) {
 	NC_CHECK(nc_get_vara(igrp, varid, start, count, buf));
-report(iterp->rank,start,count,buf);
+#ifdef DEBUGCHUNK
+	report(iterp->rank,start,count,buf);
+#endif
 	NC_CHECK(nc_put_vara(ogrp, ovarid, start, count, buf));
 #ifdef USE_NETCDF4
 	/* we have to explicitly free values for strings and vlens */

--- a/ncdump/ref_keyword1.cdl
+++ b/ncdump/ref_keyword1.cdl
@@ -1,0 +1,8 @@
+netcdf keyword1 {
+dimensions:
+    string = 128;
+    int64 = 64;
+variables:
+    int string(string);
+    int int64(int64);
+}

--- a/ncdump/ref_keyword2.cdl
+++ b/ncdump/ref_keyword2.cdl
@@ -1,0 +1,6 @@
+netcdf keyword2 {
+dimensions:
+string = 128;
+variables:
+int string(string);
+}

--- a/ncdump/test_keywords.sh
+++ b/ncdump/test_keywords.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+if test "x$srcdir" = x ; then srcdir=`pwd`; fi 
+. ../test_common.sh
+
+set -e
+
+echo "*** Test use of keywords for formats where the keyword is not defined"
+echo "*** classic: creating keyword1.nc from ref_keyword1.cdl..."
+${NCGEN} -3 -lb -o keyword1.nc $srcdir/ref_keyword1.cdl
+echo "*** creating tmp_keyword1.cdl from keyword1.nc..."
+${NCDUMP} -h keyword1.nc > tmp_keyword1.cdl
+echo "*** comparing tmp_keyword1.cdl to ref_keyword1.cdl..."
+diff -b -w tmp_keyword1.cdl $srcdir/ref_keyword1.cdl
+
+echo "*** cdf5: creating keyword2.nc from ref_keyword2.cdl..."
+${NCGEN} -5 -lb -o keyword2.nc $srcdir/ref_keyword2.cdl
+echo "*** creating tmp_keyword2.cdl from keyword2.nc..."
+${NCDUMP} -h keyword2.nc > tmp_keyword2.cdl
+echo "*** comparing tmp_keyword2.cdl to ref_keyword2.cdl..."
+diff -b -w tmp_keyword2.cdl $srcdir/ref_keyword2.cdl
+
+exit 0

--- a/ncgen/ncgen.l
+++ b/ncgen/ncgen.l
@@ -139,6 +139,35 @@ struct Specialtoken specials[] = {
 {NULL,0} /* null terminate */
 };
 
+/* Track keywords that may be identifiers depending on
+   format being produced */
+/* Define the possible format classes */
+#define KWALL (1<<NC_FORMAT_CLASSIC|1<<NC_FORMAT_64BIT_OFFSET|1<<NC_FORMAT_NETCDF4|1<<NC_FORMAT_NETCDF4_CLASSIC|1<<NC_FORMAT_64BIT_DATA) /* Used in all formats */
+#define KWCDF5 (1<<NC_FORMAT_64BIT_DATA) /* Used in cdf5 */
+#define KWNC4 (1<<NC_FORMAT_NETCDF4) /* Used in netcdf-4 */
+
+#define NKWIDENT 12
+struct KWIDENT {
+    int token;
+    const char* keyword;
+    int formats; /* Which formats use this keyword */
+} kwident[NKWIDENT] = {
+/* Order by token for binary search */
+{CHAR_K, "char", KWALL},
+{BYTE_K, "byte", KWALL},
+{SHORT_K, "short", KWALL},
+{INT_K, "int", KWALL},
+{FLOAT_K, "float", KWALL},
+{DOUBLE_K, "double", KWALL},
+{UBYTE_K, "ubyte", KWCDF5|KWNC4},
+{USHORT_K, "ushort", KWCDF5|KWNC4},
+{UINT_K, "uint", KWCDF5|KWNC4},
+{INT64_K, "int64", KWCDF5|KWNC4},
+{UINT64_K, "uint64", KWCDF5|KWNC4},
+{STRING_K, "string", KWNC4}
+};
+static int identorkw(int token);
+
 %}
 %x ST_C_COMMENT
 %x TEXT
@@ -260,26 +289,27 @@ yytext[MAXTRST-1] = '\0';
 		return lexdebug(OPAQUESTRING);
 		}
 
-compound|struct|structure {return lexdebug(COMPOUND);}
-enum				{return lexdebug(ENUM);}
+compound|struct|structure {return lexdebug(identorkw(COMPOUND));}
+enum				{return lexdebug(identorkw(ENUM));}
 opaque				{return lexdebug(OPAQUE_);}
 
-float|real		{return lexdebug(FLOAT_K);}
-char			{return lexdebug(CHAR_K);}
-byte			{return lexdebug(BYTE_K);}
-ubyte			{return lexdebug(UBYTE_K);}
-short			{return lexdebug(SHORT_K);}
-ushort			{return lexdebug(USHORT_K);}
-long|int|integer	{return lexdebug(INT_K);}
-ulong|uint|uinteger	{return lexdebug(UINT_K);}
-int64			{return lexdebug(INT64_K);}
-uint64			{return lexdebug(UINT64_K);}
-double			{return lexdebug(DOUBLE_K);}
-string                  {return lexdebug(STRING_K);}
+float|real		{return lexdebug(identorkw(FLOAT_K));}
+char			{return lexdebug(identorkw(CHAR_K));}
+byte			{return lexdebug(identorkw(BYTE_K));}
+ubyte			{return lexdebug(identorkw(UBYTE_K));}
+short			{return lexdebug(identorkw(SHORT_K));}
+ushort			{return lexdebug(identorkw(USHORT_K));}
+long|int|integer	{return lexdebug(identorkw(INT_K));}
+ulong|uint|uinteger	{return lexdebug(identorkw(UINT_K));}
+int64			{return lexdebug(identorkw(INT64_K));}
+uint64			{return lexdebug(identorkw(UINT64_K));}
+double			{return lexdebug(identorkw(DOUBLE_K));}
+string                  {return lexdebug(identorkw(STRING_K));}
 
 unlimited|UNLIMITED	{int32_val = -1;
-			 return lexdebug(NC_UNLIMITED_K);}
+			 return lexdebug(identorkw(NC_UNLIMITED_K));}
 
+			/* These are currently only keywords */
 types:			{return lexdebug(TYPES);}
 dimensions:		{return lexdebug(DIMENSIONS);}
 variables:		{return lexdebug(VARIABLES);}
@@ -874,4 +904,40 @@ collecttag(char* text, char** stagp)
 	tag = NC_NAT;
     }
     return tag;
+}
+
+/* Depending on the format, a name may be a keword or an ident */
+static int
+identorkw(int token)
+{
+    /* Binary search for yytext */
+    int n = NKWIDENT;
+    int L = 0;
+    int R = (n - 1);
+    int m, cmp;
+    struct KWIDENT* p;
+    int found = 0;
+    size_t len;
+    char* id = NULL;
+
+    for(;;) {
+	if(L > R) break;
+        m = (L + R) / 2;
+	p = &kwident[m];
+	cmp = (p->token - token);
+	if(cmp == 0) {found = 1; break;}
+	if(cmp < 0)
+	    L = (m + 1);
+	else /*cmp > 0*/
+	    R = (m - 1);
+    }
+    if(!found) return token; /* Not a keyword of interest */
+    /* See if the format applies */
+    if(p->formats & ((int)1<<k_flag)) return token;
+    /* Need to convert a non-ident token to an ident symbol */
+    len = strlen(yytext);
+    len = unescape(yytext,len,ISIDENT,&id);
+    yylval.sym = install(id);
+    efree(id);
+    return IDENT; /* treat as identifier */
 }

--- a/ncgen/ncgen.y
+++ b/ncgen/ncgen.y
@@ -217,7 +217,7 @@ NCConstant*    constant;
 	    attrdecl enumid path dimref fielddim fieldspec
 %type <sym> typeref
 %type <sym> varref
-%type <sym> type_var_ref
+%type <sym> ambiguous_ref
 %type <mark> enumidlist fieldlist fields varlist dimspec dimlist field
 	     fielddimspec fielddimlist
 %type <constant> dataitem constdata constint conststring constbool
@@ -670,7 +670,7 @@ fielddim:
 /* Use this when referencing defined objects */
 
 varref:
-	type_var_ref
+	ambiguous_ref
 	    {Symbol* vsym = $1;
 		if(vsym->objectclass != NC_VAR) {
 		    derror("Undefined or forward referenced variable: %s",vsym->name);
@@ -681,7 +681,7 @@ varref:
 	  ;
 
 typeref:
-	type_var_ref
+	ambiguous_ref
 	    {Symbol* tsym = $1;
 		if(tsym->objectclass != NC_TYPE) {
 		    derror("Undefined or forward referenced type: %s",tsym->name);
@@ -691,7 +691,7 @@ typeref:
 	    }
 	;
 
-type_var_ref:
+ambiguous_ref:
 	path
 	    {Symbol* tvsym = $1; Symbol* sym;
 		/* disambiguate*/
@@ -729,7 +729,7 @@ attrdecl:
 	    {$$ = makespecial(_SUPERBLOCK_FLAG,NULL,NULL,(void*)$4,ISCONST);}
 	| ':' ident '=' datalist
 	    { $$=makeattribute($2,NULL,NULL,$4,ATTRGLOBAL);}
-	| typeref type_var_ref ':' ident '=' datalist
+	| typeref ambiguous_ref ':' ident '=' datalist
 	    {Symbol* tsym = $1; Symbol* vsym = $2; Symbol* asym = $4;
 		if(vsym->objectclass == NC_VAR) {
 		    $$=makeattribute(asym,vsym,tsym,$6,ATTRVAR);
@@ -738,7 +738,7 @@ attrdecl:
 		    YYABORT;
 		}
 	    }
-	| type_var_ref ':' ident '=' datalist
+	| ambiguous_ref ':' ident '=' datalist
 	    {Symbol* sym = $1; Symbol* asym = $3;
 		if(sym->objectclass == NC_VAR) {
 		    $$=makeattribute(asym,sym,NULL,$5,ATTRVAR);
@@ -749,25 +749,25 @@ attrdecl:
 		    YYABORT;
 		}
 	    }
-	| type_var_ref ':' _FILLVALUE '=' datalist
+	| ambiguous_ref ':' _FILLVALUE '=' datalist
 	    {$$ = makespecial(_FILLVALUE_FLAG,$1,NULL,(void*)$5,ISLIST);}
-	| typeref type_var_ref ':' _FILLVALUE '=' datalist
+	| typeref ambiguous_ref ':' _FILLVALUE '=' datalist
 	    {$$ = makespecial(_FILLVALUE_FLAG,$2,$1,(void*)$6,ISLIST);}
-	| type_var_ref ':' _STORAGE '=' conststring
+	| ambiguous_ref ':' _STORAGE '=' conststring
 	    {$$ = makespecial(_STORAGE_FLAG,$1,NULL,(void*)$5,ISCONST);}
-	| type_var_ref ':' _CHUNKSIZES '=' intlist
+	| ambiguous_ref ':' _CHUNKSIZES '=' intlist
 	    {$$ = makespecial(_CHUNKSIZES_FLAG,$1,NULL,(void*)$5,ISLIST);}
-	| type_var_ref ':' _FLETCHER32 '=' constbool
+	| ambiguous_ref ':' _FLETCHER32 '=' constbool
 	    {$$ = makespecial(_FLETCHER32_FLAG,$1,NULL,(void*)$5,ISCONST);}
-	| type_var_ref ':' _DEFLATELEVEL '=' constint
+	| ambiguous_ref ':' _DEFLATELEVEL '=' constint
 	    {$$ = makespecial(_DEFLATE_FLAG,$1,NULL,(void*)$5,ISCONST);}
-	| type_var_ref ':' _SHUFFLE '=' constbool
+	| ambiguous_ref ':' _SHUFFLE '=' constbool
 	    {$$ = makespecial(_SHUFFLE_FLAG,$1,NULL,(void*)$5,ISCONST);}
-	| type_var_ref ':' _ENDIANNESS '=' conststring
+	| ambiguous_ref ':' _ENDIANNESS '=' conststring
 	    {$$ = makespecial(_ENDIAN_FLAG,$1,NULL,(void*)$5,ISCONST);}
-	| type_var_ref ':' _FILTER '=' conststring
+	| ambiguous_ref ':' _FILTER '=' conststring
 	    {$$ = makespecial(_FILTER_FLAG,$1,NULL,(void*)$5,ISCONST);}
-	| type_var_ref ':' _NOFILL '=' constbool
+	| ambiguous_ref ':' _NOFILL '=' constbool
 	    {$$ = makespecial(_NOFILL_FLAG,$1,NULL,(void*)$5,ISCONST);}
 	| ':' _FORMAT '=' conststring
 	    {$$ = makespecial(_FORMAT_FLAG,NULL,NULL,(void*)$4,ISCONST);}

--- a/ncgen/ncgenl.c
+++ b/ncgen/ncgenl.c
@@ -1,5 +1,5 @@
 
-#line 3 "ncgenl.c"
+#line 2 "ncgenl.c"
 
 #define  YY_INT_ALIGNED short int
 
@@ -7,11 +7,17 @@
 
 #define yy_create_buffer ncg_create_buffer
 #define yy_delete_buffer ncg_delete_buffer
-#define yy_flex_debug ncg_flex_debug
+#define yy_scan_buffer ncg_scan_buffer
+#define yy_scan_string ncg_scan_string
+#define yy_scan_bytes ncg_scan_bytes
 #define yy_init_buffer ncg_init_buffer
 #define yy_flush_buffer ncg_flush_buffer
 #define yy_load_buffer_state ncg_load_buffer_state
 #define yy_switch_to_buffer ncg_switch_to_buffer
+#define yypush_buffer_state ncgpush_buffer_state
+#define yypop_buffer_state ncgpop_buffer_state
+#define yyensure_buffer_stack ncgensure_buffer_stack
+#define yy_flex_debug ncg_flex_debug
 #define yyin ncgin
 #define yyleng ncgleng
 #define yylex ncglex
@@ -27,9 +33,243 @@
 #define FLEX_SCANNER
 #define YY_FLEX_MAJOR_VERSION 2
 #define YY_FLEX_MINOR_VERSION 6
-#define YY_FLEX_SUBMINOR_VERSION 0
+#define YY_FLEX_SUBMINOR_VERSION 4
 #if YY_FLEX_SUBMINOR_VERSION > 0
 #define FLEX_BETA
+#endif
+
+#ifdef yy_create_buffer
+#define ncg_create_buffer_ALREADY_DEFINED
+#else
+#define yy_create_buffer ncg_create_buffer
+#endif
+
+#ifdef yy_delete_buffer
+#define ncg_delete_buffer_ALREADY_DEFINED
+#else
+#define yy_delete_buffer ncg_delete_buffer
+#endif
+
+#ifdef yy_scan_buffer
+#define ncg_scan_buffer_ALREADY_DEFINED
+#else
+#define yy_scan_buffer ncg_scan_buffer
+#endif
+
+#ifdef yy_scan_string
+#define ncg_scan_string_ALREADY_DEFINED
+#else
+#define yy_scan_string ncg_scan_string
+#endif
+
+#ifdef yy_scan_bytes
+#define ncg_scan_bytes_ALREADY_DEFINED
+#else
+#define yy_scan_bytes ncg_scan_bytes
+#endif
+
+#ifdef yy_init_buffer
+#define ncg_init_buffer_ALREADY_DEFINED
+#else
+#define yy_init_buffer ncg_init_buffer
+#endif
+
+#ifdef yy_flush_buffer
+#define ncg_flush_buffer_ALREADY_DEFINED
+#else
+#define yy_flush_buffer ncg_flush_buffer
+#endif
+
+#ifdef yy_load_buffer_state
+#define ncg_load_buffer_state_ALREADY_DEFINED
+#else
+#define yy_load_buffer_state ncg_load_buffer_state
+#endif
+
+#ifdef yy_switch_to_buffer
+#define ncg_switch_to_buffer_ALREADY_DEFINED
+#else
+#define yy_switch_to_buffer ncg_switch_to_buffer
+#endif
+
+#ifdef yypush_buffer_state
+#define ncgpush_buffer_state_ALREADY_DEFINED
+#else
+#define yypush_buffer_state ncgpush_buffer_state
+#endif
+
+#ifdef yypop_buffer_state
+#define ncgpop_buffer_state_ALREADY_DEFINED
+#else
+#define yypop_buffer_state ncgpop_buffer_state
+#endif
+
+#ifdef yyensure_buffer_stack
+#define ncgensure_buffer_stack_ALREADY_DEFINED
+#else
+#define yyensure_buffer_stack ncgensure_buffer_stack
+#endif
+
+#ifdef yylex
+#define ncglex_ALREADY_DEFINED
+#else
+#define yylex ncglex
+#endif
+
+#ifdef yyrestart
+#define ncgrestart_ALREADY_DEFINED
+#else
+#define yyrestart ncgrestart
+#endif
+
+#ifdef yylex_init
+#define ncglex_init_ALREADY_DEFINED
+#else
+#define yylex_init ncglex_init
+#endif
+
+#ifdef yylex_init_extra
+#define ncglex_init_extra_ALREADY_DEFINED
+#else
+#define yylex_init_extra ncglex_init_extra
+#endif
+
+#ifdef yylex_destroy
+#define ncglex_destroy_ALREADY_DEFINED
+#else
+#define yylex_destroy ncglex_destroy
+#endif
+
+#ifdef yyget_debug
+#define ncgget_debug_ALREADY_DEFINED
+#else
+#define yyget_debug ncgget_debug
+#endif
+
+#ifdef yyset_debug
+#define ncgset_debug_ALREADY_DEFINED
+#else
+#define yyset_debug ncgset_debug
+#endif
+
+#ifdef yyget_extra
+#define ncgget_extra_ALREADY_DEFINED
+#else
+#define yyget_extra ncgget_extra
+#endif
+
+#ifdef yyset_extra
+#define ncgset_extra_ALREADY_DEFINED
+#else
+#define yyset_extra ncgset_extra
+#endif
+
+#ifdef yyget_in
+#define ncgget_in_ALREADY_DEFINED
+#else
+#define yyget_in ncgget_in
+#endif
+
+#ifdef yyset_in
+#define ncgset_in_ALREADY_DEFINED
+#else
+#define yyset_in ncgset_in
+#endif
+
+#ifdef yyget_out
+#define ncgget_out_ALREADY_DEFINED
+#else
+#define yyget_out ncgget_out
+#endif
+
+#ifdef yyset_out
+#define ncgset_out_ALREADY_DEFINED
+#else
+#define yyset_out ncgset_out
+#endif
+
+#ifdef yyget_leng
+#define ncgget_leng_ALREADY_DEFINED
+#else
+#define yyget_leng ncgget_leng
+#endif
+
+#ifdef yyget_text
+#define ncgget_text_ALREADY_DEFINED
+#else
+#define yyget_text ncgget_text
+#endif
+
+#ifdef yyget_lineno
+#define ncgget_lineno_ALREADY_DEFINED
+#else
+#define yyget_lineno ncgget_lineno
+#endif
+
+#ifdef yyset_lineno
+#define ncgset_lineno_ALREADY_DEFINED
+#else
+#define yyset_lineno ncgset_lineno
+#endif
+
+#ifdef yywrap
+#define ncgwrap_ALREADY_DEFINED
+#else
+#define yywrap ncgwrap
+#endif
+
+#ifdef yyalloc
+#define ncgalloc_ALREADY_DEFINED
+#else
+#define yyalloc ncgalloc
+#endif
+
+#ifdef yyrealloc
+#define ncgrealloc_ALREADY_DEFINED
+#else
+#define yyrealloc ncgrealloc
+#endif
+
+#ifdef yyfree
+#define ncgfree_ALREADY_DEFINED
+#else
+#define yyfree ncgfree
+#endif
+
+#ifdef yytext
+#define ncgtext_ALREADY_DEFINED
+#else
+#define yytext ncgtext
+#endif
+
+#ifdef yyleng
+#define ncgleng_ALREADY_DEFINED
+#else
+#define yyleng ncgleng
+#endif
+
+#ifdef yyin
+#define ncgin_ALREADY_DEFINED
+#else
+#define yyin ncgin
+#endif
+
+#ifdef yyout
+#define ncgout_ALREADY_DEFINED
+#else
+#define yyout ncgout
+#endif
+
+#ifdef yy_flex_debug
+#define ncg_flex_debug_ALREADY_DEFINED
+#else
+#define yy_flex_debug ncg_flex_debug
+#endif
+
+#ifdef yylineno
+#define ncglineno_ALREADY_DEFINED
+#else
+#define yylineno ncglineno
 #endif
 
 /* First, we deal with  platform-specific or compiler-specific issues. */
@@ -102,60 +342,48 @@ typedef unsigned int flex_uint32_t;
 #define UINT32_MAX             (4294967295U)
 #endif
 
+#ifndef SIZE_MAX
+#define SIZE_MAX               (~(size_t)0)
+#endif
+
 #endif /* ! C99 */
 
 #endif /* ! FLEXINT_H */
 
-#ifdef __cplusplus
+/* begin standard C++ headers. */
 
-/* The "const" storage-class-modifier is valid. */
-#define YY_USE_CONST
-
-#else	/* ! __cplusplus */
-
-/* C99 requires __STDC__ to be defined as 1. */
-#if defined (__STDC__)
-
-#define YY_USE_CONST
-
-#endif	/* defined (__STDC__) */
-#endif	/* ! __cplusplus */
-
-#ifdef YY_USE_CONST
+/* TODO: this is always defined, so inline it */
 #define yyconst const
+
+#if defined(__GNUC__) && __GNUC__ >= 3
+#define yynoreturn __attribute__((__noreturn__))
 #else
-#define yyconst
+#define yynoreturn
 #endif
 
 /* Returned upon end-of-file. */
 #define YY_NULL 0
 
-/* Promotes a possibly negative, possibly signed char to an unsigned
- * integer for use as an array index.  If the signed char is negative,
- * we want to instead treat it as an 8-bit unsigned char, hence the
- * double cast.
+/* Promotes a possibly negative, possibly signed char to an
+ *   integer in range [0..255] for use as an array index.
  */
-#define YY_SC_TO_UI(c) ((unsigned int) (unsigned char) c)
+#define YY_SC_TO_UI(c) ((YY_CHAR) (c))
 
 /* Enter a start condition.  This macro really ought to take a parameter,
  * but we do it the disgusting crufty way forced on us by the ()-less
  * definition of BEGIN.
  */
 #define BEGIN (yy_start) = 1 + 2 *
-
 /* Translate the current start state into a value that can be later handed
  * to BEGIN to return to the state.  The YYSTATE alias is for lex
  * compatibility.
  */
 #define YY_START (((yy_start) - 1) / 2)
 #define YYSTATE YY_START
-
 /* Action number for EOF rule of a given start state. */
 #define YY_STATE_EOF(state) (YY_END_OF_BUFFER + state + 1)
-
 /* Special action meaning "start processing a new file". */
-#define YY_NEW_FILE ncgrestart(ncgin  )
-
+#define YY_NEW_FILE yyrestart( yyin  )
 #define YY_END_OF_BUFFER_CHAR 0
 
 /* Size of default input buffer. */
@@ -185,14 +413,14 @@ typedef struct yy_buffer_state *YY_BUFFER_STATE;
 typedef size_t yy_size_t;
 #endif
 
-extern yy_size_t ncgleng;
+extern int yyleng;
 
-extern FILE *ncgin, *ncgout;
+extern FILE *yyin, *yyout;
 
 #define EOB_ACT_CONTINUE_SCAN 0
 #define EOB_ACT_END_OF_FILE 1
 #define EOB_ACT_LAST_MATCH 2
-
+    
     #define YY_LESS_LINENO(n)
     #define YY_LINENO_REWIND_TO(ptr)
     
@@ -200,16 +428,15 @@ extern FILE *ncgin, *ncgout;
 #define yyless(n) \
 	do \
 		{ \
-		/* Undo effects of setting up ncgtext. */ \
+		/* Undo effects of setting up yytext. */ \
         int yyless_macro_arg = (n); \
         YY_LESS_LINENO(yyless_macro_arg);\
 		*yy_cp = (yy_hold_char); \
 		YY_RESTORE_YY_MORE_OFFSET \
 		(yy_c_buf_p) = yy_cp = yy_bp + yyless_macro_arg - YY_MORE_ADJ; \
-		YY_DO_BEFORE_ACTION; /* set up ncgtext again */ \
+		YY_DO_BEFORE_ACTION; /* set up yytext again */ \
 		} \
 	while ( 0 )
-
 #define unput(c) yyunput( c, (yytext_ptr)  )
 
 #ifndef YY_STRUCT_YY_BUFFER_STATE
@@ -224,7 +451,7 @@ struct yy_buffer_state
 	/* Size of input buffer in bytes, not including room for EOB
 	 * characters.
 	 */
-	yy_size_t yy_buf_size;
+	int yy_buf_size;
 
 	/* Number of characters read into yy_ch_buf, not including EOB
 	 * characters.
@@ -252,7 +479,7 @@ struct yy_buffer_state
 
     int yy_bs_lineno; /**< The line count. */
     int yy_bs_column; /**< The column count. */
-    
+
 	/* Whether to try to fill the input buffer when we reach the
 	 * end of it.
 	 */
@@ -269,8 +496,8 @@ struct yy_buffer_state
 	 * possible backing-up.
 	 *
 	 * When we actually see the EOF, we change the status to "new"
-	 * (via ncgrestart()), so that the user can continue scanning by
-	 * just pointing ncgin at a new input file.
+	 * (via yyrestart()), so that the user can continue scanning by
+	 * just pointing yyin at a new input file.
 	 */
 #define YY_BUFFER_EOF_PENDING 2
 
@@ -280,7 +507,7 @@ struct yy_buffer_state
 /* Stack of input buffers. */
 static size_t yy_buffer_stack_top = 0; /**< index of top of stack. */
 static size_t yy_buffer_stack_max = 0; /**< capacity of stack. */
-static YY_BUFFER_STATE * yy_buffer_stack = 0; /**< Stack as an array. */
+static YY_BUFFER_STATE * yy_buffer_stack = NULL; /**< Stack as an array. */
 
 /* We provide macros for accessing buffer states in case in the
  * future we want to put the buffer states in a more general
@@ -291,109 +518,98 @@ static YY_BUFFER_STATE * yy_buffer_stack = 0; /**< Stack as an array. */
 #define YY_CURRENT_BUFFER ( (yy_buffer_stack) \
                           ? (yy_buffer_stack)[(yy_buffer_stack_top)] \
                           : NULL)
-
 /* Same as previous macro, but useful when we know that the buffer stack is not
  * NULL or when we need an lvalue. For internal use only.
  */
 #define YY_CURRENT_BUFFER_LVALUE (yy_buffer_stack)[(yy_buffer_stack_top)]
 
-/* yy_hold_char holds the character lost when ncgtext is formed. */
+/* yy_hold_char holds the character lost when yytext is formed. */
 static char yy_hold_char;
 static int yy_n_chars;		/* number of characters read into yy_ch_buf */
-yy_size_t ncgleng;
+int yyleng;
 
 /* Points to current character in buffer. */
-static char *yy_c_buf_p = (char *) 0;
+static char *yy_c_buf_p = NULL;
 static int yy_init = 0;		/* whether we need to initialize */
 static int yy_start = 0;	/* start state number */
 
-/* Flag which is used to allow ncgwrap()'s to do buffer switches
- * instead of setting up a fresh ncgin.  A bit of a hack ...
+/* Flag which is used to allow yywrap()'s to do buffer switches
+ * instead of setting up a fresh yyin.  A bit of a hack ...
  */
 static int yy_did_buffer_switch_on_eof;
 
-void ncgrestart (FILE *input_file  );
-void ncg_switch_to_buffer (YY_BUFFER_STATE new_buffer  );
-YY_BUFFER_STATE ncg_create_buffer (FILE *file,int size  );
-void ncg_delete_buffer (YY_BUFFER_STATE b  );
-void ncg_flush_buffer (YY_BUFFER_STATE b  );
-void ncgpush_buffer_state (YY_BUFFER_STATE new_buffer  );
-void ncgpop_buffer_state (void );
+void yyrestart ( FILE *input_file  );
+void yy_switch_to_buffer ( YY_BUFFER_STATE new_buffer  );
+YY_BUFFER_STATE yy_create_buffer ( FILE *file, int size  );
+void yy_delete_buffer ( YY_BUFFER_STATE b  );
+void yy_flush_buffer ( YY_BUFFER_STATE b  );
+void yypush_buffer_state ( YY_BUFFER_STATE new_buffer  );
+void yypop_buffer_state ( void );
 
-static void ncgensure_buffer_stack (void );
-static void ncg_load_buffer_state (void );
-static void ncg_init_buffer (YY_BUFFER_STATE b,FILE *file  );
+static void yyensure_buffer_stack ( void );
+static void yy_load_buffer_state ( void );
+static void yy_init_buffer ( YY_BUFFER_STATE b, FILE *file  );
+#define YY_FLUSH_BUFFER yy_flush_buffer( YY_CURRENT_BUFFER )
 
-#define YY_FLUSH_BUFFER ncg_flush_buffer(YY_CURRENT_BUFFER )
+YY_BUFFER_STATE yy_scan_buffer ( char *base, yy_size_t size  );
+YY_BUFFER_STATE yy_scan_string ( const char *yy_str  );
+YY_BUFFER_STATE yy_scan_bytes ( const char *bytes, int len  );
 
-YY_BUFFER_STATE ncg_scan_buffer (char *base,yy_size_t size  );
-YY_BUFFER_STATE ncg_scan_string (yyconst char *yy_str  );
-YY_BUFFER_STATE ncg_scan_bytes (yyconst char *bytes,yy_size_t len  );
+void *yyalloc ( yy_size_t  );
+void *yyrealloc ( void *, yy_size_t  );
+void yyfree ( void *  );
 
-void *ncgalloc (yy_size_t  );
-void *ncgrealloc (void *,yy_size_t  );
-void ncgfree (void *  );
-
-#define yy_new_buffer ncg_create_buffer
-
+#define yy_new_buffer yy_create_buffer
 #define yy_set_interactive(is_interactive) \
 	{ \
 	if ( ! YY_CURRENT_BUFFER ){ \
-        ncgensure_buffer_stack (); \
+        yyensure_buffer_stack (); \
 		YY_CURRENT_BUFFER_LVALUE =    \
-            ncg_create_buffer(ncgin,YY_BUF_SIZE ); \
+            yy_create_buffer( yyin, YY_BUF_SIZE ); \
 	} \
 	YY_CURRENT_BUFFER_LVALUE->yy_is_interactive = is_interactive; \
 	}
-
 #define yy_set_bol(at_bol) \
 	{ \
 	if ( ! YY_CURRENT_BUFFER ){\
-        ncgensure_buffer_stack (); \
+        yyensure_buffer_stack (); \
 		YY_CURRENT_BUFFER_LVALUE =    \
-            ncg_create_buffer(ncgin,YY_BUF_SIZE ); \
+            yy_create_buffer( yyin, YY_BUF_SIZE ); \
 	} \
 	YY_CURRENT_BUFFER_LVALUE->yy_at_bol = at_bol; \
 	}
-
 #define YY_AT_BOL() (YY_CURRENT_BUFFER_LVALUE->yy_at_bol)
 
 /* Begin user sect3 */
+typedef flex_uint8_t YY_CHAR;
 
-typedef unsigned char YY_CHAR;
-
-FILE *ncgin = (FILE *) 0, *ncgout = (FILE *) 0;
+FILE *yyin = NULL, *yyout = NULL;
 
 typedef int yy_state_type;
 
-extern int ncglineno;
+extern int yylineno;
+int yylineno = 1;
 
-int ncglineno = 1;
-
-extern char *ncgtext;
+extern char *yytext;
 #ifdef yytext_ptr
 #undef yytext_ptr
 #endif
-#define yytext_ptr ncgtext
+#define yytext_ptr yytext
 
-static yy_state_type yy_get_previous_state (void );
-static yy_state_type yy_try_NUL_trans (yy_state_type current_state  );
-static int yy_get_next_buffer (void );
-#if defined(__GNUC__) && __GNUC__ >= 3
-__attribute__((__noreturn__))
-#endif
-static void yy_fatal_error (yyconst char msg[]  );
+static yy_state_type yy_get_previous_state ( void );
+static yy_state_type yy_try_NUL_trans ( yy_state_type current_state  );
+static int yy_get_next_buffer ( void );
+static void yynoreturn yy_fatal_error ( const char* msg  );
 
 /* Done after the current pattern has been matched and before the
- * corresponding action - sets up ncgtext.
+ * corresponding action - sets up yytext.
  */
 #define YY_DO_BEFORE_ACTION \
 	(yytext_ptr) = yy_bp; \
-	ncgleng = (size_t) (yy_cp - yy_bp); \
+	yyleng = (int) (yy_cp - yy_bp); \
 	(yy_hold_char) = *yy_cp; \
 	*yy_cp = '\0'; \
 	(yy_c_buf_p) = yy_cp;
-
 #define YY_NUM_RULES 49
 #define YY_END_OF_BUFFER 50
 /* This struct is not used in this scanner,
@@ -403,7 +619,7 @@ struct yy_trans_info
 	flex_int32_t yy_verify;
 	flex_int32_t yy_nxt;
 	};
-static yyconst flex_int16_t yy_accept[422] =
+static const flex_int16_t yy_accept[422] =
     {   0,
         0,    0,   46,   46,    0,    0,   50,   48,    1,   44,
        48,   48,   48,   48,   38,   32,   36,   36,   35,   35,
@@ -454,7 +670,7 @@ static yyconst flex_int16_t yy_accept[422] =
         0
     } ;
 
-static yyconst YY_CHAR yy_ec[256] =
+static const YY_CHAR yy_ec[256] =
     {   0,
         1,    1,    1,    1,    1,    1,    1,    1,    2,    3,
         1,    2,    2,    1,    1,    1,    1,    1,    1,    1,
@@ -486,7 +702,7 @@ static yyconst YY_CHAR yy_ec[256] =
         1,    1,    1,    1,    1
     } ;
 
-static yyconst YY_CHAR yy_meta[69] =
+static const YY_CHAR yy_meta[69] =
     {   0,
         1,    1,    2,    1,    1,    1,    3,    4,    5,    5,
         6,    7,    8,    8,    8,    8,    8,    8,    8,    1,
@@ -497,7 +713,7 @@ static yyconst YY_CHAR yy_meta[69] =
        11,   11,   11,   14,    1,   11,   11,   11
     } ;
 
-static yyconst flex_uint16_t yy_base[440] =
+static const flex_int16_t yy_base[440] =
     {   0,
         0,    0,  325,  321,  264,  255,  318, 2387,   67, 2387,
        64,  269,   61,   62,   95,   77,  136,  259,   51,   61,
@@ -549,7 +765,7 @@ static yyconst flex_uint16_t yy_base[440] =
      2315, 2329, 2339, 2345, 2353, 2355, 2361, 2367, 2373
     } ;
 
-static yyconst flex_int16_t yy_def[440] =
+static const flex_int16_t yy_def[440] =
     {   0,
       421,    1,  422,  422,  423,  423,  421,  421,  421,  421,
       424,  425,  421,  426,  421,  427,  421,   17,  428,  428,
@@ -601,7 +817,7 @@ static yyconst flex_int16_t yy_def[440] =
       421,  421,  421,  421,  421,  421,  421,  421,  421
     } ;
 
-static yyconst flex_uint16_t yy_nxt[2456] =
+static const flex_int16_t yy_nxt[2456] =
     {   0,
         8,    9,   10,    9,    8,   11,   12,    8,   13,   14,
        15,   16,   17,   18,   18,   18,   18,   18,   18,    8,
@@ -875,7 +1091,7 @@ static yyconst flex_uint16_t yy_nxt[2456] =
       421,  421,  421,  421,  421
     } ;
 
-static yyconst flex_int16_t yy_chk[2456] =
+static const flex_int16_t yy_chk[2456] =
     {   0,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
@@ -1152,8 +1368,8 @@ static yyconst flex_int16_t yy_chk[2456] =
 static yy_state_type yy_last_accepting_state;
 static char *yy_last_accepting_cpos;
 
-extern int ncg_flex_debug;
-int ncg_flex_debug = 0;
+extern int yy_flex_debug;
+int yy_flex_debug = 0;
 
 /* The intent behind this definition is that it'll catch
  * any uses of REJECT which flex missed.
@@ -1162,7 +1378,7 @@ int ncg_flex_debug = 0;
 #define yymore() yymore_used_but_not_detected
 #define YY_MORE_ADJ 0
 #define YY_RESTORE_YY_MORE_OFFSET
-char *ncgtext;
+char *yytext;
 #line 1 "ncgen.l"
 #line 2 "ncgen.l"
 /*********************************************************************
@@ -1305,7 +1521,36 @@ struct Specialtoken specials[] = {
 {NULL,0} /* null terminate */
 };
 
+/* Track keywords that may be identifiers depending on
+   format being produced */
+/* Define the possible format classes */
+#define KWALL (1<<NC_FORMAT_CLASSIC|1<<NC_FORMAT_64BIT_OFFSET|1<<NC_FORMAT_NETCDF4|1<<NC_FORMAT_NETCDF4_CLASSIC|1<<NC_FORMAT_64BIT_DATA) /* Used in all formats */
+#define KWCDF5 (1<<NC_FORMAT_64BIT_DATA) /* Used in cdf5 */
+#define KWNC4 (1<<NC_FORMAT_NETCDF4) /* Used in netcdf-4 */
 
+#define NKWIDENT 12
+struct KWIDENT {
+    int token;
+    const char* keyword;
+    int formats; /* Which formats use this keyword */
+} kwident[NKWIDENT] = {
+/* Order by token for binary search */
+{CHAR_K, "char", KWALL},
+{BYTE_K, "byte", KWALL},
+{SHORT_K, "short", KWALL},
+{INT_K, "int", KWALL},
+{FLOAT_K, "float", KWALL},
+{DOUBLE_K, "double", KWALL},
+{UBYTE_K, "ubyte", KWCDF5|KWNC4},
+{USHORT_K, "ushort", KWCDF5|KWNC4},
+{UINT_K, "uint", KWCDF5|KWNC4},
+{INT64_K, "int64", KWCDF5|KWNC4},
+{UINT64_K, "uint64", KWCDF5|KWNC4},
+{STRING_K, "string", KWNC4}
+};
+static int identorkw(int token);
+
+#line 1553 "ncgenl.c"
 
 /* The most correct (validating) version of UTF8 character set
    (Taken from: http://www.w3.org/2005/03/23-lex-U)
@@ -1348,7 +1593,7 @@ ID ([A-Za-z_]|{UTF8})([A-Z.@#\[\]a-z_0-9+-]|{UTF8})*
 /* Note: this definition of string will work for utf8 as well,
    although it is a very relaxed definition
 */
-#line 1352 "ncgenl.c"
+#line 1596 "ncgenl.c"
 
 #define INITIAL 0
 #define ST_C_COMMENT 1
@@ -1366,36 +1611,36 @@ ID ([A-Za-z_]|{UTF8})([A-Z.@#\[\]a-z_0-9+-]|{UTF8})*
 #define YY_EXTRA_TYPE void *
 #endif
 
-static int yy_init_globals (void );
+static int yy_init_globals ( void );
 
 /* Accessor methods to globals.
    These are made visible to non-reentrant scanners for convenience. */
 
-int ncglex_destroy (void );
+int yylex_destroy ( void );
 
-int ncgget_debug (void );
+int yyget_debug ( void );
 
-void ncgset_debug (int debug_flag  );
+void yyset_debug ( int debug_flag  );
 
-YY_EXTRA_TYPE ncgget_extra (void );
+YY_EXTRA_TYPE yyget_extra ( void );
 
-void ncgset_extra (YY_EXTRA_TYPE user_defined  );
+void yyset_extra ( YY_EXTRA_TYPE user_defined  );
 
-FILE *ncgget_in (void );
+FILE *yyget_in ( void );
 
-void ncgset_in  (FILE * _in_str  );
+void yyset_in  ( FILE * _in_str  );
 
-FILE *ncgget_out (void );
+FILE *yyget_out ( void );
 
-void ncgset_out  (FILE * _out_str  );
+void yyset_out  ( FILE * _out_str  );
 
-yy_size_t ncgget_leng (void );
+			int yyget_leng ( void );
 
-char *ncgget_text (void );
+char *yyget_text ( void );
 
-int ncgget_lineno (void );
+int yyget_lineno ( void );
 
-void ncgset_lineno (int _line_number  );
+void yyset_lineno ( int _line_number  );
 
 /* Macros after this point can all be overridden by user definitions in
  * section 1.
@@ -1403,32 +1648,31 @@ void ncgset_lineno (int _line_number  );
 
 #ifndef YY_SKIP_YYWRAP
 #ifdef __cplusplus
-extern "C" int ncgwrap (void );
+extern "C" int yywrap ( void );
 #else
-extern int ncgwrap (void );
+extern int yywrap ( void );
 #endif
 #endif
 
 #ifndef YY_NO_UNPUT
     
-    static void yyunput (int c,char *buf_ptr  );
+    static void yyunput ( int c, char *buf_ptr  );
     
 #endif
 
 #ifndef yytext_ptr
-static void yy_flex_strncpy (char *,yyconst char *,int );
+static void yy_flex_strncpy ( char *, const char *, int );
 #endif
 
 #ifdef YY_NEED_STRLEN
-static int yy_flex_strlen (yyconst char * );
+static int yy_flex_strlen ( const char * );
 #endif
 
 #ifndef YY_NO_INPUT
-
 #ifdef __cplusplus
-static int yyinput (void );
+static int yyinput ( void );
 #else
-static int input (void );
+static int input ( void );
 #endif
 
 #endif
@@ -1448,7 +1692,7 @@ static int input (void );
 /* This used to be an fputs(), but since the string might contain NUL's,
  * we now use fwrite().
  */
-#define ECHO do { if (fwrite( ncgtext, ncgleng, 1, ncgout )) {} } while (0)
+#define ECHO do { if (fwrite( yytext, (size_t) yyleng, 1, yyout )) {} } while (0)
 #endif
 
 /* Gets input and stuffs it into "buf".  number of characters read, or YY_NULL,
@@ -1459,20 +1703,20 @@ static int input (void );
 	if ( YY_CURRENT_BUFFER_LVALUE->yy_is_interactive ) \
 		{ \
 		int c = '*'; \
-		size_t n; \
+		int n; \
 		for ( n = 0; n < max_size && \
-			     (c = getc( ncgin )) != EOF && c != '\n'; ++n ) \
+			     (c = getc( yyin )) != EOF && c != '\n'; ++n ) \
 			buf[n] = (char) c; \
 		if ( c == '\n' ) \
 			buf[n++] = (char) c; \
-		if ( c == EOF && ferror( ncgin ) ) \
+		if ( c == EOF && ferror( yyin ) ) \
 			YY_FATAL_ERROR( "input in flex scanner failed" ); \
 		result = n; \
 		} \
 	else \
 		{ \
 		errno=0; \
-		while ( (result = fread(buf, 1, max_size, ncgin))==0 && ferror(ncgin)) \
+		while ( (result = (int) fread(buf, 1, (yy_size_t) max_size, yyin)) == 0 && ferror(yyin)) \
 			{ \
 			if( errno != EINTR) \
 				{ \
@@ -1480,7 +1724,7 @@ static int input (void );
 				break; \
 				} \
 			errno=0; \
-			clearerr(ncgin); \
+			clearerr(yyin); \
 			} \
 		}\
 \
@@ -1513,12 +1757,12 @@ static int input (void );
 #ifndef YY_DECL
 #define YY_DECL_IS_OURS 1
 
-extern int ncglex (void);
+extern int yylex (void);
 
-#define YY_DECL int ncglex (void)
+#define YY_DECL int yylex (void)
 #endif /* !YY_DECL */
 
-/* Code executed at the beginning of each rule, after ncgtext and ncgleng
+/* Code executed at the beginning of each rule, after yytext and yyleng
  * have been set up.
  */
 #ifndef YY_USER_ACTION
@@ -1552,31 +1796,31 @@ YY_DECL
 		if ( ! (yy_start) )
 			(yy_start) = 1;	/* first start state */
 
-		if ( ! ncgin )
-			ncgin = stdin;
+		if ( ! yyin )
+			yyin = stdin;
 
-		if ( ! ncgout )
-			ncgout = stdout;
+		if ( ! yyout )
+			yyout = stdout;
 
 		if ( ! YY_CURRENT_BUFFER ) {
-			ncgensure_buffer_stack ();
+			yyensure_buffer_stack ();
 			YY_CURRENT_BUFFER_LVALUE =
-				ncg_create_buffer(ncgin,YY_BUF_SIZE );
+				yy_create_buffer( yyin, YY_BUF_SIZE );
 		}
 
-		ncg_load_buffer_state( );
+		yy_load_buffer_state(  );
 		}
 
 	{
-#line 221 "ncgen.l"
+#line 250 "ncgen.l"
 
-#line 1574 "ncgenl.c"
+#line 1817 "ncgenl.c"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
 		yy_cp = (yy_c_buf_p);
 
-		/* Support of ncgtext. */
+		/* Support of yytext. */
 		*yy_cp = (yy_hold_char);
 
 		/* yy_bp points to the position in yy_ch_buf of the start of
@@ -1598,9 +1842,9 @@ yy_match:
 				{
 				yy_current_state = (int) yy_def[yy_current_state];
 				if ( yy_current_state >= 422 )
-					yy_c = yy_meta[(unsigned int) yy_c];
+					yy_c = yy_meta[yy_c];
 				}
-			yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
+			yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 			++yy_cp;
 			}
 		while ( yy_base[yy_current_state] != 2387 );
@@ -1629,14 +1873,14 @@ do_action:	/* This label is used only to access EOF actions. */
 
 case 1:
 YY_RULE_SETUP
-#line 222 "ncgen.l"
+#line 251 "ncgen.l"
 { /* whitespace */
 		  break;
 		}
 	YY_BREAK
 case 2:
 YY_RULE_SETUP
-#line 226 "ncgen.l"
+#line 255 "ncgen.l"
 { /* comment */
                           break;
                         }
@@ -1644,19 +1888,19 @@ YY_RULE_SETUP
 case 3:
 /* rule 3 can match eol */
 YY_RULE_SETUP
-#line 230 "ncgen.l"
+#line 259 "ncgen.l"
 {int len; char* s = NULL;
 			 /* In netcdf4, this will be used in a variety
                             of places, so only remove escapes */
 /*
-if(ncgleng > MAXTRST) {
+if(yyleng > MAXTRST) {
 yyerror("string too long, truncated\n");
-ncgtext[MAXTRST-1] = '\0';
+yytext[MAXTRST-1] = '\0';
 }
 */
-			len = unescape((char *)ncgtext+1,ncgleng-2,!ISIDENT,&s);
+			len = unescape((char *)yytext+1,yyleng-2,!ISIDENT,&s);
 			if(len < 0) {
-			    sprintf(errstr,"Illegal character: %s",ncgtext);
+			    sprintf(errstr,"Illegal character: %s",yytext);
 			    yyerror(errstr);
 			}
 			bbClear(lextext);
@@ -1668,10 +1912,10 @@ ncgtext[MAXTRST-1] = '\0';
 	YY_BREAK
 case 4:
 YY_RULE_SETUP
-#line 251 "ncgen.l"
+#line 280 "ncgen.l"
 { /* drop leading 0x; pad to even number of chars */
-		char* p = ncgtext+2;
-		int len = ncgleng - 2;
+		char* p = yytext+2;
+		int len = yyleng - 2;
 		bbClear(lextext);
 	        bbAppendn(lextext,p,len);
 	        if((len % 2) == 1) bbAppend(lextext,'0');
@@ -1683,120 +1927,121 @@ YY_RULE_SETUP
 	YY_BREAK
 case 5:
 YY_RULE_SETUP
-#line 263 "ncgen.l"
-{return lexdebug(COMPOUND);}
+#line 292 "ncgen.l"
+{return lexdebug(identorkw(COMPOUND));}
 	YY_BREAK
 case 6:
 YY_RULE_SETUP
-#line 264 "ncgen.l"
-{return lexdebug(ENUM);}
+#line 293 "ncgen.l"
+{return lexdebug(identorkw(ENUM));}
 	YY_BREAK
 case 7:
 YY_RULE_SETUP
-#line 265 "ncgen.l"
+#line 294 "ncgen.l"
 {return lexdebug(OPAQUE_);}
 	YY_BREAK
 case 8:
 YY_RULE_SETUP
-#line 267 "ncgen.l"
-{return lexdebug(FLOAT_K);}
+#line 296 "ncgen.l"
+{return lexdebug(identorkw(FLOAT_K));}
 	YY_BREAK
 case 9:
 YY_RULE_SETUP
-#line 268 "ncgen.l"
-{return lexdebug(CHAR_K);}
+#line 297 "ncgen.l"
+{return lexdebug(identorkw(CHAR_K));}
 	YY_BREAK
 case 10:
 YY_RULE_SETUP
-#line 269 "ncgen.l"
-{return lexdebug(BYTE_K);}
+#line 298 "ncgen.l"
+{return lexdebug(identorkw(BYTE_K));}
 	YY_BREAK
 case 11:
 YY_RULE_SETUP
-#line 270 "ncgen.l"
-{return lexdebug(UBYTE_K);}
+#line 299 "ncgen.l"
+{return lexdebug(identorkw(UBYTE_K));}
 	YY_BREAK
 case 12:
 YY_RULE_SETUP
-#line 271 "ncgen.l"
-{return lexdebug(SHORT_K);}
+#line 300 "ncgen.l"
+{return lexdebug(identorkw(SHORT_K));}
 	YY_BREAK
 case 13:
 YY_RULE_SETUP
-#line 272 "ncgen.l"
-{return lexdebug(USHORT_K);}
+#line 301 "ncgen.l"
+{return lexdebug(identorkw(USHORT_K));}
 	YY_BREAK
 case 14:
 YY_RULE_SETUP
-#line 273 "ncgen.l"
-{return lexdebug(INT_K);}
+#line 302 "ncgen.l"
+{return lexdebug(identorkw(INT_K));}
 	YY_BREAK
 case 15:
 YY_RULE_SETUP
-#line 274 "ncgen.l"
-{return lexdebug(UINT_K);}
+#line 303 "ncgen.l"
+{return lexdebug(identorkw(UINT_K));}
 	YY_BREAK
 case 16:
 YY_RULE_SETUP
-#line 275 "ncgen.l"
-{return lexdebug(INT64_K);}
+#line 304 "ncgen.l"
+{return lexdebug(identorkw(INT64_K));}
 	YY_BREAK
 case 17:
 YY_RULE_SETUP
-#line 276 "ncgen.l"
-{return lexdebug(UINT64_K);}
+#line 305 "ncgen.l"
+{return lexdebug(identorkw(UINT64_K));}
 	YY_BREAK
 case 18:
 YY_RULE_SETUP
-#line 277 "ncgen.l"
-{return lexdebug(DOUBLE_K);}
+#line 306 "ncgen.l"
+{return lexdebug(identorkw(DOUBLE_K));}
 	YY_BREAK
 case 19:
 YY_RULE_SETUP
-#line 278 "ncgen.l"
-{return lexdebug(STRING_K);}
+#line 307 "ncgen.l"
+{return lexdebug(identorkw(STRING_K));}
 	YY_BREAK
 case 20:
 YY_RULE_SETUP
-#line 280 "ncgen.l"
+#line 309 "ncgen.l"
 {int32_val = -1;
-			 return lexdebug(NC_UNLIMITED_K);}
+			 return lexdebug(identorkw(NC_UNLIMITED_K));}
 	YY_BREAK
+/* These are currently only keywords */
 case 21:
 YY_RULE_SETUP
-#line 283 "ncgen.l"
+#line 313 "ncgen.l"
 {return lexdebug(TYPES);}
 	YY_BREAK
 case 22:
 YY_RULE_SETUP
-#line 284 "ncgen.l"
+#line 314 "ncgen.l"
 {return lexdebug(DIMENSIONS);}
 	YY_BREAK
 case 23:
 YY_RULE_SETUP
-#line 285 "ncgen.l"
+#line 315 "ncgen.l"
 {return lexdebug(VARIABLES);}
 	YY_BREAK
 case 24:
 YY_RULE_SETUP
-#line 286 "ncgen.l"
+#line 316 "ncgen.l"
 {return lexdebug(DATA);}
 	YY_BREAK
 case 25:
 YY_RULE_SETUP
-#line 287 "ncgen.l"
+#line 317 "ncgen.l"
 {return lexdebug(GROUP);}
 	YY_BREAK
 case 26:
 YY_RULE_SETUP
-#line 289 "ncgen.l"
+#line 319 "ncgen.l"
 {BEGIN(TEXT);return lexdebug(NETCDF);}
 	YY_BREAK
 case 27:
 YY_RULE_SETUP
-#line 291 "ncgen.l"
+#line 321 "ncgen.l"
 { /* missing value (pre-2.4 backward compatibility) */
-                if (ncgtext[0] == '-') {
+                if (yytext[0] == '-') {
 		    double_val = NEGNC_INFINITE;
                 } else {
 		    double_val = NC_INFINITE;
@@ -1807,7 +2052,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 28:
 YY_RULE_SETUP
-#line 300 "ncgen.l"
+#line 330 "ncgen.l"
 { /* missing value (pre-2.4 backward compatibility) */
 		double_val = NAN;
 		specialconstants = 1;
@@ -1816,9 +2061,9 @@ YY_RULE_SETUP
 	YY_BREAK
 case 29:
 YY_RULE_SETUP
-#line 306 "ncgen.l"
+#line 336 "ncgen.l"
 {/* missing value (pre-2.4 backward compatibility)*/
-                if (ncgtext[0] == '-') {
+                if (yytext[0] == '-') {
 		    float_val = NEGNC_INFINITEF;
                 } else {
 		    float_val = NC_INFINITEF;
@@ -1829,7 +2074,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 30:
 YY_RULE_SETUP
-#line 315 "ncgen.l"
+#line 345 "ncgen.l"
 { /* missing value (pre-2.4 backward compatibility) */
 		float_val = NANF;
 		specialconstants = 1;
@@ -1838,7 +2083,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 31:
 YY_RULE_SETUP
-#line 321 "ncgen.l"
+#line 351 "ncgen.l"
 {
 #ifdef USE_NETCDF4
 		if(l_flag == L_C || l_flag == L_BINARY)
@@ -1851,10 +2096,10 @@ YY_RULE_SETUP
 	YY_BREAK
 case 32:
 YY_RULE_SETUP
-#line 331 "ncgen.l"
+#line 361 "ncgen.l"
 {
 		bbClear(lextext);
-		bbAppendn(lextext,(char*)ncgtext,ncgleng+1); /* include null */
+		bbAppendn(lextext,(char*)yytext,yyleng+1); /* include null */
 	        bbNull(lextext);
 		yylval.sym = makepath(bbContents(lextext));
 		return lexdebug(PATH);
@@ -1862,10 +2107,10 @@ YY_RULE_SETUP
 	YY_BREAK
 case 33:
 YY_RULE_SETUP
-#line 340 "ncgen.l"
+#line 370 "ncgen.l"
 {struct Specialtoken* st;
 		bbClear(lextext);
-		bbAppendn(lextext,(char*)ncgtext,ncgleng+1); /* include null */
+		bbAppendn(lextext,(char*)yytext,yyleng+1); /* include null */
 		bbNull(lextext);
 		for(st=specials;st->name;st++) {
 		    if(strcmp(bbContents(lextext),st->name)==0) {return lexdebug(st->token);}
@@ -1876,13 +2121,13 @@ YY_RULE_SETUP
 case 34:
 /* rule 34 can match eol */
 YY_RULE_SETUP
-#line 350 "ncgen.l"
+#line 380 "ncgen.l"
 {
 		    int c;
 		    char* p; char* q;
 		    /* copy the trimmed name */
 		    bbClear(lextext);
-		    bbAppendn(lextext,(char*)ncgtext,ncgleng+1); /* include null */
+		    bbAppendn(lextext,(char*)yytext,yyleng+1); /* include null */
 		    bbNull(lextext);
 		    p = bbContents(lextext);
 		    q = p;
@@ -1896,10 +2141,10 @@ YY_RULE_SETUP
 	YY_BREAK
 case 35:
 YY_RULE_SETUP
-#line 367 "ncgen.l"
+#line 397 "ncgen.l"
 { char* id = NULL; int len;
-		    len = strlen(ncgtext);
-		    len = unescape(ncgtext,len,ISIDENT,&id);
+		    len = strlen(yytext);
+		    len = unescape(yytext,len,ISIDENT,&id);
 		    if(NCSTREQ(id, FILL_STRING)) {
 			efree(id);
 		        return lexdebug(FILLMARKER);
@@ -1911,7 +2156,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 36:
 YY_RULE_SETUP
-#line 379 "ncgen.l"
+#line 409 "ncgen.l"
 {
 		/*
 		  We need to try to see what size of integer ((u)int).
@@ -1992,25 +2237,25 @@ done: return 0;
 	YY_BREAK
 case 37:
 YY_RULE_SETUP
-#line 457 "ncgen.l"
+#line 487 "ncgen.l"
 {
 		int c;
 		int token = 0;
-		int slen = strlen(ncgtext);
+		int slen = strlen(yytext);
 		char* stag = NULL;
 	        int tag = NC_NAT;
-		char* hex = ncgtext+2; /* point to first true hex digit */
+		char* hex = yytext+2; /* point to first true hex digit */
 		int xlen = (slen - 3);  /* true hex length */
 
-		ncgtext[slen-1] = '\0';
+		yytext[slen-1] = '\0';
 	        /* capture the tag string */
-		tag = collecttag(ncgtext,&stag);
+		tag = collecttag(yytext,&stag);
 		if(tag == NC_NAT) {
 		    sprintf(errstr,"Illegal integer suffix: %s",stag);
 		    yyerror(errstr);
 		    goto done;
 		}
-		ncgtext[slen - strlen(stag)] = '\0';
+		yytext[slen - strlen(stag)] = '\0';
 	        if(xlen > 16) { /* truncate hi order digits */
 		    hex += (xlen - 16);
 		}
@@ -2032,8 +2277,8 @@ YY_RULE_SETUP
 		    token = UINT64_CONST;
 		    break;
 		default: /* should never happen */
-		    if (sscanf((char*)ncgtext, "%i", &uint32_val) != 1) {
-		        sprintf(errstr,"bad unsigned int constant: %s",(char*)ncgtext);
+		    if (sscanf((char*)yytext, "%i", &uint32_val) != 1) {
+		        sprintf(errstr,"bad unsigned int constant: %s",(char*)yytext);
 		        yyerror(errstr);
 		    }
 		    token = UINT_CONST;
@@ -2043,10 +2288,10 @@ YY_RULE_SETUP
 	YY_BREAK
 case 38:
 YY_RULE_SETUP
-#line 504 "ncgen.l"
+#line 534 "ncgen.l"
 {
-		if (sscanf((char*)ncgtext, "%le", &double_val) != 1) {
-		    sprintf(errstr,"bad long or double constant: %s",(char*)ncgtext);
+		if (sscanf((char*)yytext, "%le", &double_val) != 1) {
+		    sprintf(errstr,"bad long or double constant: %s",(char*)yytext);
 		    yyerror(errstr);
 		}
                 return lexdebug(DOUBLE_CONST);
@@ -2054,10 +2299,10 @@ YY_RULE_SETUP
 	YY_BREAK
 case 39:
 YY_RULE_SETUP
-#line 511 "ncgen.l"
+#line 541 "ncgen.l"
 {
-		if (sscanf((char*)ncgtext, "%e", &float_val) != 1) {
-		    sprintf(errstr,"bad float constant: %s",(char*)ncgtext);
+		if (sscanf((char*)yytext, "%e", &float_val) != 1) {
+		    sprintf(errstr,"bad float constant: %s",(char*)yytext);
 		    yyerror(errstr);
 		}
                 return lexdebug(FLOAT_CONST);
@@ -2066,19 +2311,19 @@ YY_RULE_SETUP
 case 40:
 /* rule 40 can match eol */
 YY_RULE_SETUP
-#line 518 "ncgen.l"
+#line 548 "ncgen.l"
 {
-	        (void) sscanf((char*)&ncgtext[1],"%c",&byte_val);
+	        (void) sscanf((char*)&yytext[1],"%c",&byte_val);
 		return lexdebug(BYTE_CONST);
                 }
 	YY_BREAK
 case 41:
 YY_RULE_SETUP
-#line 522 "ncgen.l"
+#line 552 "ncgen.l"
 {
-		int oct = unescapeoct(&ncgtext[2]);
+		int oct = unescapeoct(&yytext[2]);
 		if(oct < 0) {
-		    sprintf(errstr,"bad octal character constant: %s",(char*)ncgtext);
+		    sprintf(errstr,"bad octal character constant: %s",(char*)yytext);
 		    yyerror(errstr);
 		}
 	        byte_val = (unsigned int)oct;
@@ -2087,11 +2332,11 @@ YY_RULE_SETUP
 	YY_BREAK
 case 42:
 YY_RULE_SETUP
-#line 531 "ncgen.l"
+#line 561 "ncgen.l"
 {
-		int hex = unescapehex(&ncgtext[3]);
+		int hex = unescapehex(&yytext[3]);
 		if(byte_val < 0) {
-		    sprintf(errstr,"bad hex character constant: %s",(char*)ncgtext);
+		    sprintf(errstr,"bad hex character constant: %s",(char*)yytext);
 		    yyerror(errstr);
 		}
 		byte_val = (unsigned int)hex;
@@ -2100,9 +2345,9 @@ YY_RULE_SETUP
 	YY_BREAK
 case 43:
 YY_RULE_SETUP
-#line 540 "ncgen.l"
+#line 570 "ncgen.l"
 {
-	       switch ((char)ncgtext[2]) {
+	       switch ((char)yytext[2]) {
 	          case 'a': byte_val = '\007'; break; /* not everyone under-
 						       * stands '\a' yet */
      	          case 'b': byte_val = '\b'; break;
@@ -2114,7 +2359,7 @@ YY_RULE_SETUP
 		  case '\\': byte_val = '\\'; break;
 		  case '?': byte_val = '\177'; break;
 		  case '\'': byte_val = '\''; break;
-		  default: byte_val = (char)ncgtext[2];
+		  default: byte_val = (char)yytext[2];
 	           }
 		return lexdebug(BYTE_CONST);
                 }
@@ -2122,7 +2367,7 @@ YY_RULE_SETUP
 case 44:
 /* rule 44 can match eol */
 YY_RULE_SETUP
-#line 558 "ncgen.l"
+#line 588 "ncgen.l"
 {
 		lineno++ ;
                 break;
@@ -2130,7 +2375,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 45:
 YY_RULE_SETUP
-#line 563 "ncgen.l"
+#line 593 "ncgen.l"
 {/*initial*/
 	    BEGIN(ST_C_COMMENT);
 	    break;
@@ -2139,21 +2384,21 @@ YY_RULE_SETUP
 case 46:
 /* rule 46 can match eol */
 YY_RULE_SETUP
-#line 568 "ncgen.l"
+#line 598 "ncgen.l"
 {/* continuation */
 				     break;
 				}
 	YY_BREAK
 case 47:
 YY_RULE_SETUP
-#line 572 "ncgen.l"
+#line 602 "ncgen.l"
 {/* final */
 			    BEGIN(INITIAL);
 			    break;
 			}
 	YY_BREAK
 case YY_STATE_EOF(ST_C_COMMENT):
-#line 577 "ncgen.l"
+#line 607 "ncgen.l"
 {/* final, error */
 			    fprintf(stderr,"unterminated /**/ comment");
 			    BEGIN(INITIAL);
@@ -2162,17 +2407,17 @@ case YY_STATE_EOF(ST_C_COMMENT):
 	YY_BREAK
 case 48:
 YY_RULE_SETUP
-#line 583 "ncgen.l"
+#line 613 "ncgen.l"
 {/* Note: this next rule will not work for UTF8 characters */
-		return lexdebug(ncgtext[0]) ;
+		return lexdebug(yytext[0]) ;
 		}
 	YY_BREAK
 case 49:
 YY_RULE_SETUP
-#line 586 "ncgen.l"
+#line 616 "ncgen.l"
 ECHO;
 	YY_BREAK
-#line 2176 "ncgenl.c"
+#line 2420 "ncgenl.c"
 case YY_STATE_EOF(INITIAL):
 case YY_STATE_EOF(TEXT):
 	yyterminate();
@@ -2190,15 +2435,15 @@ case YY_STATE_EOF(TEXT):
 			{
 			/* We're scanning a new file or input source.  It's
 			 * possible that this happened because the user
-			 * just pointed ncgin at a new source and called
-			 * ncglex().  If so, then we have to assure
+			 * just pointed yyin at a new source and called
+			 * yylex().  If so, then we have to assure
 			 * consistency between YY_CURRENT_BUFFER and our
 			 * globals.  Here is the right place to do so, because
 			 * this is the first action (other than possibly a
 			 * back-up) that will match for the new input source.
 			 */
 			(yy_n_chars) = YY_CURRENT_BUFFER_LVALUE->yy_n_chars;
-			YY_CURRENT_BUFFER_LVALUE->yy_input_file = ncgin;
+			YY_CURRENT_BUFFER_LVALUE->yy_input_file = yyin;
 			YY_CURRENT_BUFFER_LVALUE->yy_buffer_status = YY_BUFFER_NORMAL;
 			}
 
@@ -2251,11 +2496,11 @@ case YY_STATE_EOF(TEXT):
 				{
 				(yy_did_buffer_switch_on_eof) = 0;
 
-				if ( ncgwrap( ) )
+				if ( yywrap(  ) )
 					{
 					/* Note: because we've taken care in
 					 * yy_get_next_buffer() to have set up
-					 * ncgtext, we can now set up
+					 * yytext, we can now set up
 					 * yy_c_buf_p so that if some total
 					 * hoser (like flex itself) wants to
 					 * call the scanner after we return the
@@ -2305,7 +2550,7 @@ case YY_STATE_EOF(TEXT):
 	} /* end of action switch */
 		} /* end of scanning one token */
 	} /* end of user's declarations */
-} /* end of ncglex */
+} /* end of yylex */
 
 /* yy_get_next_buffer - try to read in a new buffer
  *
@@ -2318,7 +2563,7 @@ static int yy_get_next_buffer (void)
 {
     	char *dest = YY_CURRENT_BUFFER_LVALUE->yy_ch_buf;
 	char *source = (yytext_ptr);
-	yy_size_t number_to_move, i;
+	int number_to_move, i;
 	int ret_val;
 
 	if ( (yy_c_buf_p) > &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[(yy_n_chars) + 1] )
@@ -2347,7 +2592,7 @@ static int yy_get_next_buffer (void)
 	/* Try to read more data. */
 
 	/* First move last chars to start of buffer. */
-	number_to_move = (yy_size_t) ((yy_c_buf_p) - (yytext_ptr)) - 1;
+	number_to_move = (int) ((yy_c_buf_p) - (yytext_ptr) - 1);
 
 	for ( i = 0; i < number_to_move; ++i )
 		*(dest++) = *(source++);
@@ -2360,7 +2605,7 @@ static int yy_get_next_buffer (void)
 
 	else
 		{
-			yy_size_t num_to_read =
+			int num_to_read =
 			YY_CURRENT_BUFFER_LVALUE->yy_buf_size - number_to_move - 1;
 
 		while ( num_to_read <= 0 )
@@ -2374,7 +2619,7 @@ static int yy_get_next_buffer (void)
 
 			if ( b->yy_is_our_buffer )
 				{
-				yy_size_t new_size = b->yy_buf_size * 2;
+				int new_size = b->yy_buf_size * 2;
 
 				if ( new_size <= 0 )
 					b->yy_buf_size += b->yy_buf_size / 8;
@@ -2383,11 +2628,12 @@ static int yy_get_next_buffer (void)
 
 				b->yy_ch_buf = (char *)
 					/* Include room in for 2 EOB chars. */
-					ncgrealloc((void *) b->yy_ch_buf,b->yy_buf_size + 2  );
+					yyrealloc( (void *) b->yy_ch_buf,
+							 (yy_size_t) (b->yy_buf_size + 2)  );
 				}
 			else
 				/* Can't grow it, we don't own it. */
-				b->yy_ch_buf = 0;
+				b->yy_ch_buf = NULL;
 
 			if ( ! b->yy_ch_buf )
 				YY_FATAL_ERROR(
@@ -2415,7 +2661,7 @@ static int yy_get_next_buffer (void)
 		if ( number_to_move == YY_MORE_ADJ )
 			{
 			ret_val = EOB_ACT_END_OF_FILE;
-			ncgrestart(ncgin  );
+			yyrestart( yyin  );
 			}
 
 		else
@@ -2429,12 +2675,15 @@ static int yy_get_next_buffer (void)
 	else
 		ret_val = EOB_ACT_CONTINUE_SCAN;
 
-	if ((int) ((yy_n_chars) + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
+	if (((yy_n_chars) + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
 		/* Extend the array by 50%, plus the number we really need. */
 		int new_size = (yy_n_chars) + number_to_move + ((yy_n_chars) >> 1);
-		YY_CURRENT_BUFFER_LVALUE->yy_ch_buf = (char *) ncgrealloc((void *) YY_CURRENT_BUFFER_LVALUE->yy_ch_buf,new_size  );
+		YY_CURRENT_BUFFER_LVALUE->yy_ch_buf = (char *) yyrealloc(
+			(void *) YY_CURRENT_BUFFER_LVALUE->yy_ch_buf, (yy_size_t) new_size  );
 		if ( ! YY_CURRENT_BUFFER_LVALUE->yy_ch_buf )
 			YY_FATAL_ERROR( "out of dynamic memory in yy_get_next_buffer()" );
+		/* "- 2" to take care of EOB's */
+		YY_CURRENT_BUFFER_LVALUE->yy_buf_size = (int) (new_size - 2);
 	}
 
 	(yy_n_chars) += number_to_move;
@@ -2467,9 +2716,9 @@ static int yy_get_next_buffer (void)
 			{
 			yy_current_state = (int) yy_def[yy_current_state];
 			if ( yy_current_state >= 422 )
-				yy_c = yy_meta[(unsigned int) yy_c];
+				yy_c = yy_meta[yy_c];
 			}
-		yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
+		yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 		}
 
 	return yy_current_state;
@@ -2495,9 +2744,9 @@ static int yy_get_next_buffer (void)
 		{
 		yy_current_state = (int) yy_def[yy_current_state];
 		if ( yy_current_state >= 422 )
-			yy_c = yy_meta[(unsigned int) yy_c];
+			yy_c = yy_meta[yy_c];
 		}
-	yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
+	yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 	yy_is_jam = (yy_current_state == 421);
 
 		return yy_is_jam ? 0 : yy_current_state;
@@ -2511,13 +2760,13 @@ static int yy_get_next_buffer (void)
     
     yy_cp = (yy_c_buf_p);
 
-	/* undo effects of setting up ncgtext */
+	/* undo effects of setting up yytext */
 	*yy_cp = (yy_hold_char);
 
 	if ( yy_cp < YY_CURRENT_BUFFER_LVALUE->yy_ch_buf + 2 )
 		{ /* need to shift things up to make room */
 		/* +2 for EOB chars. */
-		yy_size_t number_to_move = (yy_n_chars) + 2;
+		int number_to_move = (yy_n_chars) + 2;
 		char *dest = &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[
 					YY_CURRENT_BUFFER_LVALUE->yy_buf_size + 2];
 		char *source =
@@ -2529,7 +2778,7 @@ static int yy_get_next_buffer (void)
 		yy_cp += (int) (dest - source);
 		yy_bp += (int) (dest - source);
 		YY_CURRENT_BUFFER_LVALUE->yy_n_chars =
-			(yy_n_chars) = YY_CURRENT_BUFFER_LVALUE->yy_buf_size;
+			(yy_n_chars) = (int) YY_CURRENT_BUFFER_LVALUE->yy_buf_size;
 
 		if ( yy_cp < YY_CURRENT_BUFFER_LVALUE->yy_ch_buf + 2 )
 			YY_FATAL_ERROR( "flex scanner push-back overflow" );
@@ -2568,7 +2817,7 @@ static int yy_get_next_buffer (void)
 
 		else
 			{ /* need more input */
-			yy_size_t offset = (yy_c_buf_p) - (yytext_ptr);
+			int offset = (int) ((yy_c_buf_p) - (yytext_ptr));
 			++(yy_c_buf_p);
 
 			switch ( yy_get_next_buffer(  ) )
@@ -2585,14 +2834,14 @@ static int yy_get_next_buffer (void)
 					 */
 
 					/* Reset buffer status. */
-					ncgrestart(ncgin );
+					yyrestart( yyin );
 
 					/*FALLTHROUGH*/
 
 				case EOB_ACT_END_OF_FILE:
 					{
-					if ( ncgwrap( ) )
-						return EOF;
+					if ( yywrap(  ) )
+						return 0;
 
 					if ( ! (yy_did_buffer_switch_on_eof) )
 						YY_NEW_FILE;
@@ -2611,7 +2860,7 @@ static int yy_get_next_buffer (void)
 		}
 
 	c = *(unsigned char *) (yy_c_buf_p);	/* cast for 8-bit char's */
-	*(yy_c_buf_p) = '\0';	/* preserve ncgtext */
+	*(yy_c_buf_p) = '\0';	/* preserve yytext */
 	(yy_hold_char) = *++(yy_c_buf_p);
 
 	return c;
@@ -2623,32 +2872,32 @@ static int yy_get_next_buffer (void)
  * 
  * @note This function does not reset the start condition to @c INITIAL .
  */
-    void ncgrestart  (FILE * input_file )
+    void yyrestart  (FILE * input_file )
 {
     
 	if ( ! YY_CURRENT_BUFFER ){
-        ncgensure_buffer_stack ();
+        yyensure_buffer_stack ();
 		YY_CURRENT_BUFFER_LVALUE =
-            ncg_create_buffer(ncgin,YY_BUF_SIZE );
+            yy_create_buffer( yyin, YY_BUF_SIZE );
 	}
 
-	ncg_init_buffer(YY_CURRENT_BUFFER,input_file );
-	ncg_load_buffer_state( );
+	yy_init_buffer( YY_CURRENT_BUFFER, input_file );
+	yy_load_buffer_state(  );
 }
 
 /** Switch to a different input buffer.
  * @param new_buffer The new input buffer.
  * 
  */
-    void ncg_switch_to_buffer  (YY_BUFFER_STATE  new_buffer )
+    void yy_switch_to_buffer  (YY_BUFFER_STATE  new_buffer )
 {
     
 	/* TODO. We should be able to replace this entire function body
 	 * with
-	 *		ncgpop_buffer_state();
-	 *		ncgpush_buffer_state(new_buffer);
+	 *		yypop_buffer_state();
+	 *		yypush_buffer_state(new_buffer);
      */
-	ncgensure_buffer_stack ();
+	yyensure_buffer_stack ();
 	if ( YY_CURRENT_BUFFER == new_buffer )
 		return;
 
@@ -2661,21 +2910,21 @@ static int yy_get_next_buffer (void)
 		}
 
 	YY_CURRENT_BUFFER_LVALUE = new_buffer;
-	ncg_load_buffer_state( );
+	yy_load_buffer_state(  );
 
 	/* We don't actually know whether we did this switch during
-	 * EOF (ncgwrap()) processing, but the only time this flag
-	 * is looked at is after ncgwrap() is called, so it's safe
+	 * EOF (yywrap()) processing, but the only time this flag
+	 * is looked at is after yywrap() is called, so it's safe
 	 * to go ahead and always set it.
 	 */
 	(yy_did_buffer_switch_on_eof) = 1;
 }
 
-static void ncg_load_buffer_state  (void)
+static void yy_load_buffer_state  (void)
 {
     	(yy_n_chars) = YY_CURRENT_BUFFER_LVALUE->yy_n_chars;
 	(yytext_ptr) = (yy_c_buf_p) = YY_CURRENT_BUFFER_LVALUE->yy_buf_pos;
-	ncgin = YY_CURRENT_BUFFER_LVALUE->yy_input_file;
+	yyin = YY_CURRENT_BUFFER_LVALUE->yy_input_file;
 	(yy_hold_char) = *(yy_c_buf_p);
 }
 
@@ -2685,35 +2934,35 @@ static void ncg_load_buffer_state  (void)
  * 
  * @return the allocated buffer state.
  */
-    YY_BUFFER_STATE ncg_create_buffer  (FILE * file, int  size )
+    YY_BUFFER_STATE yy_create_buffer  (FILE * file, int  size )
 {
 	YY_BUFFER_STATE b;
     
-	b = (YY_BUFFER_STATE) ncgalloc(sizeof( struct yy_buffer_state )  );
+	b = (YY_BUFFER_STATE) yyalloc( sizeof( struct yy_buffer_state )  );
 	if ( ! b )
-		YY_FATAL_ERROR( "out of dynamic memory in ncg_create_buffer()" );
+		YY_FATAL_ERROR( "out of dynamic memory in yy_create_buffer()" );
 
-	b->yy_buf_size = (yy_size_t)size;
+	b->yy_buf_size = size;
 
 	/* yy_ch_buf has to be 2 characters longer than the size given because
 	 * we need to put in 2 end-of-buffer characters.
 	 */
-	b->yy_ch_buf = (char *) ncgalloc(b->yy_buf_size + 2  );
+	b->yy_ch_buf = (char *) yyalloc( (yy_size_t) (b->yy_buf_size + 2)  );
 	if ( ! b->yy_ch_buf )
-		YY_FATAL_ERROR( "out of dynamic memory in ncg_create_buffer()" );
+		YY_FATAL_ERROR( "out of dynamic memory in yy_create_buffer()" );
 
 	b->yy_is_our_buffer = 1;
 
-	ncg_init_buffer(b,file );
+	yy_init_buffer( b, file );
 
 	return b;
 }
 
 /** Destroy the buffer.
- * @param b a buffer created with ncg_create_buffer()
+ * @param b a buffer created with yy_create_buffer()
  * 
  */
-    void ncg_delete_buffer (YY_BUFFER_STATE  b )
+    void yy_delete_buffer (YY_BUFFER_STATE  b )
 {
     
 	if ( ! b )
@@ -2723,27 +2972,27 @@ static void ncg_load_buffer_state  (void)
 		YY_CURRENT_BUFFER_LVALUE = (YY_BUFFER_STATE) 0;
 
 	if ( b->yy_is_our_buffer )
-		ncgfree((void *) b->yy_ch_buf  );
+		yyfree( (void *) b->yy_ch_buf  );
 
-	ncgfree((void *) b  );
+	yyfree( (void *) b  );
 }
 
 /* Initializes or reinitializes a buffer.
  * This function is sometimes called more than once on the same buffer,
- * such as during a ncgrestart() or at EOF.
+ * such as during a yyrestart() or at EOF.
  */
-    static void ncg_init_buffer  (YY_BUFFER_STATE  b, FILE * file )
+    static void yy_init_buffer  (YY_BUFFER_STATE  b, FILE * file )
 
 {
 	int oerrno = errno;
     
-	ncg_flush_buffer(b );
+	yy_flush_buffer( b );
 
 	b->yy_input_file = file;
 	b->yy_fill_buffer = 1;
 
-    /* If b is the current buffer, then ncg_init_buffer was _probably_
-     * called from ncgrestart() or through yy_get_next_buffer.
+    /* If b is the current buffer, then yy_init_buffer was _probably_
+     * called from yyrestart() or through yy_get_next_buffer.
      * In that case, we don't want to reset the lineno or column.
      */
     if (b != YY_CURRENT_BUFFER){
@@ -2760,7 +3009,7 @@ static void ncg_load_buffer_state  (void)
  * @param b the buffer state to be flushed, usually @c YY_CURRENT_BUFFER.
  * 
  */
-    void ncg_flush_buffer (YY_BUFFER_STATE  b )
+    void yy_flush_buffer (YY_BUFFER_STATE  b )
 {
     	if ( ! b )
 		return;
@@ -2780,7 +3029,7 @@ static void ncg_load_buffer_state  (void)
 	b->yy_buffer_status = YY_BUFFER_NEW;
 
 	if ( b == YY_CURRENT_BUFFER )
-		ncg_load_buffer_state( );
+		yy_load_buffer_state(  );
 }
 
 /** Pushes the new state onto the stack. The new state becomes
@@ -2789,14 +3038,14 @@ static void ncg_load_buffer_state  (void)
  *  @param new_buffer The new state.
  *  
  */
-void ncgpush_buffer_state (YY_BUFFER_STATE new_buffer )
+void yypush_buffer_state (YY_BUFFER_STATE new_buffer )
 {
     	if (new_buffer == NULL)
 		return;
 
-	ncgensure_buffer_stack();
+	yyensure_buffer_stack();
 
-	/* This block is copied from ncg_switch_to_buffer. */
+	/* This block is copied from yy_switch_to_buffer. */
 	if ( YY_CURRENT_BUFFER )
 		{
 		/* Flush out information for old buffer. */
@@ -2810,8 +3059,8 @@ void ncgpush_buffer_state (YY_BUFFER_STATE new_buffer )
 		(yy_buffer_stack_top)++;
 	YY_CURRENT_BUFFER_LVALUE = new_buffer;
 
-	/* copied from ncg_switch_to_buffer. */
-	ncg_load_buffer_state( );
+	/* copied from yy_switch_to_buffer. */
+	yy_load_buffer_state(  );
 	(yy_did_buffer_switch_on_eof) = 1;
 }
 
@@ -2819,18 +3068,18 @@ void ncgpush_buffer_state (YY_BUFFER_STATE new_buffer )
  *  The next element becomes the new top.
  *  
  */
-void ncgpop_buffer_state (void)
+void yypop_buffer_state (void)
 {
     	if (!YY_CURRENT_BUFFER)
 		return;
 
-	ncg_delete_buffer(YY_CURRENT_BUFFER );
+	yy_delete_buffer(YY_CURRENT_BUFFER );
 	YY_CURRENT_BUFFER_LVALUE = NULL;
 	if ((yy_buffer_stack_top) > 0)
 		--(yy_buffer_stack_top);
 
 	if (YY_CURRENT_BUFFER) {
-		ncg_load_buffer_state( );
+		yy_load_buffer_state(  );
 		(yy_did_buffer_switch_on_eof) = 1;
 	}
 }
@@ -2838,7 +3087,7 @@ void ncgpop_buffer_state (void)
 /* Allocates the stack if it does not exist.
  *  Guarantees space for at least one push.
  */
-static void ncgensure_buffer_stack (void)
+static void yyensure_buffer_stack (void)
 {
 	yy_size_t num_to_alloc;
     
@@ -2848,15 +3097,15 @@ static void ncgensure_buffer_stack (void)
 		 * scanner will even need a stack. We use 2 instead of 1 to avoid an
 		 * immediate realloc on the next call.
          */
-		num_to_alloc = 1; /* After all that talk, this was set to 1 anyways... */
-		(yy_buffer_stack) = (struct yy_buffer_state**)ncgalloc
+      num_to_alloc = 1; /* After all that talk, this was set to 1 anyways... */
+		(yy_buffer_stack) = (struct yy_buffer_state**)yyalloc
 								(num_to_alloc * sizeof(struct yy_buffer_state*)
 								);
 		if ( ! (yy_buffer_stack) )
-			YY_FATAL_ERROR( "out of dynamic memory in ncgensure_buffer_stack()" );
-								  
+			YY_FATAL_ERROR( "out of dynamic memory in yyensure_buffer_stack()" );
+
 		memset((yy_buffer_stack), 0, num_to_alloc * sizeof(struct yy_buffer_state*));
-				
+
 		(yy_buffer_stack_max) = num_to_alloc;
 		(yy_buffer_stack_top) = 0;
 		return;
@@ -2868,12 +3117,12 @@ static void ncgensure_buffer_stack (void)
 		yy_size_t grow_size = 8 /* arbitrary grow size */;
 
 		num_to_alloc = (yy_buffer_stack_max) + grow_size;
-		(yy_buffer_stack) = (struct yy_buffer_state**)ncgrealloc
+		(yy_buffer_stack) = (struct yy_buffer_state**)yyrealloc
 								((yy_buffer_stack),
 								num_to_alloc * sizeof(struct yy_buffer_state*)
 								);
 		if ( ! (yy_buffer_stack) )
-			YY_FATAL_ERROR( "out of dynamic memory in ncgensure_buffer_stack()" );
+			YY_FATAL_ERROR( "out of dynamic memory in yyensure_buffer_stack()" );
 
 		/* zero only the new slots.*/
 		memset((yy_buffer_stack) + (yy_buffer_stack_max), 0, grow_size * sizeof(struct yy_buffer_state*));
@@ -2885,9 +3134,9 @@ static void ncgensure_buffer_stack (void)
  * @param base the character buffer
  * @param size the size in bytes of the character buffer
  * 
- * @return the newly allocated buffer state object. 
+ * @return the newly allocated buffer state object.
  */
-YY_BUFFER_STATE ncg_scan_buffer  (char * base, yy_size_t  size )
+YY_BUFFER_STATE yy_scan_buffer  (char * base, yy_size_t  size )
 {
 	YY_BUFFER_STATE b;
     
@@ -2895,69 +3144,69 @@ YY_BUFFER_STATE ncg_scan_buffer  (char * base, yy_size_t  size )
 	     base[size-2] != YY_END_OF_BUFFER_CHAR ||
 	     base[size-1] != YY_END_OF_BUFFER_CHAR )
 		/* They forgot to leave room for the EOB's. */
-		return 0;
+		return NULL;
 
-	b = (YY_BUFFER_STATE) ncgalloc(sizeof( struct yy_buffer_state )  );
+	b = (YY_BUFFER_STATE) yyalloc( sizeof( struct yy_buffer_state )  );
 	if ( ! b )
-		YY_FATAL_ERROR( "out of dynamic memory in ncg_scan_buffer()" );
+		YY_FATAL_ERROR( "out of dynamic memory in yy_scan_buffer()" );
 
-	b->yy_buf_size = size - 2;	/* "- 2" to take care of EOB's */
+	b->yy_buf_size = (int) (size - 2);	/* "- 2" to take care of EOB's */
 	b->yy_buf_pos = b->yy_ch_buf = base;
 	b->yy_is_our_buffer = 0;
-	b->yy_input_file = 0;
+	b->yy_input_file = NULL;
 	b->yy_n_chars = b->yy_buf_size;
 	b->yy_is_interactive = 0;
 	b->yy_at_bol = 1;
 	b->yy_fill_buffer = 0;
 	b->yy_buffer_status = YY_BUFFER_NEW;
 
-	ncg_switch_to_buffer(b  );
+	yy_switch_to_buffer( b  );
 
 	return b;
 }
 
-/** Setup the input buffer state to scan a string. The next call to ncglex() will
+/** Setup the input buffer state to scan a string. The next call to yylex() will
  * scan from a @e copy of @a str.
  * @param yystr a NUL-terminated string to scan
  * 
  * @return the newly allocated buffer state object.
  * @note If you want to scan bytes that may contain NUL values, then use
- *       ncg_scan_bytes() instead.
+ *       yy_scan_bytes() instead.
  */
-YY_BUFFER_STATE ncg_scan_string (yyconst char * yystr )
+YY_BUFFER_STATE yy_scan_string (const char * yystr )
 {
     
-	return ncg_scan_bytes(yystr,strlen(yystr) );
+	return yy_scan_bytes( yystr, (int) strlen(yystr) );
 }
 
-/** Setup the input buffer state to scan the given bytes. The next call to ncglex() will
+/** Setup the input buffer state to scan the given bytes. The next call to yylex() will
  * scan from a @e copy of @a bytes.
  * @param yybytes the byte buffer to scan
  * @param _yybytes_len the number of bytes in the buffer pointed to by @a bytes.
  * 
  * @return the newly allocated buffer state object.
  */
-YY_BUFFER_STATE ncg_scan_bytes  (yyconst char * yybytes, yy_size_t  _yybytes_len )
+YY_BUFFER_STATE yy_scan_bytes  (const char * yybytes, int  _yybytes_len )
 {
 	YY_BUFFER_STATE b;
 	char *buf;
 	yy_size_t n;
-	yy_size_t i;
+	int i;
     
 	/* Get memory for full buffer, including space for trailing EOB's. */
-	n = _yybytes_len + 2;
-	buf = (char *) ncgalloc(n  );
+	n = (yy_size_t) (_yybytes_len + 2);
+	buf = (char *) yyalloc( n  );
 	if ( ! buf )
-		YY_FATAL_ERROR( "out of dynamic memory in ncg_scan_bytes()" );
+		YY_FATAL_ERROR( "out of dynamic memory in yy_scan_bytes()" );
 
 	for ( i = 0; i < _yybytes_len; ++i )
 		buf[i] = yybytes[i];
 
 	buf[_yybytes_len] = buf[_yybytes_len+1] = YY_END_OF_BUFFER_CHAR;
 
-	b = ncg_scan_buffer(buf,n );
+	b = yy_scan_buffer( buf, n );
 	if ( ! b )
-		YY_FATAL_ERROR( "bad buffer in ncg_scan_bytes()" );
+		YY_FATAL_ERROR( "bad buffer in yy_scan_bytes()" );
 
 	/* It's okay to grow etc. this buffer, and we should throw it
 	 * away when we're done.
@@ -2971,9 +3220,9 @@ YY_BUFFER_STATE ncg_scan_bytes  (yyconst char * yybytes, yy_size_t  _yybytes_len
 #define YY_EXIT_FAILURE 2
 #endif
 
-static void yy_fatal_error (yyconst char* msg )
+static void yynoreturn yy_fatal_error (const char* msg )
 {
-			(void) fprintf( stderr, "%s\n", msg );
+			fprintf( stderr, "%s\n", msg );
 	exit( YY_EXIT_FAILURE );
 }
 
@@ -2983,14 +3232,14 @@ static void yy_fatal_error (yyconst char* msg )
 #define yyless(n) \
 	do \
 		{ \
-		/* Undo effects of setting up ncgtext. */ \
+		/* Undo effects of setting up yytext. */ \
         int yyless_macro_arg = (n); \
         YY_LESS_LINENO(yyless_macro_arg);\
-		ncgtext[ncgleng] = (yy_hold_char); \
-		(yy_c_buf_p) = ncgtext + yyless_macro_arg; \
+		yytext[yyleng] = (yy_hold_char); \
+		(yy_c_buf_p) = yytext + yyless_macro_arg; \
 		(yy_hold_char) = *(yy_c_buf_p); \
 		*(yy_c_buf_p) = '\0'; \
-		ncgleng = yyless_macro_arg; \
+		yyleng = yyless_macro_arg; \
 		} \
 	while ( 0 )
 
@@ -2999,126 +3248,126 @@ static void yy_fatal_error (yyconst char* msg )
 /** Get the current line number.
  * 
  */
-int ncgget_lineno  (void)
+int yyget_lineno  (void)
 {
-        
-    return ncglineno;
+    
+    return yylineno;
 }
 
 /** Get the input stream.
  * 
  */
-FILE *ncgget_in  (void)
+FILE *yyget_in  (void)
 {
-        return ncgin;
+        return yyin;
 }
 
 /** Get the output stream.
  * 
  */
-FILE *ncgget_out  (void)
+FILE *yyget_out  (void)
 {
-        return ncgout;
+        return yyout;
 }
 
 /** Get the length of the current token.
  * 
  */
-yy_size_t ncgget_leng  (void)
+int yyget_leng  (void)
 {
-        return ncgleng;
+        return yyleng;
 }
 
 /** Get the current token.
  * 
  */
 
-char *ncgget_text  (void)
+char *yyget_text  (void)
 {
-        return ncgtext;
+        return yytext;
 }
 
 /** Set the current line number.
  * @param _line_number line number
  * 
  */
-void ncgset_lineno (int  _line_number )
+void yyset_lineno (int  _line_number )
 {
     
-    ncglineno = _line_number;
+    yylineno = _line_number;
 }
 
 /** Set the input stream. This does not discard the current
  * input buffer.
  * @param _in_str A readable stream.
  * 
- * @see ncg_switch_to_buffer
+ * @see yy_switch_to_buffer
  */
-void ncgset_in (FILE *  _in_str )
+void yyset_in (FILE *  _in_str )
 {
-        ncgin = _in_str ;
+        yyin = _in_str ;
 }
 
-void ncgset_out (FILE *  _out_str )
+void yyset_out (FILE *  _out_str )
 {
-        ncgout = _out_str ;
+        yyout = _out_str ;
 }
 
-int ncgget_debug  (void)
+int yyget_debug  (void)
 {
-        return ncg_flex_debug;
+        return yy_flex_debug;
 }
 
-void ncgset_debug (int  _bdebug )
+void yyset_debug (int  _bdebug )
 {
-        ncg_flex_debug = _bdebug ;
+        yy_flex_debug = _bdebug ;
 }
 
 static int yy_init_globals (void)
 {
         /* Initialization is the same as for the non-reentrant scanner.
-     * This function is called from ncglex_destroy(), so don't allocate here.
+     * This function is called from yylex_destroy(), so don't allocate here.
      */
 
-    (yy_buffer_stack) = 0;
+    (yy_buffer_stack) = NULL;
     (yy_buffer_stack_top) = 0;
     (yy_buffer_stack_max) = 0;
-    (yy_c_buf_p) = (char *) 0;
+    (yy_c_buf_p) = NULL;
     (yy_init) = 0;
     (yy_start) = 0;
 
 /* Defined in main.c */
 #ifdef YY_STDINIT
-    ncgin = stdin;
-    ncgout = stdout;
+    yyin = stdin;
+    yyout = stdout;
 #else
-    ncgin = (FILE *) 0;
-    ncgout = (FILE *) 0;
+    yyin = NULL;
+    yyout = NULL;
 #endif
 
     /* For future reference: Set errno on error, since we are called by
-     * ncglex_init()
+     * yylex_init()
      */
     return 0;
 }
 
-/* ncglex_destroy is for both reentrant and non-reentrant scanners. */
-int ncglex_destroy  (void)
+/* yylex_destroy is for both reentrant and non-reentrant scanners. */
+int yylex_destroy  (void)
 {
     
     /* Pop the buffer stack, destroying each element. */
 	while(YY_CURRENT_BUFFER){
-		ncg_delete_buffer(YY_CURRENT_BUFFER  );
+		yy_delete_buffer( YY_CURRENT_BUFFER  );
 		YY_CURRENT_BUFFER_LVALUE = NULL;
-		ncgpop_buffer_state();
+		yypop_buffer_state();
 	}
 
 	/* Destroy the stack itself. */
-	ncgfree((yy_buffer_stack) );
+	yyfree((yy_buffer_stack) );
 	(yy_buffer_stack) = NULL;
 
     /* Reset the globals. This is important in a non-reentrant scanner so the next time
-     * ncglex() is called, initialization will occur. */
+     * yylex() is called, initialization will occur. */
     yy_init_globals( );
 
     return 0;
@@ -3129,7 +3378,7 @@ int ncglex_destroy  (void)
  */
 
 #ifndef yytext_ptr
-static void yy_flex_strncpy (char* s1, yyconst char * s2, int n )
+static void yy_flex_strncpy (char* s1, const char * s2, int n )
 {
 		
 	int i;
@@ -3139,7 +3388,7 @@ static void yy_flex_strncpy (char* s1, yyconst char * s2, int n )
 #endif
 
 #ifdef YY_NEED_STRLEN
-static int yy_flex_strlen (yyconst char * s )
+static int yy_flex_strlen (const char * s )
 {
 	int n;
 	for ( n = 0; s[n]; ++n )
@@ -3149,12 +3398,12 @@ static int yy_flex_strlen (yyconst char * s )
 }
 #endif
 
-void *ncgalloc (yy_size_t  size )
+void *yyalloc (yy_size_t  size )
 {
-			return (void *) malloc( size );
+			return malloc(size);
 }
 
-void *ncgrealloc  (void * ptr, yy_size_t  size )
+void *yyrealloc  (void * ptr, yy_size_t  size )
 {
 		
 	/* The cast to (char *) in the following accommodates both
@@ -3164,26 +3413,25 @@ void *ncgrealloc  (void * ptr, yy_size_t  size )
 	 * any pointer type to void*, and deal with argument conversions
 	 * as though doing an assignment.
 	 */
-	return (void *) realloc( (char *) ptr, size );
+	return realloc(ptr, size);
 }
 
-void ncgfree (void * ptr )
+void yyfree (void * ptr )
 {
-			free( (char *) ptr );	/* see ncgrealloc() for (char *) cast */
+			free( (char *) ptr );	/* see yyrealloc() for (char *) cast */
 }
 
 #define YYTABLES_NAME "yytables"
 
-#line 586 "ncgen.l"
-
+#line 616 "ncgen.l"
 
 static int
 lexdebug(int token)
 {
     if(debug >= 2)
     {
-	char* text = ncgtext;
-	text[ncgleng] = 0;
+	char* text = yytext;
+	text[yyleng] = 0;
         fprintf(stderr,"Token=%d |%s| line=%d\n",token,text,lineno);
     }
     return token;
@@ -3467,5 +3715,41 @@ collecttag(char* text, char** stagp)
 	tag = NC_NAT;
     }
     return tag;
+}
+
+/* Depending on the format, a name may be a keword or an ident */
+static int
+identorkw(int token)
+{
+    /* Binary search for yytext */
+    int n = NKWIDENT;
+    int L = 0;
+    int R = (n - 1);
+    int m, cmp;
+    struct KWIDENT* p;
+    int found = 0;
+    size_t len;
+    char* id = NULL;
+
+    for(;;) {
+	if(L > R) break;
+        m = (L + R) / 2;
+	p = &kwident[m];
+	cmp = (p->token - token);
+	if(cmp == 0) {found = 1; break;}
+	if(cmp < 0)
+	    L = (m + 1);
+	else /*cmp > 0*/
+	    R = (m - 1);
+    }
+    if(!found) return token; /* Not a keyword of interest */
+    /* See if the format applies */
+    if(p->formats & ((int)1<<k_flag)) return token;
+    /* Need to convert a non-ident token to an ident symbol */
+    len = strlen(yytext);
+    len = unescape(yytext,len,ISIDENT,&id);
+    yylval.sym = install(id);
+    efree(id);
+    return IDENT; /* treat as identifier */
 }
 

--- a/ncgen/ncgeny.c
+++ b/ncgen/ncgeny.c
@@ -677,7 +677,7 @@ static const char *const yytname[] =
   "dim_or_attr_decl", "dimdeclist", "dimdecl", "dimd", "vasection",
   "vadecls", "vadecl_or_attr", "vardecl", "varlist", "varspec", "dimspec",
   "dimlist", "dimref", "fieldlist", "fieldspec", "fielddimspec",
-  "fielddimlist", "fielddim", "varref", "typeref", "type_var_ref",
+  "fielddimlist", "fielddim", "varref", "typeref", "ambiguous_ref",
   "attrdecllist", "attrdecl", "path", "datasection", "datadecls",
   "datadecl", "datalist", "datalist0", "datalist1", "dataitem",
   "constdata", "econstref", "function", "arglist", "simpleconstant",


### PR DESCRIPTION
re: https://github.com/Unidata/netcdf-c/issues/1750

Built-in type-name keywords are currently flagged when used as
identifiers in formats that do not support that type.  So if a
user declares a dimension named "string" in a classic .cdl file,
it causes an error.

This PR modifies ncgen to allow those format-specific type keywords
to be used as identifiers when compiling to formats that do not
support that type. Also added a test for this.

Also a couple of misc. changes to conditional-ize some debug output.