### PR TITLE
Fix setting of use_szlib

### DIFF
--- a/nc-config.cmake.in
+++ b/nc-config.cmake.in
@@ -73,7 +73,7 @@ else
     has_hdf5="yes"
 fi
 
-has_szlib="@USE_SZLIB@"
+has_szlib="@USE_SZIP@"
 if [ -z "$has_szlib" -o "$has_szlib" = "OFF" ]; then
     has_szlib="no"
 else


### PR DESCRIPTION
The `USE_SZLIB` symbol only appeared one time in this file in the entire project.  I think that `USE_SZIP` is the intended symbol.