### PR TITLE
Fix out of tree builds with configure

### DIFF
--- a/lib_flags.am
+++ b/lib_flags.am
@@ -6,7 +6,7 @@
 # libraries for netCDF-4.
 #
 
-AM_CPPFLAGS = -I$(top_srcdir)/include
+AM_CPPFLAGS = -I$(top_builddir)/include -I$(top_srcdir)/include
 AM_LDFLAGS =
 
 if USE_DAP


### PR DESCRIPTION
 - add $(top_builddir)/include to include directory search

Since we create some includes during the build