### PR TITLE
Fix some HDF5-related tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -727,7 +727,7 @@ IF(USE_HDF5)
   ENDIF()
 
   #Check to see if H5Z_SZIP exists in HDF5_Libraries. If so, we must use szip library.
-  set (CMAKE_REQUIRED_INCLUDES ${HAVE_HDF5_H})
+  set (CMAKE_REQUIRED_INCLUDES ${HDF5_INCLUDE_DIR})
   CHECK_C_SOURCE_COMPILES("#include <H5public.h>
    #if !H5_HAVE_FILTER_SZIP
    #error
@@ -781,8 +781,9 @@ IF(USE_HDF5)
   CHECK_LIBRARY_EXISTS(${HDF5_C_LIBRARY_hdf5} H5Literate "" HAVE_H5Literate)
 
   IF(NOT HAVE_H5Literate)
+  set (CMAKE_REQUIRED_INCLUDES ${HDF5_INCLUDE_DIR})
   CHECK_C_SOURCE_COMPILES("#include <H5public.h>
-   #if !(H5Literate_vers == 1)
+   #if !defined H5Literate_vers
    #error
    #endif
    int main() {int x = 1;}" HAVE_H5Literate_Macro)


### PR DESCRIPTION
Some of the tests for HDF5 symbols are failing due to not finding the include file which skews the test results.  Added the `CMAKE_REQUIRED_INCLUDES` command to set the path.  In one place this was already set, but used `HAVE_HDF5_H` which is not an include path and isn't even set at the location where it was used.  We may not need these set more than once, but I added them before each `CHECK_C_SOURCE_COMPILES` in case those blocks get moved around and the value gets unset when it should be set.

Also changed the `H5Literate_vers` check to check  that it is defined instead of checking the value.  As best I can see, as long as it is defined, then the `H5Literate` symbol will be defined which is what is needed.  Checked with 1.10.7 and 1.12.0