### PR TITLE
docs: fix simple typo, maximim -> maximum

### DIFF
--- a/libnczarr/zvar.c
+++ b/libnczarr/zvar.c
@@ -258,7 +258,7 @@ give_var_secret_name(NC_VAR_INFO_T *var, const char *name)
  * @param ncid File ID.
  * @param name Name.
  * @param xtype Type.
- * @param ndims Number of dims. ZARR has maximim of 32.
+ * @param ndims Number of dims. ZARR has maximum of 32.
  * @param dimidsp Array of dim IDs.
  * @param varidp Gets the var ID.
  *


### PR DESCRIPTION
There is a small typo in libnczarr/zvar.c.

Should read `maximum` rather than `maximim`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md