### PR TITLE
Fix time zone parser bug, github #1417

### DIFF
--- a/libdispatch/nctime.c
+++ b/libdispatch/nctime.c
@@ -317,25 +317,23 @@ cdParseRelunits(cdCalenType timetype, char* relunits, cdUnitTime* unit, cdCompTi
 	char basetime_1[CD_MAX_CHARTIME];
 	char basetime_2[CD_MAX_CHARTIME];
 	char basetime[2 * CD_MAX_CHARTIME + 1];
-	int nconv1, nconv2, nconv;
+	int nconv;
 
-					     /* Parse the relunits */
-	/* Allow ISO-8601 "T" date-time separator as well as blank separator */
-	nconv1 = sscanf(relunits,"%s since %[^T]T%s",charunits,basetime_1,basetime_2);
-	if(nconv1==EOF || nconv1==0){
+	/* Parse the relunits.  First parse assuming white space only. */
+	nconv = sscanf(relunits,"%s since %s %s",charunits,basetime_1,basetime_2);
+
+	/* Handle ISO-8601 "T" date-time separator in place of blank separator. */
+	if (nconv!=EOF && nconv>=2) {
+	    if (strchr (basetime_1, 'T') != NULL) {
+		nconv = sscanf(relunits,"%s since %[^T]T%s",charunits,basetime_1,basetime_2);
+	    }
+	}
+
+	if(nconv==EOF || nconv==0){
 		cdError("Error on relative units conversion, string = %s\n",relunits);
 		return 1;
 	}
-	nconv2 = sscanf(relunits,"%s since %s %s",charunits,basetime_1,basetime_2);
-	if(nconv2==EOF || nconv2==0){
-		cdError("Error on relative units conversion, string = %s\n",relunits);
-		return 1;
-	}
-	if(nconv1 < nconv2) {
-	    nconv = nconv2;
-	} else {
-	    nconv = sscanf(relunits,"%s since %[^T]T%s",charunits,basetime_1,basetime_2);
-	}
+
 					     /* Get the units */
 	cdTrim(charunits,CD_MAX_RELUNITS);
 	if(!strncasecmp(charunits,"sec",3) || !strcasecmp(charunits,"s")){


### PR DESCRIPTION
Fixes time zone bug reported in #1417.  Does not resolve the request to add time zones in `ncdump -t` printed output.

Also fixes #1864 (duplicate).