### PR TITLE
Fix test procedure for NCF-187 bug.

### DIFF
--- a/nc_test4/tst_fills2.c
+++ b/nc_test4/tst_fills2.c
@@ -374,6 +374,8 @@ main(int argc, char **argv)
       if (nc_create(FILE_NAME, NC_NETCDF4 | NC_CLASSIC_MODEL, &ncid)) ERR;
       if (nc_def_dim(ncid, "x", 182, &dimids[0])) ERR;
       if (nc_def_var(ncid, "u_obs", NC_FLOAT, 1, dimids, &varid)) ERR;
+      if (nc_close(ncid)) ERR;
+      if (nc_open(FILE_NAME, NC_WRITE, &ncid)) ERR;
       if (nc_put_att_double (ncid, varid, "_FillValue", NC_FLOAT, 1, &fillval)) ERR;
       if (nc_close(ncid)) ERR;
       SUMMARIZE_ERR;


### PR DESCRIPTION
To let it match procedure of 6a6e8c0, or it cannot reproduce this bug.
( especially backporting this bugfix patch to legacy version [<= 4.3.3.1] in CentOS 7 )

btw the link of [NCF-187](https://bugtracking.unidata.ucar.edu/browse/NCF-187) is broken, is there backup/mirror page to see full descriptions of this bug?