### PR TITLE
Add test for using attributes like GFDL FMS does

### DIFF
--- a/nc_test/tst_atts3.c
+++ b/nc_test/tst_atts3.c
@@ -419,8 +419,6 @@ main(int argc, char **argv)
     {
         int ncid;
 
-        /*int int_in[ATT_LEN], int_out[ATT_LEN] = {NC_MIN_INT, 128, NC_MAX_INT};*/
-
         /* Create a file with a global attribute of each type of zero length. */
 #ifdef TEST_PNETCDF
         if (nc_create_par(FILE_NAME, NC_CLOBBER, MPI_COMM_WORLD, MPI_INFO_NULL,&ncid)) ERR;
@@ -441,7 +439,6 @@ main(int argc, char **argv)
         int ncid;
         signed char schar_in[ATT_LEN];
         short short_in[ATT_LEN];
-        /*int int_in[ATT_LEN], int_out[ATT_LEN] = {NC_MIN_INT, 128, NC_MAX_INT};*/
         int int_in[ATT_LEN];
         float float_in[ATT_LEN];
         double double_in[ATT_LEN];

--- a/nc_test/tst_atts3.c
+++ b/nc_test/tst_atts3.c
@@ -1,10 +1,10 @@
-/* This is part of the netCDF package. Copyright 2005-2018 University
+/* This is part of the netCDF package. Copyright 2005-2020 University
    Corporation for Atmospheric Research/Unidata. See COPYRIGHT file
    for conditions of use.
 
    Test attributes.
 
-   Ed Hartnett, WK Liao, 1996
+   Ed Hartnett, WK Liao
 */
 
 #include "config.h"

--- a/nc_test/tst_atts3.c
+++ b/nc_test/tst_atts3.c
@@ -4,7 +4,7 @@
 
    Test attributes.
 
-   $Id: tst_atts3.c 2796 2014-10-28 03:40:29Z wkliao $
+   Ed Hartnett, WK Liao, 1996
 */
 
 #include "config.h"
@@ -38,7 +38,7 @@
 #define ATT_UINT64_NAME "Number_of_drinks_in_career_to_date"
 
 /*
-#define ATT_USHORT_NAME "Chamber_Gas_Electric_and_Telephone_Bill_Share"
+  #define ATT_USHORT_NAME "Chamber_Gas_Electric_and_Telephone_Bill_Share"
 */
 #define ATT_FLOAT_NAME "Average_Nanoseconds_for_Lose_Win_or_Appeal"
 #define ATT_LEN 3
@@ -84,50 +84,50 @@ Cry 'God for Harry, England, and Saint George!'";
 int
 tst_att_ordering(int cmode)
 {
-   int ncid;
-   char name[NUM_ATTS][ATT_MAX_NAME + 1] = {"Gc", "Gb", "Gs", "Gi", "Gf",
-					    "Gd", "Gatt-name-dashes", "Gatt.name.dots"};
-   int len[NUM_ATTS] = {0, 2, 3, 3, 3, 3, 1, 1};
-   signed char b[2] = {-128, 127};
-   short s[3] = {-32768, 0, 32767};
-   int i[3] = {42, 0, -42};
-   float f[3] = {42.0, -42.0, 42.0};
-   double d[3] = {420.0, -420.0, 420.0};
-   int att_name_dashes = -1, att_name_dots = -2;
-   char name_in[NC_MAX_NAME];
-   int j;
+    int ncid;
+    char name[NUM_ATTS][ATT_MAX_NAME + 1] = {"Gc", "Gb", "Gs", "Gi", "Gf",
+                                             "Gd", "Gatt-name-dashes", "Gatt.name.dots"};
+    int len[NUM_ATTS] = {0, 2, 3, 3, 3, 3, 1, 1};
+    signed char b[2] = {-128, 127};
+    short s[3] = {-32768, 0, 32767};
+    int i[3] = {42, 0, -42};
+    float f[3] = {42.0, -42.0, 42.0};
+    double d[3] = {420.0, -420.0, 420.0};
+    int att_name_dashes = -1, att_name_dots = -2;
+    char name_in[NC_MAX_NAME];
+    int j;
 
-   /* Create a file with some global atts. */
+    /* Create a file with some global atts. */
 #ifdef TEST_PNETCDF
-   if (nc_create_par(FILE_NAME, cmode, MPI_COMM_WORLD, MPI_INFO_NULL,&ncid)) ERR;
+    if (nc_create_par(FILE_NAME, cmode, MPI_COMM_WORLD, MPI_INFO_NULL,&ncid)) ERR;
 #else
-   if (nc_create(FILE_NAME, cmode, &ncid)) ERR;
+    if (nc_create(FILE_NAME, cmode, &ncid)) ERR;
 #endif
-   if (nc_put_att_text(ncid, NC_GLOBAL, name[0], len[0], NULL)) ERR;
-   if (nc_put_att_schar(ncid, NC_GLOBAL, name[1], NC_BYTE, len[1], b)) ERR;
-   if (nc_put_att_short(ncid, NC_GLOBAL, name[2], NC_SHORT, len[2], s)) ERR;
-   if (nc_put_att_int(ncid, NC_GLOBAL, name[3], NC_INT, len[3], i)) ERR;
-   if (nc_put_att_float(ncid, NC_GLOBAL, name[4], NC_FLOAT, len[4], f)) ERR;
-   if (nc_put_att_double(ncid, NC_GLOBAL, name[5], NC_DOUBLE, len[5], d)) ERR;
-   if (nc_put_att_int(ncid, NC_GLOBAL, name[6], NC_INT, len[6], &att_name_dashes)) ERR;
-   if (nc_put_att_int(ncid, NC_GLOBAL, name[7], NC_INT, len[7], &att_name_dots)) ERR;
-   if (nc_close(ncid)) ERR;
+    if (nc_put_att_text(ncid, NC_GLOBAL, name[0], len[0], NULL)) ERR;
+    if (nc_put_att_schar(ncid, NC_GLOBAL, name[1], NC_BYTE, len[1], b)) ERR;
+    if (nc_put_att_short(ncid, NC_GLOBAL, name[2], NC_SHORT, len[2], s)) ERR;
+    if (nc_put_att_int(ncid, NC_GLOBAL, name[3], NC_INT, len[3], i)) ERR;
+    if (nc_put_att_float(ncid, NC_GLOBAL, name[4], NC_FLOAT, len[4], f)) ERR;
+    if (nc_put_att_double(ncid, NC_GLOBAL, name[5], NC_DOUBLE, len[5], d)) ERR;
+    if (nc_put_att_int(ncid, NC_GLOBAL, name[6], NC_INT, len[6], &att_name_dashes)) ERR;
+    if (nc_put_att_int(ncid, NC_GLOBAL, name[7], NC_INT, len[7], &att_name_dots)) ERR;
+    if (nc_close(ncid)) ERR;
 
-   /* Reopen the file and check the order. */
+    /* Reopen the file and check the order. */
 #ifdef TEST_PNETCDF
-   if (nc_open_par(FILE_NAME, 0, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid)) ERR;
+    if (nc_open_par(FILE_NAME, 0, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid)) ERR;
 #else
-   if (nc_open(FILE_NAME, 0, &ncid)) ERR;
+    if (nc_open(FILE_NAME, 0, &ncid)) ERR;
 #endif
-   for (j = 0; j < NUM_ATTS; j++)
-   {
-      if (nc_inq_attname(ncid, NC_GLOBAL, j, name_in)) ERR;
-      if (strcmp(name_in, name[j])) ERR;
-   }
+    for (j = 0; j < NUM_ATTS; j++)
+    {
+        if (nc_inq_attname(ncid, NC_GLOBAL, j, name_in)) ERR;
+        if (strcmp(name_in, name[j])) ERR;
+    }
 
-   /* Close up shop. */
-   if (nc_close(ncid)) ERR;
-   return err;
+    /* Close up shop. */
+    if (nc_close(ncid)) ERR;
+    return err;
 }
 
 int
@@ -142,552 +142,552 @@ main(int argc, char **argv)
     long long longlong_in[ATT_LEN] = {-1LL, -1LL, -1LL};
 
 #ifdef TEST_PNETCDF
-   MPI_Init(&argc, &argv);
+    MPI_Init(&argc, &argv);
 #endif
     (void) signal(SIGFPE, SIG_IGN);
 
-   printf("\n*** Testing netcdf-3 attribute functions.\n");
-   printf("*** testing really simple global atts...");
+    printf("\n*** Testing netcdf-3 attribute functions.\n");
+    printf("*** testing really simple global atts...");
 #define NUM_SIMPLE_ATTS 9
-   {
-      int ncid;
-      char name[NUM_SIMPLE_ATTS][ATT_MAX_NAME + 1] = {"Gc", "Gb", "Gs", "Gi", "Gf",
-						      "Gd", "G7", "G8", "G9"};
-      char name_in[NC_MAX_NAME];
-      int j;
+    {
+        int ncid;
+        char name[NUM_SIMPLE_ATTS][ATT_MAX_NAME + 1] = {"Gc", "Gb", "Gs", "Gi", "Gf",
+                                                        "Gd", "G7", "G8", "G9"};
+        char name_in[NC_MAX_NAME];
+        int j;
 
-      /* Create a file with some global atts. */
+        /* Create a file with some global atts. */
 #ifdef TEST_PNETCDF
-      if (nc_create_par(FILE_NAME, NC_CLOBBER, MPI_COMM_WORLD, MPI_INFO_NULL,&ncid)) ERR;
+        if (nc_create_par(FILE_NAME, NC_CLOBBER, MPI_COMM_WORLD, MPI_INFO_NULL,&ncid)) ERR;
 #else
-      if (nc_create(FILE_NAME, NC_CLOBBER, &ncid)) ERR;
+        if (nc_create(FILE_NAME, NC_CLOBBER, &ncid)) ERR;
 #endif
-      for (j = 0; j < NUM_SIMPLE_ATTS; j++)
-	 if (nc_put_att_int(ncid, NC_GLOBAL, name[j], NC_INT, 0, NULL)) ERR;
-      if (nc_close(ncid)) ERR;
+        for (j = 0; j < NUM_SIMPLE_ATTS; j++)
+            if (nc_put_att_int(ncid, NC_GLOBAL, name[j], NC_INT, 0, NULL)) ERR;
+        if (nc_close(ncid)) ERR;
 
-      /* Reopen the file and check the order. */
+        /* Reopen the file and check the order. */
 #ifdef TEST_PNETCDF
-      if (nc_open_par(FILE_NAME, 0, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid)) ERR;
+        if (nc_open_par(FILE_NAME, 0, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid)) ERR;
 #else
-      if (nc_open(FILE_NAME, 0, &ncid)) ERR;
+        if (nc_open(FILE_NAME, 0, &ncid)) ERR;
 #endif
-      for (j = 0; j < NUM_SIMPLE_ATTS; j++)
-      {
-	 if (nc_inq_attname(ncid, NC_GLOBAL, j, name_in)) ERR;
-	 if (strcmp(name_in, name[j])) ERR;
-      }
+        for (j = 0; j < NUM_SIMPLE_ATTS; j++)
+        {
+            if (nc_inq_attname(ncid, NC_GLOBAL, j, name_in)) ERR;
+            if (strcmp(name_in, name[j])) ERR;
+        }
 
-      /* Close up shop. */
-      if (nc_close(ncid)) ERR;
-   }
-   SUMMARIZE_ERR;
-   printf("*** testing simple global atts...");
-   {
-      int ncid;
-      nc_type att_type;
-      size_t att_len;
-      int i;
+        /* Close up shop. */
+        if (nc_close(ncid)) ERR;
+    }
+    SUMMARIZE_ERR;
+    printf("*** testing simple global atts...");
+    {
+        int ncid;
+        nc_type att_type;
+        size_t att_len;
+        int i;
 
-      char *speech_in;
+        char *speech_in;
 
-      /* This won't work, because classic files can't create these types. */
+        /* This won't work, because classic files can't create these types. */
 #ifdef TEST_PNETCDF
-      if (nc_create_par(FILE_NAME, NC_CLOBBER, MPI_COMM_WORLD, MPI_INFO_NULL,&ncid)) ERR;
+        if (nc_create_par(FILE_NAME, NC_CLOBBER, MPI_COMM_WORLD, MPI_INFO_NULL,&ncid)) ERR;
 #else
-      if (nc_create(FILE_NAME, NC_CLOBBER, &ncid)) ERR;
+        if (nc_create(FILE_NAME, NC_CLOBBER, &ncid)) ERR;
 #endif
-      if (nc_put_att_int(ncid, NC_GLOBAL, ATT_INT_NAME, NC_INT, ATT_LEN,
-			    int_out)) ERR;
-      /* It is also OK to read classic types converted into
-       * supported C types. though the conversion may encounter
-       * out-of-range values */
-      if (nc_get_att_uchar(ncid, NC_GLOBAL, ATT_INT_NAME, uchar_in) != NC_ERANGE) ERR;
-      for (i = 0; i < ATT_LEN; i++) {
-        if (i == 0 || i == 2) continue;
-	if (uchar_in[i] != (unsigned char) int_out[i]) ERR;
-      }
+        if (nc_put_att_int(ncid, NC_GLOBAL, ATT_INT_NAME, NC_INT, ATT_LEN,
+                           int_out)) ERR;
+        /* It is also OK to read classic types converted into
+         * supported C types. though the conversion may encounter
+         * out-of-range values */
+        if (nc_get_att_uchar(ncid, NC_GLOBAL, ATT_INT_NAME, uchar_in) != NC_ERANGE) ERR;
+        for (i = 0; i < ATT_LEN; i++) {
+            if (i == 0 || i == 2) continue;
+            if (uchar_in[i] != (unsigned char) int_out[i]) ERR;
+        }
 
-      /* This was bug NCF-171: on 32-bit platforms, bad values returned */
-      if (nc_get_att_longlong(ncid, NC_GLOBAL, ATT_INT_NAME, longlong_in)) ERR;
-      for (i = 0; i < ATT_LEN; i++)
-      	if (longlong_in[i] != (long long) int_out[i]) ERR;
-      if (nc_close(ncid)) ERR;
+        /* This was bug NCF-171: on 32-bit platforms, bad values returned */
+        if (nc_get_att_longlong(ncid, NC_GLOBAL, ATT_INT_NAME, longlong_in)) ERR;
+        for (i = 0; i < ATT_LEN; i++)
+            if (longlong_in[i] != (long long) int_out[i]) ERR;
+        if (nc_close(ncid)) ERR;
 
-      /* Create a file with a global attribute of each type. */
+        /* Create a file with a global attribute of each type. */
 #ifdef TEST_PNETCDF
-      if (nc_create_par(FILE_NAME, NC_CLOBBER, MPI_COMM_WORLD, MPI_INFO_NULL,&ncid)) ERR;
+        if (nc_create_par(FILE_NAME, NC_CLOBBER, MPI_COMM_WORLD, MPI_INFO_NULL,&ncid)) ERR;
 #else
-      if (nc_create(FILE_NAME, NC_CLOBBER, &ncid)) ERR;
+        if (nc_create(FILE_NAME, NC_CLOBBER, &ncid)) ERR;
 #endif
-      if (nc_put_att_text(ncid, NC_GLOBAL, ATT_TEXT_NAME, strlen(speech)+1, speech)) ERR;
-      if (nc_put_att_schar(ncid, NC_GLOBAL, ATT_SCHAR_NAME, NC_BYTE, ATT_LEN, schar_out)) ERR;
-      if (nc_put_att_short(ncid, NC_GLOBAL, ATT_SHORT_NAME, NC_SHORT, ATT_LEN, short_out)) ERR;
-      if (nc_put_att_int(ncid, NC_GLOBAL, ATT_INT_NAME, NC_INT, ATT_LEN, int_out)) ERR;
-      if (nc_put_att_float(ncid, NC_GLOBAL, ATT_FLOAT_NAME, NC_FLOAT, ATT_LEN, float_out)) ERR;
-      if (nc_put_att_double(ncid, NC_GLOBAL, ATT_DOUBLE_NAME, NC_DOUBLE, ATT_LEN, double_out)) ERR;
-      if (nc_close(ncid)) ERR;
+        if (nc_put_att_text(ncid, NC_GLOBAL, ATT_TEXT_NAME, strlen(speech)+1, speech)) ERR;
+        if (nc_put_att_schar(ncid, NC_GLOBAL, ATT_SCHAR_NAME, NC_BYTE, ATT_LEN, schar_out)) ERR;
+        if (nc_put_att_short(ncid, NC_GLOBAL, ATT_SHORT_NAME, NC_SHORT, ATT_LEN, short_out)) ERR;
+        if (nc_put_att_int(ncid, NC_GLOBAL, ATT_INT_NAME, NC_INT, ATT_LEN, int_out)) ERR;
+        if (nc_put_att_float(ncid, NC_GLOBAL, ATT_FLOAT_NAME, NC_FLOAT, ATT_LEN, float_out)) ERR;
+        if (nc_put_att_double(ncid, NC_GLOBAL, ATT_DOUBLE_NAME, NC_DOUBLE, ATT_LEN, double_out)) ERR;
+        if (nc_close(ncid)) ERR;
 
-      /* Open the file and check attributes. */
+        /* Open the file and check attributes. */
 #ifdef TEST_PNETCDF
-      if (nc_open_par(FILE_NAME, 0, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid)) ERR;
+        if (nc_open_par(FILE_NAME, 0, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid)) ERR;
 #else
-      if (nc_open(FILE_NAME, 0, &ncid)) ERR;
+        if (nc_open(FILE_NAME, 0, &ncid)) ERR;
 #endif
-      /* Check text. */
-      if (nc_inq_att(ncid, NC_GLOBAL, ATT_TEXT_NAME, &att_type, &att_len))
-	 ERR;
-      if (att_type != NC_CHAR || att_len != strlen(speech) + 1) ERR;
-      if (!(speech_in = malloc(att_len + 1))) ERR;
-      if (nc_get_att_text(ncid, NC_GLOBAL, ATT_TEXT_NAME, speech_in)) ERR;
-      if (strcmp(speech, speech_in)) ERR;
-      free(speech_in);
-      /* Check numeric values. */
-      if (nc_get_att_schar(ncid, NC_GLOBAL, ATT_SCHAR_NAME, schar_in)) ERR;
-      for (i = 0; i < ATT_LEN; i++)
-	 if (schar_in[i] != schar_out[i]) ERR;
-      if (nc_get_att_short(ncid, NC_GLOBAL, ATT_SHORT_NAME, short_in)) ERR;
-      for (i = 0; i < ATT_LEN; i++)
-	 if (short_in[i] != short_out[i]) ERR;
-      if (nc_get_att_int(ncid, NC_GLOBAL, ATT_INT_NAME, int_in)) ERR;
-      for (i = 0; i < ATT_LEN; i++)
-	 if (int_in[i] != int_out[i]) ERR;
-      if (nc_get_att_float(ncid, NC_GLOBAL, ATT_FLOAT_NAME, float_in)) ERR;
-      for (i = 0; i < ATT_LEN; i++)
-	 if (float_in[i] != float_out[i]) ERR;
-      if (nc_get_att_double(ncid, NC_GLOBAL, ATT_DOUBLE_NAME, double_in)) ERR;
-      for (i = 0; i < ATT_LEN; i++)
-	 if (double_in[i] != double_out[i]) ERR;
-      if (nc_close(ncid)) ERR;
-   }
-   SUMMARIZE_ERR;
-   printf("*** testing attribute data type conversions...");
+        /* Check text. */
+        if (nc_inq_att(ncid, NC_GLOBAL, ATT_TEXT_NAME, &att_type, &att_len))
+            ERR;
+        if (att_type != NC_CHAR || att_len != strlen(speech) + 1) ERR;
+        if (!(speech_in = malloc(att_len + 1))) ERR;
+        if (nc_get_att_text(ncid, NC_GLOBAL, ATT_TEXT_NAME, speech_in)) ERR;
+        if (strcmp(speech, speech_in)) ERR;
+        free(speech_in);
+        /* Check numeric values. */
+        if (nc_get_att_schar(ncid, NC_GLOBAL, ATT_SCHAR_NAME, schar_in)) ERR;
+        for (i = 0; i < ATT_LEN; i++)
+            if (schar_in[i] != schar_out[i]) ERR;
+        if (nc_get_att_short(ncid, NC_GLOBAL, ATT_SHORT_NAME, short_in)) ERR;
+        for (i = 0; i < ATT_LEN; i++)
+            if (short_in[i] != short_out[i]) ERR;
+        if (nc_get_att_int(ncid, NC_GLOBAL, ATT_INT_NAME, int_in)) ERR;
+        for (i = 0; i < ATT_LEN; i++)
+            if (int_in[i] != int_out[i]) ERR;
+        if (nc_get_att_float(ncid, NC_GLOBAL, ATT_FLOAT_NAME, float_in)) ERR;
+        for (i = 0; i < ATT_LEN; i++)
+            if (float_in[i] != float_out[i]) ERR;
+        if (nc_get_att_double(ncid, NC_GLOBAL, ATT_DOUBLE_NAME, double_in)) ERR;
+        for (i = 0; i < ATT_LEN; i++)
+            if (double_in[i] != double_out[i]) ERR;
+        if (nc_close(ncid)) ERR;
+    }
+    SUMMARIZE_ERR;
+    printf("*** testing attribute data type conversions...");
 
-   {
-      int ncid;
-      int i;
+    {
+        int ncid;
+        int i;
 
-      /* Reopen the file and try different type conversions. */
+        /* Reopen the file and try different type conversions. */
 #ifdef TEST_PNETCDF
-      if (nc_open_par(FILE_NAME, 0, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid)) ERR;
+        if (nc_open_par(FILE_NAME, 0, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid)) ERR;
 #else
-      if (nc_open(FILE_NAME, 0, &ncid)) ERR;
+        if (nc_open(FILE_NAME, 0, &ncid)) ERR;
 #endif
 
-      /* No text conversions are allowed, and people who try them should
-       * be locked up, away from decent folk! */
-      if (nc_get_att_short(ncid, NC_GLOBAL, ATT_TEXT_NAME, short_in) != NC_ECHAR) ERR;
-      if (nc_get_att_int(ncid, NC_GLOBAL, ATT_TEXT_NAME, int_in) != NC_ECHAR) ERR;
-      if (nc_get_att_float(ncid, NC_GLOBAL, ATT_TEXT_NAME, float_in) != NC_ECHAR) ERR;
-      if (nc_get_att_double(ncid, NC_GLOBAL, ATT_TEXT_NAME, double_in) != NC_ECHAR) ERR;
+        /* No text conversions are allowed, and people who try them should
+         * be locked up, away from decent folk! */
+        if (nc_get_att_short(ncid, NC_GLOBAL, ATT_TEXT_NAME, short_in) != NC_ECHAR) ERR;
+        if (nc_get_att_int(ncid, NC_GLOBAL, ATT_TEXT_NAME, int_in) != NC_ECHAR) ERR;
+        if (nc_get_att_float(ncid, NC_GLOBAL, ATT_TEXT_NAME, float_in) != NC_ECHAR) ERR;
+        if (nc_get_att_double(ncid, NC_GLOBAL, ATT_TEXT_NAME, double_in) != NC_ECHAR) ERR;
 
-      /* Read all atts (except text) as double. */
-      if (nc_get_att_double(ncid, NC_GLOBAL, ATT_SCHAR_NAME, double_in)) ERR;
-      for (i = 0; i < ATT_LEN; i++)
-	 if (double_in[i] != schar_out[i]) ERR;
-      if (nc_get_att_double(ncid, NC_GLOBAL, ATT_SHORT_NAME, double_in)) ERR;
-      for (i = 0; i < ATT_LEN; i++)
-	 if (double_in[i] != short_out[i]) ERR;
-      if (nc_get_att_double(ncid, NC_GLOBAL, ATT_INT_NAME, double_in)) ERR;
-      for (i = 0; i < ATT_LEN; i++)
-	 if (double_in[i] != int_out[i]) ERR;
-      if (nc_get_att_double(ncid, NC_GLOBAL, ATT_FLOAT_NAME, double_in)) ERR;
-      for (i = 0; i < ATT_LEN; i++)
-	 if (double_in[i] != float_out[i]) ERR;
-      if (nc_get_att_double(ncid, NC_GLOBAL, ATT_DOUBLE_NAME, double_in)) ERR;
-      for (i = 0; i < ATT_LEN; i++)
-	 if (double_in[i] != double_out[i]) ERR;
+        /* Read all atts (except text) as double. */
+        if (nc_get_att_double(ncid, NC_GLOBAL, ATT_SCHAR_NAME, double_in)) ERR;
+        for (i = 0; i < ATT_LEN; i++)
+            if (double_in[i] != schar_out[i]) ERR;
+        if (nc_get_att_double(ncid, NC_GLOBAL, ATT_SHORT_NAME, double_in)) ERR;
+        for (i = 0; i < ATT_LEN; i++)
+            if (double_in[i] != short_out[i]) ERR;
+        if (nc_get_att_double(ncid, NC_GLOBAL, ATT_INT_NAME, double_in)) ERR;
+        for (i = 0; i < ATT_LEN; i++)
+            if (double_in[i] != int_out[i]) ERR;
+        if (nc_get_att_double(ncid, NC_GLOBAL, ATT_FLOAT_NAME, double_in)) ERR;
+        for (i = 0; i < ATT_LEN; i++)
+            if (double_in[i] != float_out[i]) ERR;
+        if (nc_get_att_double(ncid, NC_GLOBAL, ATT_DOUBLE_NAME, double_in)) ERR;
+        for (i = 0; i < ATT_LEN; i++)
+            if (double_in[i] != double_out[i]) ERR;
 
-      /* Read all atts (except text) as float. */
-      if (nc_get_att_float(ncid, NC_GLOBAL, ATT_SCHAR_NAME, float_in)) ERR;
-      for (i = 0; i < ATT_LEN; i++)
-	 if (float_in[i] != schar_out[i]) ERR;
-      if (nc_get_att_float(ncid, NC_GLOBAL, ATT_SHORT_NAME, float_in)) ERR;
-      for (i = 0; i < ATT_LEN; i++)
-	 if (float_in[i] != short_out[i]) ERR;
-      if (nc_get_att_float(ncid, NC_GLOBAL, ATT_INT_NAME, float_in)) ERR;
-      for (i = 0; i < ATT_LEN; i++)
-	 if (float_in[i] != int_out[i]) ERR;
-      if (nc_get_att_float(ncid, NC_GLOBAL, ATT_FLOAT_NAME, float_in)) ERR;
-      for (i = 0; i < ATT_LEN; i++)
-	 if (float_in[i] != float_out[i]) ERR;
-      if (nc_get_att_float(ncid, NC_GLOBAL, ATT_DOUBLE_NAME, float_in)) ERR;
-      for (i = 0; i < ATT_LEN; i++)
-	  if (float_in[i] != (float) double_out[i]) ERR;
+        /* Read all atts (except text) as float. */
+        if (nc_get_att_float(ncid, NC_GLOBAL, ATT_SCHAR_NAME, float_in)) ERR;
+        for (i = 0; i < ATT_LEN; i++)
+            if (float_in[i] != schar_out[i]) ERR;
+        if (nc_get_att_float(ncid, NC_GLOBAL, ATT_SHORT_NAME, float_in)) ERR;
+        for (i = 0; i < ATT_LEN; i++)
+            if (float_in[i] != short_out[i]) ERR;
+        if (nc_get_att_float(ncid, NC_GLOBAL, ATT_INT_NAME, float_in)) ERR;
+        for (i = 0; i < ATT_LEN; i++)
+            if (float_in[i] != int_out[i]) ERR;
+        if (nc_get_att_float(ncid, NC_GLOBAL, ATT_FLOAT_NAME, float_in)) ERR;
+        for (i = 0; i < ATT_LEN; i++)
+            if (float_in[i] != float_out[i]) ERR;
+        if (nc_get_att_float(ncid, NC_GLOBAL, ATT_DOUBLE_NAME, float_in)) ERR;
+        for (i = 0; i < ATT_LEN; i++)
+            if (float_in[i] != (float) double_out[i]) ERR;
 
-      /* Read all atts (except text) as int. */
-      if (nc_get_att_int(ncid, NC_GLOBAL, ATT_SCHAR_NAME, int_in)) ERR;
-      for (i = 0; i < ATT_LEN; i++)
-	 if (int_in[i] != schar_out[i]) ERR;
-      if (nc_get_att_int(ncid, NC_GLOBAL, ATT_SHORT_NAME, int_in)) ERR;
-      for (i = 0; i < ATT_LEN; i++)
-	 if (int_in[i] != short_out[i]) ERR;
-      if (nc_get_att_int(ncid, NC_GLOBAL, ATT_INT_NAME, int_in)) ERR;
-      for (i = 0; i < ATT_LEN; i++)
-	 if (int_in[i] != int_out[i]) ERR;
-      if (nc_get_att_int(ncid, NC_GLOBAL, ATT_FLOAT_NAME, int_in)) ERR;
-      for (i = 0; i < ATT_LEN; i++)
-	  if (int_in[i] != (int) float_out[i]) ERR;
-      if (nc_get_att_int(ncid, NC_GLOBAL, ATT_DOUBLE_NAME, int_in)) ERR;
-      for (i = 0; i < ATT_LEN; i++)
-	  if (int_in[i] != (int) double_out[i]) ERR;
+        /* Read all atts (except text) as int. */
+        if (nc_get_att_int(ncid, NC_GLOBAL, ATT_SCHAR_NAME, int_in)) ERR;
+        for (i = 0; i < ATT_LEN; i++)
+            if (int_in[i] != schar_out[i]) ERR;
+        if (nc_get_att_int(ncid, NC_GLOBAL, ATT_SHORT_NAME, int_in)) ERR;
+        for (i = 0; i < ATT_LEN; i++)
+            if (int_in[i] != short_out[i]) ERR;
+        if (nc_get_att_int(ncid, NC_GLOBAL, ATT_INT_NAME, int_in)) ERR;
+        for (i = 0; i < ATT_LEN; i++)
+            if (int_in[i] != int_out[i]) ERR;
+        if (nc_get_att_int(ncid, NC_GLOBAL, ATT_FLOAT_NAME, int_in)) ERR;
+        for (i = 0; i < ATT_LEN; i++)
+            if (int_in[i] != (int) float_out[i]) ERR;
+        if (nc_get_att_int(ncid, NC_GLOBAL, ATT_DOUBLE_NAME, int_in)) ERR;
+        for (i = 0; i < ATT_LEN; i++)
+            if (int_in[i] != (int) double_out[i]) ERR;
 
-      /* Read all atts (except text) as short. */
-      if (nc_get_att_short(ncid, NC_GLOBAL, ATT_SCHAR_NAME, short_in)) ERR;
-      for (i = 0; i < ATT_LEN; i++)
-	 if (short_in[i] != schar_out[i]) ERR;
-      if (nc_get_att_short(ncid, NC_GLOBAL, ATT_SHORT_NAME, short_in)) ERR;
-      for (i = 0; i < ATT_LEN; i++)
-	 if (short_in[i] != short_out[i]) ERR;
-      if (nc_get_att_short(ncid, NC_GLOBAL, ATT_INT_NAME, short_in) != NC_ERANGE) ERR;
-      for (i = 0; i < ATT_LEN; i++) {
-          if (i == 0 || i == 2) continue;
-	  if (short_in[i] != (short) int_out[i]) ERR;
-      }
-      if (nc_get_att_short(ncid, NC_GLOBAL, ATT_FLOAT_NAME, short_in)) ERR;
-      for (i = 0; i < ATT_LEN; i++)
-	  if (short_in[i] != (short) float_out[i]) ERR;
-      if (nc_get_att_short(ncid, NC_GLOBAL, ATT_DOUBLE_NAME, short_in)) ERR;
-      for (i = 0; i < ATT_LEN; i++)
-	  if (short_in[i] != (short) double_out[i]) ERR;
+        /* Read all atts (except text) as short. */
+        if (nc_get_att_short(ncid, NC_GLOBAL, ATT_SCHAR_NAME, short_in)) ERR;
+        for (i = 0; i < ATT_LEN; i++)
+            if (short_in[i] != schar_out[i]) ERR;
+        if (nc_get_att_short(ncid, NC_GLOBAL, ATT_SHORT_NAME, short_in)) ERR;
+        for (i = 0; i < ATT_LEN; i++)
+            if (short_in[i] != short_out[i]) ERR;
+        if (nc_get_att_short(ncid, NC_GLOBAL, ATT_INT_NAME, short_in) != NC_ERANGE) ERR;
+        for (i = 0; i < ATT_LEN; i++) {
+            if (i == 0 || i == 2) continue;
+            if (short_in[i] != (short) int_out[i]) ERR;
+        }
+        if (nc_get_att_short(ncid, NC_GLOBAL, ATT_FLOAT_NAME, short_in)) ERR;
+        for (i = 0; i < ATT_LEN; i++)
+            if (short_in[i] != (short) float_out[i]) ERR;
+        if (nc_get_att_short(ncid, NC_GLOBAL, ATT_DOUBLE_NAME, short_in)) ERR;
+        for (i = 0; i < ATT_LEN; i++)
+            if (short_in[i] != (short) double_out[i]) ERR;
 
-      /* Read all atts (except text) as schar. */
-      if (nc_get_att_schar(ncid, NC_GLOBAL, ATT_SCHAR_NAME, schar_in)) ERR;
-      for (i = 0; i < ATT_LEN; i++)
-	 if (schar_in[i] != schar_out[i]) ERR;
-      if (nc_get_att_schar(ncid, NC_GLOBAL, ATT_SHORT_NAME, schar_in) != NC_ERANGE) ERR;
-      for (i = 0; i < ATT_LEN; i++) {
-         if (i == 0 || i == 2) continue;
-	 if (schar_in[i] != (signed char) short_out[i]) ERR;
-      }
-      if (nc_get_att_schar(ncid, NC_GLOBAL, ATT_INT_NAME, schar_in) != NC_ERANGE) ERR;
-      for (i = 0; i < ATT_LEN; i++) {
-         if (i == 0 || i == 2) continue;
-	 if (schar_in[i] != (signed char) int_out[i]) ERR;
-      }
-      if (nc_get_att_schar(ncid, NC_GLOBAL, ATT_FLOAT_NAME, schar_in)) ERR;
-      for (i = 0; i < ATT_LEN; i++)
-	 if (schar_in[i] != (signed char) float_out[i]) ERR;
-      if (nc_get_att_schar(ncid, NC_GLOBAL, ATT_DOUBLE_NAME, schar_in)) ERR;
-      for (i = 0; i < ATT_LEN; i++)
-	 if (schar_in[i] != (signed char) double_out[i]) ERR;
+        /* Read all atts (except text) as schar. */
+        if (nc_get_att_schar(ncid, NC_GLOBAL, ATT_SCHAR_NAME, schar_in)) ERR;
+        for (i = 0; i < ATT_LEN; i++)
+            if (schar_in[i] != schar_out[i]) ERR;
+        if (nc_get_att_schar(ncid, NC_GLOBAL, ATT_SHORT_NAME, schar_in) != NC_ERANGE) ERR;
+        for (i = 0; i < ATT_LEN; i++) {
+            if (i == 0 || i == 2) continue;
+            if (schar_in[i] != (signed char) short_out[i]) ERR;
+        }
+        if (nc_get_att_schar(ncid, NC_GLOBAL, ATT_INT_NAME, schar_in) != NC_ERANGE) ERR;
+        for (i = 0; i < ATT_LEN; i++) {
+            if (i == 0 || i == 2) continue;
+            if (schar_in[i] != (signed char) int_out[i]) ERR;
+        }
+        if (nc_get_att_schar(ncid, NC_GLOBAL, ATT_FLOAT_NAME, schar_in)) ERR;
+        for (i = 0; i < ATT_LEN; i++)
+            if (schar_in[i] != (signed char) float_out[i]) ERR;
+        if (nc_get_att_schar(ncid, NC_GLOBAL, ATT_DOUBLE_NAME, schar_in)) ERR;
+        for (i = 0; i < ATT_LEN; i++)
+            if (schar_in[i] != (signed char) double_out[i]) ERR;
 
-      /* Read all atts (except text) as uchar. */
-      if (nc_get_att_uchar(ncid, NC_GLOBAL, ATT_SCHAR_NAME, uchar_in)) ERR;
-      for (i = 0; i < ATT_LEN; i++)
-	 if (uchar_in[i] != (unsigned char) schar_out[i]) ERR;
-      if (nc_get_att_uchar(ncid, NC_GLOBAL, ATT_SHORT_NAME, uchar_in) != NC_ERANGE) ERR;
-      if (nc_get_att_uchar(ncid, NC_GLOBAL, ATT_INT_NAME, uchar_in) != NC_ERANGE) ERR;
-      for (i = 0; i < ATT_LEN; i++) {
-         if (i == 0 || i == 2) continue;
-	 if (uchar_in[i] != (unsigned char) int_out[i]) ERR;
-      }
-      if (nc_get_att_uchar(ncid, NC_GLOBAL, ATT_FLOAT_NAME, uchar_in) != NC_ERANGE) ERR;
-      for (i = 0; i < ATT_LEN; i++) {
-         if (i == 0) continue;
-	 if (uchar_in[i] != (unsigned char) float_out[i]) ERR;
-      }
-      if (nc_get_att_uchar(ncid, NC_GLOBAL, ATT_DOUBLE_NAME, uchar_in) != NC_ERANGE) ERR;
-      for (i = 0; i < ATT_LEN; i++) {
-         if (i == 0) continue;
-	 if (uchar_in[i] != (unsigned char) double_out[i]) ERR;
-      }
+        /* Read all atts (except text) as uchar. */
+        if (nc_get_att_uchar(ncid, NC_GLOBAL, ATT_SCHAR_NAME, uchar_in)) ERR;
+        for (i = 0; i < ATT_LEN; i++)
+            if (uchar_in[i] != (unsigned char) schar_out[i]) ERR;
+        if (nc_get_att_uchar(ncid, NC_GLOBAL, ATT_SHORT_NAME, uchar_in) != NC_ERANGE) ERR;
+        if (nc_get_att_uchar(ncid, NC_GLOBAL, ATT_INT_NAME, uchar_in) != NC_ERANGE) ERR;
+        for (i = 0; i < ATT_LEN; i++) {
+            if (i == 0 || i == 2) continue;
+            if (uchar_in[i] != (unsigned char) int_out[i]) ERR;
+        }
+        if (nc_get_att_uchar(ncid, NC_GLOBAL, ATT_FLOAT_NAME, uchar_in) != NC_ERANGE) ERR;
+        for (i = 0; i < ATT_LEN; i++) {
+            if (i == 0) continue;
+            if (uchar_in[i] != (unsigned char) float_out[i]) ERR;
+        }
+        if (nc_get_att_uchar(ncid, NC_GLOBAL, ATT_DOUBLE_NAME, uchar_in) != NC_ERANGE) ERR;
+        for (i = 0; i < ATT_LEN; i++) {
+            if (i == 0) continue;
+            if (uchar_in[i] != (unsigned char) double_out[i]) ERR;
+        }
 
-      /* Read all atts (except text) into long long variable. */
-      if (nc_get_att_longlong(ncid, NC_GLOBAL, ATT_SCHAR_NAME, longlong_in)) ERR;
-      for (i = 0; i < ATT_LEN; i++)
-	 if (longlong_in[i] != schar_out[i]) ERR;
-      if (nc_get_att_longlong(ncid, NC_GLOBAL, ATT_SHORT_NAME, longlong_in)) ERR;
-      for (i = 0; i < ATT_LEN; i++)
-	 if (longlong_in[i] != short_out[i]) ERR;
-      if (nc_get_att_longlong(ncid, NC_GLOBAL, ATT_INT_NAME, longlong_in)) ERR;
-      /* This was bug NCF-171: on 32-bit platforms, bad values returned */
-      if (nc_get_att_longlong(ncid, NC_GLOBAL, ATT_INT_NAME, longlong_in)) ERR;
-      for (i = 0; i < ATT_LEN; i++)
-      	if (longlong_in[i] != (long long) int_out[i]) ERR;
-      if (nc_get_att_longlong(ncid, NC_GLOBAL, ATT_FLOAT_NAME, longlong_in)) ERR;
-      for (i = 0; i < ATT_LEN; i++)
-	 if (longlong_in[i] != (long long)float_out[i]) ERR;
-      if (nc_get_att_longlong(ncid, NC_GLOBAL, ATT_DOUBLE_NAME, longlong_in)) ERR;
-      for (i = 0; i < ATT_LEN; i++)
-	 if (longlong_in[i] != (long long)double_out[i]) ERR;
+        /* Read all atts (except text) into long long variable. */
+        if (nc_get_att_longlong(ncid, NC_GLOBAL, ATT_SCHAR_NAME, longlong_in)) ERR;
+        for (i = 0; i < ATT_LEN; i++)
+            if (longlong_in[i] != schar_out[i]) ERR;
+        if (nc_get_att_longlong(ncid, NC_GLOBAL, ATT_SHORT_NAME, longlong_in)) ERR;
+        for (i = 0; i < ATT_LEN; i++)
+            if (longlong_in[i] != short_out[i]) ERR;
+        if (nc_get_att_longlong(ncid, NC_GLOBAL, ATT_INT_NAME, longlong_in)) ERR;
+        /* This was bug NCF-171: on 32-bit platforms, bad values returned */
+        if (nc_get_att_longlong(ncid, NC_GLOBAL, ATT_INT_NAME, longlong_in)) ERR;
+        for (i = 0; i < ATT_LEN; i++)
+            if (longlong_in[i] != (long long) int_out[i]) ERR;
+        if (nc_get_att_longlong(ncid, NC_GLOBAL, ATT_FLOAT_NAME, longlong_in)) ERR;
+        for (i = 0; i < ATT_LEN; i++)
+            if (longlong_in[i] != (long long)float_out[i]) ERR;
+        if (nc_get_att_longlong(ncid, NC_GLOBAL, ATT_DOUBLE_NAME, longlong_in)) ERR;
+        for (i = 0; i < ATT_LEN; i++)
+            if (longlong_in[i] != (long long)double_out[i]) ERR;
 
-      if (nc_close(ncid)) ERR;
-   }
-   SUMMARIZE_ERR;
-   printf("*** testing zero-length attributes...");
-   {
-      int ncid;
+        if (nc_close(ncid)) ERR;
+    }
+    SUMMARIZE_ERR;
+    printf("*** testing zero-length attributes...");
+    {
+        int ncid;
 
-      /*int int_in[ATT_LEN], int_out[ATT_LEN] = {NC_MIN_INT, 128, NC_MAX_INT};*/
+        /*int int_in[ATT_LEN], int_out[ATT_LEN] = {NC_MIN_INT, 128, NC_MAX_INT};*/
 
-      /* Create a file with a global attribute of each type of zero length. */
+        /* Create a file with a global attribute of each type of zero length. */
 #ifdef TEST_PNETCDF
-      if (nc_create_par(FILE_NAME, NC_CLOBBER, MPI_COMM_WORLD, MPI_INFO_NULL,&ncid)) ERR;
+        if (nc_create_par(FILE_NAME, NC_CLOBBER, MPI_COMM_WORLD, MPI_INFO_NULL,&ncid)) ERR;
 #else
-      if (nc_create(FILE_NAME, NC_CLOBBER, &ncid)) ERR;
+        if (nc_create(FILE_NAME, NC_CLOBBER, &ncid)) ERR;
 #endif
-      if (nc_put_att_text(ncid, NC_GLOBAL, ATT_TEXT_NAME, 0, NULL)) ERR;
-      if (nc_put_att_schar(ncid, NC_GLOBAL, ATT_SCHAR_NAME, NC_BYTE, 0, NULL)) ERR;
-      if (nc_put_att_short(ncid, NC_GLOBAL, ATT_SHORT_NAME, NC_SHORT, 0, NULL)) ERR;
-      if (nc_put_att_int(ncid, NC_GLOBAL, ATT_INT_NAME, NC_INT, 0, NULL)) ERR;
-      if (nc_put_att_float(ncid, NC_GLOBAL, ATT_FLOAT_NAME, NC_FLOAT, 0, NULL)) ERR;
-      if (nc_put_att_double(ncid, NC_GLOBAL, ATT_DOUBLE_NAME, NC_DOUBLE, 0, NULL)) ERR;
-      if (nc_close(ncid)) ERR;
-   }
+        if (nc_put_att_text(ncid, NC_GLOBAL, ATT_TEXT_NAME, 0, NULL)) ERR;
+        if (nc_put_att_schar(ncid, NC_GLOBAL, ATT_SCHAR_NAME, NC_BYTE, 0, NULL)) ERR;
+        if (nc_put_att_short(ncid, NC_GLOBAL, ATT_SHORT_NAME, NC_SHORT, 0, NULL)) ERR;
+        if (nc_put_att_int(ncid, NC_GLOBAL, ATT_INT_NAME, NC_INT, 0, NULL)) ERR;
+        if (nc_put_att_float(ncid, NC_GLOBAL, ATT_FLOAT_NAME, NC_FLOAT, 0, NULL)) ERR;
+        if (nc_put_att_double(ncid, NC_GLOBAL, ATT_DOUBLE_NAME, NC_DOUBLE, 0, NULL)) ERR;
+        if (nc_close(ncid)) ERR;
+    }
 
-   /* Make sure we can read all these zero-length atts. */
-   {
-      int ncid;
-      signed char schar_in[ATT_LEN];
-      short short_in[ATT_LEN];
-      /*int int_in[ATT_LEN], int_out[ATT_LEN] = {NC_MIN_INT, 128, NC_MAX_INT};*/
-      int int_in[ATT_LEN];
-      float float_in[ATT_LEN];
-      double double_in[ATT_LEN];
-      size_t len;
-      nc_type xtype;
-
-#ifdef TEST_PNETCDF
-      if (nc_open_par(FILE_NAME, 0, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid)) ERR;
-#else
-      if (nc_open(FILE_NAME, 0, &ncid)) ERR;
-#endif
-      if (nc_get_att_text(ncid, NC_GLOBAL, ATT_TEXT_NAME, NULL)) ERR;
-      if (nc_inq_att(ncid, NC_GLOBAL, ATT_TEXT_NAME, &xtype, &len)) ERR;
-      if (len || xtype != NC_CHAR) ERR;
-      if (nc_get_att_schar(ncid, NC_GLOBAL, ATT_SCHAR_NAME, schar_in)) ERR;
-      if (nc_inq_att(ncid, NC_GLOBAL, ATT_SCHAR_NAME, &xtype, &len)) ERR;
-      if (len || xtype != NC_BYTE) ERR;
-      if (nc_get_att_short(ncid, NC_GLOBAL, ATT_SHORT_NAME, short_in)) ERR;
-      if (nc_inq_att(ncid, NC_GLOBAL, ATT_SHORT_NAME, &xtype, &len)) ERR;
-      if (len || xtype != NC_SHORT) ERR;
-      if (nc_get_att_int(ncid, NC_GLOBAL, ATT_INT_NAME, int_in)) ERR;
-      if (nc_inq_att(ncid, NC_GLOBAL, ATT_INT_NAME, &xtype, &len)) ERR;
-      if (len || xtype != NC_INT) ERR;
-      if (nc_get_att_float(ncid, NC_GLOBAL, ATT_FLOAT_NAME, float_in)) ERR;
-      if (nc_inq_att(ncid, NC_GLOBAL, ATT_FLOAT_NAME, &xtype, &len)) ERR;
-      if (len || xtype != NC_FLOAT) ERR;
-      if (nc_get_att_double(ncid, NC_GLOBAL, ATT_DOUBLE_NAME, double_in)) ERR;
-      if (nc_inq_att(ncid, NC_GLOBAL, ATT_DOUBLE_NAME, &xtype, &len)) ERR;
-      if (len || xtype != NC_DOUBLE) ERR;
-      /* Conversions no longer result in range errors, since there's no data. */
-      if (nc_get_att_schar(ncid, NC_GLOBAL, ATT_DOUBLE_NAME, schar_in)) ERR;
-      if (nc_get_att_schar(ncid, NC_GLOBAL, ATT_FLOAT_NAME, schar_in)) ERR;
-      if (nc_get_att_schar(ncid, NC_GLOBAL, ATT_INT_NAME, schar_in)) ERR;
-      if (nc_get_att_schar(ncid, NC_GLOBAL, ATT_SHORT_NAME, schar_in)) ERR;
-      if (nc_close(ncid)) ERR;
-   }
-
-   SUMMARIZE_ERR;
-   printf("*** testing zero-length attributes and redef...(this test skipped for HDF5-1.8.0 beta1");
-   {
-      int ncid;
-      signed char schar_in[ATT_LEN];
-      short short_in[ATT_LEN];
-      int int_in[ATT_LEN];
-      float float_in[ATT_LEN];
-      double double_in[ATT_LEN];
-
-
-      /* Create a file with a global attribute of each type of zero length. */
-#ifdef TEST_PNETCDF
-      if (nc_create_par(FILE_NAME, NC_CLOBBER, MPI_COMM_WORLD, MPI_INFO_NULL,&ncid)) ERR;
-#else
-      if (nc_create(FILE_NAME, NC_CLOBBER, &ncid)) ERR;
-#endif
-      if (nc_enddef(ncid)) ERR;
-      if (nc_redef(ncid)) ERR;
-      if (nc_put_att_text(ncid, NC_GLOBAL, ATT_TEXT_NAME, 0, NULL)) ERR;
-      if (nc_put_att_schar(ncid, NC_GLOBAL, ATT_SCHAR_NAME, NC_BYTE, 0, NULL)) ERR;
-      if (nc_put_att_short(ncid, NC_GLOBAL, ATT_SHORT_NAME, NC_SHORT, 0, NULL)) ERR;
-      if (nc_put_att_int(ncid, NC_GLOBAL, ATT_INT_NAME, NC_INT, 0, NULL)) ERR;
-      if (nc_put_att_float(ncid, NC_GLOBAL, ATT_FLOAT_NAME, NC_FLOAT, 0, NULL)) ERR;
-      if (nc_put_att_double(ncid, NC_GLOBAL, ATT_DOUBLE_NAME, NC_DOUBLE, 0, NULL)) ERR;
-      if (nc_close(ncid)) ERR;
-
-      /* Make sure we can read all these zero-length atts added during a
-       * redef. */
-#ifdef TEST_PNETCDF
-      if (nc_open_par(FILE_NAME, 0, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid)) ERR;
-#else
-      if (nc_open(FILE_NAME, 0, &ncid)) ERR;
-#endif
-      if (nc_get_att_text(ncid, NC_GLOBAL, ATT_TEXT_NAME, NULL)) ERR;
-      if (nc_get_att_schar(ncid, NC_GLOBAL, ATT_SCHAR_NAME, schar_in)) ERR;
-      if (nc_get_att_short(ncid, NC_GLOBAL, ATT_SHORT_NAME, short_in)) ERR;
-      if (nc_get_att_int(ncid, NC_GLOBAL, ATT_INT_NAME, int_in)) ERR;
-      if (nc_get_att_float(ncid, NC_GLOBAL, ATT_FLOAT_NAME, float_in)) ERR;
-      if (nc_get_att_double(ncid, NC_GLOBAL, ATT_DOUBLE_NAME, double_in)) ERR;
-      /* Conversions no longer result in range errors, since there's no data. */
-      if (nc_get_att_schar(ncid, NC_GLOBAL, ATT_DOUBLE_NAME, schar_in)) ERR;
-      if (nc_get_att_schar(ncid, NC_GLOBAL, ATT_FLOAT_NAME, schar_in)) ERR;
-      if (nc_get_att_schar(ncid, NC_GLOBAL, ATT_INT_NAME, schar_in)) ERR;
-      if (nc_get_att_schar(ncid, NC_GLOBAL, ATT_SHORT_NAME, schar_in)) ERR;
-      if (nc_close(ncid)) ERR;
-   }
-   SUMMARIZE_ERR;
-
-   printf("*** testing attribute deletes and renames...");
-   {
-      int ncid, varid, dimids[2];
-      nc_type att_type;
-      size_t att_len;
-      char *speech_in;
-      char name_in[NC_MAX_NAME + 1];
-      int attid_in, natts_in;
-      int int_out[ATT_LEN] = {-100000, 128, 100000};
-
-      /* Create a file with a global attribute. */
-#ifdef TEST_PNETCDF
-      if (nc_create_par(FILE_NAME, NC_CLOBBER, MPI_COMM_WORLD, MPI_INFO_NULL,&ncid)) ERR;
-#else
-      if (nc_create(FILE_NAME, NC_CLOBBER, &ncid)) ERR;
-#endif
-      if (nc_put_att_text(ncid, NC_GLOBAL, ATT_TEXT_NAME, strlen(speech)+1,
-			  speech)) ERR;
-      if (nc_close(ncid)) ERR;
-
-      /* Rename it. */
-#ifdef TEST_PNETCDF
-      if (nc_open_par(FILE_NAME, NC_WRITE, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid)) ERR;
-#else
-      if (nc_open(FILE_NAME, NC_WRITE, &ncid)) ERR;
-#endif
-      if (nc_inq_attid(ncid, NC_GLOBAL, ATT_TEXT_NAME, &attid_in)) ERR;
-      if (attid_in != 0) ERR;
-      if (nc_inq_attname(ncid, NC_GLOBAL, attid_in, name_in)) ERR;
-      if (strcmp(name_in, ATT_TEXT_NAME)) ERR;
-      if (nc_redef(ncid)) ERR;
-      if (nc_rename_att(ncid, NC_GLOBAL, ATT_TEXT_NAME, ATT_TEXT_NAME2)) ERR;
-      if (nc_inq_attname(ncid, NC_GLOBAL, attid_in, name_in)) ERR;
-      if (strcmp(name_in, ATT_TEXT_NAME2)) ERR;
-      if (nc_close(ncid)) ERR;
+    /* Make sure we can read all these zero-length atts. */
+    {
+        int ncid;
+        signed char schar_in[ATT_LEN];
+        short short_in[ATT_LEN];
+        /*int int_in[ATT_LEN], int_out[ATT_LEN] = {NC_MIN_INT, 128, NC_MAX_INT};*/
+        int int_in[ATT_LEN];
+        float float_in[ATT_LEN];
+        double double_in[ATT_LEN];
+        size_t len;
+        nc_type xtype;
 
 #ifdef TEST_PNETCDF
-      if (nc_open_par(FILE_NAME, NC_WRITE, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid)) ERR;
+        if (nc_open_par(FILE_NAME, 0, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid)) ERR;
 #else
-      if (nc_open(FILE_NAME, NC_WRITE, &ncid)) ERR;
+        if (nc_open(FILE_NAME, 0, &ncid)) ERR;
 #endif
-      if (nc_inq_att(ncid, NC_GLOBAL, ATT_TEXT_NAME2, &att_type, &att_len)) ERR;
-      if (att_type != NC_CHAR || att_len != strlen(speech) + 1) ERR;
-      if (!(speech_in = malloc(att_len + 1))) ERR;
-      if (nc_get_att_text(ncid, NC_GLOBAL, ATT_TEXT_NAME2, speech_in)) ERR;
-      if (strcmp(speech, speech_in)) ERR;
-      free(speech_in);
-      if (nc_get_att_text(ncid, NC_GLOBAL, ATT_TEXT_NAME, speech_in) != NC_ENOTATT) ERR;
-      if (nc_close(ncid)) ERR;
+        if (nc_get_att_text(ncid, NC_GLOBAL, ATT_TEXT_NAME, NULL)) ERR;
+        if (nc_inq_att(ncid, NC_GLOBAL, ATT_TEXT_NAME, &xtype, &len)) ERR;
+        if (len || xtype != NC_CHAR) ERR;
+        if (nc_get_att_schar(ncid, NC_GLOBAL, ATT_SCHAR_NAME, schar_in)) ERR;
+        if (nc_inq_att(ncid, NC_GLOBAL, ATT_SCHAR_NAME, &xtype, &len)) ERR;
+        if (len || xtype != NC_BYTE) ERR;
+        if (nc_get_att_short(ncid, NC_GLOBAL, ATT_SHORT_NAME, short_in)) ERR;
+        if (nc_inq_att(ncid, NC_GLOBAL, ATT_SHORT_NAME, &xtype, &len)) ERR;
+        if (len || xtype != NC_SHORT) ERR;
+        if (nc_get_att_int(ncid, NC_GLOBAL, ATT_INT_NAME, int_in)) ERR;
+        if (nc_inq_att(ncid, NC_GLOBAL, ATT_INT_NAME, &xtype, &len)) ERR;
+        if (len || xtype != NC_INT) ERR;
+        if (nc_get_att_float(ncid, NC_GLOBAL, ATT_FLOAT_NAME, float_in)) ERR;
+        if (nc_inq_att(ncid, NC_GLOBAL, ATT_FLOAT_NAME, &xtype, &len)) ERR;
+        if (len || xtype != NC_FLOAT) ERR;
+        if (nc_get_att_double(ncid, NC_GLOBAL, ATT_DOUBLE_NAME, double_in)) ERR;
+        if (nc_inq_att(ncid, NC_GLOBAL, ATT_DOUBLE_NAME, &xtype, &len)) ERR;
+        if (len || xtype != NC_DOUBLE) ERR;
+        /* Conversions no longer result in range errors, since there's no data. */
+        if (nc_get_att_schar(ncid, NC_GLOBAL, ATT_DOUBLE_NAME, schar_in)) ERR;
+        if (nc_get_att_schar(ncid, NC_GLOBAL, ATT_FLOAT_NAME, schar_in)) ERR;
+        if (nc_get_att_schar(ncid, NC_GLOBAL, ATT_INT_NAME, schar_in)) ERR;
+        if (nc_get_att_schar(ncid, NC_GLOBAL, ATT_SHORT_NAME, schar_in)) ERR;
+        if (nc_close(ncid)) ERR;
+    }
 
-      /* Now delete the att. */
+    SUMMARIZE_ERR;
+    printf("*** testing zero-length attributes and redef...(this test skipped for HDF5-1.8.0 beta1");
+    {
+        int ncid;
+        signed char schar_in[ATT_LEN];
+        short short_in[ATT_LEN];
+        int int_in[ATT_LEN];
+        float float_in[ATT_LEN];
+        double double_in[ATT_LEN];
+
+
+        /* Create a file with a global attribute of each type of zero length. */
 #ifdef TEST_PNETCDF
-      if (nc_open_par(FILE_NAME, NC_WRITE, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid)) ERR;
+        if (nc_create_par(FILE_NAME, NC_CLOBBER, MPI_COMM_WORLD, MPI_INFO_NULL,&ncid)) ERR;
 #else
-      if (nc_open(FILE_NAME, NC_WRITE, &ncid)) ERR;
+        if (nc_create(FILE_NAME, NC_CLOBBER, &ncid)) ERR;
 #endif
-      if (nc_redef(ncid)) ERR;
-      if (nc_del_att(ncid, NC_GLOBAL, ATT_TEXT_NAME2)) ERR;
-      if (nc_close(ncid)) ERR;
+        if (nc_enddef(ncid)) ERR;
+        if (nc_redef(ncid)) ERR;
+        if (nc_put_att_text(ncid, NC_GLOBAL, ATT_TEXT_NAME, 0, NULL)) ERR;
+        if (nc_put_att_schar(ncid, NC_GLOBAL, ATT_SCHAR_NAME, NC_BYTE, 0, NULL)) ERR;
+        if (nc_put_att_short(ncid, NC_GLOBAL, ATT_SHORT_NAME, NC_SHORT, 0, NULL)) ERR;
+        if (nc_put_att_int(ncid, NC_GLOBAL, ATT_INT_NAME, NC_INT, 0, NULL)) ERR;
+        if (nc_put_att_float(ncid, NC_GLOBAL, ATT_FLOAT_NAME, NC_FLOAT, 0, NULL)) ERR;
+        if (nc_put_att_double(ncid, NC_GLOBAL, ATT_DOUBLE_NAME, NC_DOUBLE, 0, NULL)) ERR;
+        if (nc_close(ncid)) ERR;
 
-      /* Now create a file with a variable, which has an att. */
+        /* Make sure we can read all these zero-length atts added during a
+         * redef. */
 #ifdef TEST_PNETCDF
-      if (nc_create_par(FILE_NAME, NC_CLOBBER, MPI_COMM_WORLD, MPI_INFO_NULL,&ncid)) ERR;
+        if (nc_open_par(FILE_NAME, 0, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid)) ERR;
 #else
-      if (nc_create(FILE_NAME, NC_CLOBBER, &ncid)) ERR;
+        if (nc_open(FILE_NAME, 0, &ncid)) ERR;
 #endif
-      if (nc_put_att_text(ncid, NC_GLOBAL, ATT_TEXT_NAME, strlen(speech)+1, speech)) ERR;
-      if (nc_def_dim(ncid, DIM1_NAME, DIM1_LEN, &dimids[0])) ERR;
-      if (nc_def_dim(ncid, DIM2_NAME, DIM2_LEN, &dimids[1])) ERR;
-      if (nc_def_var(ncid, VAR1_NAME, NC_INT, 2, dimids, &varid)) ERR;
-      if (nc_put_att_int(ncid, varid, ATT_INT_NAME, NC_INT, 3, int_out)) ERR;
-      if (nc_close(ncid)) ERR;
+        if (nc_get_att_text(ncid, NC_GLOBAL, ATT_TEXT_NAME, NULL)) ERR;
+        if (nc_get_att_schar(ncid, NC_GLOBAL, ATT_SCHAR_NAME, schar_in)) ERR;
+        if (nc_get_att_short(ncid, NC_GLOBAL, ATT_SHORT_NAME, short_in)) ERR;
+        if (nc_get_att_int(ncid, NC_GLOBAL, ATT_INT_NAME, int_in)) ERR;
+        if (nc_get_att_float(ncid, NC_GLOBAL, ATT_FLOAT_NAME, float_in)) ERR;
+        if (nc_get_att_double(ncid, NC_GLOBAL, ATT_DOUBLE_NAME, double_in)) ERR;
+        /* Conversions no longer result in range errors, since there's no data. */
+        if (nc_get_att_schar(ncid, NC_GLOBAL, ATT_DOUBLE_NAME, schar_in)) ERR;
+        if (nc_get_att_schar(ncid, NC_GLOBAL, ATT_FLOAT_NAME, schar_in)) ERR;
+        if (nc_get_att_schar(ncid, NC_GLOBAL, ATT_INT_NAME, schar_in)) ERR;
+        if (nc_get_att_schar(ncid, NC_GLOBAL, ATT_SHORT_NAME, schar_in)) ERR;
+        if (nc_close(ncid)) ERR;
+    }
+    SUMMARIZE_ERR;
 
-      /* Reopen the file and delete it. Make sure it's gone. */
+    printf("*** testing attribute deletes and renames...");
+    {
+        int ncid, varid, dimids[2];
+        nc_type att_type;
+        size_t att_len;
+        char *speech_in;
+        char name_in[NC_MAX_NAME + 1];
+        int attid_in, natts_in;
+        int int_out[ATT_LEN] = {-100000, 128, 100000};
+
+        /* Create a file with a global attribute. */
 #ifdef TEST_PNETCDF
-      if (nc_open_par(FILE_NAME, NC_WRITE, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid)) ERR;
+        if (nc_create_par(FILE_NAME, NC_CLOBBER, MPI_COMM_WORLD, MPI_INFO_NULL,&ncid)) ERR;
 #else
-      if (nc_open(FILE_NAME, NC_WRITE, &ncid)) ERR;
+        if (nc_create(FILE_NAME, NC_CLOBBER, &ncid)) ERR;
 #endif
-      if (nc_redef(ncid)) ERR;
-      if (nc_del_att(ncid, 0, ATT_INT_NAME)) ERR;
-      if (nc_close(ncid)) ERR;
+        if (nc_put_att_text(ncid, NC_GLOBAL, ATT_TEXT_NAME, strlen(speech)+1,
+                            speech)) ERR;
+        if (nc_close(ncid)) ERR;
 
-      /* Reopen the file and readd the attribute. Enddef and redef,
-       * and delete it, then check to make sure it's gone. */
+        /* Rename it. */
 #ifdef TEST_PNETCDF
-      if (nc_open_par(FILE_NAME, NC_WRITE, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid)) ERR;
+        if (nc_open_par(FILE_NAME, NC_WRITE, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid)) ERR;
 #else
-      if (nc_open(FILE_NAME, NC_WRITE, &ncid)) ERR;
+        if (nc_open(FILE_NAME, NC_WRITE, &ncid)) ERR;
 #endif
-      if (nc_redef(ncid)) ERR;
-      if (nc_put_att_int(ncid, varid, ATT_INT_NAME, NC_INT, 3, int_out)) ERR;
-      if (nc_enddef(ncid)) ERR;
-      if (nc_redef(ncid)) ERR;
-      if (nc_del_att(ncid, 0, ATT_INT_NAME)) ERR;
-      if (nc_inq_varnatts(ncid, 0, &natts_in)) ERR;
-      if (natts_in != 0) ERR;
-      if (nc_close(ncid)) ERR;
-   }
+        if (nc_inq_attid(ncid, NC_GLOBAL, ATT_TEXT_NAME, &attid_in)) ERR;
+        if (attid_in != 0) ERR;
+        if (nc_inq_attname(ncid, NC_GLOBAL, attid_in, name_in)) ERR;
+        if (strcmp(name_in, ATT_TEXT_NAME)) ERR;
+        if (nc_redef(ncid)) ERR;
+        if (nc_rename_att(ncid, NC_GLOBAL, ATT_TEXT_NAME, ATT_TEXT_NAME2)) ERR;
+        if (nc_inq_attname(ncid, NC_GLOBAL, attid_in, name_in)) ERR;
+        if (strcmp(name_in, ATT_TEXT_NAME2)) ERR;
+        if (nc_close(ncid)) ERR;
 
-   SUMMARIZE_ERR;
-   printf("*** testing attribute create order...");
+#ifdef TEST_PNETCDF
+        if (nc_open_par(FILE_NAME, NC_WRITE, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid)) ERR;
+#else
+        if (nc_open(FILE_NAME, NC_WRITE, &ncid)) ERR;
+#endif
+        if (nc_inq_att(ncid, NC_GLOBAL, ATT_TEXT_NAME2, &att_type, &att_len)) ERR;
+        if (att_type != NC_CHAR || att_len != strlen(speech) + 1) ERR;
+        if (!(speech_in = malloc(att_len + 1))) ERR;
+        if (nc_get_att_text(ncid, NC_GLOBAL, ATT_TEXT_NAME2, speech_in)) ERR;
+        if (strcmp(speech, speech_in)) ERR;
+        free(speech_in);
+        if (nc_get_att_text(ncid, NC_GLOBAL, ATT_TEXT_NAME, speech_in) != NC_ENOTATT) ERR;
+        if (nc_close(ncid)) ERR;
+
+        /* Now delete the att. */
+#ifdef TEST_PNETCDF
+        if (nc_open_par(FILE_NAME, NC_WRITE, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid)) ERR;
+#else
+        if (nc_open(FILE_NAME, NC_WRITE, &ncid)) ERR;
+#endif
+        if (nc_redef(ncid)) ERR;
+        if (nc_del_att(ncid, NC_GLOBAL, ATT_TEXT_NAME2)) ERR;
+        if (nc_close(ncid)) ERR;
+
+        /* Now create a file with a variable, which has an att. */
+#ifdef TEST_PNETCDF
+        if (nc_create_par(FILE_NAME, NC_CLOBBER, MPI_COMM_WORLD, MPI_INFO_NULL,&ncid)) ERR;
+#else
+        if (nc_create(FILE_NAME, NC_CLOBBER, &ncid)) ERR;
+#endif
+        if (nc_put_att_text(ncid, NC_GLOBAL, ATT_TEXT_NAME, strlen(speech)+1, speech)) ERR;
+        if (nc_def_dim(ncid, DIM1_NAME, DIM1_LEN, &dimids[0])) ERR;
+        if (nc_def_dim(ncid, DIM2_NAME, DIM2_LEN, &dimids[1])) ERR;
+        if (nc_def_var(ncid, VAR1_NAME, NC_INT, 2, dimids, &varid)) ERR;
+        if (nc_put_att_int(ncid, varid, ATT_INT_NAME, NC_INT, 3, int_out)) ERR;
+        if (nc_close(ncid)) ERR;
+
+        /* Reopen the file and delete it. Make sure it's gone. */
+#ifdef TEST_PNETCDF
+        if (nc_open_par(FILE_NAME, NC_WRITE, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid)) ERR;
+#else
+        if (nc_open(FILE_NAME, NC_WRITE, &ncid)) ERR;
+#endif
+        if (nc_redef(ncid)) ERR;
+        if (nc_del_att(ncid, 0, ATT_INT_NAME)) ERR;
+        if (nc_close(ncid)) ERR;
+
+        /* Reopen the file and readd the attribute. Enddef and redef,
+         * and delete it, then check to make sure it's gone. */
+#ifdef TEST_PNETCDF
+        if (nc_open_par(FILE_NAME, NC_WRITE, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid)) ERR;
+#else
+        if (nc_open(FILE_NAME, NC_WRITE, &ncid)) ERR;
+#endif
+        if (nc_redef(ncid)) ERR;
+        if (nc_put_att_int(ncid, varid, ATT_INT_NAME, NC_INT, 3, int_out)) ERR;
+        if (nc_enddef(ncid)) ERR;
+        if (nc_redef(ncid)) ERR;
+        if (nc_del_att(ncid, 0, ATT_INT_NAME)) ERR;
+        if (nc_inq_varnatts(ncid, 0, &natts_in)) ERR;
+        if (natts_in != 0) ERR;
+        if (nc_close(ncid)) ERR;
+    }
+
+    SUMMARIZE_ERR;
+    printf("*** testing attribute create order...");
 
 #define ATT0 "Maturin"
 #define ATT1 "Aubery"
-   {
-      int ncid, varid, dimids[2];
-      int attid_in;
-      const int number = 42;
+    {
+        int ncid, varid, dimids[2];
+        int attid_in;
+        const int number = 42;
 
-      /* Create a file with several global attributes. */
+        /* Create a file with several global attributes. */
 #ifdef TEST_PNETCDF
-      if (nc_create_par(FILE_NAME, NC_CLOBBER, MPI_COMM_WORLD, MPI_INFO_NULL,&ncid)) ERR;
+        if (nc_create_par(FILE_NAME, NC_CLOBBER, MPI_COMM_WORLD, MPI_INFO_NULL,&ncid)) ERR;
 #else
-      if (nc_create(FILE_NAME, NC_CLOBBER, &ncid)) ERR;
+        if (nc_create(FILE_NAME, NC_CLOBBER, &ncid)) ERR;
 #endif
-      if (nc_put_att_int(ncid, NC_GLOBAL, ATT0, NC_INT, 1, &number)) ERR;
-      if (nc_put_att_int(ncid, NC_GLOBAL, ATT1, NC_INT, 1, &number)) ERR;
-      if (nc_close(ncid)) ERR;
+        if (nc_put_att_int(ncid, NC_GLOBAL, ATT0, NC_INT, 1, &number)) ERR;
+        if (nc_put_att_int(ncid, NC_GLOBAL, ATT1, NC_INT, 1, &number)) ERR;
+        if (nc_close(ncid)) ERR;
 
-      /* Open it and check the order. */
+        /* Open it and check the order. */
 #ifdef TEST_PNETCDF
-      if (nc_open_par(FILE_NAME, NC_WRITE, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid)) ERR;
+        if (nc_open_par(FILE_NAME, NC_WRITE, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid)) ERR;
 #else
-      if (nc_open(FILE_NAME, NC_WRITE, &ncid)) ERR;
+        if (nc_open(FILE_NAME, NC_WRITE, &ncid)) ERR;
 #endif
-      if (nc_inq_attid(ncid, NC_GLOBAL, ATT0, &attid_in)) ERR;
-      if (attid_in != 0) ERR;
-      if (nc_inq_attid(ncid, NC_GLOBAL, ATT1, &attid_in)) ERR;
-      if (attid_in != 1) ERR;
-      if (nc_close(ncid)) ERR;
+        if (nc_inq_attid(ncid, NC_GLOBAL, ATT0, &attid_in)) ERR;
+        if (attid_in != 0) ERR;
+        if (nc_inq_attid(ncid, NC_GLOBAL, ATT1, &attid_in)) ERR;
+        if (attid_in != 1) ERR;
+        if (nc_close(ncid)) ERR;
 
-      /* Now create a file with a variable, which has two atts. */
+        /* Now create a file with a variable, which has two atts. */
 #ifdef TEST_PNETCDF
-      if (nc_create_par(FILE_NAME, NC_CLOBBER, MPI_COMM_WORLD, MPI_INFO_NULL,&ncid)) ERR;
+        if (nc_create_par(FILE_NAME, NC_CLOBBER, MPI_COMM_WORLD, MPI_INFO_NULL,&ncid)) ERR;
 #else
-      if (nc_create(FILE_NAME, NC_CLOBBER, &ncid)) ERR;
+        if (nc_create(FILE_NAME, NC_CLOBBER, &ncid)) ERR;
 #endif
-      if (nc_def_dim(ncid, DIM1_NAME, DIM1_LEN, &dimids[0])) ERR;
-      if (nc_def_dim(ncid, DIM2_NAME, DIM2_LEN, &dimids[1])) ERR;
-      if (nc_def_var(ncid, VAR1_NAME, NC_INT, 2, dimids, &varid)) ERR;
-      if (nc_put_att_int(ncid, varid, ATT0, NC_INT, 1, &number)) ERR;
-      if (nc_put_att_int(ncid, varid, ATT1, NC_INT, 1, &number)) ERR;
-      if (nc_close(ncid)) ERR;
+        if (nc_def_dim(ncid, DIM1_NAME, DIM1_LEN, &dimids[0])) ERR;
+        if (nc_def_dim(ncid, DIM2_NAME, DIM2_LEN, &dimids[1])) ERR;
+        if (nc_def_var(ncid, VAR1_NAME, NC_INT, 2, dimids, &varid)) ERR;
+        if (nc_put_att_int(ncid, varid, ATT0, NC_INT, 1, &number)) ERR;
+        if (nc_put_att_int(ncid, varid, ATT1, NC_INT, 1, &number)) ERR;
+        if (nc_close(ncid)) ERR;
 
-      /* Reopen the file and check the order of the attributes on the var. */
+        /* Reopen the file and check the order of the attributes on the var. */
 #ifdef TEST_PNETCDF
-      if (nc_open_par(FILE_NAME, NC_WRITE, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid)) ERR;
+        if (nc_open_par(FILE_NAME, NC_WRITE, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid)) ERR;
 #else
-      if (nc_open(FILE_NAME, NC_WRITE, &ncid)) ERR;
+        if (nc_open(FILE_NAME, NC_WRITE, &ncid)) ERR;
 #endif
-      if (nc_inq_attid(ncid, 0, ATT0, &attid_in)) ERR;
-      if (attid_in != 0) ERR;
-      if (nc_inq_attid(ncid, 0, ATT1, &attid_in)) ERR;
-      if (attid_in != 1) ERR;
-      if (nc_close(ncid)) ERR;
-   }
+        if (nc_inq_attid(ncid, 0, ATT0, &attid_in)) ERR;
+        if (attid_in != 0) ERR;
+        if (nc_inq_attid(ncid, 0, ATT1, &attid_in)) ERR;
+        if (attid_in != 1) ERR;
+        if (nc_close(ncid)) ERR;
+    }
 
-   SUMMARIZE_ERR;
-   printf("*** testing attribute ordering some more...");
+    SUMMARIZE_ERR;
+    printf("*** testing attribute ordering some more...");
 
 #define VAR_NAME "i"
 #define A1_NAME "i"
@@ -696,161 +696,177 @@ main(int argc, char **argv)
 #define A1_LEN 3
 #define A2_LEN 4
 #define A3_LEN 5
-   {
-      int ncid;
-      int varid, natts, nvars;
-      double dvalue[] = {999.99, 999.99, 999.99, 999.99, 999.99};
-      char name_in[NC_MAX_NAME + 1];
+    {
+        int ncid;
+        int varid, natts, nvars;
+        double dvalue[] = {999.99, 999.99, 999.99, 999.99, 999.99};
+        char name_in[NC_MAX_NAME + 1];
 
-      /* Create a file with one var, and attach three atts to it. */
+        /* Create a file with one var, and attach three atts to it. */
 #ifdef TEST_PNETCDF
-      if (nc_create_par(FILE_NAME, NC_CLOBBER, MPI_COMM_WORLD, MPI_INFO_NULL,&ncid)) ERR;
+        if (nc_create_par(FILE_NAME, NC_CLOBBER, MPI_COMM_WORLD, MPI_INFO_NULL,&ncid)) ERR;
 #else
-      if (nc_create(FILE_NAME, NC_CLOBBER, &ncid)) ERR;
+        if (nc_create(FILE_NAME, NC_CLOBBER, &ncid)) ERR;
 #endif
-      if (nc_def_var(ncid, VAR_NAME, NC_INT, 0, NULL, &varid)) ERR;
-      if (nc_put_att_double(ncid, varid, A1_NAME, NC_INT, A1_LEN, dvalue)) ERR;
-      if (nc_put_att_double(ncid, varid, A2_NAME, NC_INT, A2_LEN, dvalue)) ERR;
-      if (nc_put_att_double(ncid, varid, A3_NAME, NC_INT, A3_LEN, dvalue)) ERR;
-      if (nc_close(ncid)) ERR;
+        if (nc_def_var(ncid, VAR_NAME, NC_INT, 0, NULL, &varid)) ERR;
+        if (nc_put_att_double(ncid, varid, A1_NAME, NC_INT, A1_LEN, dvalue)) ERR;
+        if (nc_put_att_double(ncid, varid, A2_NAME, NC_INT, A2_LEN, dvalue)) ERR;
+        if (nc_put_att_double(ncid, varid, A3_NAME, NC_INT, A3_LEN, dvalue)) ERR;
+        if (nc_close(ncid)) ERR;
 
-      /* Reopen the file and check. */
+        /* Reopen the file and check. */
 #ifdef TEST_PNETCDF
-      if (nc_open_par(FILE_NAME, 0, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid)) ERR;
+        if (nc_open_par(FILE_NAME, 0, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid)) ERR;
 #else
-      if (nc_open(FILE_NAME, 0, &ncid)) ERR;
+        if (nc_open(FILE_NAME, 0, &ncid)) ERR;
 #endif
-      if (nc_inq_nvars(ncid, &nvars)) ERR;
-      if (nvars != 1) ERR;
-      if (nc_inq_varnatts(ncid, 0, &natts)) ERR;
-      if (natts != 3) ERR;
-      if (nc_inq_attname(ncid, 0, 0, name_in)) ERR;
-      if (strcmp(name_in, A1_NAME)) ERR;
-      if (nc_inq_attname(ncid, 0, 1, name_in)) ERR;
-      if (strcmp(name_in, A2_NAME)) ERR;
-      if (nc_inq_attname(ncid, 0, 2, name_in)) ERR;
-      if (strcmp(name_in, A3_NAME)) ERR;
+        if (nc_inq_nvars(ncid, &nvars)) ERR;
+        if (nvars != 1) ERR;
+        if (nc_inq_varnatts(ncid, 0, &natts)) ERR;
+        if (natts != 3) ERR;
+        if (nc_inq_attname(ncid, 0, 0, name_in)) ERR;
+        if (strcmp(name_in, A1_NAME)) ERR;
+        if (nc_inq_attname(ncid, 0, 1, name_in)) ERR;
+        if (strcmp(name_in, A2_NAME)) ERR;
+        if (nc_inq_attname(ncid, 0, 2, name_in)) ERR;
+        if (strcmp(name_in, A3_NAME)) ERR;
 
-      /* Close up shop. */
-      if (nc_close(ncid)) ERR;
-   }
+        /* Close up shop. */
+        if (nc_close(ncid)) ERR;
+    }
 
-   SUMMARIZE_ERR;
-   printf("*** testing attribute ordering even more...");
+    SUMMARIZE_ERR;
+    printf("*** testing attribute ordering even more...");
 
-   /* Test the ordering of atts for each cmode. */
-   if (tst_att_ordering(NC_CLOBBER)) ERR;
-   if (tst_att_ordering(NC_CLOBBER|NC_64BIT_OFFSET)) ERR;
+    /* Test the ordering of atts for each cmode. */
+    if (tst_att_ordering(NC_CLOBBER)) ERR;
+    if (tst_att_ordering(NC_CLOBBER|NC_64BIT_OFFSET)) ERR;
 
-   SUMMARIZE_ERR;
-   printf("*** testing attributes and enddef/redef...");
+    SUMMARIZE_ERR;
+    printf("*** testing attributes and enddef/redef...");
 
 #define ATT_1 "a"
 #define ATT_2 "b"
 #define ATT_3 "c"
-   {
-      int ncid, att = 1;
+    {
+        int ncid, att = 1;
 
 #ifdef TEST_PNETCDF
-      if (nc_create_par(FILE_NAME, NC_CLOBBER, MPI_COMM_WORLD, MPI_INFO_NULL,&ncid)) ERR;
+        if (nc_create_par(FILE_NAME, NC_CLOBBER, MPI_COMM_WORLD, MPI_INFO_NULL,&ncid)) ERR;
 #else
-      if (nc_create(FILE_NAME, NC_CLOBBER, &ncid)) ERR;
+        if (nc_create(FILE_NAME, NC_CLOBBER, &ncid)) ERR;
 #endif
-      if (nc_enddef(ncid)) ERR;
-      if (nc_redef(ncid)) ERR;
-      if (nc_put_att(ncid, NC_GLOBAL, ATT_1, NC_INT, 1, &att)) ERR;
-      if (nc_put_att(ncid, NC_GLOBAL, ATT_2, NC_INT, 1, &att)) ERR;
-      if (nc_put_att(ncid, NC_GLOBAL, ATT_3, NC_INT, 1, &att)) ERR;
+        if (nc_enddef(ncid)) ERR;
+        if (nc_redef(ncid)) ERR;
+        if (nc_put_att(ncid, NC_GLOBAL, ATT_1, NC_INT, 1, &att)) ERR;
+        if (nc_put_att(ncid, NC_GLOBAL, ATT_2, NC_INT, 1, &att)) ERR;
+        if (nc_put_att(ncid, NC_GLOBAL, ATT_3, NC_INT, 1, &att)) ERR;
 
-      if (nc_close(ncid)) ERR;
+        if (nc_close(ncid)) ERR;
 
 #ifdef TEST_PNETCDF
-      if (nc_open_par(FILE_NAME, 0, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid)) ERR;
+        if (nc_open_par(FILE_NAME, 0, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid)) ERR;
 #else
-      if (nc_open(FILE_NAME, 0, &ncid)) ERR;
+        if (nc_open(FILE_NAME, 0, &ncid)) ERR;
 #endif
-      if (nc_close(ncid)) ERR;
-   }
+        if (nc_close(ncid)) ERR;
+    }
 
-   SUMMARIZE_ERR;
-   printf("*** testing copy of simple global atts...");
-   {
-      int ncid, ncid2;
-      nc_type att_type;
-      size_t att_len;
-      int i;
+    SUMMARIZE_ERR;
+    printf("*** testing copy of simple global atts...");
+    {
+        int ncid, ncid2;
+        nc_type att_type;
+        size_t att_len;
+        int i;
 
-      char *speech_in;
-      signed char schar_in[ATT_LEN], schar_out[ATT_LEN] = {NC_MIN_BYTE, 1, NC_MAX_BYTE};
-      short short_in[ATT_LEN], short_out[ATT_LEN] = {NC_MIN_SHORT, -128, NC_MAX_SHORT};
-      int int_in[ATT_LEN], int_out[ATT_LEN] = {-100000, 128, 100000};
-      float float_in[ATT_LEN], float_out[ATT_LEN] = {.5, 0.25, 0.125};
-      double double_in[ATT_LEN], double_out[ATT_LEN] = {0.25, .5, 0.125};
+        char *speech_in;
+        signed char schar_in[ATT_LEN], schar_out[ATT_LEN] = {NC_MIN_BYTE, 1, NC_MAX_BYTE};
+        short short_in[ATT_LEN], short_out[ATT_LEN] = {NC_MIN_SHORT, -128, NC_MAX_SHORT};
+        int int_in[ATT_LEN], int_out[ATT_LEN] = {-100000, 128, 100000};
+        float float_in[ATT_LEN], float_out[ATT_LEN] = {.5, 0.25, 0.125};
+        double double_in[ATT_LEN], double_out[ATT_LEN] = {0.25, .5, 0.125};
 
-      /* Create a file with a global attribute of each type. */
+        /* Create a file with a global attribute of each type. */
 #ifdef TEST_PNETCDF
-      if (nc_create_par(FILE_NAME, NC_CLOBBER, MPI_COMM_WORLD, MPI_INFO_NULL,&ncid)) ERR;
+        if (nc_create_par(FILE_NAME, NC_CLOBBER, MPI_COMM_WORLD, MPI_INFO_NULL,&ncid)) ERR;
 #else
-      if (nc_create(FILE_NAME, NC_CLOBBER, &ncid)) ERR;
+        if (nc_create(FILE_NAME, NC_CLOBBER, &ncid)) ERR;
 #endif
-      if (nc_put_att_text(ncid, NC_GLOBAL, ATT_TEXT_NAME, strlen(speech)+1, speech)) ERR;
-      if (nc_put_att_schar(ncid, NC_GLOBAL, ATT_SCHAR_NAME, NC_BYTE, ATT_LEN, schar_out)) ERR;
-      if (nc_put_att_short(ncid, NC_GLOBAL, ATT_SHORT_NAME, NC_SHORT, ATT_LEN, short_out)) ERR;
-      if (nc_put_att_int(ncid, NC_GLOBAL, ATT_INT_NAME, NC_INT, ATT_LEN, int_out)) ERR;
-      if (nc_put_att_float(ncid, NC_GLOBAL, ATT_FLOAT_NAME, NC_FLOAT, ATT_LEN, float_out)) ERR;
-      if (nc_put_att_double(ncid, NC_GLOBAL, ATT_DOUBLE_NAME, NC_DOUBLE, ATT_LEN, double_out)) ERR;
+        if (nc_put_att_text(ncid, NC_GLOBAL, ATT_TEXT_NAME, strlen(speech)+1, speech)) ERR;
+        if (nc_put_att_schar(ncid, NC_GLOBAL, ATT_SCHAR_NAME, NC_BYTE, ATT_LEN, schar_out)) ERR;
+        if (nc_put_att_short(ncid, NC_GLOBAL, ATT_SHORT_NAME, NC_SHORT, ATT_LEN, short_out)) ERR;
+        if (nc_put_att_int(ncid, NC_GLOBAL, ATT_INT_NAME, NC_INT, ATT_LEN, int_out)) ERR;
+        if (nc_put_att_float(ncid, NC_GLOBAL, ATT_FLOAT_NAME, NC_FLOAT, ATT_LEN, float_out)) ERR;
+        if (nc_put_att_double(ncid, NC_GLOBAL, ATT_DOUBLE_NAME, NC_DOUBLE, ATT_LEN, double_out)) ERR;
 
-      /* Create another file and copy all the attributes. */
+        /* Create another file and copy all the attributes. */
 #ifdef TEST_PNETCDF
-      if (nc_create_par(FILE_NAME2, NC_CLOBBER, MPI_COMM_WORLD, MPI_INFO_NULL,&ncid2)) ERR;
+        if (nc_create_par(FILE_NAME2, NC_CLOBBER, MPI_COMM_WORLD, MPI_INFO_NULL,&ncid2)) ERR;
 #else
-      if (nc_create(FILE_NAME2, NC_CLOBBER, &ncid2)) ERR;
+        if (nc_create(FILE_NAME2, NC_CLOBBER, &ncid2)) ERR;
 #endif
-      if (nc_copy_att(ncid, NC_GLOBAL, ATT_TEXT_NAME, ncid2, NC_GLOBAL)) ERR;
-      if (nc_copy_att(ncid, NC_GLOBAL, ATT_SCHAR_NAME, ncid2, NC_GLOBAL)) ERR;
-      if (nc_copy_att(ncid, NC_GLOBAL, ATT_SHORT_NAME, ncid2, NC_GLOBAL)) ERR;
-      if (nc_copy_att(ncid, NC_GLOBAL, ATT_INT_NAME, ncid2, NC_GLOBAL)) ERR;
-      if (nc_copy_att(ncid, NC_GLOBAL, ATT_FLOAT_NAME, ncid2, NC_GLOBAL)) ERR;
-      if (nc_copy_att(ncid, NC_GLOBAL, ATT_DOUBLE_NAME, ncid2, NC_GLOBAL)) ERR;
+        if (nc_copy_att(ncid, NC_GLOBAL, ATT_TEXT_NAME, ncid2, NC_GLOBAL)) ERR;
+        if (nc_copy_att(ncid, NC_GLOBAL, ATT_SCHAR_NAME, ncid2, NC_GLOBAL)) ERR;
+        if (nc_copy_att(ncid, NC_GLOBAL, ATT_SHORT_NAME, ncid2, NC_GLOBAL)) ERR;
+        if (nc_copy_att(ncid, NC_GLOBAL, ATT_INT_NAME, ncid2, NC_GLOBAL)) ERR;
+        if (nc_copy_att(ncid, NC_GLOBAL, ATT_FLOAT_NAME, ncid2, NC_GLOBAL)) ERR;
+        if (nc_copy_att(ncid, NC_GLOBAL, ATT_DOUBLE_NAME, ncid2, NC_GLOBAL)) ERR;
 
-      /* Close both files. */
-      if (nc_close(ncid)) ERR;
-      if (nc_close(ncid2)) ERR;
+        /* Close both files. */
+        if (nc_close(ncid)) ERR;
+        if (nc_close(ncid2)) ERR;
 
-      /* Open the file and check attributes. */
+        /* Open the file and check attributes. */
 #ifdef TEST_PNETCDF
-      if (nc_open_par(FILE_NAME2, 0, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid)) ERR;
+        if (nc_open_par(FILE_NAME2, 0, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid)) ERR;
 #else
-      if (nc_open(FILE_NAME2, 0, &ncid)) ERR;
+        if (nc_open(FILE_NAME2, 0, &ncid)) ERR;
 #endif
-      /* Check text. */
-      if (nc_inq_att(ncid, NC_GLOBAL, ATT_TEXT_NAME, &att_type, &att_len)) ERR;
-      if (att_type != NC_CHAR || att_len != strlen(speech) + 1) ERR;
-      if (!(speech_in = malloc(att_len + 1))) ERR;
-      if (nc_get_att_text(ncid, NC_GLOBAL, ATT_TEXT_NAME, speech_in)) ERR;
-      if (strcmp(speech, speech_in)) ERR;
-      free(speech_in);
-      /* Check numeric values. */
-      if (nc_get_att_schar(ncid, NC_GLOBAL, ATT_SCHAR_NAME, schar_in)) ERR;
-      for (i = 0; i < ATT_LEN; i++)
-	 if (schar_in[i] != schar_out[i]) ERR;
-      if (nc_get_att_short(ncid, NC_GLOBAL, ATT_SHORT_NAME, short_in)) ERR;
-      for (i = 0; i < ATT_LEN; i++)
-	 if (short_in[i] != short_out[i]) ERR;
-      if (nc_get_att_int(ncid, NC_GLOBAL, ATT_INT_NAME, int_in)) ERR;
-      for (i = 0; i < ATT_LEN; i++)
-	 if (int_in[i] != int_out[i]) ERR;
-      if (nc_get_att_float(ncid, NC_GLOBAL, ATT_FLOAT_NAME, float_in)) ERR;
-      for (i = 0; i < ATT_LEN; i++)
-	 if (float_in[i] != float_out[i]) ERR;
-      if (nc_get_att_double(ncid, NC_GLOBAL, ATT_DOUBLE_NAME, double_in)) ERR;
-      for (i = 0; i < ATT_LEN; i++)
-	 if (double_in[i] != double_out[i]) ERR;
-      if (nc_close(ncid)) ERR;
-   }
-   SUMMARIZE_ERR;
+        /* Check text. */
+        if (nc_inq_att(ncid, NC_GLOBAL, ATT_TEXT_NAME, &att_type, &att_len)) ERR;
+        if (att_type != NC_CHAR || att_len != strlen(speech) + 1) ERR;
+        if (!(speech_in = malloc(att_len + 1))) ERR;
+        if (nc_get_att_text(ncid, NC_GLOBAL, ATT_TEXT_NAME, speech_in)) ERR;
+        if (strcmp(speech, speech_in)) ERR;
+        free(speech_in);
+        /* Check numeric values. */
+        if (nc_get_att_schar(ncid, NC_GLOBAL, ATT_SCHAR_NAME, schar_in)) ERR;
+        for (i = 0; i < ATT_LEN; i++)
+            if (schar_in[i] != schar_out[i]) ERR;
+        if (nc_get_att_short(ncid, NC_GLOBAL, ATT_SHORT_NAME, short_in)) ERR;
+        for (i = 0; i < ATT_LEN; i++)
+            if (short_in[i] != short_out[i]) ERR;
+        if (nc_get_att_int(ncid, NC_GLOBAL, ATT_INT_NAME, int_in)) ERR;
+        for (i = 0; i < ATT_LEN; i++)
+            if (int_in[i] != int_out[i]) ERR;
+        if (nc_get_att_float(ncid, NC_GLOBAL, ATT_FLOAT_NAME, float_in)) ERR;
+        for (i = 0; i < ATT_LEN; i++)
+            if (float_in[i] != float_out[i]) ERR;
+        if (nc_get_att_double(ncid, NC_GLOBAL, ATT_DOUBLE_NAME, double_in)) ERR;
+        for (i = 0; i < ATT_LEN; i++)
+            if (double_in[i] != double_out[i]) ERR;
+        if (nc_close(ncid)) ERR;
+    }
+    SUMMARIZE_ERR;
+    printf("*** testing double att like in GFDL FMS code...");
+    {
+        int ncid;
+        long long int i = 50;
+
+
+        if (nc_create(FILE_NAME, NC_CLOBBER, &ncid)) ERR;
+        if (nc_put_att_longlong(ncid, NC_GLOBAL, ATT_1, NC_INT64, 1, &i)) ERR;
+        if (nc_close(ncid)) ERR;
+
+        if (nc_open(FILE_NAME, 0, &ncid)) ERR;
+        if (nc_close(ncid)) ERR;
+    }
+
+    SUMMARIZE_ERR;
+
 #ifdef TEST_PNETCDF
-   MPI_Finalize();
+    MPI_Finalize();
 #endif
-   FINAL_RESULTS;
+    FINAL_RESULTS;
 }

--- a/nc_test/tst_atts3.c
+++ b/nc_test/tst_atts3.c
@@ -854,12 +854,11 @@ main(int argc, char **argv)
         int ncid;
         long long int i = 50;
 
-
+	/* Try to write a file with a global att, but it won't work,
+	 * since NC_INT64 is not supported in classic binary
+	 * format. */
         if (nc_create(FILE_NAME, NC_CLOBBER, &ncid)) ERR;
-        if (nc_put_att_longlong(ncid, NC_GLOBAL, ATT_1, NC_INT64, 1, &i)) ERR;
-        if (nc_close(ncid)) ERR;
-
-        if (nc_open(FILE_NAME, 0, &ncid)) ERR;
+        if (nc_put_att_longlong(ncid, NC_GLOBAL, ATT_1, NC_INT64, 1, &i) != NC_EBADTYPE) ERR;
         if (nc_close(ncid)) ERR;
     }
 


### PR DESCRIPTION
Part of #1807 

In this PR I add a test that demonstrates that attempting to write an NC_INT64 attribute in a classic format file results in an NC_EBADTYPE error.