### PR TITLE
Fix name of the HDF5_C_LIBRARY_hdf5 CMake variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -724,7 +724,7 @@ IF(USE_HDF5)
   FIND_PACKAGE(Threads)
 
   # There is a missing case in the above code so default it
-  IF(NOT HDF5_C_LIBRARY_HDF5 OR "${HDF5_C_LIBRARY_hdf5}" STREQUAL "" )
+  IF(NOT HDF5_C_LIBRARY_hdf5 OR "${HDF5_C_LIBRARY_hdf5}" STREQUAL "" )
     SET(HDF5_C_LIBRARY_hdf5 "${HDF5_C_LIBRARY}")
   ENDIF()
 


### PR DESCRIPTION
The name of the variable `HDF5_C_LIBRARY_hdf5` is misspelled as `HDF5_C_LIBRARY_HDF5` in one of the `if` statements in `CMakeLists.txt`. This patch fixes the spelling.