### PR TITLE
Add HAVE_MPI_INFO_F2C to cmake config.h input file

### DIFF
--- a/config.h.cmake.in
+++ b/config.h.cmake.in
@@ -313,6 +313,9 @@ are set when opening a binary file on Windows. */
 /* Define to 1 if you have the `MPI_Comm_f2c' function. */
 #cmakedefine HAVE_MPI_COMM_F2C 1
 
+/* Define to 1 if you have the `MPI_Info_f2c' function. */
+#cmakedefine HAVE_MPI_INFO_F2C 1
+
 /* Define to 1 if you have the `mremap' function. */
 #cmakedefine HAVE_MREMAP 1
 


### PR DESCRIPTION
Without this define parallel netCDF-Fortran did not work
correctly with Open MPI, for example
examples/F90/simple_xy_par_wr.f90
reported
*** An error occurred in MPI_Info_dup
*** reported by process [2543714305,2]
*** on communicator MPI_COMM_WORLD
*** MPI_ERR_INFO: invalid info object
*** MPI_ERRORS_ARE_FATAL (processes in this communicator will now abort,
***    and potentially your MPI job)

Fixes Unidata/netcdf-fortran#109