### PR TITLE
Fix undefined struct member access

### DIFF
--- a/libhdf5/hdf5file.c
+++ b/libhdf5/hdf5file.c
@@ -224,8 +224,10 @@ nc4_close_netcdf4_file(NC_FILE_INFO_T *h5, int abort, NC_memio *memio)
     NC4_clear_provenance(&h5->provenance);
 
     /* Free the http info */
+#ifdef ENABLE_HDF5_ROS3
     ncurifree(hdf5_info->http.uri);
     NC_authfree(hdf5_info->http.auth);
+#endif
 
     /* Close hdf file. It may not be open, since this function is also
      * called by NC_create() when a file opening is aborted. */


### PR DESCRIPTION
The `http` field of the hdf5 info struct is not defined unless `ENABLE_HDF5_ROS3` or `ENABLE_BYTERANGE` or `ENABLE_S3_SDK` is defined.  Based on a quick look at the code, I think that the `ENABLE_HDF5_ROS3` define is the relavant one here.  Maybe a better fix is to check if any of them are defined...

Fixes #1889 and #1888