### PR TITLE
Fix build on Windows with clang-cl

### DIFF
--- a/config.h.cmake.in
+++ b/config.h.cmake.in
@@ -46,7 +46,9 @@ are set when opening a binary file on Windows. */
    #define read _read
    #define lseek _lseeki64
 
+   #ifndef __clang__
    #define fstat _fstat64
+   #endif
 
    #define off_t __int64
    #define _off_t __int64


### PR DESCRIPTION
The library fails to build on Windows with llvm toolset because `_fstat64` is defined twice.