### PR TITLE
Fix nc_redef() - when called twice on netcdf-4 file, it should return no error

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,7 @@ This file contains a high-level description of this package's evolution. Release
 
 ## 4.8.0 - TBD
 
+* [Bug Fix] Don't return error for extra calls to nc_redef() for netCDF/HDF5 files, unless classic model is in use. See [https://github.com/Unidata/netcdf-c/issues/1779].
 * [Bug Fix] Now allow szip to be used on variables with unlimited dimension [https://github.com/Unidata/netcdf-c/issues/1774].
 * [Enhancement] Add support for cloud storage using a variant of the Zarr storage format. Warning: this feature is highly experimental and is subject to rapid evolution [https://www.unidata.ucar.edu/blogs/developer/en/entry/overview-of-zarr-support-in].
 * [Bug Fix] Fix nccopy to properly set default chunking parameters when not otherwise specified. This can significantly improve performance in selected cases. Note that if seeing slow performance with nccopy, then, as a work-around, specifically set the chunking parameters. [https://github.com/Unidata/netcdf-c/issues/1763].

--- a/libhdf5/hdf5file.c
+++ b/libhdf5/hdf5file.c
@@ -425,9 +425,10 @@ NC4_redef(int ncid)
         return retval;
     assert(nc4_info);
 
-    /* If we're already in define mode, return an error. */
+    /* If we're already in define mode, return an error for classic
+     * files, or netCDF/HDF5 files when classic mode is in use. */
     if (nc4_info->flags & NC_INDEF)
-        return NC_EINDEFINE;
+	return (nc4_info->cmode & NC_CLASSIC_MODEL) ? NC_EINDEFINE : NC_NOERR;
 
     /* If the file is read-only, return an error. */
     if (nc4_info->no_write)

--- a/nc_test4/tst_files.c
+++ b/nc_test4/tst_files.c
@@ -501,6 +501,16 @@ test_redef(int format)
    if (nc_enddef(ncid)) ERR;
    if (nc_redef(ncid)) ERR;
 
+   /* NetCDF/HDF5 files ignore the repeated redef(). */
+   if (format != NC_FORMAT_NETCDF4)
+   {
+       if (nc_redef(ncid) != NC_EINDEFINE) ERR;
+   }
+   else
+   {
+       if (nc_redef(ncid)) ERR;
+   }
+   
    /* Close it up. */
    if (format != NC_FORMAT_NETCDF4)
       if (nc_enddef(ncid)) ERR;

--- a/nc_test4/tst_files.c
+++ b/nc_test4/tst_files.c
@@ -497,6 +497,10 @@ test_redef(int format)
    if (strcmp(var_name, REDEF_VAR2_NAME) || xtype_in != NC_BYTE || ndims != REDEF_NDIMS ||
        dimids_in[0] != dimids[0] || dimids_in[1] != dimids[1]) ERR;
 
+   /* Try enddef/redef. */
+   if (nc_enddef(ncid)) ERR;
+   if (nc_redef(ncid)) ERR;
+
    /* Close it up. */
    if (format != NC_FORMAT_NETCDF4)
       if (nc_enddef(ncid)) ERR;


### PR DESCRIPTION
For classic files (or netCDF/HDF5 files with classic model), calling nc_redef() twice should and does result in NC_EINDEFINE error.

But, in accordance with the automatic handling of enddef/redef for netCDF/HDF5 files, extra calls to redef should just be ignored for netCDF/HDF5 files.

THis PR fixes this issue and makes the code work in accordance with the documentation.

Fixes #1779 