### PR TITLE
Support aligned access for selected Arm processors.

### DIFF
--- a/libdap4/d4util.c
+++ b/libdap4/d4util.c
@@ -459,3 +459,11 @@ NCD4_errorNC(int code, const int line, const char* file)
 {
     return NCD4_error(code,line,file,nc_strerror(code));
 }
+
+d4size_t
+NCD4_getcounter(void* p)
+{
+    COUNTERTYPE v;
+    memcpy(&v,p,sizeof(v));
+    return (d4size_t)v;
+}

--- a/libdap4/ncd4.h
+++ b/libdap4/ncd4.h
@@ -197,7 +197,17 @@ extern int nc__dap4(void);
 
 #undef GETCOUNTER
 #undef SKIPCOUNTER
+
+/* Unclear which macros are defined for which compilers.
+   see: https://sourceforge.net/p/predef/wiki/Architectures/
+*/
+#if defined(__ARM_ARCH_7__) || defined(__ARM_ARCH_6__)
+static d4size_t
+GETCOUNTER(void* p)
+{COUNTERTYPE v; memcpy(v,p,sizeof(v)); return (d4size_t)v;}
+#else
 #define GETCOUNTER(p) ((d4size_t)*((COUNTERTYPE*)(p)))
+#endif
 #define SKIPCOUNTER(p) {p=INCR(p,COUNTERSIZE);}
 
 #undef PUSH

--- a/libdap4/ncd4.h
+++ b/libdap4/ncd4.h
@@ -202,9 +202,8 @@ extern int nc__dap4(void);
    see: https://sourceforge.net/p/predef/wiki/Architectures/
 */
 #if defined(__arm__) && __ARM_ARCH < 8
-static d4size_t
-GETCOUNTER(void* p)
-{COUNTERTYPE v; memcpy(v,p,sizeof(v)); return (d4size_t)v;}
+EXTERNL d4size_t NCD4_getcounter(void* p);
+#define GETCOUNTER(p) NCD4_getcounter(p)
 #else
 #define GETCOUNTER(p) ((d4size_t)*((COUNTERTYPE*)(p)))
 #endif /*defined(__arm__) && __ARM_ARCH < 8*/

--- a/libdap4/ncd4.h
+++ b/libdap4/ncd4.h
@@ -201,13 +201,14 @@ extern int nc__dap4(void);
 /* Unclear which macros are defined for which compilers.
    see: https://sourceforge.net/p/predef/wiki/Architectures/
 */
-#if defined(__ARM_ARCH_7__) || defined(__ARM_ARCH_6__)
+#if defined(__arm__) && __ARM_ARCH < 8
 static d4size_t
 GETCOUNTER(void* p)
 {COUNTERTYPE v; memcpy(v,p,sizeof(v)); return (d4size_t)v;}
 #else
 #define GETCOUNTER(p) ((d4size_t)*((COUNTERTYPE*)(p)))
-#endif
+#endif /*defined(__arm__) && __ARM_ARCH < 8*/
+
 #define SKIPCOUNTER(p) {p=INCR(p,COUNTERSIZE);}
 
 #undef PUSH


### PR DESCRIPTION
* Fixes #1854 

re: https://github.com/Unidata/netcdf-c/issues/1854

Apparently some older Arm processors will fail if asked to
read a 64 bit value from memory if not on an 8 byte boundary.
The primary problem is in reading counter values in the dap4 stream.
So if the Arm processor is detected, then memcpy the value
to an aligned 64 bit value before using it.