### PR TITLE
Remove trailing comma from _NCProperties attribute value.

### DIFF
--- a/libhdf5/nc4info.c
+++ b/libhdf5/nc4info.c
@@ -90,6 +90,7 @@ NC4_provenance_init(void)
     ncbytescat(buffer,printbuf);
 
 #ifdef NCPROPERTIES_EXTRA
+    if(NCPROPERTIES_EXTRA != NULL && strlen(NCPROPERTIES_EXTRA) > 0)
     { const char* p;
     /* Add any extra fields */
     p = NCPROPERTIES_EXTRA;

--- a/libnczarr/zprov.c
+++ b/libnczarr/zprov.c
@@ -90,6 +90,7 @@ NCZ_provenance_init(void)
 #endif
 
 #ifdef NCPROPERTIES_EXTRA
+    if(NCPROPERTIES_EXTRA != NULL && strlen(NCPROPERTIES_EXTRA) > 0)
     {
     /* Add any extra fields */
     const char* p = NCPROPERTIES_EXTRA;


### PR DESCRIPTION
If NCPROPERTIES_EXTRA (see configure.ac) is defined
but is null or empty, then an extra comma is being generated
at the end of _NCProperties global attribute.

Soln: check for null/empty NCPROPERTIES_EXTRA value.