### PR TITLE
parse projection functions

### DIFF
--- a/libdap2/constraints.c
+++ b/libdap2/constraints.c
@@ -114,6 +114,7 @@ qualifyprojectionnames(DCEprojection* proj)
     NCerror ncstat = NC_NOERR;
     NClist* fullpath = nclistnew();
 
+    if (proj->discrim == CES_VAR) {
     ASSERT((proj->discrim == CES_VAR
             && proj->var->annotation != NULL
             && ((CDFnode*)proj->var->annotation)->ocnode != NULL));
@@ -129,6 +130,7 @@ fprintf(stderr,"qualify: %s -> ",
 fprintf(stderr,"%s\n",
 	dumpprojection(proj));
 #endif
+    }
     nclistfree(fullpath);
     return ncstat;
 }
@@ -138,6 +140,7 @@ static NCerror
 qualifyprojectionsizes(DCEprojection* proj)
 {
     size_t i,j;
+    if (proj->discrim == CES_VAR) {
     ASSERT(proj->discrim == CES_VAR);
 #ifdef DEBUG
 fprintf(stderr,"qualifyprojectionsizes.before: %s\n",
@@ -168,6 +171,7 @@ fprintf(stderr,"qualifyprojectionsizes.before: %s\n",
 fprintf(stderr,"qualifyprojectionsizes.after: %s\n",
 		dumpprojection(proj));
 #endif
+    }
     return NC_NOERR;
 }
 

--- a/libdap2/dce.y
+++ b/libdap2/dce.y
@@ -58,7 +58,7 @@ projection:
 	  segmentlist
 	    {$$=projection(parsestate,$1);}
 	| function
-	    {$$=$1;}
+	    {$$=projection(parsestate,$1);}
 	;
 
 function:

--- a/libdap2/dcetab.c
+++ b/libdap2/dcetab.c
@@ -1305,7 +1305,7 @@ yyreduce:
 
   case 13:
 #line 61 "dce.y" /* yacc.c:1646  */
-    {(yyval)=(yyvsp[0]);}
+    {(yyval)=projection(parsestate,(yyvsp[0]));}
 #line 1310 "dcetab.c" /* yacc.c:1646  */
     break;
 


### PR DESCRIPTION
projection functions seemed to get lost in the initial parsing (before sending DAS/DDS/DODS requests). Attempting to implement/use projection functions per `6.1.1.3` below to subset (_run for side effect only_ in this case).

see [Data Access Protocol (DAP), version 2. ESE-RFC-004.1.2](https://www.opendap.org/index.php/support/design-documentation)

#### 6.1.1.3 Calling server-side functions
```
Functions MAY be called as part of either the projection or selection
clauses. In the case of a selection, the function MUST return a value which can be used when evaluating the
clause. In the case of a projection, the function MUST return a DAP variable which will then be the return
value of the request or it MUST return nothing in which case it is run for side effect only
```

_note: IP below not persistent, but should be able to verify regardless, fails before requests_
```
[]$ ncdump -h "http://3.86.50.71:5000/dap/noaa.nwm.short_range.channel_rt/run/latest?streamflow,bbox(-72.292668,41.275831,-70.949589,42.057538)"
(proj->discrim == CES_VAR && proj->var->annotation != NULL && ((CDFnode*)proj->var->annotation)->ocnode != NULL)

ncdump: ../../libdap2/constraints.c:118: qualifyprojectionnames: Assertion `dappanic("(proj->discrim == CES_VAR && proj->var->annotation != NULL && ((CDFnode*)proj->var->annotation)->ocnode != NULL)")' failed.
Aborted (core dumped)
```

`libdap2/dcetab.c` generated w/ _bison_ sequence in https://github.com/Unidata/netcdf-c/blob/master/libdap2/Makefile.am#L61 as not built via make/cmake
