### PR TITLE
Fix if statement to apply to fflush

### DIFF
--- a/libnczarr/zwalk.c
+++ b/libnczarr/zwalk.c
@@ -206,8 +206,9 @@ NCZ_transfer(struct Common* common, NCZSlice* slices)
 		  common, &chunkodom)))
 	goto done;
 
-    if(wdebug >= 4)
+    if(wdebug >= 4) {
 	fprintf(stderr,"allprojections:\n%s",nczprint_allsliceprojections(common->rank,common->allprojections)); fflush(stderr);
+    }
 
     wholechunk = iswholechunk(common,slices);
 


### PR DESCRIPTION
Even though the `fflush()` is on the same line as the `fprintf(stderr, ...` statement, it is not part of the `if` and is therefore, executed even if the `wdebug` is not active.  This results in `fflush()` being called more than it should.  

Added parenthesis to property protect the fflush call.