### PR TITLE
Remove some potentially harmful duplicate code

### DIFF
--- a/libnczarr/zwalk.c
+++ b/libnczarr/zwalk.c
@@ -285,9 +285,6 @@ NCZ_transfer(struct Common* common, NCZSlice* slices)
 	slpodom = nczodom_fromslices(common->rank,slpslices);
 	memodom = nczodom_fromslices(common->rank,memslices);
 
-        /* This is the key action: walk this set of slices and transfer data */
-	if((stat = NCZ_walk(proj,chunkodom,slpodom,memodom,common,chunkdata))) goto done;
-
 	{ /* walk with odometer, possibly optimized */
 	    if(wdebug >= 1)
 	    fprintf(stderr,"case: odometer; slp.optimized=%d:\n",slpodom->properties.optimized);


### PR DESCRIPTION
I noticed a piece of duplicate code in libnczarr that could, in rare circumstances, cause bad data to be read/written. 