### PR TITLE
Update links related to netCDF-Java and the TDS

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ software for various languages:
 
 * [C library and utilities](http://github.com/Unidata/netcdf-c)
 * [Fortran](http://github.com/Unidata/netcdf-fortran)
-* [Java](http://www.unidata.ucar.edu/downloads/netcdf/netcdf-java-4/)
+* [Java](https://www.unidata.ucar.edu/downloads/netcdf-java/
 * [Python](http://github.com/Unidata/netcdf4-python)
 * [C++](http://github.com/Unidata/netcdf-cxx4)
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1655,8 +1655,8 @@ experimental version is available now in the snapshot distributions.
 
 Other clients and servers support access through a netCDF interface to
 netCDF and other kinds of data, including clients written using the
-[netCDF-Java library](http://www.unidata.ucar.edu/software/netcdf-java/) and servers that use the
-[THREDDS Data Server](/software/thredds/current/tds/TDS.html).
+[netCDF-Java library](https://www.unidata.ucar.edu/software/netcdf-java/) and servers that use the
+[THREDDS Data Server](https://www.unidata.ucar.edu/software/tds/).
 
 The [GrADS Data Server](http://grads.iges.org/grads/gds/) provides
 subsetting and analysis services across the Internet for any
@@ -1677,7 +1677,7 @@ Several programs and packages have been developed that convert between
 [GDAL](http://www.gdal.org/), [GrADS](software.html#GrADS), and
 [wgrib2](http://www.cpc.noaa.gov/products/wesley/wgrib2/).
 
-The Unidata [netCDF Java Library](http://www.unidata.ucar.edu/software/netcdf-java/index.html) can
+The Unidata [netCDF Java Library](https://www.unidata.ucar.edu/software/netcdf-java/) can
 read GRIB1 and GRIB2 data (and many other data formats) through a netCDF
 interface. As a command-line example, you could convert *fileIn.grib* to
 *fileOut.nc* as follows:
@@ -1987,8 +1987,6 @@ What other future work on netCDF is planned? {#What-other-future-work-on-netCDF-
 
 Issues, bugs, and plans for netCDF are maintained in the Unidata issue
 tracker sites for
-[netCDF-C](https://www.unidata.ucar.edu/jira/browse/NCF), [Common Data Model / NetCDF-Java](https://www.unidata.ucar.edu/jira/browse/CDM),
-[netCDF-Fortran](https://www.unidata.ucar.edu/jira/browse/NCFORTRAN),
-and [netCDF-CXX4](https://www.unidata.ucar.edu/jira/browse/NCXXF), and
-[old netCDF-C++
-(deprecated)](https://www.unidata.ucar.edu/jira/browse/NCCPP).
+[netCDF-C](https://github.com/Unidata/netcdf-c/issues), [Common Data Model / NetCDF-Java](https://github.com/Unidata/netcdf-java/issues),
+[netCDF-Fortran](https://github.com/Unidata/netcdf-fortran/issues),
+and [netCDF-CXX4](https://github.com/Unidata/netcdf-cxx4/issues), and

--- a/docs/static-pages/software.html
+++ b/docs/static-pages/software.html
@@ -1212,7 +1212,7 @@ or using ECMWF reanalysis on a reduced grid
         </li>
         <li>
           Support for non-gridded data through the <a
-          href="/software/netcdf-java/CDM/" >Common Data Model (CDM)</a>
+          href="https://docs.unidata.ucar.edu/netcdf-java/current/userguide/common_data_model_overview.html">Common Data Model (CDM)</a>
         </li>
       </ul>
       The IDV uses the <a href="http://www.ssec.wisc.edu/~billh/visad.html"
@@ -1377,23 +1377,25 @@ or using ECMWF reanalysis on a reduced grid
     <h2><a id="Java interface" name="Java interface">Java interface</a></h2>
     <p>
       The <a href="/software/netcdf-java/"
-      >NetCDF-Java 4.2 Library</a> is a Java interface to netCDF files,
+      >NetCDF-Java Library</a> is a Java interface to netCDF files,
       as well as to many other types of scientific data formats. It
       is freely available and the source code is released under the
-      (MIT-style) netCDF C library license. Previous versions use the GNU
-      Lesser General Public License (LGPL).
+      BSD-3 license. Previous versions used the (MIT-style) netCDF C
+      library license, and prior to that, the GNU Lesser General
+      Public License (LGPL).
     </p>
     <p>
       The library implements a Common Data Model (<a
-      href="/software/netcdf-java/CDM/" >CDM</a>), a generalization
+      href="https://docs.unidata.ucar.edu/netcdf-java/current/userguide/common_data_model_overview.html" >CDM</a>), a generalization
       of the netCDF, OpenDAP and HDF5 data models. The library is a
       prototype for the netCDF-4 project, which provides a C language API
       for the "data access layer" of the CDM, on top of the HDF5 file
       format. The NetCDF-Java library is a 100% Java framework for <em>reading</em> netCDF
       and other file formats into the CDM, as well as <em>writing</em> to the
-      netCDF-3 file format.
+      netCDF-3 file format. Write support for the netCDF-4 is provided by 
+      native calls to the netCDF-C library.
       The library also implements <a
-      href="http://www.unidata.ucar.edu/software/netcdf/ncml/">NcML</a>,
+      href="https://docs.unidata.ucar.edu/netcdf-java/current/userguide/ncml_overview.html">NcML</a>,
       which allows you to add metadata to CDM datasets, as well as to create
       virtual datasets through aggregation.
     </p>
@@ -1913,7 +1915,7 @@ or using ECMWF reanalysis on a reduced grid
       <a
       href="http://nctoolbox.github.io/nctoolbox/" >nctoolbox</a> is a MATLAB
       interface that provides read-only access to <a
-      href="/software/netcdf-java/CDM/index.html" >Common Data Model</a>
+      href="https://docs.unidata.ucar.edu/netcdf-java/current/userguide/common_data_model_overview.html" >Common Data Model</a>
       datasets.
       Under the hood, nctoolbox uses Unidata's NetCDF-Java as the data access layer.
       This allows nctoolbox to access to netCDF, OPeNDAP, HDF5, GRIB, GRIB2, HDF4,
@@ -2964,7 +2966,7 @@ or using ECMWF reanalysis on a reduced grid
     </p>
     <p>
       xray adopts the <a
-      href="http://www.unidata.ucar.edu/software/thredds/current/netcdf-java/CDM"
+      href="https://docs.unidata.ucar.edu/netcdf-java/current/userguide/common_data_model_overview.html"
       >Common Data Model</a> for self-describing scientific data in
       widespread use in the Earth sciences (e.g., netCDF and OPeNDAP):
       xray.Dataset is an in-memory representation of a netCDF file.

--- a/docs/testserver.dox
+++ b/docs/testserver.dox
@@ -13,7 +13,7 @@
 The test suite for the DAP2 and DAP4 (aka DAP) protocols optionally
 uses a continuously running test server to verify that the
 DAP protocols can successfully be used against a remote server such
-as a Unidata Thredds server or a OPeNDAP Hyrax server.
+as a Unidata THREDDS Data Server or a OPeNDAP Hyrax server.
 
 The way that this is tests is to establish two servlets running
 under a Tomcat server on some machine with a known IP address
@@ -156,9 +156,9 @@ to verify that the d4ts test server is working.
 # Building d4ts.war and dts.war {#remotesvc_buildservlets}
 
 In order to build the servlet (.war) files, you will need to
-clone the Thredds directory on github: https://github.com/Unidata/thredds.
+clone the Thredds directory on github: https://github.com/Unidata/tds.
 
-Once you have a clone, you will need to enter the thredds directory
+Once you have a clone, you will need to enter the tds directory
 and build by invoking gradle using this command.
 ````
 ./gradlew --info --no-daemon  clean assemble

--- a/docs/tutorial.dox
+++ b/docs/tutorial.dox
@@ -116,7 +116,7 @@ support-netcdf@unidata.ucar.edu.
 Unidata supports netCDF APIs in C, C++, Fortran 77, Fortran 90, and
 Java.
 
-The <a href="http://www.unidata.ucar.edu/software/netcdf-java">netCDF
+The <a href="https://www.unidata.ucar.edu/software/netcdf-java/">netCDF
 Java</a> API is a complete implementation of netCDF in Java. It is
 distributed independently of the other APIs. If you are writing web
 server software, you should certainly be doing so in Java.
@@ -169,7 +169,7 @@ C, C++, Fortran 77, Fortran 90, and Java APIs:
 - C++ - The NetCDF C++ Interface Guide.
 - Fortran 77 - The NetCDF Fortran 77 Interface Guide.
 - Fortran 90 - The NetCDF Fortran 90 Interface Guide.
-- Java <a href="http://www.unidata.ucar.edu/software/netcdf-java/v2.1/NetcdfJavaUserManual.htm">The netCDF-Java Users Guide</a>.
+- Java - <a href="https://docs.unidata.ucar.edu/netcdf-java/current/userguide/">The netCDF-Java User Guide</a>.
 
 Man pages for the C, F77, and F90 interfaces, and ncgen and ncdump,
 are available on the documentation page of the netCDF web site


### PR DESCRIPTION
This pull request contains updates to various links (and some text) related to netCDF-Java and the THREDDS Data Server. I also updated some links related to the issue trackers for netCDF-C, netCDF-Fortran, and netCDF-CXX4 since we no longer use Jira.