### PR TITLE
Convert filename from ANSI to UTF-8 before calling HDF5.

### DIFF
--- a/include/hdf5internal.h
+++ b/include/hdf5internal.h
@@ -197,4 +197,23 @@ extern int NC4_isnetcdf4(struct NC_FILE_INFO*); /*libsrc4/nc4hdf.c*/
 
 extern int nc4_find_default_chunksizes2(NC_GRP_INFO_T *grp, NC_VAR_INFO_T *var);
 
+#ifdef _WIN32
+
+/* Maxinum length of a typical path in UTF-8.
+ * When converting from ANSI to UTF-8, the length will be up to 3 times,
+ * so round up 260*3 to 1024. (260=MAX_PATH) */
+#define MAX_PATHBUF_SIZE 1024
+
+/* Struct for converting ANSI to UTF-8. */
+typedef struct pathbuf
+{
+    void *ptr;
+    char buffer[MAX_PATHBUF_SIZE];
+} pathbuf_t;
+
+const char *nc4_ndf5_ansi_to_utf8(pathbuf_t *pb, const char *path);
+void nc4_hdf5_free_pathbuf(pathbuf_t *pb);
+
+#endif /* _WIN32 */
+
 #endif /* _HDF5INTERNAL_ */

--- a/libhdf5/hdf5create.c
+++ b/libhdf5/hdf5create.c
@@ -22,6 +22,12 @@ static const int ILLEGAL_CREATE_FLAGS = (NC_NOWRITE|NC_MMAP|NC_64BIT_OFFSET|NC_C
 /* From nc4mem.c */
 extern int NC4_create_image_file(NC_FILE_INFO_T* h5, size_t);
 
+#ifdef _WIN32
+static hid_t nc4_H5Fcreate(const char *filename, unsigned flags, hid_t fcpl_id, hid_t fapl_id);
+#else
+#define nc4_H5Fcreate  H5Fcreate
+#endif
+
 /**
  * @internal Create a netCDF-4/HDF5 file.
  *
@@ -217,13 +223,13 @@ nc4_create_file(const char *path, int cmode, size_t initialsz,
             /* Configure FAPL to use the core file driver */
             if (H5Pset_fapl_core(fapl_id, alloc_incr, (nc4_info->mem.persist?1:0)) < 0)
                 BAIL(NC_EHDFERR);
-            if ((hdf5_info->hdfid = H5Fcreate(path, flags, fcpl_id, fapl_id)) < 0)
+            if ((hdf5_info->hdfid = nc4_H5Fcreate(path, flags, fcpl_id, fapl_id)) < 0)
                 BAIL(EACCES);
         }
         else /* Normal file */
         {
             /* Create the HDF5 file. */
-            if ((hdf5_info->hdfid = H5Fcreate(path, flags, fcpl_id, fapl_id)) < 0)
+            if ((hdf5_info->hdfid = nc4_H5Fcreate(path, flags, fcpl_id, fapl_id)) < 0)
                 BAIL(EACCES);
         }
 
@@ -306,3 +312,31 @@ NC4_create(const char* path, int cmode, size_t initialsz, int basepe,
 
     return res;
 }
+
+#ifdef _WIN32
+
+/**
+ * Wrapper function for H5Fcreate.
+ * Converts the filename from ANSI to UTF-8 as needed before calling H5Fcreate.
+ *
+ * @param filename The filename encoded ANSI to access.
+ * @param flags File access flags.
+ * @param fcpl_id File creation property list identifier.
+ * @param fapl_id File access property list identifier.
+ * @return A file identifier if succeeded. A negative value if failed.
+ */
+static hid_t
+nc4_H5Fcreate(const char *filename, unsigned flags, hid_t fcpl_id, hid_t fapl_id)
+{
+    pathbuf_t pb;
+    hid_t hid;
+
+    filename = nc4_ndf5_ansi_to_utf8(&pb, filename);
+    if (!filename)
+        return H5I_INVALID_HID;
+    hid = H5Fcreate(filename, flags, fcpl_id, fapl_id);
+    nc4_hdf5_free_pathbuf(&pb);
+    return hid;
+}
+
+#endif /* _WIN32 */


### PR DESCRIPTION
Fixes #1786.

Made `nc_create` and `nc_open` to work the same as before regardless of the HDF5 version.
If on Windows and HDF5>=1.10.6, convert the filename encoding from ANSI to UTF-8 before calling the HDF5 function.