### PR TITLE
Fix for cURL >7.69

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,7 @@ This file contains a high-level description of this package's evolution. Release
 
 ## 4.8.0 - TBD
 
+* [Bug Fix] Fixed byte-range support with cURL > 7.69. See [https://github.com/Unidata/netcdf-c/pull/1798].
 * [Enhancement] Added new test for using compression with parallel I/O: nc_test4/tst_h_par_compress.c. See [https://github.com/Unidata/netcdf-c/pull/1784].
 * [Bug Fix] Don't return error for extra calls to nc_redef() for netCDF/HDF5 files, unless classic model is in use. See [https://github.com/Unidata/netcdf-c/issues/1779].
 * [Enhancement] Added new parallel I/O benchmark program to mimic NOAA UFS data writes, built when --enable-benchmarks is in configure. See [https://github.com/Unidata/netcdf-c/pull/1777].

--- a/libdispatch/dhttp.c
+++ b/libdispatch/dhttp.c
@@ -377,7 +377,7 @@ execute(NC_HTTP_STATE* state, int headcmd)
     if(cstat != CURLE_OK) state->httpcode = 0;
 
     if(headcmd) {
-        cstat = CURLERR(curl_easy_setopt(state->curl, CURLOPT_NOBODY, 0L));
+        cstat = CURLERR(curl_easy_setopt(state->curl, CURLOPT_HTTPGET, 1L));
         if(cstat != CURLE_OK) goto fail;
     }
 


### PR DESCRIPTION
Found on conda-forge (which is now running 7.71.1), that byte-range requests would stall. It turns out this is due to
`CURLOPT_NOBODY`--apparently setting this to 0 disables the HEAD request, but does not restore downloading the body. The way to fix this is to reset to `CURLOPT_HTTPGET` when done with a HEAD request.

This was an esoteric thing to track down, the best link I could find regarding the issues with `CURLOPT_NOBODY` is:
https://curl.haxx.se/mail/curlphp-2008-03/0073.html

I can confirm this fixes ncdump doing a byte-range request on this URL on 4.7.4:
https://remotetest.unidata.ucar.edu/thredds/fileServer/testdata/2004050412_eta_211.nc#bytes

Unfortunately, I was not able to build master using cmake to test.