### PR TITLE
Fix the handling of certain alias types in CDL files.

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -4,7 +4,7 @@
 
 name: Run netCDF Tests
 
-on: [pull_request]
+on: [pull_request,push]
 
 jobs:
 

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -4,7 +4,7 @@
 
 name: Run netCDF Tests
 
-on: [pull_request,push]
+on: [pull_request]
 
 jobs:
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,7 @@ Release Notes       {#RELEASE_NOTES}
 This file contains a high-level description of this package's evolution. Releases are in reverse chronological order (most recent first). Note that, as of netcdf 4.2, the `netcdf-c++` and `netcdf-fortran` libraries have been separated into their own libraries.
 ## 4.8.1 - TBD
 
+* [Bug Fix] Allow some primitive type names to be used as identifiers depending on the file format. See [Github #1984](https://github.com/Unidata/netcdf-c/issues/1984).  
 * [Enhancement] Add support for reading/writing pure Zarr storage format that supports the XArray _ARRAY_DIMENSIONS attribute. See [Github #1952](https://github.com/Unidata/netcdf-c/pull/1952) for more information.
 * [Update] Updated version of bzip2 used in filter testing/functionality, in support of [Github #1969](https://github.com/Unidata/netcdf-c/issues/1969).
 * [Bug Fix] Corrected HDF5 version detection logic as described in [Github #1962](https://github.com/Unidata/netcdf-c/issues/1962).  

--- a/ncdump/Makefile.am
+++ b/ncdump/Makefile.am
@@ -162,8 +162,9 @@ ref_provenance_v1.nc ref_tst_radix.cdl tst_radix.cdl test_radix.sh	\
 ref_nccopy_w.cdl tst_nccopy_w3.sh tst_nccopy_w4.sh			\
 ref_no_ncproperty.nc test_unicode_directory.sh				\
 ref_roman_szip_simple.cdl ref_roman_szip_unlim.cdl ref_tst_perdimspecs.cdl \
-test_keywords.sh ref_keyword1.cdl ref_keyword2.cdl ref_tst_nofilters.cdl \
-test_unicode_path.sh
+test_keywords.sh ref_keyword1.cdl ref_keyword2.cdl                      \
+ref_keyword3.cdl ref_keyword4.cdl                                       \
+ref_tst_nofilters.cdl test_unicode_path.sh
 
 # The L512.bin file is file containing exactly 512 bytes each of value 0.
 # It is used for creating hdf5 files with varying offsets for testing.
@@ -199,5 +200,7 @@ tst_ncf199.cdl tst_tst_gattenum.cdl tst_tst_usuffix.cdl ctest.c		\
 ctest64.c nccopy3_subset_out.nc camrun.c tst_ncf213.cdl tst_ncf213.nc	\
 tst_radix.nc tmp_radix.cdl ctest_small_3.c ctest_small_4.c		\
 ctest_special_atts_4.c tst_roman_szip_simple.cdl			\
-tst_roman_szip_unlim.cdl tst_perdimpspecs.nc tmppds.* \
-keyword1.nc keyword2.nc tmp_keyword1.cdl tmp_keyword2.cdl
+tst_roman_szip_unlim.cdl tst_perdimpspecs.nc tmppds.*                   \
+keyword1.nc keyword2.nc keyword3.nc keyword4.nc                         \
+tmp_keyword1.cdl tmp_keyword2.cdl tmp_keyword3.cdl tmp_keyword4.cdl
+

--- a/ncdump/ref_keyword3.cdl
+++ b/ncdump/ref_keyword3.cdl
@@ -1,0 +1,5 @@
+netcdf keyword3 {
+variables:
+    real f;
+    long l;
+}

--- a/ncdump/ref_keyword4.cdl
+++ b/ncdump/ref_keyword4.cdl
@@ -1,0 +1,9 @@
+netcdf x {
+dimensions:
+    string = 17;
+variables:
+int string;
+  int string:x = 17;
+int :string = 17;
+data: string = 1;
+}

--- a/ncdump/test_keywords.sh
+++ b/ncdump/test_keywords.sh
@@ -20,4 +20,25 @@ ${NCDUMP} -h keyword2.nc > tmp_keyword2.cdl
 echo "*** comparing tmp_keyword2.cdl to ref_keyword2.cdl..."
 diff -b -w tmp_keyword2.cdl $srcdir/ref_keyword2.cdl
 
+echo "*** Test use of type aliases such as 'long' or 'real'..."
+echo "*** classic: creating keyword3.nc from ref_keyword3.cdl..."
+${NCGEN} -3 -lb -o keyword3.nc $srcdir/ref_keyword3.cdl
+echo "*** creating tmp_keyword3.cdl from keyword3.nc..."
+# We need to convert float back to real and int back to long
+${NCDUMP} -h keyword3.nc | sed -e 's/float/real/g' -e 's/int/long/g' >tmp_keyword3.cdl
+echo "*** comparing tmp_keyword3.cdl to ref_keyword3.cdl..."
+diff -b -w tmp_keyword3.cdl $srcdir/ref_keyword3.cdl
+
+echo "*** Test use of keywords both pass and fail"
+# This should succeed
+${NCGEN} -3 -lb -o keyword4.nc $srcdir/ref_keyword4.cdl
+echo "***pass: ncgen -3 X ref_keyword4"
+# This should (x)fail
+if ${NCGEN} -4 -lb -o keyword4.nc $srcdir/ref_keyword4.cdl ; then
+echo "***erroneous pass: ncgen -4 X ref_keyword4"
+exit 1
+else
+echo "***xfail: ncgen -4 X ref_keyword4"
+fi
+
 exit 0

--- a/ncgen/generate.c
+++ b/ncgen/generate.c
@@ -449,8 +449,10 @@ generate_array(Symbol* vsym, Bytebuffer* code, Datalist* filler, Generator* gene
     }
     nunlimited = countunlimited(args.dimset);
 
-    if(vsym->var.special._Storage == NC_CHUNKED)
-        memcpy(args.chunksizes,vsym->var.special._ChunkSizes,sizeof(size_t)*args.rank);
+    if(vsym->var.special._Storage == NC_CHUNKED) {
+	if(vsym->var.special._ChunkSizes)
+            memcpy(args.chunksizes,vsym->var.special._ChunkSizes,sizeof(size_t)*args.rank);
+    }	
 
     memset(index,0,sizeof(index));
 

--- a/ncgen/genlib.h
+++ b/ncgen/genlib.h
@@ -82,6 +82,7 @@ extern struct Datalist* getfiller(Symbol*); /* symbol isa variable|type */
 
 /* from: ncgen.y */
 extern Symbol* install(const char *sname);
+extern Symbol* installin(const char *sname,Symbol* grp);
 extern void freesymbol(Symbol*);
 extern Symbol* basetypefor(nc_type nctype);/* Convert nctype to a Symbol*/
 extern Symbol* makearraytype(Symbol*, Dimset*);

--- a/ncgen/ncgen.l
+++ b/ncgen/ncgen.l
@@ -115,6 +115,7 @@ char char_val;                 /* last char value read */
 signed char byte_val;                 /* last byte value read */
 unsigned char ubyte_val;       /* last byte value read */
 
+/* Forward */
 static Symbol* makepath(char* text);
 static int lexdebug(int);
 static unsigned long long parseULL(int radix, char* text, int*);
@@ -122,6 +123,7 @@ static nc_type downconvert(unsigned long long uint64, int*, int, int);
 static int tagmatch(nc_type nct, int tag);
 static int nct2lexeme(nc_type nct);
 static int collecttag(char* text, char** stagp);
+static int identcheck(int token);
 
 struct Specialtoken specials[] = {
 {"_FillValue",_FILLVALUE,_FILLVALUE_FLAG},
@@ -139,35 +141,6 @@ struct Specialtoken specials[] = {
 {"_Filter",_FILTER,_FILTER_FLAG},
 {NULL,0} /* null terminate */
 };
-
-/* Track keywords that may be identifiers depending on
-   format being produced */
-/* Define the possible format classes */
-#define KWALL (1<<NC_FORMAT_CLASSIC|1<<NC_FORMAT_64BIT_OFFSET|1<<NC_FORMAT_NETCDF4|1<<NC_FORMAT_NETCDF4_CLASSIC|1<<NC_FORMAT_64BIT_DATA) /* Used in all formats */
-#define KWCDF5 (1<<NC_FORMAT_64BIT_DATA) /* Used in cdf5 */
-#define KWNC4 (1<<NC_FORMAT_NETCDF4) /* Used in netcdf-4 */
-
-#define NKWIDENT 12
-struct KWIDENT {
-    int token;
-    const char* keyword;
-    int formats; /* Which formats use this keyword */
-} kwident[NKWIDENT] = {
-/* Order by token for binary search */
-{CHAR_K, "char", KWALL},
-{BYTE_K, "byte", KWALL},
-{SHORT_K, "short", KWALL},
-{INT_K, "int", KWALL},
-{FLOAT_K, "float", KWALL},
-{DOUBLE_K, "double", KWALL},
-{UBYTE_K, "ubyte", KWCDF5|KWNC4},
-{USHORT_K, "ushort", KWCDF5|KWNC4},
-{UINT_K, "uint", KWCDF5|KWNC4},
-{INT64_K, "int64", KWCDF5|KWNC4},
-{UINT64_K, "uint64", KWCDF5|KWNC4},
-{STRING_K, "string", KWNC4}
-};
-static int identorkw(int token);
 
 %}
 %x ST_C_COMMENT
@@ -290,27 +263,33 @@ yytext[MAXTRST-1] = '\0';
 		return lexdebug(OPAQUESTRING);
 		}
 
-compound|struct|structure {return lexdebug(identorkw(COMPOUND));}
-enum				{return lexdebug(identorkw(ENUM));}
+compound|struct|structure {return lexdebug(COMPOUND);}
+enum				{return lexdebug(ENUM);}
 opaque				{return lexdebug(OPAQUE_);}
 
-float|real		{return lexdebug(identorkw(FLOAT_K));}
-char			{return lexdebug(identorkw(CHAR_K));}
-byte			{return lexdebug(identorkw(BYTE_K));}
-ubyte			{return lexdebug(identorkw(UBYTE_K));}
-short			{return lexdebug(identorkw(SHORT_K));}
-ushort			{return lexdebug(identorkw(USHORT_K));}
-long|int|integer	{return lexdebug(identorkw(INT_K));}
-ulong|uint|uinteger	{return lexdebug(identorkw(UINT_K));}
-int64			{return lexdebug(identorkw(INT64_K));}
-uint64			{return lexdebug(identorkw(UINT64_K));}
-double			{return lexdebug(identorkw(DOUBLE_K));}
-string                  {return lexdebug(identorkw(STRING_K));}
+float			{return lexdebug(FLOAT_K);}
+double			{return lexdebug(DOUBLE_K);}
+char			{return lexdebug(CHAR_K);}
+byte			{return lexdebug(BYTE_K);}
+short			{return lexdebug(SHORT_K);}
+int			{return lexdebug(INT_K);}
+ubyte			{return lexdebug(identcheck(UBYTE_K));}
+ushort			{return lexdebug(identcheck(USHORT_K));}
+uint			{return lexdebug(identcheck(UINT_K));}
+int64			{return lexdebug(identcheck(INT64_K));}
+uint64			{return lexdebug(identcheck(UINT64_K));}
+string                  {return lexdebug(identcheck(STRING_K));}
+
+real			{return lexdebug(FLOAT_K);}
+long			{return lexdebug(INT_K);}
+integer			{return lexdebug(INT_K);}
+ulong			{return lexdebug(identcheck(UINT_K));}
+uinteger		{return lexdebug(identcheck(UINT_K));}
+
 
 unlimited|UNLIMITED	{int32_val = -1;
-			 return lexdebug(identorkw(NC_UNLIMITED_K));}
+			 return lexdebug(NC_UNLIMITED_K);}
 
-			/* These are currently only keywords */
 types:			{return lexdebug(TYPES);}
 dimensions:		{return lexdebug(DIMENSIONS);}
 variables:		{return lexdebug(VARIABLES);}
@@ -620,9 +599,7 @@ lexdebug(int token)
 {
     if(debug >= 2)
     {
-	char* text = yytext;
-	text[yyleng] = 0;
-        fprintf(stderr,"Token=%d |%s| line=%d\n",token,text,lineno);
+        fprintf(stderr,"Token=%d |%s| line=%d\n",token,yytext,lineno);
     }
     return token;
 }
@@ -907,38 +884,28 @@ collecttag(char* text, char** stagp)
     return tag;
 }
 
-/* Depending on the format, a name may be a keword or an ident */
 static int
-identorkw(int token)
+identcheck(int token)
 {
-    /* Binary search for yytext */
-    int n = NKWIDENT;
-    int L = 0;
-    int R = (n - 1);
-    int m, cmp;
-    struct KWIDENT* p;
-    int found = 0;
-    size_t len;
-    char* id = NULL;
-
-    for(;;) {
-	if(L > R) break;
-        m = (L + R) / 2;
-	p = &kwident[m];
-	cmp = (p->token - token);
-	if(cmp == 0) {found = 1; break;}
-	if(cmp < 0)
-	    L = (m + 1);
-	else /*cmp > 0*/
-	    R = (m - 1);
+    switch (token) {
+    case UBYTE_K:
+    case USHORT_K:
+    case UINT_K:
+    case INT64_K:
+    case UINT64_K:
+	if(k_flag != NC_FORMAT_NETCDF4 	&& k_flag != NC_FORMAT_64BIT_DATA) {
+	    yylval.sym = install(yytext);
+   	    token = IDENT;
+	}
+	break;
+    case STRING_K:
+	if(k_flag != NC_FORMAT_NETCDF4) {
+	    yylval.sym = install(yytext);
+   	    token = IDENT;
+	}
+	break;
+    default:
+         break;    
     }
-    if(!found) return token; /* Not a keyword of interest */
-    /* See if the format applies */
-    if(p->formats & ((int)1<<k_flag)) return token;
-    /* Need to convert a non-ident token to an ident symbol */
-    len = strlen(yytext);
-    len = unescape(yytext,len,ISIDENT,&id);
-    yylval.sym = install(id);
-    efree(id);
-    return IDENT; /* treat as identifier */
+    return token;
 }

--- a/ncgen/ncgenl.c
+++ b/ncgen/ncgenl.c
@@ -1,5 +1,5 @@
 
-#line 3 "ncgenl.c"
+#line 2 "ncgenl.c"
 
 #define  YY_INT_ALIGNED short int
 
@@ -7,11 +7,17 @@
 
 #define yy_create_buffer ncg_create_buffer
 #define yy_delete_buffer ncg_delete_buffer
-#define yy_flex_debug ncg_flex_debug
+#define yy_scan_buffer ncg_scan_buffer
+#define yy_scan_string ncg_scan_string
+#define yy_scan_bytes ncg_scan_bytes
 #define yy_init_buffer ncg_init_buffer
 #define yy_flush_buffer ncg_flush_buffer
 #define yy_load_buffer_state ncg_load_buffer_state
 #define yy_switch_to_buffer ncg_switch_to_buffer
+#define yypush_buffer_state ncgpush_buffer_state
+#define yypop_buffer_state ncgpop_buffer_state
+#define yyensure_buffer_stack ncgensure_buffer_stack
+#define yy_flex_debug ncg_flex_debug
 #define yyin ncgin
 #define yyleng ncgleng
 #define yylex ncglex
@@ -27,9 +33,243 @@
 #define FLEX_SCANNER
 #define YY_FLEX_MAJOR_VERSION 2
 #define YY_FLEX_MINOR_VERSION 6
-#define YY_FLEX_SUBMINOR_VERSION 0
+#define YY_FLEX_SUBMINOR_VERSION 4
 #if YY_FLEX_SUBMINOR_VERSION > 0
 #define FLEX_BETA
+#endif
+
+#ifdef yy_create_buffer
+#define ncg_create_buffer_ALREADY_DEFINED
+#else
+#define yy_create_buffer ncg_create_buffer
+#endif
+
+#ifdef yy_delete_buffer
+#define ncg_delete_buffer_ALREADY_DEFINED
+#else
+#define yy_delete_buffer ncg_delete_buffer
+#endif
+
+#ifdef yy_scan_buffer
+#define ncg_scan_buffer_ALREADY_DEFINED
+#else
+#define yy_scan_buffer ncg_scan_buffer
+#endif
+
+#ifdef yy_scan_string
+#define ncg_scan_string_ALREADY_DEFINED
+#else
+#define yy_scan_string ncg_scan_string
+#endif
+
+#ifdef yy_scan_bytes
+#define ncg_scan_bytes_ALREADY_DEFINED
+#else
+#define yy_scan_bytes ncg_scan_bytes
+#endif
+
+#ifdef yy_init_buffer
+#define ncg_init_buffer_ALREADY_DEFINED
+#else
+#define yy_init_buffer ncg_init_buffer
+#endif
+
+#ifdef yy_flush_buffer
+#define ncg_flush_buffer_ALREADY_DEFINED
+#else
+#define yy_flush_buffer ncg_flush_buffer
+#endif
+
+#ifdef yy_load_buffer_state
+#define ncg_load_buffer_state_ALREADY_DEFINED
+#else
+#define yy_load_buffer_state ncg_load_buffer_state
+#endif
+
+#ifdef yy_switch_to_buffer
+#define ncg_switch_to_buffer_ALREADY_DEFINED
+#else
+#define yy_switch_to_buffer ncg_switch_to_buffer
+#endif
+
+#ifdef yypush_buffer_state
+#define ncgpush_buffer_state_ALREADY_DEFINED
+#else
+#define yypush_buffer_state ncgpush_buffer_state
+#endif
+
+#ifdef yypop_buffer_state
+#define ncgpop_buffer_state_ALREADY_DEFINED
+#else
+#define yypop_buffer_state ncgpop_buffer_state
+#endif
+
+#ifdef yyensure_buffer_stack
+#define ncgensure_buffer_stack_ALREADY_DEFINED
+#else
+#define yyensure_buffer_stack ncgensure_buffer_stack
+#endif
+
+#ifdef yylex
+#define ncglex_ALREADY_DEFINED
+#else
+#define yylex ncglex
+#endif
+
+#ifdef yyrestart
+#define ncgrestart_ALREADY_DEFINED
+#else
+#define yyrestart ncgrestart
+#endif
+
+#ifdef yylex_init
+#define ncglex_init_ALREADY_DEFINED
+#else
+#define yylex_init ncglex_init
+#endif
+
+#ifdef yylex_init_extra
+#define ncglex_init_extra_ALREADY_DEFINED
+#else
+#define yylex_init_extra ncglex_init_extra
+#endif
+
+#ifdef yylex_destroy
+#define ncglex_destroy_ALREADY_DEFINED
+#else
+#define yylex_destroy ncglex_destroy
+#endif
+
+#ifdef yyget_debug
+#define ncgget_debug_ALREADY_DEFINED
+#else
+#define yyget_debug ncgget_debug
+#endif
+
+#ifdef yyset_debug
+#define ncgset_debug_ALREADY_DEFINED
+#else
+#define yyset_debug ncgset_debug
+#endif
+
+#ifdef yyget_extra
+#define ncgget_extra_ALREADY_DEFINED
+#else
+#define yyget_extra ncgget_extra
+#endif
+
+#ifdef yyset_extra
+#define ncgset_extra_ALREADY_DEFINED
+#else
+#define yyset_extra ncgset_extra
+#endif
+
+#ifdef yyget_in
+#define ncgget_in_ALREADY_DEFINED
+#else
+#define yyget_in ncgget_in
+#endif
+
+#ifdef yyset_in
+#define ncgset_in_ALREADY_DEFINED
+#else
+#define yyset_in ncgset_in
+#endif
+
+#ifdef yyget_out
+#define ncgget_out_ALREADY_DEFINED
+#else
+#define yyget_out ncgget_out
+#endif
+
+#ifdef yyset_out
+#define ncgset_out_ALREADY_DEFINED
+#else
+#define yyset_out ncgset_out
+#endif
+
+#ifdef yyget_leng
+#define ncgget_leng_ALREADY_DEFINED
+#else
+#define yyget_leng ncgget_leng
+#endif
+
+#ifdef yyget_text
+#define ncgget_text_ALREADY_DEFINED
+#else
+#define yyget_text ncgget_text
+#endif
+
+#ifdef yyget_lineno
+#define ncgget_lineno_ALREADY_DEFINED
+#else
+#define yyget_lineno ncgget_lineno
+#endif
+
+#ifdef yyset_lineno
+#define ncgset_lineno_ALREADY_DEFINED
+#else
+#define yyset_lineno ncgset_lineno
+#endif
+
+#ifdef yywrap
+#define ncgwrap_ALREADY_DEFINED
+#else
+#define yywrap ncgwrap
+#endif
+
+#ifdef yyalloc
+#define ncgalloc_ALREADY_DEFINED
+#else
+#define yyalloc ncgalloc
+#endif
+
+#ifdef yyrealloc
+#define ncgrealloc_ALREADY_DEFINED
+#else
+#define yyrealloc ncgrealloc
+#endif
+
+#ifdef yyfree
+#define ncgfree_ALREADY_DEFINED
+#else
+#define yyfree ncgfree
+#endif
+
+#ifdef yytext
+#define ncgtext_ALREADY_DEFINED
+#else
+#define yytext ncgtext
+#endif
+
+#ifdef yyleng
+#define ncgleng_ALREADY_DEFINED
+#else
+#define yyleng ncgleng
+#endif
+
+#ifdef yyin
+#define ncgin_ALREADY_DEFINED
+#else
+#define yyin ncgin
+#endif
+
+#ifdef yyout
+#define ncgout_ALREADY_DEFINED
+#else
+#define yyout ncgout
+#endif
+
+#ifdef yy_flex_debug
+#define ncg_flex_debug_ALREADY_DEFINED
+#else
+#define yy_flex_debug ncg_flex_debug
+#endif
+
+#ifdef yylineno
+#define ncglineno_ALREADY_DEFINED
+#else
+#define yylineno ncglineno
 #endif
 
 /* First, we deal with  platform-specific or compiler-specific issues. */
@@ -102,60 +342,48 @@ typedef unsigned int flex_uint32_t;
 #define UINT32_MAX             (4294967295U)
 #endif
 
+#ifndef SIZE_MAX
+#define SIZE_MAX               (~(size_t)0)
+#endif
+
 #endif /* ! C99 */
 
 #endif /* ! FLEXINT_H */
 
-#ifdef __cplusplus
+/* begin standard C++ headers. */
 
-/* The "const" storage-class-modifier is valid. */
-#define YY_USE_CONST
-
-#else	/* ! __cplusplus */
-
-/* C99 requires __STDC__ to be defined as 1. */
-#if defined (__STDC__)
-
-#define YY_USE_CONST
-
-#endif	/* defined (__STDC__) */
-#endif	/* ! __cplusplus */
-
-#ifdef YY_USE_CONST
+/* TODO: this is always defined, so inline it */
 #define yyconst const
+
+#if defined(__GNUC__) && __GNUC__ >= 3
+#define yynoreturn __attribute__((__noreturn__))
 #else
-#define yyconst
+#define yynoreturn
 #endif
 
 /* Returned upon end-of-file. */
 #define YY_NULL 0
 
-/* Promotes a possibly negative, possibly signed char to an unsigned
- * integer for use as an array index.  If the signed char is negative,
- * we want to instead treat it as an 8-bit unsigned char, hence the
- * double cast.
+/* Promotes a possibly negative, possibly signed char to an
+ *   integer in range [0..255] for use as an array index.
  */
-#define YY_SC_TO_UI(c) ((unsigned int) (unsigned char) c)
+#define YY_SC_TO_UI(c) ((YY_CHAR) (c))
 
 /* Enter a start condition.  This macro really ought to take a parameter,
  * but we do it the disgusting crufty way forced on us by the ()-less
  * definition of BEGIN.
  */
 #define BEGIN (yy_start) = 1 + 2 *
-
 /* Translate the current start state into a value that can be later handed
  * to BEGIN to return to the state.  The YYSTATE alias is for lex
  * compatibility.
  */
 #define YY_START (((yy_start) - 1) / 2)
 #define YYSTATE YY_START
-
 /* Action number for EOF rule of a given start state. */
 #define YY_STATE_EOF(state) (YY_END_OF_BUFFER + state + 1)
-
 /* Special action meaning "start processing a new file". */
-#define YY_NEW_FILE ncgrestart(ncgin  )
-
+#define YY_NEW_FILE yyrestart( yyin  )
 #define YY_END_OF_BUFFER_CHAR 0
 
 /* Size of default input buffer. */
@@ -185,14 +413,14 @@ typedef struct yy_buffer_state *YY_BUFFER_STATE;
 typedef size_t yy_size_t;
 #endif
 
-extern yy_size_t ncgleng;
+extern int yyleng;
 
-extern FILE *ncgin, *ncgout;
+extern FILE *yyin, *yyout;
 
 #define EOB_ACT_CONTINUE_SCAN 0
 #define EOB_ACT_END_OF_FILE 1
 #define EOB_ACT_LAST_MATCH 2
-
+    
     #define YY_LESS_LINENO(n)
     #define YY_LINENO_REWIND_TO(ptr)
     
@@ -200,16 +428,15 @@ extern FILE *ncgin, *ncgout;
 #define yyless(n) \
 	do \
 		{ \
-		/* Undo effects of setting up ncgtext. */ \
+		/* Undo effects of setting up yytext. */ \
         int yyless_macro_arg = (n); \
         YY_LESS_LINENO(yyless_macro_arg);\
 		*yy_cp = (yy_hold_char); \
 		YY_RESTORE_YY_MORE_OFFSET \
 		(yy_c_buf_p) = yy_cp = yy_bp + yyless_macro_arg - YY_MORE_ADJ; \
-		YY_DO_BEFORE_ACTION; /* set up ncgtext again */ \
+		YY_DO_BEFORE_ACTION; /* set up yytext again */ \
 		} \
 	while ( 0 )
-
 #define unput(c) yyunput( c, (yytext_ptr)  )
 
 #ifndef YY_STRUCT_YY_BUFFER_STATE
@@ -224,7 +451,7 @@ struct yy_buffer_state
 	/* Size of input buffer in bytes, not including room for EOB
 	 * characters.
 	 */
-	yy_size_t yy_buf_size;
+	int yy_buf_size;
 
 	/* Number of characters read into yy_ch_buf, not including EOB
 	 * characters.
@@ -252,7 +479,7 @@ struct yy_buffer_state
 
     int yy_bs_lineno; /**< The line count. */
     int yy_bs_column; /**< The column count. */
-    
+
 	/* Whether to try to fill the input buffer when we reach the
 	 * end of it.
 	 */
@@ -269,8 +496,8 @@ struct yy_buffer_state
 	 * possible backing-up.
 	 *
 	 * When we actually see the EOF, we change the status to "new"
-	 * (via ncgrestart()), so that the user can continue scanning by
-	 * just pointing ncgin at a new input file.
+	 * (via yyrestart()), so that the user can continue scanning by
+	 * just pointing yyin at a new input file.
 	 */
 #define YY_BUFFER_EOF_PENDING 2
 
@@ -280,7 +507,7 @@ struct yy_buffer_state
 /* Stack of input buffers. */
 static size_t yy_buffer_stack_top = 0; /**< index of top of stack. */
 static size_t yy_buffer_stack_max = 0; /**< capacity of stack. */
-static YY_BUFFER_STATE * yy_buffer_stack = 0; /**< Stack as an array. */
+static YY_BUFFER_STATE * yy_buffer_stack = NULL; /**< Stack as an array. */
 
 /* We provide macros for accessing buffer states in case in the
  * future we want to put the buffer states in a more general
@@ -291,111 +518,100 @@ static YY_BUFFER_STATE * yy_buffer_stack = 0; /**< Stack as an array. */
 #define YY_CURRENT_BUFFER ( (yy_buffer_stack) \
                           ? (yy_buffer_stack)[(yy_buffer_stack_top)] \
                           : NULL)
-
 /* Same as previous macro, but useful when we know that the buffer stack is not
  * NULL or when we need an lvalue. For internal use only.
  */
 #define YY_CURRENT_BUFFER_LVALUE (yy_buffer_stack)[(yy_buffer_stack_top)]
 
-/* yy_hold_char holds the character lost when ncgtext is formed. */
+/* yy_hold_char holds the character lost when yytext is formed. */
 static char yy_hold_char;
 static int yy_n_chars;		/* number of characters read into yy_ch_buf */
-yy_size_t ncgleng;
+int yyleng;
 
 /* Points to current character in buffer. */
-static char *yy_c_buf_p = (char *) 0;
+static char *yy_c_buf_p = NULL;
 static int yy_init = 0;		/* whether we need to initialize */
 static int yy_start = 0;	/* start state number */
 
-/* Flag which is used to allow ncgwrap()'s to do buffer switches
- * instead of setting up a fresh ncgin.  A bit of a hack ...
+/* Flag which is used to allow yywrap()'s to do buffer switches
+ * instead of setting up a fresh yyin.  A bit of a hack ...
  */
 static int yy_did_buffer_switch_on_eof;
 
-void ncgrestart (FILE *input_file  );
-void ncg_switch_to_buffer (YY_BUFFER_STATE new_buffer  );
-YY_BUFFER_STATE ncg_create_buffer (FILE *file,int size  );
-void ncg_delete_buffer (YY_BUFFER_STATE b  );
-void ncg_flush_buffer (YY_BUFFER_STATE b  );
-void ncgpush_buffer_state (YY_BUFFER_STATE new_buffer  );
-void ncgpop_buffer_state (void );
+void yyrestart ( FILE *input_file  );
+void yy_switch_to_buffer ( YY_BUFFER_STATE new_buffer  );
+YY_BUFFER_STATE yy_create_buffer ( FILE *file, int size  );
+void yy_delete_buffer ( YY_BUFFER_STATE b  );
+void yy_flush_buffer ( YY_BUFFER_STATE b  );
+void yypush_buffer_state ( YY_BUFFER_STATE new_buffer  );
+void yypop_buffer_state ( void );
 
-static void ncgensure_buffer_stack (void );
-static void ncg_load_buffer_state (void );
-static void ncg_init_buffer (YY_BUFFER_STATE b,FILE *file  );
+static void yyensure_buffer_stack ( void );
+static void yy_load_buffer_state ( void );
+static void yy_init_buffer ( YY_BUFFER_STATE b, FILE *file  );
+#define YY_FLUSH_BUFFER yy_flush_buffer( YY_CURRENT_BUFFER )
 
-#define YY_FLUSH_BUFFER ncg_flush_buffer(YY_CURRENT_BUFFER )
+YY_BUFFER_STATE yy_scan_buffer ( char *base, yy_size_t size  );
+YY_BUFFER_STATE yy_scan_string ( const char *yy_str  );
+YY_BUFFER_STATE yy_scan_bytes ( const char *bytes, int len  );
 
-YY_BUFFER_STATE ncg_scan_buffer (char *base,yy_size_t size  );
-YY_BUFFER_STATE ncg_scan_string (yyconst char *yy_str  );
-YY_BUFFER_STATE ncg_scan_bytes (yyconst char *bytes,yy_size_t len  );
+void *yyalloc ( yy_size_t  );
+void *yyrealloc ( void *, yy_size_t  );
+void yyfree ( void *  );
 
-void *ncgalloc (yy_size_t  );
-void *ncgrealloc (void *,yy_size_t  );
-void ncgfree (void *  );
-
-#define yy_new_buffer ncg_create_buffer
-
+#define yy_new_buffer yy_create_buffer
 #define yy_set_interactive(is_interactive) \
 	{ \
 	if ( ! YY_CURRENT_BUFFER ){ \
-        ncgensure_buffer_stack (); \
+        yyensure_buffer_stack (); \
 		YY_CURRENT_BUFFER_LVALUE =    \
-            ncg_create_buffer(ncgin,YY_BUF_SIZE ); \
+            yy_create_buffer( yyin, YY_BUF_SIZE ); \
 	} \
 	YY_CURRENT_BUFFER_LVALUE->yy_is_interactive = is_interactive; \
 	}
-
 #define yy_set_bol(at_bol) \
 	{ \
 	if ( ! YY_CURRENT_BUFFER ){\
-        ncgensure_buffer_stack (); \
+        yyensure_buffer_stack (); \
 		YY_CURRENT_BUFFER_LVALUE =    \
-            ncg_create_buffer(ncgin,YY_BUF_SIZE ); \
+            yy_create_buffer( yyin, YY_BUF_SIZE ); \
 	} \
 	YY_CURRENT_BUFFER_LVALUE->yy_at_bol = at_bol; \
 	}
-
 #define YY_AT_BOL() (YY_CURRENT_BUFFER_LVALUE->yy_at_bol)
 
 /* Begin user sect3 */
+typedef flex_uint8_t YY_CHAR;
 
-typedef unsigned char YY_CHAR;
-
-FILE *ncgin = (FILE *) 0, *ncgout = (FILE *) 0;
+FILE *yyin = NULL, *yyout = NULL;
 
 typedef int yy_state_type;
 
-extern int ncglineno;
+extern int yylineno;
+int yylineno = 1;
 
-int ncglineno = 1;
-
-extern char *ncgtext;
+extern char *yytext;
 #ifdef yytext_ptr
 #undef yytext_ptr
 #endif
-#define yytext_ptr ncgtext
+#define yytext_ptr yytext
 
-static yy_state_type yy_get_previous_state (void );
-static yy_state_type yy_try_NUL_trans (yy_state_type current_state  );
-static int yy_get_next_buffer (void );
-#if defined(__GNUC__) && __GNUC__ >= 3
-__attribute__((__noreturn__))
-#endif
-static void yy_fatal_error (yyconst char msg[]  );
+static yy_state_type yy_get_previous_state ( void );
+static yy_state_type yy_try_NUL_trans ( yy_state_type current_state  );
+static int yy_get_next_buffer ( void );
+static void yynoreturn yy_fatal_error ( const char* msg  );
 
 /* Done after the current pattern has been matched and before the
- * corresponding action - sets up ncgtext.
+ * corresponding action - sets up yytext.
  */
 #define YY_DO_BEFORE_ACTION \
 	(yytext_ptr) = yy_bp; \
-	ncgleng = (size_t) (yy_cp - yy_bp); \
+	yyleng = (int) (yy_cp - yy_bp); \
 	(yy_hold_char) = *yy_cp; \
 	*yy_cp = '\0'; \
 	(yy_c_buf_p) = yy_cp;
-
-#define YY_NUM_RULES 49
-#define YY_END_OF_BUFFER 50
+#define YY_NUM_RULES 54
+#define YY_END_OF_BUFFER 55
 /* This struct is not used in this scanner,
    but its presence is necessary. */
 struct yy_trans_info
@@ -403,58 +619,58 @@ struct yy_trans_info
 	flex_int32_t yy_verify;
 	flex_int32_t yy_nxt;
 	};
-static yyconst flex_int16_t yy_accept[422] =
+static const flex_int16_t yy_accept[425] =
     {   0,
-        0,    0,   46,   46,    0,    0,   50,   48,    1,   44,
-       48,   48,   48,   48,   38,   32,   36,   36,   35,   35,
-       35,   35,   35,   35,   35,   48,   35,   35,   35,   35,
-       35,   35,   35,   35,   35,   35,   35,   35,   35,   35,
-       35,   35,   48,   48,   48,   46,   49,   34,   49,    1,
-        0,    3,    0,    0,    0,   38,   36,    0,    0,   38,
-       38,    0,   39,   45,    2,   32,    0,    0,    0,    0,
-       36,   36,   36,   36,    0,   35,    0,    0,    0,    0,
-       35,   35,   35,   35,   35,   35,   35,   35,   35,   35,
-       35,   35,   35,   35,   35,   35,   35,   35,   35,   35,
+        0,    0,   51,   51,    0,    0,   55,   53,    1,   49,
+       53,   53,   53,   53,   43,   37,   41,   41,   40,   40,
+       40,   40,   40,   40,   40,   53,   40,   40,   40,   40,
+       40,   40,   40,   40,   40,   40,   40,   40,   40,   40,
+       40,   40,   53,   53,   53,   51,   54,   39,   54,    1,
+        0,    3,    0,    0,    0,   43,   41,    0,    0,   43,
+       43,    0,   44,   50,    2,   37,    0,    0,    0,    0,
+       41,   41,   41,   41,    0,   40,    0,    0,    0,    0,
+       40,   40,   40,   40,   40,   40,   40,   40,   40,   40,
+       40,   40,   40,   40,   40,   40,   40,   40,   40,   40,
 
-       35,   35,   35,   35,   35,   35,   35,   35,   35,   35,
-       35,   35,   35,   35,   35,   35,   35,   35,   35,   35,
-       35,   35,   35,    0,    0,   46,    0,   47,   34,   40,
-        0,    0,    0,    0,   38,    0,    0,   38,    2,   32,
+       40,   40,   40,   40,   40,   40,   40,   40,   40,   40,
+       40,   40,   40,   40,   40,   40,   40,   40,   40,   40,
+       40,   40,   40,    0,    0,   51,    0,   52,   39,   45,
+        0,    0,    0,    0,   43,    0,    0,   43,    2,   37,
         0,    0,    0,    0,    0,    0,    0,    4,    0,    0,
-       35,   35,   35,   35,   35,   35,   31,   28,   35,   35,
-       35,   35,   35,   35,   35,   35,   35,   35,   35,   35,
-       35,   35,   35,   35,   35,   35,   35,   35,   35,   35,
-       14,   35,   28,   35,   35,   35,   35,   35,   35,   35,
-       35,   35,   35,   35,   35,    0,   43,    0,    0,   38,
+       40,   40,   40,   40,   40,   40,   36,   33,   40,   40,
+       40,   40,   40,   40,   40,   40,   40,   40,   40,   40,
+       40,   40,   40,   40,   40,   40,   40,   40,   40,   40,
+       13,   40,   33,   40,   40,   40,   40,   40,   40,   40,
+       40,   40,   40,   40,   40,    0,   48,    0,    0,   43,
 
-        0,   32,    0,    0,    0,    0,    0,    0,    0,    4,
-       37,   37,    0,   35,   35,   29,   35,   35,   30,   35,
-       35,   35,   35,   35,   35,   35,   35,   35,   35,   35,
-       35,   35,   10,    9,   35,   35,   35,   35,    6,   35,
-       35,   35,   35,   14,   35,   35,   35,    8,   35,   35,
-       35,   35,   35,   15,   35,   35,   35,   35,    0,    0,
-       29,    0,   32,    0,    0,    0,    0,    0,    0,    0,
-       35,   35,   35,   35,   35,   35,   35,   35,   35,   35,
-       35,   35,   35,   35,   35,   35,   35,   35,   35,   24,
-       35,   35,   35,   16,   35,   35,   35,   35,   12,   35,
+        0,   37,    0,    0,    0,    0,    0,    0,    0,    4,
+       42,   42,    0,   40,   40,   34,   40,   40,   35,   40,
+       40,   40,   40,   40,   40,   40,   40,   40,   40,   40,
+       40,   40,   11,   10,   40,   40,   40,   40,    6,   40,
+       40,   40,   40,   21,   40,   40,   40,   20,   40,   40,
+       40,   40,   40,   16,   40,   40,   40,   40,    0,    0,
+       34,    0,   37,    0,    0,    0,    0,    0,    0,    0,
+       40,   40,   40,   40,   40,   40,   40,   40,   40,   40,
+       40,   40,   40,   40,   40,   40,   40,   40,   40,   29,
+       40,   40,    8,   40,   17,   40,   40,   40,   40,   12,
 
-       35,   35,   11,   35,   35,   15,   35,   35,   35,   41,
-       42,    0,    0,    0,    0,   35,   35,   35,   26,   35,
-       35,   35,   35,   35,   35,   35,   35,   35,   35,   35,
-       35,   35,   35,   35,   35,   18,   25,   35,    7,   19,
-        5,   21,   17,   35,   35,   13,   35,    0,    0,   35,
-       35,   35,   35,   35,   35,   35,   35,   33,   35,   35,
-       35,   35,   35,   35,   35,   35,   35,   35,   35,   35,
-        0,   35,   27,   35,   35,   35,   35,   35,   35,   35,
-       35,   35,    5,   35,   35,   35,   35,   27,   27,   20,
-       35,   35,   35,   35,   35,   35,   35,   35,   35,   35,
+       40,   40,   40,   14,   40,   40,   23,   40,   40,   40,
+       46,   47,    0,    0,    0,    0,   40,   40,   40,   31,
+       40,   40,   40,   40,   40,   40,   40,   40,   40,   40,
+       40,   40,   40,   40,   40,   40,    9,   30,   40,    7,
+       19,    5,   26,   18,   40,   40,   15,   40,    0,    0,
+       40,   40,   40,   40,   40,   40,   40,   40,   38,   40,
+       40,   40,   40,   40,   40,   40,   40,   22,   40,   40,
+       40,   40,    0,   40,   32,   40,   40,   40,   40,   40,
+       40,   40,   40,   40,    5,   40,   40,   24,   40,   40,
+       32,   32,   25,   40,   40,   40,   40,   40,   40,   40,
 
-       35,   35,   35,   35,   35,   35,   35,   23,   35,   35,
-       35,   22,   35,   35,   35,   35,   35,   35,   35,   35,
-        0
+       40,   40,   40,   40,   40,   40,   40,   40,   40,   40,
+       28,   40,   40,   40,   27,   40,   40,   40,   40,   40,
+       40,   40,   40,    0
     } ;
 
-static yyconst YY_CHAR yy_ec[256] =
+static const YY_CHAR yy_ec[256] =
     {   0,
         1,    1,    1,    1,    1,    1,    1,    1,    2,    3,
         1,    2,    2,    1,    1,    1,    1,    1,    1,    1,
@@ -486,7 +702,7 @@ static yyconst YY_CHAR yy_ec[256] =
         1,    1,    1,    1,    1
     } ;
 
-static yyconst YY_CHAR yy_meta[69] =
+static const YY_CHAR yy_meta[69] =
     {   0,
         1,    1,    2,    1,    1,    1,    3,    4,    5,    5,
         6,    7,    8,    8,    8,    8,    8,    8,    8,    1,
@@ -497,111 +713,113 @@ static yyconst YY_CHAR yy_meta[69] =
        11,   11,   11,   14,    1,   11,   11,   11
     } ;
 
-static yyconst flex_uint16_t yy_base[440] =
+static const flex_int16_t yy_base[443] =
     {   0,
-        0,    0,  325,  321,  264,  255,  318, 2387,   67, 2387,
+        0,    0,  325,  321,  264,  255,  318, 2461,   67, 2461,
        64,  269,   61,   62,   95,   77,  136,  259,   51,   61,
       188,   97,  118,  150,   65,  195,  233,  153,  183,  222,
       241,  202,  207,  213,  238,  246,  243,  257,  268,  264,
-      298,  276,  221,  219,  218,  270,  236,    0, 2387,   79,
-       87, 2387,  244,  238,  344,    0,  206,  358,  190,    0,
-     2387,  370, 2387, 2387,    0,  342,  377,  177,  175,  174,
-      200, 2387,   54,  377,    0,  254,  397,  171,  170,  169,
+      298,  276,  221,  219,  218,  270,  236,    0, 2461,   79,
+       87, 2461,  244,  238,  344,    0,  206,  358,  190,    0,
+     2461,  370, 2461, 2461,    0,  342,  377,  177,  175,  174,
+      200, 2461,   54,  377,    0,  254,  397,  171,  170,  169,
       358,   85,  404,  373,  376,  398,  391,  406,  412,  417,
       421,  428,  432,  451,  454,  443,  473,  476,  486,  489,
 
       494,  499,  511,  508,  520,  530,  546,  542,  550,  553,
       556,  560,  563,  566,  586,  598,  602,  605,  608,  623,
-      612,  644,  647,  168,  167,  222,  217, 2387,    0, 2387,
+      612,  644,  647,  168,  167,  222,  217, 2461,    0, 2461,
       221,  680,  219,  703,  710,  179,  728,  749,    0,  691,
       666,  765,  159,  158,  135,  130,  128,  651,  125,  123,
       739,  716,  721,  751,  764,  770,  757,  775,  783,  760,
       794,  800,  806,  809,  813,  824,  820,  844,  839,  830,
       854,  850,  862,  869,  874,  886,  904,  893,  908,  917,
       947,  934,  912,  964,  943,  954,  900,  957,  973,  969,
-      987,  990,  995, 1006,  999,  118, 2387,  735,    0, 2387,
+      987,  990,  995, 1006,  999,  118, 2461,  735,    0, 2461,
 
        50, 1030, 1062,  117,  115,  112,  110,  108,  104,  904,
-       72, 2387,  103, 1020, 1025, 1043, 1046, 1064, 1051, 1069,
+       72, 2461,  103, 1020, 1025, 1043, 1046, 1064, 1051, 1069,
      1076, 1055, 1085, 1088, 1099, 1094, 1118, 1102, 1125, 1132,
      1137, 1142, 1149, 1156, 1167, 1162, 1172, 1175, 1179, 1192,
      1197, 1210, 1214, 1205, 1223, 1230, 1227, 1217, 1240, 1247,
      1262, 1253, 1265, 1298, 1278, 1283, 1295, 1301,  160,  154,
-     2387,  107, 1314, 1350,   93,   91,   77,   73,   72,   70,
+     2461,  107, 1314, 1350,   93,   91,   77,   73,   72,   70,
      1332, 1344, 1335, 1320, 1356, 1340, 1352, 1374, 1388, 1391,
-     1366, 1396, 1406, 1412, 1409, 1422, 1428, 1442, 1445, 2387,
-     1448, 1452, 1462, 1459, 1478, 1465, 1495, 1498, 1482, 1508,
+     1366, 1396, 1406, 1412, 1409, 1422, 1428, 1442, 1445, 2461,
+     1448, 1452, 1459, 1462, 1465, 1478, 1495, 1501, 1498, 1482,
 
-     1501, 1515, 1485, 1519, 1531, 1534, 1540, 1545, 1549, 2387,
-     2387,   85,   65,   59,   36, 1564, 1556, 1575, 1553, 1590,
-     1571, 1587, 1594, 1609, 1606, 1601, 1612, 1627, 1642, 1645,
-     1648, 1651, 1661, 1667, 1682, 1685, 2387, 1697, 1691, 1700,
-     1716, 2387, 1703, 1733, 1721, 1707, 1740,   39,   27, 1751,
-     1746, 1754, 1770, 1766, 1758, 1788, 1784, 1763, 1800, 1803,
-     1814, 1818, 1833, 1807, 1821, 1825, 1837, 1851, 1857, 1867,
-       24, 1870, 1874, 1882, 1888, 1892, 1900, 1904, 1908, 1923,
-     1938, 1934, 1913, 1943, 1918, 1948, 1954,   36, 1958, 1964,
-     1968, 1978, 1989, 1994, 2002, 2010, 1999, 2020, 2013, 2033,
+     1512, 1515, 1518, 1521, 1536, 1551, 1533, 1556, 1567, 1570,
+     2461, 2461,   85,   65,   59,   36, 1581, 1574, 1586, 1589,
+     1604, 1612, 1622, 1629, 1619, 1626, 1636, 1652, 1662, 1659,
+     1670, 1673, 1676, 1692, 1696, 1706, 1709, 2461, 1712, 1715,
+     1718, 1727, 2461, 1722, 1752, 1757, 1732, 1762,   39,   27,
+     1768, 1765, 1775, 1783, 1778, 1808, 1799, 1817, 1820, 1824,
+     1833, 1850, 1857, 1864, 1854, 1867, 1873, 1876, 1880, 1897,
+     1906, 1910,   24, 1913, 1921, 1931, 1927, 1945, 1957, 1961,
+     1952, 1964, 1969, 1994, 1975, 1999, 2005, 2008, 2012, 2019,
+       36, 2015, 2024, 2049, 2054, 2045, 2057, 2079, 2087, 2068,
 
-     2025, 2036, 2050, 2059, 2045, 2056, 2070, 2387, 2075, 2089,
-     2082, 2387, 2093, 2096, 2100, 2108, 2112, 2132, 2119, 2138,
-     2387, 2206, 2220, 2234, 2248, 2257, 2266, 2275, 2288, 2302,
-     2315, 2329, 2339, 2345, 2353, 2355, 2361, 2367, 2373
+     2062, 2075, 2099, 2092, 2109, 2105, 2117, 2112, 2142, 2129,
+     2461, 2148, 2155, 2151, 2461, 2135, 2166, 2159, 2172, 2189,
+     2192, 2196, 2212, 2461, 2280, 2294, 2308, 2322, 2331, 2340,
+     2349, 2362, 2376, 2389, 2403, 2413, 2419, 2427, 2429, 2435,
+     2441, 2447
     } ;
 
-static yyconst flex_int16_t yy_def[440] =
+static const flex_int16_t yy_def[443] =
     {   0,
-      421,    1,  422,  422,  423,  423,  421,  421,  421,  421,
-      424,  425,  421,  426,  421,  427,  421,   17,  428,  428,
-      428,  428,  428,  428,  428,  421,  428,  428,  428,  428,
-       21,  428,  428,  428,  428,  428,  428,  428,  428,  428,
-      428,  428,  421,  421,  421,  429,  429,  430,  421,  421,
-      424,  421,  424,  421,  431,   15,   17,  421,  421,   15,
-      421,  421,  421,  421,  432,  433,  421,  421,  421,  421,
-       17,  421,  421,  421,  434,  428,  421,  421,  421,  421,
-      428,   21,   21,  428,  428,  428,  428,  428,  428,  428,
-      428,  428,  428,  428,  428,  428,  428,  428,  428,  428,
+      424,    1,  425,  425,  426,  426,  424,  424,  424,  424,
+      427,  428,  424,  429,  424,  430,  424,   17,  431,  431,
+      431,  431,  431,  431,  431,  424,  431,  431,  431,  431,
+       21,  431,  431,  431,  431,  431,  431,  431,  431,  431,
+      431,  431,  424,  424,  424,  432,  432,  433,  424,  424,
+      427,  424,  427,  424,  434,   15,   17,  424,  424,   15,
+      424,  424,  424,  424,  435,  436,  424,  424,  424,  424,
+       17,  424,  424,  424,  437,  431,  424,  424,  424,  424,
+      431,   21,   21,  431,  431,  431,  431,  431,  431,  431,
+      431,  431,  431,  431,  431,  431,  431,  431,  431,  431,
 
-      428,  428,  428,  428,  428,  428,  428,  428,  428,  428,
-      428,  428,  428,  428,  428,  428,  428,  428,  428,  428,
-      428,  428,  428,  421,  421,  429,  429,  421,  430,  421,
-      421,  421,  435,  421,  421,  421,  421,  421,  432,  433,
-      436,  421,  421,  421,  421,  421,  421,  437,  421,  421,
-      428,  428,  428,  428,  428,  428,  428,  428,  428,  428,
-      428,  428,  428,  428,  428,  428,  428,  428,  428,  428,
-      428,  428,  428,  428,  428,  428,  428,  428,  428,  428,
-      428,  428,  428,  428,  428,  428,  428,  428,  428,  428,
-      428,  428,  428,  428,  428,  421,  421,  421,  438,  421,
+      431,  431,  431,  431,  431,  431,  431,  431,  431,  431,
+      431,  431,  431,  431,  431,  431,  431,  431,  431,  431,
+      431,  431,  431,  424,  424,  432,  432,  424,  433,  424,
+      424,  424,  438,  424,  424,  424,  424,  424,  435,  436,
+      439,  424,  424,  424,  424,  424,  424,  440,  424,  424,
+      431,  431,  431,  431,  431,  431,  431,  431,  431,  431,
+      431,  431,  431,  431,  431,  431,  431,  431,  431,  431,
+      431,  431,  431,  431,  431,  431,  431,  431,  431,  431,
+      431,  431,  431,  431,  431,  431,  431,  431,  431,  431,
+      431,  431,  431,  431,  431,  424,  424,  424,  441,  424,
 
-      421,  439,  421,  421,  421,  421,  421,  421,  421,  437,
-      421,  421,  421,  428,  428,  428,  428,  428,  428,  428,
-      428,  428,  428,  428,  428,  428,  428,  428,  428,  428,
-      428,  428,  428,  428,  428,  428,  428,  428,  428,  428,
-      428,  428,  428,  428,  428,  428,  428,  428,  428,  428,
-      428,  428,  428,  428,  428,  428,  428,  428,  421,  421,
-      421,  421,  439,  421,  421,  421,  421,  421,  421,  421,
-      428,  428,  428,  428,  428,  428,  428,  428,  428,  428,
-      428,  428,  428,  428,  428,  428,  428,  428,  428,  421,
-      428,  428,  428,  428,  428,  428,  428,  428,  428,  428,
+      424,  442,  424,  424,  424,  424,  424,  424,  424,  440,
+      424,  424,  424,  431,  431,  431,  431,  431,  431,  431,
+      431,  431,  431,  431,  431,  431,  431,  431,  431,  431,
+      431,  431,  431,  431,  431,  431,  431,  431,  431,  431,
+      431,  431,  431,  431,  431,  431,  431,  431,  431,  431,
+      431,  431,  431,  431,  431,  431,  431,  431,  424,  424,
+      424,  424,  442,  424,  424,  424,  424,  424,  424,  424,
+      431,  431,  431,  431,  431,  431,  431,  431,  431,  431,
+      431,  431,  431,  431,  431,  431,  431,  431,  431,  424,
+      431,  431,  431,  431,  431,  431,  431,  431,  431,  431,
 
-      428,  428,  428,  428,  428,  428,  428,  428,  428,  421,
-      421,  421,  421,  421,  421,  428,  428,  428,  428,  428,
-      428,  428,  428,  428,  428,  428,  428,  428,  428,  428,
-      428,  428,  428,  428,  428,  428,  421,  428,  428,  428,
-      428,  421,  428,  428,  428,  428,  428,  421,  421,  428,
-      428,  428,  428,  428,  428,  428,  428,  428,  428,  428,
-      428,  428,  428,  428,  428,  428,  428,  428,  428,  428,
-      421,  428,  428,  428,  428,  428,  428,  428,  428,  428,
-      428,  428,  428,  428,  428,  428,  428,  421,  428,  428,
-      428,  428,  428,  428,  428,  428,  428,  428,  428,  428,
+      431,  431,  431,  431,  431,  431,  431,  431,  431,  431,
+      424,  424,  424,  424,  424,  424,  431,  431,  431,  431,
+      431,  431,  431,  431,  431,  431,  431,  431,  431,  431,
+      431,  431,  431,  431,  431,  431,  431,  424,  431,  431,
+      431,  431,  424,  431,  431,  431,  431,  431,  424,  424,
+      431,  431,  431,  431,  431,  431,  431,  431,  431,  431,
+      431,  431,  431,  431,  431,  431,  431,  431,  431,  431,
+      431,  431,  424,  431,  431,  431,  431,  431,  431,  431,
+      431,  431,  431,  431,  431,  431,  431,  431,  431,  431,
+      424,  431,  431,  431,  431,  431,  431,  431,  431,  431,
 
-      428,  428,  428,  428,  428,  428,  428,  421,  428,  428,
-      428,  421,  428,  428,  428,  428,  428,  428,  428,  428,
-        0,  421,  421,  421,  421,  421,  421,  421,  421,  421,
-      421,  421,  421,  421,  421,  421,  421,  421,  421
+      431,  431,  431,  431,  431,  431,  431,  431,  431,  431,
+      424,  431,  431,  431,  424,  431,  431,  431,  431,  431,
+      431,  431,  431,    0,  424,  424,  424,  424,  424,  424,
+      424,  424,  424,  424,  424,  424,  424,  424,  424,  424,
+      424,  424
     } ;
 
-static yyconst flex_uint16_t yy_nxt[2456] =
+static const flex_int16_t yy_nxt[2530] =
     {   0,
         8,    9,   10,    9,    8,   11,   12,    8,   13,   14,
        15,   16,   17,   18,   18,   18,   18,   18,   18,    8,
@@ -611,271 +829,279 @@ static yyconst flex_uint16_t yy_nxt[2456] =
        35,   19,   36,   37,   19,   19,   38,   39,   40,   41,
        42,   19,   19,    8,    8,   43,   44,   45,   50,   52,
        50,   56,   56,   57,   57,   57,   57,   57,   57,   57,
-       50,  261,   50,   72,   64,  388,   58,   58,   65,   77,
-       59,  263,   52,   76,   76,  261,   90,  371,  262,   77,
+       50,  261,   50,   72,   64,  391,   58,   58,   65,   77,
+       59,  263,   52,   76,   76,  261,   90,  373,  262,   77,
 
       202,  212,   53,   77,   72,   58,   58,   60,   60,   60,
        60,   60,   60,   60,   81,   67,   78,   79,   80,   61,
-       62,   63,  212,  349,   61,   53,   78,   79,   80,  263,
-       78,   79,   80,  348,  140,   77,  315,  202,   61,   62,
-       63,  314,   68,   69,   70,   61,   56,   84,   71,   71,
-       71,   71,   71,   71,   71,  313,   77,  263,   72,  312,
-      311,   58,   78,   79,   80,   73,  310,   76,   66,   72,
+       62,   63,  212,  350,   61,   53,   78,   79,   80,  263,
+       78,   79,   80,  349,  140,   77,  316,  202,   61,   62,
+       63,  315,   68,   69,   70,   61,   56,   84,   71,   71,
+       71,   71,   71,   71,   71,  314,   77,  263,   72,  313,
+      312,   58,   78,   79,   80,   73,  311,   76,   66,   72,
        85,   74,  270,   75,  140,   86,  269,   72,   87,  268,
        58,  202,   91,   78,   79,   80,   73,  213,   77,   76,
        88,   77,  209,   72,   66,   74,   82,   82,   89,  208,
 
        83,   83,   83,   83,   83,   83,   83,   91,   91,   91,
        91,   91,   91,   91,   99,   78,   79,   80,   78,   79,
-       80,   77,  207,  140,  201,  197,   77,  197,  421,  127,
-      100,  196,   91,  150,  149,   76,  101,  421,  147,  146,
-       77,   66,  136,  421,  130,   77,  421,  128,   78,   79,
+       80,   77,  207,  140,  201,  197,   77,  197,  424,  127,
+      100,  196,   91,  150,  149,   76,  101,  424,  147,  146,
+       77,   66,  136,  424,  130,   77,  424,  128,   78,   79,
        80,   77,  106,   78,   79,   80,   92,   93,   94,   95,
        77,   96,  102,  107,   97,  108,   98,   78,   79,   80,
       103,   77,   78,   79,   80,  104,   77,  127,   78,   79,
        80,   77,  125,  124,   77,   91,  110,   78,   79,   80,
-      111,  109,   77,  105,  112,   77,  421,  113,   78,   79,
+      111,  109,   77,  105,  112,   77,  424,  113,   78,   79,
 
        80,  114,   77,   78,   79,   80,   77,   55,   78,   79,
-       80,   78,   79,   80,   77,  115,  123,  421,   49,   78,
+       80,   78,   79,   80,   77,  115,  123,  424,   49,   78,
        79,   80,   78,   79,   80,  117,  116,   49,   47,   78,
-       79,   80,   47,   78,   79,   80,   77,  421,  421,  118,
-      421,   78,   79,   80,  421,  421,  119,  421,  120,  421,
-      121,  421,  421,  141,  421,  122,  132,  132,  132,  132,
-      132,  132,  421,   78,   79,   80,  134,  134,  421,  421,
-      135,  135,  135,  135,  135,  135,  135,  421,  137,  137,
+       79,   80,   47,   78,   79,   80,   77,  424,  424,  118,
+      424,   78,   79,   80,  424,  424,  119,  424,  120,  424,
+      121,  424,  424,  141,  424,  122,  132,  132,  132,  132,
+      132,  132,  424,   78,   79,   80,  134,  134,  424,  424,
+      135,  135,  135,  135,  135,  135,  135,  424,  137,  137,
       142,  133,  138,  138,  138,  138,  138,  138,  138,   66,
-       66,   66,   66,   66,   66,   66,   77,  421,  421,   72,
+       66,   66,   66,   66,   66,   66,   77,  424,  424,   72,
 
-       76,   76,   76,   76,   76,  421,   73,  143,  144,  145,
-       72,   77,   76,   76,   77,  421,   76,  151,   72,  421,
-      157,  155,  421,   78,   79,   80,  154,   73,  152,   77,
-      153,  421,  156,  152,   72,   76,   77,  158,   78,   79,
-       80,   78,   79,   80,   77,  421,  159,  152,  421,  153,
-       77,  421,  421,  421,  152,   77,   78,   79,   80,   77,
-       76,  421,  157,   78,   79,   80,   77,  421,  421,  421,
-       77,   78,   79,   80,  421,  160,  161,   78,   79,   80,
-      421,   77,   78,   79,   80,  421,   78,   79,   80,   77,
-      421,  421,   77,   78,   79,   80,  167,   78,   79,   80,
+       76,   76,   76,   76,   76,  424,   73,  143,  144,  145,
+       72,   77,   76,   76,   77,  424,   76,  151,   72,  424,
+      157,  155,  424,   78,   79,   80,  154,   73,  152,   77,
+      153,  424,  156,  152,   72,   76,   77,  158,   78,   79,
+       80,   78,   79,   80,   77,  424,  159,  152,  424,  153,
+       77,  424,  424,  424,  152,   77,   78,   79,   80,   77,
+       76,  424,  157,   78,   79,   80,   77,  424,  424,  424,
+       77,   78,   79,   80,  424,  160,  161,   78,   79,   80,
+      424,   77,   78,   79,   80,  424,   78,   79,   80,   77,
+      424,  424,   77,   78,   79,   80,  167,   78,   79,   80,
 
-      166,  421,  163,  162,  164,  421,  421,  165,   78,   79,
-       80,   77,  421,  421,   77,  421,   78,   79,   80,   78,
-       79,   80,  421,  169,   77,  421,  168,   77,  421,  173,
-      421,  421,   77,  421,  170,  171,  421,   77,   78,   79,
-       80,   78,   79,   80,  172,  174,   77,  421,  421,   77,
-      421,   78,   79,   80,   78,   79,   80,  175,   77,   78,
-       79,   80,  176,  421,   78,   79,   80,  177,   77,  421,
-      421,  421,  421,   78,   79,   80,   78,   79,   80,  178,
-       77,  421,  421,  179,   77,   78,   79,   80,   77,  421,
-      421,   77,  421,  421,   77,   78,   79,   80,   77,  180,
+      166,  424,  163,  162,  164,  424,  424,  165,   78,   79,
+       80,   77,  424,  424,   77,  424,   78,   79,   80,   78,
+       79,   80,  424,  169,   77,  424,  168,   77,  424,  173,
+      424,  424,   77,  424,  170,  171,  424,   77,   78,   79,
+       80,   78,   79,   80,  172,  174,   77,  424,  424,   77,
+      424,   78,   79,   80,   78,   79,   80,  175,   77,   78,
+       79,   80,  176,  424,   78,   79,   80,  177,   77,  424,
+      424,  424,  424,   78,   79,   80,   78,   79,   80,  178,
+       77,  424,  424,  179,   77,   78,   79,   80,   77,  424,
+      424,   77,  424,  424,   77,   78,   79,   80,   77,  180,
 
       181,   77,  182,  185,   77,  183,  186,   78,   79,   80,
       157,   78,   79,   80,  184,   78,   79,   80,   78,   79,
        80,   78,   79,   80,   77,   78,   79,   80,   78,   79,
-       80,   78,   79,   80,  421,  421,   77,  421,  421,  187,
-       77,  421,  421,   77,  421,  421,   77,  421,  421,  421,
-       77,   78,   79,   80,  188,  421,  189,  421,  421,  421,
+       80,   78,   79,   80,  424,  424,   77,  424,  424,  187,
+       77,  424,  424,   77,  424,  424,   77,  424,  424,  424,
+       77,   78,   79,   80,  188,  424,  189,  424,  424,  424,
       191,   77,  193,   78,   79,   80,  190,   78,   79,   80,
        78,   79,   80,   78,   79,   80,  192,   78,   79,   80,
-      211,  421,   77,  421,  212,   77,  197,  421,   78,   79,
-       80,  194,  198,  198,  198,  198,  198,  198,  421,  421,
+      211,  424,   77,  424,  212,   77,  197,  424,   78,   79,
+       80,  194,  198,  198,  198,  198,  198,  198,  424,  424,
 
-      421,  211,  141,  195,  203,  421,  421,  421,  212,   78,
+      424,  211,  141,  195,  203,  424,  424,  424,  212,   78,
        79,   80,   78,   79,   80,  135,  135,  135,  135,  135,
       135,  135,  135,  135,  135,  135,  135,  135,  135,  142,
-      421,  204,  205,  206,  200,  421,   63,  421,  421,  200,
+      424,  204,  205,  206,  200,  424,   63,  424,  424,  200,
       138,  138,  138,  138,  138,  138,  138,  259,  259,  259,
       259,  259,  259,  200,   77,   63,  143,  144,  145,   77,
       200,  138,  138,  138,  138,  138,  138,  138,  140,  140,
-      140,  140,  140,   61,  421,   63,  421,   77,   61,  421,
-      214,   78,   79,   80,  140,  421,   78,   79,   80,   77,
-      421,  215,   61,  218,   63,   77,  421,  421,   77,   61,
+      140,  140,  140,   61,  424,   63,  424,   77,   61,  424,
+      214,   78,   79,   80,  140,  424,   78,   79,   80,   77,
+      424,  215,   61,  218,   63,   77,  424,  424,   77,   61,
 
-      421,  421,   77,  140,   78,   79,   80,  421,   77,  216,
-      421,  220,  217,   77,  421,  421,   78,   79,   80,  221,
+      424,  424,   77,  140,   78,   79,   80,  424,   77,  216,
+      424,  220,  217,   77,  424,  424,   78,   79,   80,  221,
       219,   77,   78,   79,   80,   78,   79,   80,  140,   78,
-       79,   80,   77,  421,  421,   78,   79,   80,   77,  222,
-       78,   79,   80,  223,   77,  421,  421,   77,   78,   79,
-       80,   77,  228,  225,  421,  227,  224,  421,   77,   78,
-       79,   80,   77,  421,  421,   78,   79,   80,   77,  226,
+       79,   80,   77,  424,  424,   78,   79,   80,   77,  222,
+       78,   79,   80,  223,   77,  424,  424,   77,   78,   79,
+       80,   77,  228,  225,  424,  227,  224,  424,   77,   78,
+       79,   80,   77,  424,  424,   78,   79,   80,   77,  226,
       229,   78,   79,   80,   78,   79,   80,   77,   78,   79,
-       80,  421,   77,  231,  421,   78,   79,   80,   77,   78,
-       79,   80,   77,  421,  233,   78,   79,   80,  230,  421,
+       80,  424,   77,  231,  424,   78,   79,   80,   77,   78,
+       79,   80,   77,  424,  233,   78,   79,   80,  230,  424,
 
-       77,  421,  421,  421,   78,   79,   80,   77,  232,   78,
-       79,   80,   77,  421,  236,   78,   79,   80,  234,   78,
-       79,   80,  421,  235,   77,  421,  421,   78,   79,   80,
-      237,   77,  421,  211,   78,   79,   80,  212,   77,   78,
-       79,   80,   77,  421,  239,  238,   77,  421,  240,  421,
+       77,  424,  424,  424,   78,   79,   80,   77,  232,   78,
+       79,   80,   77,  424,  236,   78,   79,   80,  234,   78,
+       79,   80,  424,  235,   77,  424,  424,   78,   79,   80,
+      237,   77,  424,  211,   78,   79,   80,  212,   77,   78,
+       79,   80,   77,  424,  239,  238,   77,  424,  240,  424,
        77,   78,   79,   80,  211,   77,  249,  219,   78,   79,
-       80,  212,  421,  421,  242,   78,   79,   80,  421,   78,
+       80,  212,  424,  424,  242,   78,   79,   80,  424,   78,
        79,   80,   77,   78,   79,   80,  241,   78,   79,   80,
-      244,   77,   78,   79,   80,   77,  421,  245,  421,  421,
-      421,  243,   77,  421,  421,   77,  421,  421,  247,   78,
+      244,   77,   78,   79,   80,   77,  424,  245,  424,  424,
+      424,  243,   77,  424,  424,   77,  424,  424,  247,   78,
 
-       79,   80,   77,  421,  248,  250,  246,   77,   78,   79,
-       80,   77,   78,   79,   80,  421,  251,  252,  421,   78,
-       79,   80,   78,   79,   80,   77,  421,  253,   77,   78,
-       79,   80,  421,   77,   78,   79,   80,   77,   78,   79,
-       80,  141,  255,  256,   77,  254,  421,  258,  421,  421,
-      421,  421,   78,   79,   80,   78,   79,   80,   77,  257,
-       78,   79,   80,   77,   78,   79,   80,  421,  264,  421,
+       79,   80,   77,  424,  248,  250,  246,   77,   78,   79,
+       80,   77,   78,   79,   80,  424,  251,  252,  424,   78,
+       79,   80,   78,   79,   80,   77,  424,  253,   77,   78,
+       79,   80,  424,   77,   78,   79,   80,   77,   78,   79,
+       80,  141,  255,  256,   77,  254,  424,  258,  424,  424,
+      424,  424,   78,   79,   80,   78,   79,   80,   77,  257,
+       78,   79,   80,   77,   78,   79,   80,  424,  264,  424,
       271,   78,   79,   80,  202,  202,  202,  202,  202,  202,
-      202,   77,  421,  272,   77,   78,   79,   80,  274,   77,
-       78,   79,   80,   77,  421,  265,  266,  267,  273,  275,
+      202,   77,  424,  272,   77,   78,   79,   80,  274,   77,
+       78,   79,   80,   77,  424,  265,  266,  267,  273,  275,
 
-      421,  421,   77,  421,  421,  277,  421,   77,   78,   79,
-       80,   78,   79,   80,   77,  421,   78,   79,   80,  421,
-       78,   79,   80,   77,  421,  421,   77,  421,  276,   78,
-       79,   80,   77,  278,   78,   79,   80,   77,  279,  421,
-       77,   78,   79,   80,  421,  282,  280,  421,  421,  421,
+      424,  424,   77,  424,  424,  277,  424,   77,   78,   79,
+       80,   78,   79,   80,   77,  424,   78,   79,   80,  424,
+       78,   79,   80,   77,  424,  424,   77,  424,  276,   78,
+       79,   80,   77,  278,   78,   79,   80,   77,  279,  424,
+       77,   78,   79,   80,  424,  282,  280,  424,  424,  424,
        78,   79,   80,   78,   79,   80,   77,  281,  284,   78,
        79,   80,  283,   77,   78,   79,   80,   78,   79,   80,
-       77,  421,  421,  285,  421,   77,  421,  286,  421,  421,
-       77,  290,  421,   78,   79,   80,  288,   77,  421,  421,
-       78,   79,   80,  287,   77,  421,  421,   78,   79,   80,
+       77,  424,  424,  285,  424,   77,  424,  286,  424,  424,
+       77,  290,  424,   78,   79,   80,  288,   77,  424,  424,
+       78,   79,   80,  287,   77,  424,  424,   78,   79,   80,
 
-       77,  421,   78,   79,   80,   77,  421,   78,   79,   80,
-       77,  421,  421,   77,   78,   79,   80,   77,  421,  421,
-      289,   78,   79,   80,  291,  292,  294,   78,   79,   80,
-       77,  421,   78,   79,   80,   77,  421,   78,   79,   80,
-       78,   79,   80,   77,   78,   79,   80,  296,   77,  421,
-      248,  293,   77,  421,  421,   77,  421,   78,   79,   80,
-      295,   77,   78,   79,   80,   77,  421,  421,   77,  421,
-       78,   79,   80,  297,  421,   78,   79,   80,   77,   78,
-       79,   80,   78,   79,   80,   77,  298,  421,   78,   79,
-       80,   77,   78,   79,   80,   78,   79,   80,  299,  300,
+       77,  424,   78,   79,   80,   77,  424,   78,   79,   80,
+       77,  424,  424,   77,   78,   79,   80,   77,  424,  424,
+      289,   78,   79,   80,  291,  292,  295,   78,   79,   80,
+       77,  424,   78,   79,   80,   77,  424,   78,   79,   80,
+       78,   79,   80,   77,   78,   79,   80,  297,   77,  424,
+      293,  294,   77,  424,  424,   77,  424,   78,   79,   80,
+      296,   77,   78,   79,   80,   77,  424,  424,   77,  424,
+       78,   79,   80,  298,  424,   78,   79,   80,   77,   78,
+       79,   80,   78,   79,   80,   77,  299,  424,   78,   79,
+       80,   77,   78,   79,   80,   78,   79,   80,  300,  301,
 
-       77,  421,  421,   77,  301,   78,   79,   80,  421,  303,
-      302,  421,   78,   79,   80,  304,   77,  421,   78,   79,
-       80,   77,  421,  421,  306,  141,  421,   78,   79,   80,
-       78,   79,   80,   77,  307,  421,   77,  421,  421,   77,
-      421,  309,  305,   78,   79,   80,  319,  421,   78,   79,
-       80,  308,  264,  263,  263,  263,  263,  263,   77,  421,
+       77,  424,  424,   77,  302,   78,   79,   80,  424,  304,
+      303,  424,   78,   79,   80,  305,   77,  424,   78,   79,
+       80,   77,  424,  424,  307,  141,  424,   78,   79,   80,
+       78,   79,   80,   77,  308,  424,   77,  424,  424,   77,
+      424,  310,  306,   78,   79,   80,  320,  424,   78,   79,
+       80,  309,  264,  263,  263,  263,  263,  263,   77,  424,
        78,   79,   80,   78,   79,   80,   78,   79,   80,  263,
-       77,  421,  317,   77,  421,  421,  316,  421,   77,  265,
-      266,  267,   77,  318,  320,   78,   79,   80,  263,  321,
-       77,  421,  322,  421,   77,  421,  421,   78,   79,   80,
+       77,  424,  318,   77,  424,  424,  317,  424,   77,  265,
+      266,  267,   77,  319,  321,   78,   79,   80,  263,  322,
+       77,  424,  323,  424,   77,  424,  424,   78,   79,   80,
 
-       78,   79,   80,  421,   77,   78,   79,   80,  326,   78,
-       79,   80,   77,  263,  323,  421,  421,   78,   79,   80,
-      421,   78,   79,   80,  324,  421,   77,  421,  421,   77,
-      421,   78,   79,   80,   77,  325,  327,  421,  421,   78,
-       79,   80,  421,  421,   77,  421,  421,   77,  421,  421,
-       77,  421,  421,   78,   79,   80,   78,   79,   80,  330,
-       77,   78,   79,   80,  328,  329,   77,  331,  332,  421,
-      421,   78,   79,   80,   78,   79,   80,   78,   79,   80,
-       77,  337,  421,   77,  421,  421,   77,   78,   79,   80,
-       77,  319,  421,   78,   79,   80,  336,   77,  333,  421,
+       78,   79,   80,  424,   77,   78,   79,   80,  327,   78,
+       79,   80,   77,  263,  324,  424,  424,   78,   79,   80,
+      424,   78,   79,   80,  325,  424,   77,  424,  424,   77,
+      424,   78,   79,   80,   77,  326,  328,  424,  424,   78,
+       79,   80,  424,  424,   77,  424,  424,   77,  424,  424,
+       77,  424,  424,   78,   79,   80,   78,   79,   80,  331,
+       77,   78,   79,   80,  329,  330,   77,  332,  333,  424,
+      424,   78,   79,   80,   78,   79,   80,   78,   79,   80,
+       77,  338,  424,   77,  424,  424,   77,   78,   79,   80,
+       77,  424,  424,   78,   79,   80,  337,   77,  334,  424,
 
-       77,  421,  421,   77,  334,  335,  421,   78,   79,   80,
+       77,  424,  424,   77,  335,  336,  424,   78,   79,   80,
        78,   79,   80,   78,   79,   80,   77,   78,   79,   80,
-       77,  421,  338,   77,   78,   79,   80,   78,   79,   80,
-       78,   79,   80,   77,  342,  343,   77,  421,  421,   77,
-      319,  421,  339,   78,   79,   80,   77,   78,   79,   80,
-       78,   79,   80,   77,  340,  421,  421,   77,  421,  341,
+       77,  320,  339,  424,   78,   79,   80,   78,   79,   80,
+       78,   79,   80,   77,  424,  424,   77,  343,  424,   77,
+      424,  424,  340,   78,   79,   80,  320,   78,   79,   80,
+       77,  424,  344,   77,  424,  424,   77,  424,  341,   77,
+       78,   79,   80,   78,   79,   80,   78,   79,   80,  424,
+      424,   77,  424,  342,   77,  424,  424,   78,   79,   80,
        78,   79,   80,   78,   79,   80,   78,   79,   80,   77,
-      421,  421,   77,   78,   79,   80,  421,  344,   77,  421,
-       78,   79,   80,   77,   78,   79,   80,   77,  345,  421,
-      347,   77,  350,  421,   77,  421,   78,   79,   80,   78,
+      424,  424,  424,  424,   77,  424,  424,  345,   78,   79,
 
-       79,   80,   77,  346,  354,   78,   79,   80,  351,   77,
-       78,   79,   80,   77,   78,   79,   80,  421,   78,   79,
-       80,   78,   79,   80,  353,   77,  421,  421,   77,   78,
-       79,   80,   77,  352,  421,  421,   78,   79,   80,   77,
-       78,   79,   80,  421,   77,  355,  356,   77,  359,  357,
-       77,  421,   78,   79,   80,   78,   79,   80,  421,   78,
-       79,   80,  358,  421,  421,   77,   78,   79,   80,  360,
-      358,   78,   79,   80,   78,   79,   80,   78,   79,   80,
-       77,  421,  421,   77,  421,  421,   77,  421,  421,   77,
-      421,  421,   78,   79,   80,  358,  361,  363,  362,   77,
+       80,   78,   79,   80,  346,   77,  424,  424,   77,  351,
+      424,  348,   77,  424,  424,  424,   78,   79,   80,   77,
+      424,   78,   79,   80,   77,  347,  352,   77,  424,  424,
+      424,  424,   78,   79,   80,   78,   79,   80,  354,   78,
+       79,   80,   77,  424,  353,  355,   78,   79,   80,  424,
+       77,   78,   79,   80,   78,   79,   80,   77,  424,  358,
+       77,  424,  424,  424,   77,  424,  424,   77,  424,   78,
+       79,   80,  424,  424,   77,  424,  424,   78,   79,   80,
+      356,  357,  359,  360,   78,   79,   80,   78,   79,   80,
+       77,   78,   79,   80,   78,   79,   80,   77,  424,  424,
 
-      421,  421,  364,  421,  421,   77,  421,   78,   79,   80,
-       78,   79,   80,   78,   79,   80,   78,   79,   80,  365,
-       77,  421,  421,   77,  421,  421,   78,   79,   80,   77,
-      366,  421,   78,   79,   80,   77,  421,  421,   77,  421,
-      421,   77,  421,  421,  421,   77,  421,   78,   79,   80,
-       78,   79,   80,  244,   77,  421,   78,   79,   80,   77,
-      421,  421,   78,   79,   80,   78,   79,   80,   78,   79,
-       80,   77,   78,   79,   80,  367,  421,  368,   77,  369,
-      421,   78,   79,   80,   77,  421,   78,   79,   80,   77,
-      370,  216,   77,  421,  421,  374,   77,  421,   78,   79,
+       77,   78,   79,   80,  361,  424,  424,  424,   77,  424,
+      359,   77,  424,  362,   77,  424,  424,   78,   79,   80,
+      359,  424,  364,  363,   78,   79,   80,   78,   79,   80,
+       77,  424,  424,  365,   77,   78,   79,   80,   78,   79,
+       80,   78,   79,   80,   77,  424,  424,   77,  366,  424,
+       77,  424,  424,   77,  367,  424,   77,   78,   79,   80,
+       77,   78,   79,   80,  424,   77,  424,  424,  368,  424,
+       77,   78,   79,   80,   78,   79,   80,   78,   79,   80,
+       78,   79,   80,   78,   79,   80,  369,   78,   79,   80,
+       77,  424,   78,   79,   80,   77,  370,   78,   79,   80,
 
-       80,   77,  376,  372,   77,   78,   79,   80,   77,  421,
-      421,   78,   79,   80,  375,  373,   78,   79,   80,   78,
-       79,   80,   77,   78,   79,   80,   77,  421,   78,   79,
-       80,   78,   79,   80,  378,   78,   79,   80,   77,  421,
-      377,   77,  421,  421,  379,   77,  380,  421,  421,   78,
-       79,   80,   77,   78,   79,   80,   77,  382,  381,   77,
-      421,  421,  358,   77,  383,   78,   79,   80,   78,   79,
-       80,   77,   78,   79,   80,   77,  421,  358,  384,   78,
-       79,   80,  421,   78,   79,   80,   78,   79,   80,   77,
-       78,   79,   80,  385,  421,   77,  421,  421,   78,   79,
+       77,  424,  424,   77,  424,  424,   77,  424,  376,  424,
+      216,  424,  372,   77,  424,  371,   77,   78,   79,   80,
+      374,   77,   78,   79,   80,  424,  377,   78,   79,   80,
+       78,   79,   80,   78,   79,   80,  375,   77,  424,  424,
+       78,   79,   80,   78,   79,   80,   77,  424,   78,   79,
+       80,  379,  378,  424,  424,   77,  424,  424,   77,  424,
+      424,  424,   77,  424,   78,   79,   80,  380,  381,  424,
+      424,   77,  424,   78,   79,   80,  382,  424,  424,  424,
+      424,  424,   78,   79,   80,   78,   79,   80,   77,   78,
+       79,   80,   77,  424,  383,   77,  424,  424,   78,   79,
 
-       80,  386,   78,   79,   80,   77,  390,  306,   77,  421,
-      421,  387,   77,  421,  421,  389,   78,   79,   80,  216,
-       77,  392,   78,   79,   80,  421,   77,  421,  421,  421,
-       77,  421,   78,   79,   80,   78,   79,   80,   77,   78,
-       79,   80,   77,  421,  393,  421,   77,   78,   79,   80,
-      391,   77,  421,   78,   79,   80,   77,   78,   79,   80,
-      421,   77,  383,  394,  395,   78,   79,   80,  396,   78,
-       79,   80,   77,   78,   79,   80,   77,  421,   78,   79,
-       80,   77,  421,   78,   79,   80,   77,  398,   78,   79,
-       80,  390,   77,  421,  397,  399,   77,  421,  421,   78,
+       80,  359,   77,  424,  384,   77,  424,  424,  359,  424,
+      385,   77,  424,  424,   77,   78,   79,   80,   77,   78,
+       79,   80,   78,   79,   80,  424,  386,  424,  424,   78,
+       79,   80,   78,   79,   80,   77,  387,  424,   78,   79,
+       80,   78,   79,   80,   77,   78,   79,   80,   77,  424,
+      389,   77,  424,  388,  390,  393,  424,  424,  392,   77,
+      424,  424,   78,   79,   80,   77,  216,  424,  424,   77,
+      424,   78,   79,   80,  395,   78,   79,   80,   78,   79,
+       80,  424,  424,   77,  424,  424,   78,   79,   80,  394,
+       77,  424,   78,   79,   80,   77,   78,   79,   80,   77,
 
-       79,   80,   77,   78,   79,   80,   77,  421,   78,   79,
-       80,  400,  401,   78,   79,   80,   77,  404,  421,   78,
-       79,   80,  402,   78,   79,   80,  358,   77,  421,   78,
-       79,   80,   77,   78,   79,   80,  421,   77,  358,  421,
-       77,  421,  421,   78,   79,   80,  403,  421,   77,  421,
-      421,   77,  408,  421,   78,   79,   80,  405,   77,   78,
-       79,   80,  406,   77,   78,   79,   80,   78,   79,   80,
-      407,   77,  421,  358,   77,   78,   79,   80,   78,   79,
-       80,  421,  358,   77,  421,   78,   79,   80,   77,  412,
-       78,   79,   80,  410,   77,  421,  409,   77,   78,   79,
+      424,  396,   77,  424,  424,  424,  424,   77,  398,  399,
+       78,   79,   80,   77,  424,  424,  424,   78,   79,   80,
+      397,  424,   78,   79,   80,  400,   78,   79,   80,   78,
+       79,   80,   77,  424,   78,   79,   80,   77,  424,  424,
+       78,   79,   80,   77,  424,  424,   77,  401,  424,  385,
+       77,  402,  424,   77,  424,  393,  424,   77,  424,   78,
+       79,   80,   77,  424,   78,   79,   80,  424,  424,  424,
+       78,   79,   80,   78,   79,   80,  403,   78,   79,   80,
+       78,   79,   80,   77,   78,   79,   80,   77,  424,   78,
+       79,   80,   77,  404,  407,   77,  424,  424,  405,  424,
 
-       80,   78,   79,   80,  421,  411,  421,  358,   77,  421,
-       78,   79,   80,   77,  421,   78,   79,   80,  415,  413,
-       77,   78,   79,   80,   78,   79,   80,   77,  421,  421,
-      421,   77,  421,  414,   77,   78,   79,   80,   77,  421,
-       78,   79,   80,  358,  416,  421,   77,   78,   79,   80,
-       77,  421,  421,  358,   78,   79,   80,   77,   78,   79,
-       80,   78,   79,   80,  417,   78,   79,   80,  421,  418,
-       77,  421,  420,   78,   79,   80,   77,   78,   79,   80,
-      419,  421,  421,  421,   78,   79,   80,  421,  421,  421,
-      358,  421,  421,  421,  421,  421,  421,   78,   79,   80,
+       77,  359,  406,  359,  409,  424,   77,  424,  424,  424,
+       78,   79,   80,   77,   78,   79,   80,   77,  411,   78,
+       79,   80,   78,   79,   80,   77,  408,   78,   79,   80,
+       77,  359,  410,   78,   79,   80,  424,   77,  424,  424,
+       78,   79,   80,   77,   78,   79,   80,   77,  415,  359,
+       77,  424,   78,   79,   80,   77,  424,   78,   79,   80,
+      413,  424,  359,  424,   78,   79,   80,   77,  424,  412,
+       78,   79,   80,   77,   78,   79,   80,   78,   79,   80,
+       77,  424,   78,   79,   80,  359,   77,  418,  424,   77,
+      424,  414,  416,   77,   78,   79,   80,   77,  424,  417,
 
-      421,  421,  421,   78,   79,   80,   46,   46,   46,   46,
+       78,   79,   80,  419,   77,  424,  424,   78,   79,   80,
+       77,  424,  424,   78,   79,   80,   78,   79,   80,  424,
+       78,   79,   80,  359,   78,   79,   80,   77,  420,  424,
+       77,   78,   79,   80,   77,  424,  424,   78,   79,   80,
+      422,  424,  424,  424,  424,  424,  421,  424,  424,  423,
+       77,  424,  424,  424,   78,   79,   80,   78,   79,   80,
+      424,   78,   79,   80,  359,  424,  424,  424,  424,  424,
+      424,  424,  424,  424,  424,  424,  424,   78,   79,   80,
        46,   46,   46,   46,   46,   46,   46,   46,   46,   46,
-       48,   48,   48,   48,   48,   48,   48,   48,   48,   48,
-       48,   48,   48,   48,   51,   51,   51,   51,   51,   51,
-       51,   51,   51,   51,   51,   51,   51,   51,   54,   54,
-       54,   54,   54,   54,   54,   54,   54,   54,   54,   54,
-       54,   54,   57,  421,   57,  421,   57,  421,   57,   66,
-      421,  421,   66,  421,   66,   66,   66,   66,   66,   76,
-       76,  421,   76,   76,   76,   76,   76,   76,  126,  126,
-      126,  126,  126,  126,  126,  126,  126,  126,  126,  126,
+       46,   46,   46,   46,   48,   48,   48,   48,   48,   48,
 
-      126,  126,  129,  129,  129,  129,  129,  129,  129,  129,
-      129,  129,  129,  129,  129,  131,  421,  131,  131,  131,
-      131,  131,  131,  131,  131,  131,  131,  131,  131,  139,
-      421,  139,  139,  139,  139,  139,  139,  139,  139,  139,
-      139,  139,  139,  140,  140,  140,  140,  140,  140,  140,
-      140,  140,  148,  148,  148,  199,  421,  421,  421,  421,
-      199,  199,  199,  202,  202,  202,  202,  202,  210,  210,
-      210,  421,  421,  210,  260,  260,  260,  263,  263,  263,
-      263,  263,  263,  263,  263,  263,    7,  421,  421,  421,
-      421,  421,  421,  421,  421,  421,  421,  421,  421,  421,
+       48,   48,   48,   48,   48,   48,   48,   48,   51,   51,
+       51,   51,   51,   51,   51,   51,   51,   51,   51,   51,
+       51,   51,   54,   54,   54,   54,   54,   54,   54,   54,
+       54,   54,   54,   54,   54,   54,   57,  424,   57,  424,
+       57,  424,   57,   66,  424,  424,   66,  424,   66,   66,
+       66,   66,   66,   76,   76,  424,   76,   76,   76,   76,
+       76,   76,  126,  126,  126,  126,  126,  126,  126,  126,
+      126,  126,  126,  126,  126,  126,  129,  129,  129,  129,
+      129,  129,  129,  129,  129,  129,  129,  129,  129,  131,
+      424,  131,  131,  131,  131,  131,  131,  131,  131,  131,
 
-      421,  421,  421,  421,  421,  421,  421,  421,  421,  421,
-      421,  421,  421,  421,  421,  421,  421,  421,  421,  421,
-      421,  421,  421,  421,  421,  421,  421,  421,  421,  421,
-      421,  421,  421,  421,  421,  421,  421,  421,  421,  421,
-      421,  421,  421,  421,  421,  421,  421,  421,  421,  421,
-      421,  421,  421,  421,  421
+      131,  131,  131,  139,  424,  139,  139,  139,  139,  139,
+      139,  139,  139,  139,  139,  139,  139,  140,  140,  140,
+      140,  140,  140,  140,  140,  140,  148,  148,  148,  199,
+      424,  424,  424,  424,  199,  199,  199,  202,  202,  202,
+      202,  202,  210,  210,  210,  424,  424,  210,  260,  260,
+      260,  263,  263,  263,  263,  263,  263,  263,  263,  263,
+        7,  424,  424,  424,  424,  424,  424,  424,  424,  424,
+      424,  424,  424,  424,  424,  424,  424,  424,  424,  424,
+      424,  424,  424,  424,  424,  424,  424,  424,  424,  424,
+      424,  424,  424,  424,  424,  424,  424,  424,  424,  424,
+
+      424,  424,  424,  424,  424,  424,  424,  424,  424,  424,
+      424,  424,  424,  424,  424,  424,  424,  424,  424,  424,
+      424,  424,  424,  424,  424,  424,  424,  424,  424
     } ;
 
-static yyconst flex_int16_t yy_chk[2456] =
+static const flex_int16_t yy_chk[2530] =
     {   0,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
@@ -885,13 +1111,13 @@ static yyconst flex_int16_t yy_chk[2456] =
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    9,   11,
         9,   13,   14,   13,   13,   13,   13,   13,   13,   13,
-       50,  388,   50,   73,   16,  371,   13,   14,   16,   19,
-       14,  349,   51,   82,   82,  201,   25,  348,  201,   20,
+       50,  391,   50,   73,   16,  373,   13,   14,   16,   19,
+       14,  350,   51,   82,   82,  201,   25,  349,  201,   20,
 
-      315,  211,   11,   25,   73,   13,   14,   15,   15,   15,
+      316,  211,   11,   25,   73,   13,   14,   15,   15,   15,
        15,   15,   15,   15,   20,   16,   19,   19,   19,   15,
-       15,   15,  211,  314,   15,   51,   20,   20,   20,  313,
-       25,   25,   25,  312,  270,   22,  269,  268,   15,   15,
+       15,   15,  211,  315,   15,   51,   20,   20,   20,  314,
+       25,   25,   25,  313,  270,   22,  269,  268,   15,   15,
        15,  267,   16,   16,   16,   15,   17,   22,   17,   17,
        17,   17,   17,   17,   17,  266,   23,  265,   17,  262,
       260,   17,   22,   22,   22,   17,  259,  213,  209,   17,
@@ -1039,121 +1265,129 @@ static yyconst flex_int16_t yy_chk[2456] =
       284,    0,    0,  279,  279,  279,  280,  280,  280,  285,
       286,  282,  282,  282,  283,  284,  287,  286,  287,    0,
         0,  283,  283,  283,  285,  285,  285,  284,  284,  284,
-      288,  293,    0,  289,    0,    0,  291,  286,  286,  286,
-      292,  296,    0,  287,  287,  287,  292,  294,  288,    0,
+      288,  294,    0,  289,    0,    0,  291,  286,  286,  286,
+      292,    0,    0,  287,  287,  287,  292,  293,  288,    0,
 
-      293,    0,    0,  296,  289,  291,    0,  288,  288,  288,
-      289,  289,  289,  291,  291,  291,  295,  292,  292,  292,
-      299,    0,  295,  303,  294,  294,  294,  293,  293,  293,
-      296,  296,  296,  297,  302,  304,  298,    0,    0,  301,
-      297,    0,  298,  295,  295,  295,  300,  299,  299,  299,
-      303,  303,  303,  302,  300,    0,    0,  304,    0,  301,
-      297,  297,  297,  298,  298,  298,  301,  301,  301,  305,
-        0,    0,  306,  300,  300,  300,    0,  305,  307,    0,
-      302,  302,  302,  308,  304,  304,  304,  309,  307,    0,
-      309,  319,  316,    0,  317,    0,  305,  305,  305,  306,
+      294,    0,    0,  295,  289,  291,    0,  288,  288,  288,
+      289,  289,  289,  291,  291,  291,  296,  292,  292,  292,
+      300,  297,  296,    0,  293,  293,  293,  294,  294,  294,
+      295,  295,  295,  297,    0,    0,  299,  303,    0,  298,
+        0,    0,  299,  296,  296,  296,  298,  300,  300,  300,
+      301,    0,  305,  302,    0,    0,  303,    0,  301,  304,
+      297,  297,  297,  299,  299,  299,  298,  298,  298,    0,
+        0,  307,    0,  302,  305,    0,    0,  301,  301,  301,
+      302,  302,  302,  303,  303,  303,  304,  304,  304,  306,
+        0,    0,    0,    0,  308,    0,    0,  306,  307,  307,
 
-      306,  306,  316,  308,  321,  307,  307,  307,  317,  321,
-      308,  308,  308,  318,  309,  309,  309,    0,  319,  319,
-      319,  317,  317,  317,  320,  322,    0,    0,  320,  316,
-      316,  316,  323,  318,    0,    0,  321,  321,  321,  326,
-      318,  318,  318,    0,  325,  322,  323,  324,  326,  324,
-      327,    0,  322,  322,  322,  320,  320,  320,    0,  323,
-      323,  323,  325,    0,    0,  328,  326,  326,  326,  328,
-      327,  325,  325,  325,  324,  324,  324,  327,  327,  327,
-      329,    0,    0,  330,    0,    0,  331,    0,    0,  332,
-        0,    0,  328,  328,  328,  330,  329,  332,  331,  333,
+      307,  305,  305,  305,  308,  309,    0,    0,  310,  317,
+        0,  310,  318,    0,    0,    0,  306,  306,  306,  317,
+        0,  308,  308,  308,  319,  309,  318,  320,    0,    0,
+        0,    0,  309,  309,  309,  310,  310,  310,  321,  318,
+      318,  318,  321,    0,  319,  322,  317,  317,  317,    0,
+      322,  319,  319,  319,  320,  320,  320,  325,    0,  325,
+      323,    0,    0,    0,  326,    0,    0,  324,    0,  321,
+      321,  321,    0,    0,  327,    0,    0,  322,  322,  322,
+      323,  324,  326,  327,  325,  325,  325,  323,  323,  323,
+      328,  326,  326,  326,  324,  324,  324,  330,    0,    0,
 
-        0,    0,  333,    0,    0,  334,    0,  329,  329,  329,
-      330,  330,  330,  331,  331,  331,  332,  332,  332,  334,
-      335,    0,    0,  336,    0,    0,  333,  333,  333,  339,
-      335,    0,  334,  334,  334,  338,    0,    0,  340,    0,
-        0,  343,    0,    0,    0,  346,    0,  335,  335,  335,
-      336,  336,  336,  338,  341,    0,  339,  339,  339,  345,
-        0,    0,  338,  338,  338,  340,  340,  340,  343,  343,
-      343,  344,  346,  346,  346,  341,    0,  344,  347,  345,
-        0,  341,  341,  341,  351,    0,  345,  345,  345,  350,
-      347,  351,  352,    0,    0,  353,  355,    0,  344,  344,
+      329,  327,  327,  327,  329,    0,    0,    0,  331,    0,
+      328,  332,    0,  330,  333,    0,    0,  328,  328,  328,
+      331,    0,  333,  332,  330,  330,  330,  329,  329,  329,
+      334,    0,    0,  334,  335,  331,  331,  331,  332,  332,
+      332,  333,  333,  333,  336,    0,    0,  337,  335,    0,
+      339,    0,    0,  340,  336,    0,  341,  334,  334,  334,
+      344,  335,  335,  335,    0,  342,    0,    0,  339,    0,
+      347,  336,  336,  336,  337,  337,  337,  339,  339,  339,
+      340,  340,  340,  341,  341,  341,  342,  344,  344,  344,
+      345,    0,  342,  342,  342,  346,  345,  347,  347,  347,
 
-      344,  358,  355,  350,  354,  347,  347,  347,  353,    0,
-        0,  351,  351,  351,  354,  352,  350,  350,  350,  352,
-      352,  352,  357,  355,  355,  355,  356,    0,  358,  358,
-      358,  354,  354,  354,  357,  353,  353,  353,  359,    0,
-      356,  360,    0,    0,  359,  364,  360,    0,    0,  357,
-      357,  357,  361,  356,  356,  356,  362,  364,  361,  365,
-        0,    0,  362,  366,  365,  359,  359,  359,  360,  360,
-      360,  363,  364,  364,  364,  367,    0,  363,  366,  361,
-      361,  361,    0,  362,  362,  362,  365,  365,  365,  368,
-      366,  366,  366,  367,    0,  369,    0,    0,  363,  363,
+      348,    0,    0,  352,    0,    0,  351,    0,  354,    0,
+      352,    0,  348,  353,    0,  346,  355,  345,  345,  345,
+      351,  354,  346,  346,  346,    0,  355,  348,  348,  348,
+      352,  352,  352,  351,  351,  351,  353,  357,    0,    0,
+      353,  353,  353,  355,  355,  355,  356,    0,  354,  354,
+      354,  357,  356,    0,    0,  358,    0,    0,  359,    0,
+        0,    0,  360,    0,  357,  357,  357,  358,  360,    0,
+        0,  361,    0,  356,  356,  356,  361,    0,    0,    0,
+        0,    0,  358,  358,  358,  359,  359,  359,  362,  360,
+      360,  360,  365,    0,  362,  363,    0,    0,  361,  361,
 
-      363,  369,  367,  367,  367,  370,  374,  368,  372,    0,
-        0,  370,  373,    0,    0,  372,  368,  368,  368,  373,
-      374,  376,  369,  369,  369,    0,  375,    0,    0,    0,
-      376,    0,  370,  370,  370,  372,  372,  372,  377,  373,
-      373,  373,  378,    0,  377,    0,  379,  374,  374,  374,
-      375,  383,    0,  375,  375,  375,  385,  376,  376,  376,
-        0,  380,  385,  378,  379,  377,  377,  377,  380,  378,
-      378,  378,  382,  379,  379,  379,  381,    0,  383,  383,
-      383,  384,    0,  385,  385,  385,  386,  382,  380,  380,
-      380,  386,  387,    0,  381,  384,  389,    0,    0,  382,
+      361,  363,  364,    0,  365,  366,    0,    0,  364,    0,
+      366,  367,    0,    0,  368,  362,  362,  362,  369,  365,
+      365,  365,  363,  363,  363,    0,  367,    0,    0,  364,
+      364,  364,  366,  366,  366,  370,  369,    0,  367,  367,
+      367,  368,  368,  368,  371,  369,  369,  369,  372,    0,
+      371,  374,    0,  370,  372,  376,    0,    0,  374,  375,
+        0,    0,  370,  370,  370,  377,  375,    0,    0,  376,
+        0,  371,  371,  371,  378,  372,  372,  372,  374,  374,
+      374,    0,    0,  378,    0,    0,  375,  375,  375,  377,
+      381,    0,  377,  377,  377,  379,  376,  376,  376,  380,
 
-      382,  382,  390,  381,  381,  381,  391,    0,  384,  384,
-      384,  387,  391,  386,  386,  386,  392,  395,    0,  387,
-      387,  387,  392,  389,  389,  389,  396,  393,    0,  390,
-      390,  390,  394,  391,  391,  391,    0,  397,  394,    0,
-      395,    0,    0,  392,  392,  392,  393,    0,  396,    0,
-        0,  399,  400,    0,  393,  393,  393,  397,  398,  394,
-      394,  394,  398,  401,  397,  397,  397,  395,  395,  395,
-      399,  400,    0,  404,  402,  396,  396,  396,  399,  399,
-      399,    0,  401,  405,    0,  398,  398,  398,  403,  407,
-      401,  401,  401,  405,  406,    0,  402,  404,  400,  400,
+        0,  379,  382,    0,    0,    0,    0,  383,  381,  382,
+      378,  378,  378,  385,    0,    0,    0,  381,  381,  381,
+      380,    0,  379,  379,  379,  383,  380,  380,  380,  382,
+      382,  382,  384,    0,  383,  383,  383,  386,    0,    0,
+      385,  385,  385,  387,    0,    0,  388,  384,    0,  387,
+      389,  386,    0,  392,    0,  389,    0,  390,    0,  384,
+      384,  384,  393,    0,  386,  386,  386,    0,    0,    0,
+      387,  387,  387,  388,  388,  388,  390,  389,  389,  389,
+      392,  392,  392,  396,  390,  390,  390,  394,    0,  393,
+      393,  393,  395,  394,  398,  397,    0,    0,  395,    0,
 
-      400,  402,  402,  402,    0,  406,    0,  403,  407,    0,
-      405,  405,  405,  409,    0,  403,  403,  403,  411,  409,
-      411,  406,  406,  406,  404,  404,  404,  410,    0,    0,
-        0,  413,    0,  410,  414,  407,  407,  407,  415,    0,
-      409,  409,  409,  413,  415,    0,  416,  411,  411,  411,
-      417,    0,    0,  414,  410,  410,  410,  419,  413,  413,
-      413,  414,  414,  414,  416,  415,  415,  415,    0,  417,
-      418,    0,  419,  416,  416,  416,  420,  417,  417,  417,
-      418,    0,    0,    0,  419,  419,  419,    0,    0,    0,
-      420,    0,    0,    0,    0,    0,    0,  418,  418,  418,
+      401,  397,  396,  399,  401,    0,  400,    0,    0,    0,
+      396,  396,  396,  402,  394,  394,  394,  398,  403,  395,
+      395,  395,  397,  397,  397,  399,  400,  401,  401,  401,
+      404,  407,  402,  400,  400,  400,    0,  403,    0,    0,
+      402,  402,  402,  406,  398,  398,  398,  405,  410,  404,
+      408,    0,  399,  399,  399,  407,    0,  404,  404,  404,
+      408,    0,  406,    0,  403,  403,  403,  410,    0,  405,
+      406,  406,  406,  416,  405,  405,  405,  408,  408,  408,
+      409,    0,  407,  407,  407,  416,  412,  414,    0,  414,
+        0,  409,  412,  413,  410,  410,  410,  418,    0,  413,
 
-        0,    0,    0,  420,  420,  420,  422,  422,  422,  422,
-      422,  422,  422,  422,  422,  422,  422,  422,  422,  422,
-      423,  423,  423,  423,  423,  423,  423,  423,  423,  423,
-      423,  423,  423,  423,  424,  424,  424,  424,  424,  424,
-      424,  424,  424,  424,  424,  424,  424,  424,  425,  425,
+      416,  416,  416,  418,  417,    0,    0,  409,  409,  409,
+      419,    0,    0,  412,  412,  412,  414,  414,  414,    0,
+      413,  413,  413,  417,  418,  418,  418,  420,  419,    0,
+      421,  417,  417,  417,  422,    0,    0,  419,  419,  419,
+      421,    0,    0,    0,    0,    0,  420,    0,    0,  422,
+      423,    0,    0,    0,  420,  420,  420,  421,  421,  421,
+        0,  422,  422,  422,  423,    0,    0,    0,    0,    0,
+        0,    0,    0,    0,    0,    0,    0,  423,  423,  423,
       425,  425,  425,  425,  425,  425,  425,  425,  425,  425,
-      425,  425,  426,    0,  426,    0,  426,    0,  426,  427,
-        0,    0,  427,    0,  427,  427,  427,  427,  427,  428,
-      428,    0,  428,  428,  428,  428,  428,  428,  429,  429,
-      429,  429,  429,  429,  429,  429,  429,  429,  429,  429,
+      425,  425,  425,  425,  426,  426,  426,  426,  426,  426,
 
-      429,  429,  430,  430,  430,  430,  430,  430,  430,  430,
-      430,  430,  430,  430,  430,  431,    0,  431,  431,  431,
-      431,  431,  431,  431,  431,  431,  431,  431,  431,  432,
-        0,  432,  432,  432,  432,  432,  432,  432,  432,  432,
-      432,  432,  432,  433,  433,  433,  433,  433,  433,  433,
-      433,  433,  434,  434,  434,  435,    0,    0,    0,    0,
-      435,  435,  435,  436,  436,  436,  436,  436,  437,  437,
-      437,    0,    0,  437,  438,  438,  438,  439,  439,  439,
-      439,  439,  439,  439,  439,  439,  421,  421,  421,  421,
-      421,  421,  421,  421,  421,  421,  421,  421,  421,  421,
+      426,  426,  426,  426,  426,  426,  426,  426,  427,  427,
+      427,  427,  427,  427,  427,  427,  427,  427,  427,  427,
+      427,  427,  428,  428,  428,  428,  428,  428,  428,  428,
+      428,  428,  428,  428,  428,  428,  429,    0,  429,    0,
+      429,    0,  429,  430,    0,    0,  430,    0,  430,  430,
+      430,  430,  430,  431,  431,    0,  431,  431,  431,  431,
+      431,  431,  432,  432,  432,  432,  432,  432,  432,  432,
+      432,  432,  432,  432,  432,  432,  433,  433,  433,  433,
+      433,  433,  433,  433,  433,  433,  433,  433,  433,  434,
+        0,  434,  434,  434,  434,  434,  434,  434,  434,  434,
 
-      421,  421,  421,  421,  421,  421,  421,  421,  421,  421,
-      421,  421,  421,  421,  421,  421,  421,  421,  421,  421,
-      421,  421,  421,  421,  421,  421,  421,  421,  421,  421,
-      421,  421,  421,  421,  421,  421,  421,  421,  421,  421,
-      421,  421,  421,  421,  421,  421,  421,  421,  421,  421,
-      421,  421,  421,  421,  421
+      434,  434,  434,  435,    0,  435,  435,  435,  435,  435,
+      435,  435,  435,  435,  435,  435,  435,  436,  436,  436,
+      436,  436,  436,  436,  436,  436,  437,  437,  437,  438,
+        0,    0,    0,    0,  438,  438,  438,  439,  439,  439,
+      439,  439,  440,  440,  440,    0,    0,  440,  441,  441,
+      441,  442,  442,  442,  442,  442,  442,  442,  442,  442,
+      424,  424,  424,  424,  424,  424,  424,  424,  424,  424,
+      424,  424,  424,  424,  424,  424,  424,  424,  424,  424,
+      424,  424,  424,  424,  424,  424,  424,  424,  424,  424,
+      424,  424,  424,  424,  424,  424,  424,  424,  424,  424,
+
+      424,  424,  424,  424,  424,  424,  424,  424,  424,  424,
+      424,  424,  424,  424,  424,  424,  424,  424,  424,  424,
+      424,  424,  424,  424,  424,  424,  424,  424,  424
     } ;
 
 static yy_state_type yy_last_accepting_state;
 static char *yy_last_accepting_cpos;
 
-extern int ncg_flex_debug;
-int ncg_flex_debug = 0;
+extern int yy_flex_debug;
+int yy_flex_debug = 0;
 
 /* The intent behind this definition is that it'll catch
  * any uses of REJECT which flex missed.
@@ -1162,7 +1396,7 @@ int ncg_flex_debug = 0;
 #define yymore() yymore_used_but_not_detected
 #define YY_MORE_ADJ 0
 #define YY_RESTORE_YY_MORE_OFFSET
-char *ncgtext;
+char *yytext;
 #line 1 "ncgen.l"
 #line 2 "ncgen.l"
 /*********************************************************************
@@ -1281,6 +1515,7 @@ char char_val;                 /* last char value read */
 signed char byte_val;                 /* last byte value read */
 unsigned char ubyte_val;       /* last byte value read */
 
+/* Forward */
 static Symbol* makepath(char* text);
 static int lexdebug(int);
 static unsigned long long parseULL(int radix, char* text, int*);
@@ -1288,6 +1523,7 @@ static nc_type downconvert(unsigned long long uint64, int*, int, int);
 static int tagmatch(nc_type nct, int tag);
 static int nct2lexeme(nc_type nct);
 static int collecttag(char* text, char** stagp);
+static int identcheck(int token);
 
 struct Specialtoken specials[] = {
 {"_FillValue",_FILLVALUE,_FILLVALUE_FLAG},
@@ -1306,36 +1542,7 @@ struct Specialtoken specials[] = {
 {NULL,0} /* null terminate */
 };
 
-/* Track keywords that may be identifiers depending on
-   format being produced */
-/* Define the possible format classes */
-#define KWALL (1<<NC_FORMAT_CLASSIC|1<<NC_FORMAT_64BIT_OFFSET|1<<NC_FORMAT_NETCDF4|1<<NC_FORMAT_NETCDF4_CLASSIC|1<<NC_FORMAT_64BIT_DATA) /* Used in all formats */
-#define KWCDF5 (1<<NC_FORMAT_64BIT_DATA) /* Used in cdf5 */
-#define KWNC4 (1<<NC_FORMAT_NETCDF4) /* Used in netcdf-4 */
-
-#define NKWIDENT 12
-struct KWIDENT {
-    int token;
-    const char* keyword;
-    int formats; /* Which formats use this keyword */
-} kwident[NKWIDENT] = {
-/* Order by token for binary search */
-{CHAR_K, "char", KWALL},
-{BYTE_K, "byte", KWALL},
-{SHORT_K, "short", KWALL},
-{INT_K, "int", KWALL},
-{FLOAT_K, "float", KWALL},
-{DOUBLE_K, "double", KWALL},
-{UBYTE_K, "ubyte", KWCDF5|KWNC4},
-{USHORT_K, "ushort", KWCDF5|KWNC4},
-{UINT_K, "uint", KWCDF5|KWNC4},
-{INT64_K, "int64", KWCDF5|KWNC4},
-{UINT64_K, "uint64", KWCDF5|KWNC4},
-{STRING_K, "string", KWNC4}
-};
-static int identorkw(int token);
-
-
+#line 1545 "ncgenl.c"
 
 /* The most correct (validating) version of UTF8 character set
    (Taken from: http://www.w3.org/2005/03/23-lex-U)
@@ -1378,7 +1585,7 @@ ID ([A-Za-z_]|{UTF8})([A-Z.@#\[\]a-z_0-9+-]|{UTF8})*
 /* Note: this definition of string will work for utf8 as well,
    although it is a very relaxed definition
 */
-#line 1382 "ncgenl.c"
+#line 1588 "ncgenl.c"
 
 #define INITIAL 0
 #define ST_C_COMMENT 1
@@ -1396,36 +1603,36 @@ ID ([A-Za-z_]|{UTF8})([A-Z.@#\[\]a-z_0-9+-]|{UTF8})*
 #define YY_EXTRA_TYPE void *
 #endif
 
-static int yy_init_globals (void );
+static int yy_init_globals ( void );
 
 /* Accessor methods to globals.
    These are made visible to non-reentrant scanners for convenience. */
 
-int ncglex_destroy (void );
+int yylex_destroy ( void );
 
-int ncgget_debug (void );
+int yyget_debug ( void );
 
-void ncgset_debug (int debug_flag  );
+void yyset_debug ( int debug_flag  );
 
-YY_EXTRA_TYPE ncgget_extra (void );
+YY_EXTRA_TYPE yyget_extra ( void );
 
-void ncgset_extra (YY_EXTRA_TYPE user_defined  );
+void yyset_extra ( YY_EXTRA_TYPE user_defined  );
 
-FILE *ncgget_in (void );
+FILE *yyget_in ( void );
 
-void ncgset_in  (FILE * _in_str  );
+void yyset_in  ( FILE * _in_str  );
 
-FILE *ncgget_out (void );
+FILE *yyget_out ( void );
 
-void ncgset_out  (FILE * _out_str  );
+void yyset_out  ( FILE * _out_str  );
 
-yy_size_t ncgget_leng (void );
+			int yyget_leng ( void );
 
-char *ncgget_text (void );
+char *yyget_text ( void );
 
-int ncgget_lineno (void );
+int yyget_lineno ( void );
 
-void ncgset_lineno (int _line_number  );
+void yyset_lineno ( int _line_number  );
 
 /* Macros after this point can all be overridden by user definitions in
  * section 1.
@@ -1433,32 +1640,31 @@ void ncgset_lineno (int _line_number  );
 
 #ifndef YY_SKIP_YYWRAP
 #ifdef __cplusplus
-extern "C" int ncgwrap (void );
+extern "C" int yywrap ( void );
 #else
-extern int ncgwrap (void );
+extern int yywrap ( void );
 #endif
 #endif
 
 #ifndef YY_NO_UNPUT
     
-    static void yyunput (int c,char *buf_ptr  );
+    static void yyunput ( int c, char *buf_ptr  );
     
 #endif
 
 #ifndef yytext_ptr
-static void yy_flex_strncpy (char *,yyconst char *,int );
+static void yy_flex_strncpy ( char *, const char *, int );
 #endif
 
 #ifdef YY_NEED_STRLEN
-static int yy_flex_strlen (yyconst char * );
+static int yy_flex_strlen ( const char * );
 #endif
 
 #ifndef YY_NO_INPUT
-
 #ifdef __cplusplus
-static int yyinput (void );
+static int yyinput ( void );
 #else
-static int input (void );
+static int input ( void );
 #endif
 
 #endif
@@ -1478,7 +1684,7 @@ static int input (void );
 /* This used to be an fputs(), but since the string might contain NUL's,
  * we now use fwrite().
  */
-#define ECHO do { if (fwrite( ncgtext, ncgleng, 1, ncgout )) {} } while (0)
+#define ECHO do { if (fwrite( yytext, (size_t) yyleng, 1, yyout )) {} } while (0)
 #endif
 
 /* Gets input and stuffs it into "buf".  number of characters read, or YY_NULL,
@@ -1489,20 +1695,20 @@ static int input (void );
 	if ( YY_CURRENT_BUFFER_LVALUE->yy_is_interactive ) \
 		{ \
 		int c = '*'; \
-		size_t n; \
+		int n; \
 		for ( n = 0; n < max_size && \
-			     (c = getc( ncgin )) != EOF && c != '\n'; ++n ) \
+			     (c = getc( yyin )) != EOF && c != '\n'; ++n ) \
 			buf[n] = (char) c; \
 		if ( c == '\n' ) \
 			buf[n++] = (char) c; \
-		if ( c == EOF && ferror( ncgin ) ) \
+		if ( c == EOF && ferror( yyin ) ) \
 			YY_FATAL_ERROR( "input in flex scanner failed" ); \
 		result = n; \
 		} \
 	else \
 		{ \
 		errno=0; \
-		while ( (result = fread(buf, 1, max_size, ncgin))==0 && ferror(ncgin)) \
+		while ( (result = (int) fread(buf, 1, (yy_size_t) max_size, yyin)) == 0 && ferror(yyin)) \
 			{ \
 			if( errno != EINTR) \
 				{ \
@@ -1510,7 +1716,7 @@ static int input (void );
 				break; \
 				} \
 			errno=0; \
-			clearerr(ncgin); \
+			clearerr(yyin); \
 			} \
 		}\
 \
@@ -1543,12 +1749,12 @@ static int input (void );
 #ifndef YY_DECL
 #define YY_DECL_IS_OURS 1
 
-extern int ncglex (void);
+extern int yylex (void);
 
-#define YY_DECL int ncglex (void)
+#define YY_DECL int yylex (void)
 #endif /* !YY_DECL */
 
-/* Code executed at the beginning of each rule, after ncgtext and ncgleng
+/* Code executed at the beginning of each rule, after yytext and yyleng
  * have been set up.
  */
 #ifndef YY_USER_ACTION
@@ -1582,31 +1788,31 @@ YY_DECL
 		if ( ! (yy_start) )
 			(yy_start) = 1;	/* first start state */
 
-		if ( ! ncgin )
-			ncgin = stdin;
+		if ( ! yyin )
+			yyin = stdin;
 
-		if ( ! ncgout )
-			ncgout = stdout;
+		if ( ! yyout )
+			yyout = stdout;
 
 		if ( ! YY_CURRENT_BUFFER ) {
-			ncgensure_buffer_stack ();
+			yyensure_buffer_stack ();
 			YY_CURRENT_BUFFER_LVALUE =
-				ncg_create_buffer(ncgin,YY_BUF_SIZE );
+				yy_create_buffer( yyin, YY_BUF_SIZE );
 		}
 
-		ncg_load_buffer_state( );
+		yy_load_buffer_state(  );
 		}
 
 	{
-#line 251 "ncgen.l"
+#line 224 "ncgen.l"
 
-#line 1604 "ncgenl.c"
+#line 1809 "ncgenl.c"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
 		yy_cp = (yy_c_buf_p);
 
-		/* Support of ncgtext. */
+		/* Support of yytext. */
 		*yy_cp = (yy_hold_char);
 
 		/* yy_bp points to the position in yy_ch_buf of the start of
@@ -1627,13 +1833,13 @@ yy_match:
 			while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
 				{
 				yy_current_state = (int) yy_def[yy_current_state];
-				if ( yy_current_state >= 422 )
-					yy_c = yy_meta[(unsigned int) yy_c];
+				if ( yy_current_state >= 425 )
+					yy_c = yy_meta[yy_c];
 				}
-			yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
+			yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 			++yy_cp;
 			}
-		while ( yy_base[yy_current_state] != 2387 );
+		while ( yy_base[yy_current_state] != 2461 );
 
 yy_find_action:
 		yy_act = yy_accept[yy_current_state];
@@ -1659,14 +1865,14 @@ do_action:	/* This label is used only to access EOF actions. */
 
 case 1:
 YY_RULE_SETUP
-#line 252 "ncgen.l"
+#line 225 "ncgen.l"
 { /* whitespace */
 		  break;
 		}
 	YY_BREAK
 case 2:
 YY_RULE_SETUP
-#line 256 "ncgen.l"
+#line 229 "ncgen.l"
 { /* comment */
                           break;
                         }
@@ -1674,19 +1880,19 @@ YY_RULE_SETUP
 case 3:
 /* rule 3 can match eol */
 YY_RULE_SETUP
-#line 260 "ncgen.l"
+#line 233 "ncgen.l"
 {int len; char* s = NULL;
 			 /* In netcdf4, this will be used in a variety
                             of places, so only remove escapes */
 /*
-if(ncgleng > MAXTRST) {
+if(yyleng > MAXTRST) {
 yyerror("string too long, truncated\n");
-ncgtext[MAXTRST-1] = '\0';
+yytext[MAXTRST-1] = '\0';
 }
 */
-			len = unescape((char *)ncgtext+1,ncgleng-2,!ISIDENT,&s);
+			len = unescape((char *)yytext+1,yyleng-2,!ISIDENT,&s);
 			if(len < 0) {
-			    sprintf(errstr,"Illegal character: %s",ncgtext);
+			    sprintf(errstr,"Illegal character: %s",yytext);
 			    yyerror(errstr);
 			}
 			bbClear(lextext);
@@ -1698,10 +1904,10 @@ ncgtext[MAXTRST-1] = '\0';
 	YY_BREAK
 case 4:
 YY_RULE_SETUP
-#line 281 "ncgen.l"
+#line 254 "ncgen.l"
 { /* drop leading 0x; pad to even number of chars */
-		char* p = ncgtext+2;
-		int len = ncgleng - 2;
+		char* p = yytext+2;
+		int len = yyleng - 2;
 		bbClear(lextext);
 	        bbAppendn(lextext,p,len);
 	        if((len % 2) == 1) bbAppend(lextext,'0');
@@ -1713,121 +1919,145 @@ YY_RULE_SETUP
 	YY_BREAK
 case 5:
 YY_RULE_SETUP
-#line 293 "ncgen.l"
-{return lexdebug(identorkw(COMPOUND));}
+#line 266 "ncgen.l"
+{return lexdebug(COMPOUND);}
 	YY_BREAK
 case 6:
 YY_RULE_SETUP
-#line 294 "ncgen.l"
-{return lexdebug(identorkw(ENUM));}
+#line 267 "ncgen.l"
+{return lexdebug(ENUM);}
 	YY_BREAK
 case 7:
 YY_RULE_SETUP
-#line 295 "ncgen.l"
+#line 268 "ncgen.l"
 {return lexdebug(OPAQUE_);}
 	YY_BREAK
 case 8:
 YY_RULE_SETUP
-#line 297 "ncgen.l"
-{return lexdebug(identorkw(FLOAT_K));}
+#line 270 "ncgen.l"
+{return lexdebug(FLOAT_K);}
 	YY_BREAK
 case 9:
 YY_RULE_SETUP
-#line 298 "ncgen.l"
-{return lexdebug(identorkw(CHAR_K));}
+#line 271 "ncgen.l"
+{return lexdebug(DOUBLE_K);}
 	YY_BREAK
 case 10:
 YY_RULE_SETUP
-#line 299 "ncgen.l"
-{return lexdebug(identorkw(BYTE_K));}
+#line 272 "ncgen.l"
+{return lexdebug(CHAR_K);}
 	YY_BREAK
 case 11:
 YY_RULE_SETUP
-#line 300 "ncgen.l"
-{return lexdebug(identorkw(UBYTE_K));}
+#line 273 "ncgen.l"
+{return lexdebug(BYTE_K);}
 	YY_BREAK
 case 12:
 YY_RULE_SETUP
-#line 301 "ncgen.l"
-{return lexdebug(identorkw(SHORT_K));}
+#line 274 "ncgen.l"
+{return lexdebug(SHORT_K);}
 	YY_BREAK
 case 13:
 YY_RULE_SETUP
-#line 302 "ncgen.l"
-{return lexdebug(identorkw(USHORT_K));}
+#line 275 "ncgen.l"
+{return lexdebug(INT_K);}
 	YY_BREAK
 case 14:
 YY_RULE_SETUP
-#line 303 "ncgen.l"
-{return lexdebug(identorkw(INT_K));}
+#line 276 "ncgen.l"
+{return lexdebug(identcheck(UBYTE_K));}
 	YY_BREAK
 case 15:
 YY_RULE_SETUP
-#line 304 "ncgen.l"
-{return lexdebug(identorkw(UINT_K));}
+#line 277 "ncgen.l"
+{return lexdebug(identcheck(USHORT_K));}
 	YY_BREAK
 case 16:
 YY_RULE_SETUP
-#line 305 "ncgen.l"
-{return lexdebug(identorkw(INT64_K));}
+#line 278 "ncgen.l"
+{return lexdebug(identcheck(UINT_K));}
 	YY_BREAK
 case 17:
 YY_RULE_SETUP
-#line 306 "ncgen.l"
-{return lexdebug(identorkw(UINT64_K));}
+#line 279 "ncgen.l"
+{return lexdebug(identcheck(INT64_K));}
 	YY_BREAK
 case 18:
 YY_RULE_SETUP
-#line 307 "ncgen.l"
-{return lexdebug(identorkw(DOUBLE_K));}
+#line 280 "ncgen.l"
+{return lexdebug(identcheck(UINT64_K));}
 	YY_BREAK
 case 19:
 YY_RULE_SETUP
-#line 308 "ncgen.l"
-{return lexdebug(identorkw(STRING_K));}
+#line 281 "ncgen.l"
+{return lexdebug(identcheck(STRING_K));}
 	YY_BREAK
 case 20:
 YY_RULE_SETUP
-#line 310 "ncgen.l"
-{int32_val = -1;
-			 return lexdebug(identorkw(NC_UNLIMITED_K));}
+#line 283 "ncgen.l"
+{return lexdebug(FLOAT_K);}
 	YY_BREAK
-/* These are currently only keywords */
 case 21:
 YY_RULE_SETUP
-#line 314 "ncgen.l"
-{return lexdebug(TYPES);}
+#line 284 "ncgen.l"
+{return lexdebug(INT_K);}
 	YY_BREAK
 case 22:
 YY_RULE_SETUP
-#line 315 "ncgen.l"
-{return lexdebug(DIMENSIONS);}
+#line 285 "ncgen.l"
+{return lexdebug(INT_K);}
 	YY_BREAK
 case 23:
 YY_RULE_SETUP
-#line 316 "ncgen.l"
-{return lexdebug(VARIABLES);}
+#line 286 "ncgen.l"
+{return lexdebug(identcheck(UINT_K));}
 	YY_BREAK
 case 24:
 YY_RULE_SETUP
-#line 317 "ncgen.l"
-{return lexdebug(DATA);}
+#line 287 "ncgen.l"
+{return lexdebug(identcheck(UINT_K));}
 	YY_BREAK
 case 25:
 YY_RULE_SETUP
-#line 318 "ncgen.l"
-{return lexdebug(GROUP);}
+#line 290 "ncgen.l"
+{int32_val = -1;
+			 return lexdebug(NC_UNLIMITED_K);}
 	YY_BREAK
 case 26:
 YY_RULE_SETUP
-#line 320 "ncgen.l"
-{BEGIN(TEXT);return lexdebug(NETCDF);}
+#line 293 "ncgen.l"
+{return lexdebug(TYPES);}
 	YY_BREAK
 case 27:
 YY_RULE_SETUP
-#line 322 "ncgen.l"
+#line 294 "ncgen.l"
+{return lexdebug(DIMENSIONS);}
+	YY_BREAK
+case 28:
+YY_RULE_SETUP
+#line 295 "ncgen.l"
+{return lexdebug(VARIABLES);}
+	YY_BREAK
+case 29:
+YY_RULE_SETUP
+#line 296 "ncgen.l"
+{return lexdebug(DATA);}
+	YY_BREAK
+case 30:
+YY_RULE_SETUP
+#line 297 "ncgen.l"
+{return lexdebug(GROUP);}
+	YY_BREAK
+case 31:
+YY_RULE_SETUP
+#line 299 "ncgen.l"
+{BEGIN(TEXT);return lexdebug(NETCDF);}
+	YY_BREAK
+case 32:
+YY_RULE_SETUP
+#line 301 "ncgen.l"
 { /* missing value (pre-2.4 backward compatibility) */
-                if (ncgtext[0] == '-') {
+                if (yytext[0] == '-') {
 		    double_val = -INFINITY;
                 } else {
 		    double_val = INFINITY;
@@ -1836,20 +2066,20 @@ YY_RULE_SETUP
 		return lexdebug(DOUBLE_CONST);
 		}
 	YY_BREAK
-case 28:
+case 33:
 YY_RULE_SETUP
-#line 331 "ncgen.l"
+#line 310 "ncgen.l"
 { /* missing value (pre-2.4 backward compatibility) */
 		double_val = NAN;
 		specialconstants = 1;
 		return lexdebug(DOUBLE_CONST);
 		}
 	YY_BREAK
-case 29:
+case 34:
 YY_RULE_SETUP
-#line 337 "ncgen.l"
+#line 316 "ncgen.l"
 {/* missing value (pre-2.4 backward compatibility)*/
-                if (ncgtext[0] == '-') {
+                if (yytext[0] == '-') {
 		    float_val = -INFINITYF;
                 } else {
 		    float_val = INFINITYF;
@@ -1858,18 +2088,18 @@ YY_RULE_SETUP
 		return lexdebug(FLOAT_CONST);
 		}
 	YY_BREAK
-case 30:
+case 35:
 YY_RULE_SETUP
-#line 346 "ncgen.l"
+#line 325 "ncgen.l"
 { /* missing value (pre-2.4 backward compatibility) */
 		float_val = NANF;
 		specialconstants = 1;
 		return lexdebug(FLOAT_CONST);
 		}
 	YY_BREAK
-case 31:
+case 36:
 YY_RULE_SETUP
-#line 352 "ncgen.l"
+#line 331 "ncgen.l"
 {
 #ifdef USE_NETCDF4
 		if(l_flag == L_C || l_flag == L_BINARY)
@@ -1880,23 +2110,23 @@ YY_RULE_SETUP
 #endif
 		}
 	YY_BREAK
-case 32:
+case 37:
 YY_RULE_SETUP
-#line 362 "ncgen.l"
+#line 341 "ncgen.l"
 {
 		bbClear(lextext);
-		bbAppendn(lextext,(char*)ncgtext,ncgleng+1); /* include null */
+		bbAppendn(lextext,(char*)yytext,yyleng+1); /* include null */
 	        bbNull(lextext);
 		yylval.sym = makepath(bbContents(lextext));
 		return lexdebug(PATH);
 		}
 	YY_BREAK
-case 33:
+case 38:
 YY_RULE_SETUP
-#line 371 "ncgen.l"
+#line 350 "ncgen.l"
 {struct Specialtoken* st;
 		bbClear(lextext);
-		bbAppendn(lextext,(char*)ncgtext,ncgleng+1); /* include null */
+		bbAppendn(lextext,(char*)yytext,yyleng+1); /* include null */
 		bbNull(lextext);
 		for(st=specials;st->name;st++) {
 		    if(strcmp(bbContents(lextext),st->name)==0) {return lexdebug(st->token);}
@@ -1904,16 +2134,16 @@ YY_RULE_SETUP
 		return 0;
 		}
 	YY_BREAK
-case 34:
-/* rule 34 can match eol */
+case 39:
+/* rule 39 can match eol */
 YY_RULE_SETUP
-#line 381 "ncgen.l"
+#line 360 "ncgen.l"
 {
 		    int c;
 		    char* p; char* q;
 		    /* copy the trimmed name */
 		    bbClear(lextext);
-		    bbAppendn(lextext,(char*)ncgtext,ncgleng+1); /* include null */
+		    bbAppendn(lextext,(char*)yytext,yyleng+1); /* include null */
 		    bbNull(lextext);
 		    p = bbContents(lextext);
 		    q = p;
@@ -1925,12 +2155,12 @@ YY_RULE_SETUP
 		    return lexdebug(DATASETID);
 		}
 	YY_BREAK
-case 35:
+case 40:
 YY_RULE_SETUP
-#line 398 "ncgen.l"
+#line 377 "ncgen.l"
 { char* id = NULL; int len;
-		    len = strlen(ncgtext);
-		    len = unescape(ncgtext,len,ISIDENT,&id);
+		    len = strlen(yytext);
+		    len = unescape(yytext,len,ISIDENT,&id);
 		    if(NCSTREQ(id, FILL_STRING)) {
 			efree(id);
 		        return lexdebug(FILLMARKER);
@@ -1940,9 +2170,9 @@ YY_RULE_SETUP
 		    return lexdebug(IDENT);
 		}
 	YY_BREAK
-case 36:
+case 41:
 YY_RULE_SETUP
-#line 410 "ncgen.l"
+#line 389 "ncgen.l"
 {
 		/*
 		  We need to try to see what size of integer ((u)int).
@@ -2021,27 +2251,27 @@ YY_RULE_SETUP
 done: return 0;
 	    }
 	YY_BREAK
-case 37:
+case 42:
 YY_RULE_SETUP
-#line 488 "ncgen.l"
+#line 467 "ncgen.l"
 {
 		int c;
 		int token = 0;
-		int slen = strlen(ncgtext);
+		int slen = strlen(yytext);
 		char* stag = NULL;
 	        int tag = NC_NAT;
-		char* hex = ncgtext+2; /* point to first true hex digit */
+		char* hex = yytext+2; /* point to first true hex digit */
 		int xlen = (slen - 3);  /* true hex length */
 
-		ncgtext[slen-1] = '\0';
+		yytext[slen-1] = '\0';
 	        /* capture the tag string */
-		tag = collecttag(ncgtext,&stag);
+		tag = collecttag(yytext,&stag);
 		if(tag == NC_NAT) {
 		    sprintf(errstr,"Illegal integer suffix: %s",stag);
 		    yyerror(errstr);
 		    goto done;
 		}
-		ncgtext[slen - strlen(stag)] = '\0';
+		yytext[slen - strlen(stag)] = '\0';
 	        if(xlen > 16) { /* truncate hi order digits */
 		    hex += (xlen - 16);
 		}
@@ -2063,8 +2293,8 @@ YY_RULE_SETUP
 		    token = UINT64_CONST;
 		    break;
 		default: /* should never happen */
-		    if (sscanf((char*)ncgtext, "%i", &uint32_val) != 1) {
-		        sprintf(errstr,"bad unsigned int constant: %s",(char*)ncgtext);
+		    if (sscanf((char*)yytext, "%i", &uint32_val) != 1) {
+		        sprintf(errstr,"bad unsigned int constant: %s",(char*)yytext);
 		        yyerror(errstr);
 		    }
 		    token = UINT_CONST;
@@ -2072,68 +2302,68 @@ YY_RULE_SETUP
 		return lexdebug(token);
 	    }
 	YY_BREAK
-case 38:
+case 43:
 YY_RULE_SETUP
-#line 535 "ncgen.l"
+#line 514 "ncgen.l"
 {
-		if (sscanf((char*)ncgtext, "%le", &double_val) != 1) {
-		    sprintf(errstr,"bad long or double constant: %s",(char*)ncgtext);
+		if (sscanf((char*)yytext, "%le", &double_val) != 1) {
+		    sprintf(errstr,"bad long or double constant: %s",(char*)yytext);
 		    yyerror(errstr);
 		}
                 return lexdebug(DOUBLE_CONST);
                 }
 	YY_BREAK
-case 39:
+case 44:
 YY_RULE_SETUP
-#line 542 "ncgen.l"
+#line 521 "ncgen.l"
 {
-		if (sscanf((char*)ncgtext, "%e", &float_val) != 1) {
-		    sprintf(errstr,"bad float constant: %s",(char*)ncgtext);
+		if (sscanf((char*)yytext, "%e", &float_val) != 1) {
+		    sprintf(errstr,"bad float constant: %s",(char*)yytext);
 		    yyerror(errstr);
 		}
                 return lexdebug(FLOAT_CONST);
                 }
 	YY_BREAK
-case 40:
-/* rule 40 can match eol */
+case 45:
+/* rule 45 can match eol */
 YY_RULE_SETUP
-#line 549 "ncgen.l"
+#line 528 "ncgen.l"
 {
-	        (void) sscanf((char*)&ncgtext[1],"%c",&byte_val);
+	        (void) sscanf((char*)&yytext[1],"%c",&byte_val);
 		return lexdebug(BYTE_CONST);
                 }
 	YY_BREAK
-case 41:
+case 46:
 YY_RULE_SETUP
-#line 553 "ncgen.l"
+#line 532 "ncgen.l"
 {
-		int oct = unescapeoct(&ncgtext[2]);
+		int oct = unescapeoct(&yytext[2]);
 		if(oct < 0) {
-		    sprintf(errstr,"bad octal character constant: %s",(char*)ncgtext);
+		    sprintf(errstr,"bad octal character constant: %s",(char*)yytext);
 		    yyerror(errstr);
 		}
 	        byte_val = (unsigned int)oct;
 		return lexdebug(BYTE_CONST);
                 }
 	YY_BREAK
-case 42:
+case 47:
 YY_RULE_SETUP
-#line 562 "ncgen.l"
+#line 541 "ncgen.l"
 {
-		int hex = unescapehex(&ncgtext[3]);
+		int hex = unescapehex(&yytext[3]);
 		if(byte_val < 0) {
-		    sprintf(errstr,"bad hex character constant: %s",(char*)ncgtext);
+		    sprintf(errstr,"bad hex character constant: %s",(char*)yytext);
 		    yyerror(errstr);
 		}
 		byte_val = (unsigned int)hex;
 		return lexdebug(BYTE_CONST);
                 }
 	YY_BREAK
-case 43:
+case 48:
 YY_RULE_SETUP
-#line 571 "ncgen.l"
+#line 550 "ncgen.l"
 {
-	       switch ((char)ncgtext[2]) {
+	       switch ((char)yytext[2]) {
 	          case 'a': byte_val = '\007'; break; /* not everyone under-
 						       * stands '\a' yet */
      	          case 'b': byte_val = '\b'; break;
@@ -2145,65 +2375,65 @@ YY_RULE_SETUP
 		  case '\\': byte_val = '\\'; break;
 		  case '?': byte_val = '\177'; break;
 		  case '\'': byte_val = '\''; break;
-		  default: byte_val = (char)ncgtext[2];
+		  default: byte_val = (char)yytext[2];
 	           }
 		return lexdebug(BYTE_CONST);
                 }
 	YY_BREAK
-case 44:
-/* rule 44 can match eol */
+case 49:
+/* rule 49 can match eol */
 YY_RULE_SETUP
-#line 589 "ncgen.l"
+#line 568 "ncgen.l"
 {
 		lineno++ ;
                 break;
 		}
 	YY_BREAK
-case 45:
+case 50:
 YY_RULE_SETUP
-#line 594 "ncgen.l"
+#line 573 "ncgen.l"
 {/*initial*/
 	    BEGIN(ST_C_COMMENT);
 	    break;
 	}
 	YY_BREAK
-case 46:
-/* rule 46 can match eol */
+case 51:
+/* rule 51 can match eol */
 YY_RULE_SETUP
-#line 599 "ncgen.l"
+#line 578 "ncgen.l"
 {/* continuation */
 				     break;
 				}
 	YY_BREAK
-case 47:
+case 52:
 YY_RULE_SETUP
-#line 603 "ncgen.l"
+#line 582 "ncgen.l"
 {/* final */
 			    BEGIN(INITIAL);
 			    break;
 			}
 	YY_BREAK
 case YY_STATE_EOF(ST_C_COMMENT):
-#line 608 "ncgen.l"
+#line 587 "ncgen.l"
 {/* final, error */
 			    fprintf(stderr,"unterminated /**/ comment");
 			    BEGIN(INITIAL);
 			    break;
 			}
 	YY_BREAK
-case 48:
+case 53:
 YY_RULE_SETUP
-#line 614 "ncgen.l"
+#line 593 "ncgen.l"
 {/* Note: this next rule will not work for UTF8 characters */
-		return lexdebug(ncgtext[0]) ;
+		return lexdebug(yytext[0]) ;
 		}
 	YY_BREAK
-case 49:
+case 54:
 YY_RULE_SETUP
-#line 617 "ncgen.l"
+#line 596 "ncgen.l"
 ECHO;
 	YY_BREAK
-#line 2207 "ncgenl.c"
+#line 2436 "ncgenl.c"
 case YY_STATE_EOF(INITIAL):
 case YY_STATE_EOF(TEXT):
 	yyterminate();
@@ -2221,15 +2451,15 @@ case YY_STATE_EOF(TEXT):
 			{
 			/* We're scanning a new file or input source.  It's
 			 * possible that this happened because the user
-			 * just pointed ncgin at a new source and called
-			 * ncglex().  If so, then we have to assure
+			 * just pointed yyin at a new source and called
+			 * yylex().  If so, then we have to assure
 			 * consistency between YY_CURRENT_BUFFER and our
 			 * globals.  Here is the right place to do so, because
 			 * this is the first action (other than possibly a
 			 * back-up) that will match for the new input source.
 			 */
 			(yy_n_chars) = YY_CURRENT_BUFFER_LVALUE->yy_n_chars;
-			YY_CURRENT_BUFFER_LVALUE->yy_input_file = ncgin;
+			YY_CURRENT_BUFFER_LVALUE->yy_input_file = yyin;
 			YY_CURRENT_BUFFER_LVALUE->yy_buffer_status = YY_BUFFER_NORMAL;
 			}
 
@@ -2282,11 +2512,11 @@ case YY_STATE_EOF(TEXT):
 				{
 				(yy_did_buffer_switch_on_eof) = 0;
 
-				if ( ncgwrap( ) )
+				if ( yywrap(  ) )
 					{
 					/* Note: because we've taken care in
 					 * yy_get_next_buffer() to have set up
-					 * ncgtext, we can now set up
+					 * yytext, we can now set up
 					 * yy_c_buf_p so that if some total
 					 * hoser (like flex itself) wants to
 					 * call the scanner after we return the
@@ -2336,7 +2566,7 @@ case YY_STATE_EOF(TEXT):
 	} /* end of action switch */
 		} /* end of scanning one token */
 	} /* end of user's declarations */
-} /* end of ncglex */
+} /* end of yylex */
 
 /* yy_get_next_buffer - try to read in a new buffer
  *
@@ -2349,7 +2579,7 @@ static int yy_get_next_buffer (void)
 {
     	char *dest = YY_CURRENT_BUFFER_LVALUE->yy_ch_buf;
 	char *source = (yytext_ptr);
-	yy_size_t number_to_move, i;
+	int number_to_move, i;
 	int ret_val;
 
 	if ( (yy_c_buf_p) > &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[(yy_n_chars) + 1] )
@@ -2378,7 +2608,7 @@ static int yy_get_next_buffer (void)
 	/* Try to read more data. */
 
 	/* First move last chars to start of buffer. */
-	number_to_move = (yy_size_t) ((yy_c_buf_p) - (yytext_ptr)) - 1;
+	number_to_move = (int) ((yy_c_buf_p) - (yytext_ptr) - 1);
 
 	for ( i = 0; i < number_to_move; ++i )
 		*(dest++) = *(source++);
@@ -2391,7 +2621,7 @@ static int yy_get_next_buffer (void)
 
 	else
 		{
-			yy_size_t num_to_read =
+			int num_to_read =
 			YY_CURRENT_BUFFER_LVALUE->yy_buf_size - number_to_move - 1;
 
 		while ( num_to_read <= 0 )
@@ -2405,7 +2635,7 @@ static int yy_get_next_buffer (void)
 
 			if ( b->yy_is_our_buffer )
 				{
-				yy_size_t new_size = b->yy_buf_size * 2;
+				int new_size = b->yy_buf_size * 2;
 
 				if ( new_size <= 0 )
 					b->yy_buf_size += b->yy_buf_size / 8;
@@ -2414,11 +2644,12 @@ static int yy_get_next_buffer (void)
 
 				b->yy_ch_buf = (char *)
 					/* Include room in for 2 EOB chars. */
-					ncgrealloc((void *) b->yy_ch_buf,b->yy_buf_size + 2  );
+					yyrealloc( (void *) b->yy_ch_buf,
+							 (yy_size_t) (b->yy_buf_size + 2)  );
 				}
 			else
 				/* Can't grow it, we don't own it. */
-				b->yy_ch_buf = 0;
+				b->yy_ch_buf = NULL;
 
 			if ( ! b->yy_ch_buf )
 				YY_FATAL_ERROR(
@@ -2446,7 +2677,7 @@ static int yy_get_next_buffer (void)
 		if ( number_to_move == YY_MORE_ADJ )
 			{
 			ret_val = EOB_ACT_END_OF_FILE;
-			ncgrestart(ncgin  );
+			yyrestart( yyin  );
 			}
 
 		else
@@ -2460,12 +2691,15 @@ static int yy_get_next_buffer (void)
 	else
 		ret_val = EOB_ACT_CONTINUE_SCAN;
 
-	if ((int) ((yy_n_chars) + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
+	if (((yy_n_chars) + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
 		/* Extend the array by 50%, plus the number we really need. */
 		int new_size = (yy_n_chars) + number_to_move + ((yy_n_chars) >> 1);
-		YY_CURRENT_BUFFER_LVALUE->yy_ch_buf = (char *) ncgrealloc((void *) YY_CURRENT_BUFFER_LVALUE->yy_ch_buf,new_size  );
+		YY_CURRENT_BUFFER_LVALUE->yy_ch_buf = (char *) yyrealloc(
+			(void *) YY_CURRENT_BUFFER_LVALUE->yy_ch_buf, (yy_size_t) new_size  );
 		if ( ! YY_CURRENT_BUFFER_LVALUE->yy_ch_buf )
 			YY_FATAL_ERROR( "out of dynamic memory in yy_get_next_buffer()" );
+		/* "- 2" to take care of EOB's */
+		YY_CURRENT_BUFFER_LVALUE->yy_buf_size = (int) (new_size - 2);
 	}
 
 	(yy_n_chars) += number_to_move;
@@ -2497,10 +2731,10 @@ static int yy_get_next_buffer (void)
 		while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
 			{
 			yy_current_state = (int) yy_def[yy_current_state];
-			if ( yy_current_state >= 422 )
-				yy_c = yy_meta[(unsigned int) yy_c];
+			if ( yy_current_state >= 425 )
+				yy_c = yy_meta[yy_c];
 			}
-		yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
+		yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 		}
 
 	return yy_current_state;
@@ -2525,11 +2759,11 @@ static int yy_get_next_buffer (void)
 	while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
 		{
 		yy_current_state = (int) yy_def[yy_current_state];
-		if ( yy_current_state >= 422 )
-			yy_c = yy_meta[(unsigned int) yy_c];
+		if ( yy_current_state >= 425 )
+			yy_c = yy_meta[yy_c];
 		}
-	yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
-	yy_is_jam = (yy_current_state == 421);
+	yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
+	yy_is_jam = (yy_current_state == 424);
 
 		return yy_is_jam ? 0 : yy_current_state;
 }
@@ -2542,13 +2776,13 @@ static int yy_get_next_buffer (void)
     
     yy_cp = (yy_c_buf_p);
 
-	/* undo effects of setting up ncgtext */
+	/* undo effects of setting up yytext */
 	*yy_cp = (yy_hold_char);
 
 	if ( yy_cp < YY_CURRENT_BUFFER_LVALUE->yy_ch_buf + 2 )
 		{ /* need to shift things up to make room */
 		/* +2 for EOB chars. */
-		yy_size_t number_to_move = (yy_n_chars) + 2;
+		int number_to_move = (yy_n_chars) + 2;
 		char *dest = &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[
 					YY_CURRENT_BUFFER_LVALUE->yy_buf_size + 2];
 		char *source =
@@ -2560,7 +2794,7 @@ static int yy_get_next_buffer (void)
 		yy_cp += (int) (dest - source);
 		yy_bp += (int) (dest - source);
 		YY_CURRENT_BUFFER_LVALUE->yy_n_chars =
-			(yy_n_chars) = YY_CURRENT_BUFFER_LVALUE->yy_buf_size;
+			(yy_n_chars) = (int) YY_CURRENT_BUFFER_LVALUE->yy_buf_size;
 
 		if ( yy_cp < YY_CURRENT_BUFFER_LVALUE->yy_ch_buf + 2 )
 			YY_FATAL_ERROR( "flex scanner push-back overflow" );
@@ -2599,7 +2833,7 @@ static int yy_get_next_buffer (void)
 
 		else
 			{ /* need more input */
-			yy_size_t offset = (yy_c_buf_p) - (yytext_ptr);
+			int offset = (int) ((yy_c_buf_p) - (yytext_ptr));
 			++(yy_c_buf_p);
 
 			switch ( yy_get_next_buffer(  ) )
@@ -2616,14 +2850,14 @@ static int yy_get_next_buffer (void)
 					 */
 
 					/* Reset buffer status. */
-					ncgrestart(ncgin );
+					yyrestart( yyin );
 
 					/*FALLTHROUGH*/
 
 				case EOB_ACT_END_OF_FILE:
 					{
-					if ( ncgwrap( ) )
-						return EOF;
+					if ( yywrap(  ) )
+						return 0;
 
 					if ( ! (yy_did_buffer_switch_on_eof) )
 						YY_NEW_FILE;
@@ -2642,7 +2876,7 @@ static int yy_get_next_buffer (void)
 		}
 
 	c = *(unsigned char *) (yy_c_buf_p);	/* cast for 8-bit char's */
-	*(yy_c_buf_p) = '\0';	/* preserve ncgtext */
+	*(yy_c_buf_p) = '\0';	/* preserve yytext */
 	(yy_hold_char) = *++(yy_c_buf_p);
 
 	return c;
@@ -2654,32 +2888,32 @@ static int yy_get_next_buffer (void)
  * 
  * @note This function does not reset the start condition to @c INITIAL .
  */
-    void ncgrestart  (FILE * input_file )
+    void yyrestart  (FILE * input_file )
 {
     
 	if ( ! YY_CURRENT_BUFFER ){
-        ncgensure_buffer_stack ();
+        yyensure_buffer_stack ();
 		YY_CURRENT_BUFFER_LVALUE =
-            ncg_create_buffer(ncgin,YY_BUF_SIZE );
+            yy_create_buffer( yyin, YY_BUF_SIZE );
 	}
 
-	ncg_init_buffer(YY_CURRENT_BUFFER,input_file );
-	ncg_load_buffer_state( );
+	yy_init_buffer( YY_CURRENT_BUFFER, input_file );
+	yy_load_buffer_state(  );
 }
 
 /** Switch to a different input buffer.
  * @param new_buffer The new input buffer.
  * 
  */
-    void ncg_switch_to_buffer  (YY_BUFFER_STATE  new_buffer )
+    void yy_switch_to_buffer  (YY_BUFFER_STATE  new_buffer )
 {
     
 	/* TODO. We should be able to replace this entire function body
 	 * with
-	 *		ncgpop_buffer_state();
-	 *		ncgpush_buffer_state(new_buffer);
+	 *		yypop_buffer_state();
+	 *		yypush_buffer_state(new_buffer);
      */
-	ncgensure_buffer_stack ();
+	yyensure_buffer_stack ();
 	if ( YY_CURRENT_BUFFER == new_buffer )
 		return;
 
@@ -2692,21 +2926,21 @@ static int yy_get_next_buffer (void)
 		}
 
 	YY_CURRENT_BUFFER_LVALUE = new_buffer;
-	ncg_load_buffer_state( );
+	yy_load_buffer_state(  );
 
 	/* We don't actually know whether we did this switch during
-	 * EOF (ncgwrap()) processing, but the only time this flag
-	 * is looked at is after ncgwrap() is called, so it's safe
+	 * EOF (yywrap()) processing, but the only time this flag
+	 * is looked at is after yywrap() is called, so it's safe
 	 * to go ahead and always set it.
 	 */
 	(yy_did_buffer_switch_on_eof) = 1;
 }
 
-static void ncg_load_buffer_state  (void)
+static void yy_load_buffer_state  (void)
 {
     	(yy_n_chars) = YY_CURRENT_BUFFER_LVALUE->yy_n_chars;
 	(yytext_ptr) = (yy_c_buf_p) = YY_CURRENT_BUFFER_LVALUE->yy_buf_pos;
-	ncgin = YY_CURRENT_BUFFER_LVALUE->yy_input_file;
+	yyin = YY_CURRENT_BUFFER_LVALUE->yy_input_file;
 	(yy_hold_char) = *(yy_c_buf_p);
 }
 
@@ -2716,35 +2950,35 @@ static void ncg_load_buffer_state  (void)
  * 
  * @return the allocated buffer state.
  */
-    YY_BUFFER_STATE ncg_create_buffer  (FILE * file, int  size )
+    YY_BUFFER_STATE yy_create_buffer  (FILE * file, int  size )
 {
 	YY_BUFFER_STATE b;
     
-	b = (YY_BUFFER_STATE) ncgalloc(sizeof( struct yy_buffer_state )  );
+	b = (YY_BUFFER_STATE) yyalloc( sizeof( struct yy_buffer_state )  );
 	if ( ! b )
-		YY_FATAL_ERROR( "out of dynamic memory in ncg_create_buffer()" );
+		YY_FATAL_ERROR( "out of dynamic memory in yy_create_buffer()" );
 
-	b->yy_buf_size = (yy_size_t)size;
+	b->yy_buf_size = size;
 
 	/* yy_ch_buf has to be 2 characters longer than the size given because
 	 * we need to put in 2 end-of-buffer characters.
 	 */
-	b->yy_ch_buf = (char *) ncgalloc(b->yy_buf_size + 2  );
+	b->yy_ch_buf = (char *) yyalloc( (yy_size_t) (b->yy_buf_size + 2)  );
 	if ( ! b->yy_ch_buf )
-		YY_FATAL_ERROR( "out of dynamic memory in ncg_create_buffer()" );
+		YY_FATAL_ERROR( "out of dynamic memory in yy_create_buffer()" );
 
 	b->yy_is_our_buffer = 1;
 
-	ncg_init_buffer(b,file );
+	yy_init_buffer( b, file );
 
 	return b;
 }
 
 /** Destroy the buffer.
- * @param b a buffer created with ncg_create_buffer()
+ * @param b a buffer created with yy_create_buffer()
  * 
  */
-    void ncg_delete_buffer (YY_BUFFER_STATE  b )
+    void yy_delete_buffer (YY_BUFFER_STATE  b )
 {
     
 	if ( ! b )
@@ -2754,27 +2988,27 @@ static void ncg_load_buffer_state  (void)
 		YY_CURRENT_BUFFER_LVALUE = (YY_BUFFER_STATE) 0;
 
 	if ( b->yy_is_our_buffer )
-		ncgfree((void *) b->yy_ch_buf  );
+		yyfree( (void *) b->yy_ch_buf  );
 
-	ncgfree((void *) b  );
+	yyfree( (void *) b  );
 }
 
 /* Initializes or reinitializes a buffer.
  * This function is sometimes called more than once on the same buffer,
- * such as during a ncgrestart() or at EOF.
+ * such as during a yyrestart() or at EOF.
  */
-    static void ncg_init_buffer  (YY_BUFFER_STATE  b, FILE * file )
+    static void yy_init_buffer  (YY_BUFFER_STATE  b, FILE * file )
 
 {
 	int oerrno = errno;
     
-	ncg_flush_buffer(b );
+	yy_flush_buffer( b );
 
 	b->yy_input_file = file;
 	b->yy_fill_buffer = 1;
 
-    /* If b is the current buffer, then ncg_init_buffer was _probably_
-     * called from ncgrestart() or through yy_get_next_buffer.
+    /* If b is the current buffer, then yy_init_buffer was _probably_
+     * called from yyrestart() or through yy_get_next_buffer.
      * In that case, we don't want to reset the lineno or column.
      */
     if (b != YY_CURRENT_BUFFER){
@@ -2791,7 +3025,7 @@ static void ncg_load_buffer_state  (void)
  * @param b the buffer state to be flushed, usually @c YY_CURRENT_BUFFER.
  * 
  */
-    void ncg_flush_buffer (YY_BUFFER_STATE  b )
+    void yy_flush_buffer (YY_BUFFER_STATE  b )
 {
     	if ( ! b )
 		return;
@@ -2811,7 +3045,7 @@ static void ncg_load_buffer_state  (void)
 	b->yy_buffer_status = YY_BUFFER_NEW;
 
 	if ( b == YY_CURRENT_BUFFER )
-		ncg_load_buffer_state( );
+		yy_load_buffer_state(  );
 }
 
 /** Pushes the new state onto the stack. The new state becomes
@@ -2820,14 +3054,14 @@ static void ncg_load_buffer_state  (void)
  *  @param new_buffer The new state.
  *  
  */
-void ncgpush_buffer_state (YY_BUFFER_STATE new_buffer )
+void yypush_buffer_state (YY_BUFFER_STATE new_buffer )
 {
     	if (new_buffer == NULL)
 		return;
 
-	ncgensure_buffer_stack();
+	yyensure_buffer_stack();
 
-	/* This block is copied from ncg_switch_to_buffer. */
+	/* This block is copied from yy_switch_to_buffer. */
 	if ( YY_CURRENT_BUFFER )
 		{
 		/* Flush out information for old buffer. */
@@ -2841,8 +3075,8 @@ void ncgpush_buffer_state (YY_BUFFER_STATE new_buffer )
 		(yy_buffer_stack_top)++;
 	YY_CURRENT_BUFFER_LVALUE = new_buffer;
 
-	/* copied from ncg_switch_to_buffer. */
-	ncg_load_buffer_state( );
+	/* copied from yy_switch_to_buffer. */
+	yy_load_buffer_state(  );
 	(yy_did_buffer_switch_on_eof) = 1;
 }
 
@@ -2850,18 +3084,18 @@ void ncgpush_buffer_state (YY_BUFFER_STATE new_buffer )
  *  The next element becomes the new top.
  *  
  */
-void ncgpop_buffer_state (void)
+void yypop_buffer_state (void)
 {
     	if (!YY_CURRENT_BUFFER)
 		return;
 
-	ncg_delete_buffer(YY_CURRENT_BUFFER );
+	yy_delete_buffer(YY_CURRENT_BUFFER );
 	YY_CURRENT_BUFFER_LVALUE = NULL;
 	if ((yy_buffer_stack_top) > 0)
 		--(yy_buffer_stack_top);
 
 	if (YY_CURRENT_BUFFER) {
-		ncg_load_buffer_state( );
+		yy_load_buffer_state(  );
 		(yy_did_buffer_switch_on_eof) = 1;
 	}
 }
@@ -2869,7 +3103,7 @@ void ncgpop_buffer_state (void)
 /* Allocates the stack if it does not exist.
  *  Guarantees space for at least one push.
  */
-static void ncgensure_buffer_stack (void)
+static void yyensure_buffer_stack (void)
 {
 	yy_size_t num_to_alloc;
     
@@ -2879,15 +3113,15 @@ static void ncgensure_buffer_stack (void)
 		 * scanner will even need a stack. We use 2 instead of 1 to avoid an
 		 * immediate realloc on the next call.
          */
-		num_to_alloc = 1; /* After all that talk, this was set to 1 anyways... */
-		(yy_buffer_stack) = (struct yy_buffer_state**)ncgalloc
+      num_to_alloc = 1; /* After all that talk, this was set to 1 anyways... */
+		(yy_buffer_stack) = (struct yy_buffer_state**)yyalloc
 								(num_to_alloc * sizeof(struct yy_buffer_state*)
 								);
 		if ( ! (yy_buffer_stack) )
-			YY_FATAL_ERROR( "out of dynamic memory in ncgensure_buffer_stack()" );
-								  
+			YY_FATAL_ERROR( "out of dynamic memory in yyensure_buffer_stack()" );
+
 		memset((yy_buffer_stack), 0, num_to_alloc * sizeof(struct yy_buffer_state*));
-				
+
 		(yy_buffer_stack_max) = num_to_alloc;
 		(yy_buffer_stack_top) = 0;
 		return;
@@ -2899,12 +3133,12 @@ static void ncgensure_buffer_stack (void)
 		yy_size_t grow_size = 8 /* arbitrary grow size */;
 
 		num_to_alloc = (yy_buffer_stack_max) + grow_size;
-		(yy_buffer_stack) = (struct yy_buffer_state**)ncgrealloc
+		(yy_buffer_stack) = (struct yy_buffer_state**)yyrealloc
 								((yy_buffer_stack),
 								num_to_alloc * sizeof(struct yy_buffer_state*)
 								);
 		if ( ! (yy_buffer_stack) )
-			YY_FATAL_ERROR( "out of dynamic memory in ncgensure_buffer_stack()" );
+			YY_FATAL_ERROR( "out of dynamic memory in yyensure_buffer_stack()" );
 
 		/* zero only the new slots.*/
 		memset((yy_buffer_stack) + (yy_buffer_stack_max), 0, grow_size * sizeof(struct yy_buffer_state*));
@@ -2916,9 +3150,9 @@ static void ncgensure_buffer_stack (void)
  * @param base the character buffer
  * @param size the size in bytes of the character buffer
  * 
- * @return the newly allocated buffer state object. 
+ * @return the newly allocated buffer state object.
  */
-YY_BUFFER_STATE ncg_scan_buffer  (char * base, yy_size_t  size )
+YY_BUFFER_STATE yy_scan_buffer  (char * base, yy_size_t  size )
 {
 	YY_BUFFER_STATE b;
     
@@ -2926,69 +3160,69 @@ YY_BUFFER_STATE ncg_scan_buffer  (char * base, yy_size_t  size )
 	     base[size-2] != YY_END_OF_BUFFER_CHAR ||
 	     base[size-1] != YY_END_OF_BUFFER_CHAR )
 		/* They forgot to leave room for the EOB's. */
-		return 0;
+		return NULL;
 
-	b = (YY_BUFFER_STATE) ncgalloc(sizeof( struct yy_buffer_state )  );
+	b = (YY_BUFFER_STATE) yyalloc( sizeof( struct yy_buffer_state )  );
 	if ( ! b )
-		YY_FATAL_ERROR( "out of dynamic memory in ncg_scan_buffer()" );
+		YY_FATAL_ERROR( "out of dynamic memory in yy_scan_buffer()" );
 
-	b->yy_buf_size = size - 2;	/* "- 2" to take care of EOB's */
+	b->yy_buf_size = (int) (size - 2);	/* "- 2" to take care of EOB's */
 	b->yy_buf_pos = b->yy_ch_buf = base;
 	b->yy_is_our_buffer = 0;
-	b->yy_input_file = 0;
+	b->yy_input_file = NULL;
 	b->yy_n_chars = b->yy_buf_size;
 	b->yy_is_interactive = 0;
 	b->yy_at_bol = 1;
 	b->yy_fill_buffer = 0;
 	b->yy_buffer_status = YY_BUFFER_NEW;
 
-	ncg_switch_to_buffer(b  );
+	yy_switch_to_buffer( b  );
 
 	return b;
 }
 
-/** Setup the input buffer state to scan a string. The next call to ncglex() will
+/** Setup the input buffer state to scan a string. The next call to yylex() will
  * scan from a @e copy of @a str.
  * @param yystr a NUL-terminated string to scan
  * 
  * @return the newly allocated buffer state object.
  * @note If you want to scan bytes that may contain NUL values, then use
- *       ncg_scan_bytes() instead.
+ *       yy_scan_bytes() instead.
  */
-YY_BUFFER_STATE ncg_scan_string (yyconst char * yystr )
+YY_BUFFER_STATE yy_scan_string (const char * yystr )
 {
     
-	return ncg_scan_bytes(yystr,strlen(yystr) );
+	return yy_scan_bytes( yystr, (int) strlen(yystr) );
 }
 
-/** Setup the input buffer state to scan the given bytes. The next call to ncglex() will
+/** Setup the input buffer state to scan the given bytes. The next call to yylex() will
  * scan from a @e copy of @a bytes.
  * @param yybytes the byte buffer to scan
  * @param _yybytes_len the number of bytes in the buffer pointed to by @a bytes.
  * 
  * @return the newly allocated buffer state object.
  */
-YY_BUFFER_STATE ncg_scan_bytes  (yyconst char * yybytes, yy_size_t  _yybytes_len )
+YY_BUFFER_STATE yy_scan_bytes  (const char * yybytes, int  _yybytes_len )
 {
 	YY_BUFFER_STATE b;
 	char *buf;
 	yy_size_t n;
-	yy_size_t i;
+	int i;
     
 	/* Get memory for full buffer, including space for trailing EOB's. */
-	n = _yybytes_len + 2;
-	buf = (char *) ncgalloc(n  );
+	n = (yy_size_t) (_yybytes_len + 2);
+	buf = (char *) yyalloc( n  );
 	if ( ! buf )
-		YY_FATAL_ERROR( "out of dynamic memory in ncg_scan_bytes()" );
+		YY_FATAL_ERROR( "out of dynamic memory in yy_scan_bytes()" );
 
 	for ( i = 0; i < _yybytes_len; ++i )
 		buf[i] = yybytes[i];
 
 	buf[_yybytes_len] = buf[_yybytes_len+1] = YY_END_OF_BUFFER_CHAR;
 
-	b = ncg_scan_buffer(buf,n );
+	b = yy_scan_buffer( buf, n );
 	if ( ! b )
-		YY_FATAL_ERROR( "bad buffer in ncg_scan_bytes()" );
+		YY_FATAL_ERROR( "bad buffer in yy_scan_bytes()" );
 
 	/* It's okay to grow etc. this buffer, and we should throw it
 	 * away when we're done.
@@ -3002,9 +3236,9 @@ YY_BUFFER_STATE ncg_scan_bytes  (yyconst char * yybytes, yy_size_t  _yybytes_len
 #define YY_EXIT_FAILURE 2
 #endif
 
-static void yy_fatal_error (yyconst char* msg )
+static void yynoreturn yy_fatal_error (const char* msg )
 {
-			(void) fprintf( stderr, "%s\n", msg );
+			fprintf( stderr, "%s\n", msg );
 	exit( YY_EXIT_FAILURE );
 }
 
@@ -3014,14 +3248,14 @@ static void yy_fatal_error (yyconst char* msg )
 #define yyless(n) \
 	do \
 		{ \
-		/* Undo effects of setting up ncgtext. */ \
+		/* Undo effects of setting up yytext. */ \
         int yyless_macro_arg = (n); \
         YY_LESS_LINENO(yyless_macro_arg);\
-		ncgtext[ncgleng] = (yy_hold_char); \
-		(yy_c_buf_p) = ncgtext + yyless_macro_arg; \
+		yytext[yyleng] = (yy_hold_char); \
+		(yy_c_buf_p) = yytext + yyless_macro_arg; \
 		(yy_hold_char) = *(yy_c_buf_p); \
 		*(yy_c_buf_p) = '\0'; \
-		ncgleng = yyless_macro_arg; \
+		yyleng = yyless_macro_arg; \
 		} \
 	while ( 0 )
 
@@ -3030,126 +3264,126 @@ static void yy_fatal_error (yyconst char* msg )
 /** Get the current line number.
  * 
  */
-int ncgget_lineno  (void)
+int yyget_lineno  (void)
 {
-        
-    return ncglineno;
+    
+    return yylineno;
 }
 
 /** Get the input stream.
  * 
  */
-FILE *ncgget_in  (void)
+FILE *yyget_in  (void)
 {
-        return ncgin;
+        return yyin;
 }
 
 /** Get the output stream.
  * 
  */
-FILE *ncgget_out  (void)
+FILE *yyget_out  (void)
 {
-        return ncgout;
+        return yyout;
 }
 
 /** Get the length of the current token.
  * 
  */
-yy_size_t ncgget_leng  (void)
+int yyget_leng  (void)
 {
-        return ncgleng;
+        return yyleng;
 }
 
 /** Get the current token.
  * 
  */
 
-char *ncgget_text  (void)
+char *yyget_text  (void)
 {
-        return ncgtext;
+        return yytext;
 }
 
 /** Set the current line number.
  * @param _line_number line number
  * 
  */
-void ncgset_lineno (int  _line_number )
+void yyset_lineno (int  _line_number )
 {
     
-    ncglineno = _line_number;
+    yylineno = _line_number;
 }
 
 /** Set the input stream. This does not discard the current
  * input buffer.
  * @param _in_str A readable stream.
  * 
- * @see ncg_switch_to_buffer
+ * @see yy_switch_to_buffer
  */
-void ncgset_in (FILE *  _in_str )
+void yyset_in (FILE *  _in_str )
 {
-        ncgin = _in_str ;
+        yyin = _in_str ;
 }
 
-void ncgset_out (FILE *  _out_str )
+void yyset_out (FILE *  _out_str )
 {
-        ncgout = _out_str ;
+        yyout = _out_str ;
 }
 
-int ncgget_debug  (void)
+int yyget_debug  (void)
 {
-        return ncg_flex_debug;
+        return yy_flex_debug;
 }
 
-void ncgset_debug (int  _bdebug )
+void yyset_debug (int  _bdebug )
 {
-        ncg_flex_debug = _bdebug ;
+        yy_flex_debug = _bdebug ;
 }
 
 static int yy_init_globals (void)
 {
         /* Initialization is the same as for the non-reentrant scanner.
-     * This function is called from ncglex_destroy(), so don't allocate here.
+     * This function is called from yylex_destroy(), so don't allocate here.
      */
 
-    (yy_buffer_stack) = 0;
+    (yy_buffer_stack) = NULL;
     (yy_buffer_stack_top) = 0;
     (yy_buffer_stack_max) = 0;
-    (yy_c_buf_p) = (char *) 0;
+    (yy_c_buf_p) = NULL;
     (yy_init) = 0;
     (yy_start) = 0;
 
 /* Defined in main.c */
 #ifdef YY_STDINIT
-    ncgin = stdin;
-    ncgout = stdout;
+    yyin = stdin;
+    yyout = stdout;
 #else
-    ncgin = (FILE *) 0;
-    ncgout = (FILE *) 0;
+    yyin = NULL;
+    yyout = NULL;
 #endif
 
     /* For future reference: Set errno on error, since we are called by
-     * ncglex_init()
+     * yylex_init()
      */
     return 0;
 }
 
-/* ncglex_destroy is for both reentrant and non-reentrant scanners. */
-int ncglex_destroy  (void)
+/* yylex_destroy is for both reentrant and non-reentrant scanners. */
+int yylex_destroy  (void)
 {
     
     /* Pop the buffer stack, destroying each element. */
 	while(YY_CURRENT_BUFFER){
-		ncg_delete_buffer(YY_CURRENT_BUFFER  );
+		yy_delete_buffer( YY_CURRENT_BUFFER  );
 		YY_CURRENT_BUFFER_LVALUE = NULL;
-		ncgpop_buffer_state();
+		yypop_buffer_state();
 	}
 
 	/* Destroy the stack itself. */
-	ncgfree((yy_buffer_stack) );
+	yyfree((yy_buffer_stack) );
 	(yy_buffer_stack) = NULL;
 
     /* Reset the globals. This is important in a non-reentrant scanner so the next time
-     * ncglex() is called, initialization will occur. */
+     * yylex() is called, initialization will occur. */
     yy_init_globals( );
 
     return 0;
@@ -3160,7 +3394,7 @@ int ncglex_destroy  (void)
  */
 
 #ifndef yytext_ptr
-static void yy_flex_strncpy (char* s1, yyconst char * s2, int n )
+static void yy_flex_strncpy (char* s1, const char * s2, int n )
 {
 		
 	int i;
@@ -3170,7 +3404,7 @@ static void yy_flex_strncpy (char* s1, yyconst char * s2, int n )
 #endif
 
 #ifdef YY_NEED_STRLEN
-static int yy_flex_strlen (yyconst char * s )
+static int yy_flex_strlen (const char * s )
 {
 	int n;
 	for ( n = 0; s[n]; ++n )
@@ -3180,12 +3414,12 @@ static int yy_flex_strlen (yyconst char * s )
 }
 #endif
 
-void *ncgalloc (yy_size_t  size )
+void *yyalloc (yy_size_t  size )
 {
-			return (void *) malloc( size );
+			return malloc(size);
 }
 
-void *ncgrealloc  (void * ptr, yy_size_t  size )
+void *yyrealloc  (void * ptr, yy_size_t  size )
 {
 		
 	/* The cast to (char *) in the following accommodates both
@@ -3195,27 +3429,24 @@ void *ncgrealloc  (void * ptr, yy_size_t  size )
 	 * any pointer type to void*, and deal with argument conversions
 	 * as though doing an assignment.
 	 */
-	return (void *) realloc( (char *) ptr, size );
+	return realloc(ptr, size);
 }
 
-void ncgfree (void * ptr )
+void yyfree (void * ptr )
 {
-			free( (char *) ptr );	/* see ncgrealloc() for (char *) cast */
+			free( (char *) ptr );	/* see yyrealloc() for (char *) cast */
 }
 
 #define YYTABLES_NAME "yytables"
 
-#line 617 "ncgen.l"
-
+#line 596 "ncgen.l"
 
 static int
 lexdebug(int token)
 {
     if(debug >= 2)
     {
-	char* text = ncgtext;
-	text[ncgleng] = 0;
-        fprintf(stderr,"Token=%d |%s| line=%d\n",token,text,lineno);
+        fprintf(stderr,"Token=%d |%s| line=%d\n",token,yytext,lineno);
     }
     return token;
 }
@@ -3500,39 +3731,29 @@ collecttag(char* text, char** stagp)
     return tag;
 }
 
-/* Depending on the format, a name may be a keword or an ident */
 static int
-identorkw(int token)
+identcheck(int token)
 {
-    /* Binary search for ncgtext */
-    int n = NKWIDENT;
-    int L = 0;
-    int R = (n - 1);
-    int m, cmp;
-    struct KWIDENT* p;
-    int found = 0;
-    size_t len;
-    char* id = NULL;
-
-    for(;;) {
-	if(L > R) break;
-        m = (L + R) / 2;
-	p = &kwident[m];
-	cmp = (p->token - token);
-	if(cmp == 0) {found = 1; break;}
-	if(cmp < 0)
-	    L = (m + 1);
-	else /*cmp > 0*/
-	    R = (m - 1);
+    switch (token) {
+    case UBYTE_K:
+    case USHORT_K:
+    case UINT_K:
+    case INT64_K:
+    case UINT64_K:
+	if(k_flag != NC_FORMAT_NETCDF4 	&& k_flag != NC_FORMAT_64BIT_DATA) {
+	    yylval.sym = install(yytext);
+   	    token = IDENT;
+	}
+	break;
+    case STRING_K:
+	if(k_flag != NC_FORMAT_NETCDF4) {
+	    yylval.sym = install(yytext);
+   	    token = IDENT;
+	}
+	break;
+    default:
+         break;    
     }
-    if(!found) return token; /* Not a keyword of interest */
-    /* See if the format applies */
-    if(p->formats & ((int)1<<k_flag)) return token;
-    /* Need to convert a non-ident token to an ident symbol */
-    len = strlen(ncgtext);
-    len = unescape(ncgtext,len,ISIDENT,&id);
-    yylval.sym = install(id);
-    efree(id);
-    return IDENT; /* treat as identifier */
+    return token;
 }
 

--- a/ncgen/ncgeny.c
+++ b/ncgen/ncgeny.c
@@ -89,6 +89,8 @@ static char SccsId[] = "$Id: ncgen.y,v 1.42 2010/05/18 21:32:46 dmh Exp $";
 #define ncvar_t void
 #include "nctime.h"
 
+#undef GENLIB1
+
 /* parser controls */
 #define YY_NO_INPUT 1
 
@@ -208,7 +210,7 @@ static void yyerror(fmt,va_alist) const char* fmt; va_dcl;
 extern int lex_init(void);
 
 
-#line 212 "ncgeny.c" /* yacc.c:339  */
+#line 214 "ncgeny.c" /* yacc.c:339  */
 
 # ifndef YY_NULLPTR
 #  if defined __cplusplus && 201103L <= __cplusplus
@@ -304,7 +306,7 @@ extern int ncgdebug;
 
 union YYSTYPE
 {
-#line 151 "ncgen.y" /* yacc.c:355  */
+#line 153 "ncgen.y" /* yacc.c:355  */
 
 Symbol* sym;
 unsigned long  size; /* allow for zero size to indicate e.g. UNLIMITED*/
@@ -313,7 +315,7 @@ int            nctype; /* for tracking attribute list type*/
 Datalist*      datalist;
 NCConstant*    constant;
 
-#line 317 "ncgeny.c" /* yacc.c:355  */
+#line 319 "ncgeny.c" /* yacc.c:355  */
 };
 
 typedef union YYSTYPE YYSTYPE;
@@ -330,7 +332,7 @@ int ncgparse (void);
 
 /* Copy the second part of user declarations.  */
 
-#line 334 "ncgeny.c" /* yacc.c:358  */
+#line 336 "ncgeny.c" /* yacc.c:358  */
 
 #ifdef short
 # undef short
@@ -633,22 +635,22 @@ static const yytype_uint8 yytranslate[] =
   /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_uint16 yyrline[] =
 {
-       0,   233,   233,   239,   241,   248,   255,   255,   258,   267,
-     257,   272,   273,   274,   278,   278,   280,   290,   290,   293,
-     294,   295,   296,   299,   299,   302,   332,   334,   351,   360,
-     372,   386,   419,   420,   423,   437,   438,   439,   440,   441,
-     442,   443,   444,   445,   446,   447,   448,   451,   452,   453,
-     456,   457,   460,   460,   462,   463,   467,   475,   485,   497,
-     498,   499,   502,   503,   506,   506,   508,   530,   534,   538,
-     567,   568,   571,   572,   576,   590,   594,   599,   628,   629,
-     633,   634,   639,   649,   669,   680,   691,   710,   717,   717,
-     720,   722,   724,   726,   728,   737,   748,   750,   752,   754,
-     756,   758,   760,   762,   764,   766,   768,   773,   780,   789,
-     790,   791,   794,   795,   798,   802,   803,   807,   811,   812,
-     817,   818,   822,   823,   824,   825,   826,   827,   831,   835,
-     839,   841,   846,   847,   848,   849,   850,   851,   852,   853,
-     854,   855,   856,   857,   861,   862,   866,   868,   870,   872,
-     877,   881,   882,   888
+       0,   235,   235,   241,   243,   250,   257,   257,   260,   269,
+     259,   274,   275,   276,   280,   280,   282,   292,   292,   295,
+     296,   297,   298,   301,   301,   304,   334,   336,   353,   362,
+     374,   388,   421,   422,   425,   439,   440,   441,   442,   443,
+     444,   445,   446,   447,   448,   449,   450,   453,   454,   455,
+     458,   459,   462,   462,   464,   465,   469,   477,   487,   499,
+     500,   501,   504,   505,   508,   508,   510,   532,   536,   540,
+     569,   570,   573,   574,   578,   592,   596,   601,   630,   631,
+     635,   636,   641,   651,   671,   682,   693,   712,   719,   719,
+     722,   724,   726,   728,   730,   739,   750,   752,   754,   756,
+     758,   760,   762,   764,   766,   768,   770,   775,   782,   791,
+     792,   793,   796,   797,   800,   804,   805,   809,   813,   814,
+     819,   820,   824,   825,   826,   827,   828,   829,   833,   837,
+     841,   843,   848,   849,   850,   851,   852,   853,   854,   855,
+     856,   857,   858,   859,   863,   864,   868,   870,   872,   874,
+     879,   883,   884,   890
 };
 #endif
 
@@ -1640,19 +1642,19 @@ yyreduce:
   switch (yyn)
     {
         case 2:
-#line 236 "ncgen.y" /* yacc.c:1646  */
+#line 238 "ncgen.y" /* yacc.c:1646  */
     {if (error_count > 0) YYABORT;}
-#line 1646 "ncgeny.c" /* yacc.c:1646  */
+#line 1648 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 3:
-#line 239 "ncgen.y" /* yacc.c:1646  */
+#line 241 "ncgen.y" /* yacc.c:1646  */
     {createrootgroup(datasetname);}
-#line 1652 "ncgeny.c" /* yacc.c:1646  */
+#line 1654 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 8:
-#line 258 "ncgen.y" /* yacc.c:1646  */
+#line 260 "ncgen.y" /* yacc.c:1646  */
     {
 		Symbol* id = (yyvsp[-1].sym);
                 markcdf4("Group specification");
@@ -1660,29 +1662,29 @@ yyreduce:
                     yyerror("duplicate group declaration within parent group for %s",
                                 id->name);
             }
-#line 1664 "ncgeny.c" /* yacc.c:1646  */
+#line 1666 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 9:
-#line 267 "ncgen.y" /* yacc.c:1646  */
+#line 269 "ncgen.y" /* yacc.c:1646  */
     {listpop(groupstack);}
-#line 1670 "ncgeny.c" /* yacc.c:1646  */
+#line 1672 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 12:
-#line 273 "ncgen.y" /* yacc.c:1646  */
+#line 275 "ncgen.y" /* yacc.c:1646  */
     {}
-#line 1676 "ncgeny.c" /* yacc.c:1646  */
+#line 1678 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 13:
-#line 275 "ncgen.y" /* yacc.c:1646  */
+#line 277 "ncgen.y" /* yacc.c:1646  */
     {markcdf4("Type specification");}
-#line 1682 "ncgeny.c" /* yacc.c:1646  */
+#line 1684 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 16:
-#line 281 "ncgen.y" /* yacc.c:1646  */
+#line 283 "ncgen.y" /* yacc.c:1646  */
     { /* Use when defining a type */
               (yyvsp[0].sym)->objectclass = NC_TYPE;
               if(dupobjectcheck(NC_TYPE,(yyvsp[0].sym)))
@@ -1690,23 +1692,23 @@ yyreduce:
                             (yyvsp[0].sym)->name);
               listpush(typdefs,(void*)(yyvsp[0].sym));
 	    }
-#line 1694 "ncgeny.c" /* yacc.c:1646  */
+#line 1696 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 17:
-#line 290 "ncgen.y" /* yacc.c:1646  */
+#line 292 "ncgen.y" /* yacc.c:1646  */
     {}
-#line 1700 "ncgeny.c" /* yacc.c:1646  */
+#line 1702 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 18:
-#line 290 "ncgen.y" /* yacc.c:1646  */
+#line 292 "ncgen.y" /* yacc.c:1646  */
     {}
-#line 1706 "ncgeny.c" /* yacc.c:1646  */
+#line 1708 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 25:
-#line 304 "ncgen.y" /* yacc.c:1646  */
+#line 306 "ncgen.y" /* yacc.c:1646  */
     {
 		int i;
                 addtogroup((yyvsp[-3].sym)); /* sets prefix*/
@@ -1733,17 +1735,17 @@ yyreduce:
                 }
                 listsetlength(stack,stackbase);/* remove stack nodes*/
               }
-#line 1737 "ncgeny.c" /* yacc.c:1646  */
+#line 1739 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 26:
-#line 333 "ncgen.y" /* yacc.c:1646  */
+#line 335 "ncgen.y" /* yacc.c:1646  */
     {(yyval.mark)=listlength(stack); listpush(stack,(void*)(yyvsp[0].sym));}
-#line 1743 "ncgeny.c" /* yacc.c:1646  */
+#line 1745 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 27:
-#line 335 "ncgen.y" /* yacc.c:1646  */
+#line 337 "ncgen.y" /* yacc.c:1646  */
     {
 		    int i;
 		    (yyval.mark)=(yyvsp[-2].mark);
@@ -1758,22 +1760,22 @@ yyreduce:
 		    }
 		    listpush(stack,(void*)(yyvsp[0].sym));
 		}
-#line 1762 "ncgeny.c" /* yacc.c:1646  */
+#line 1764 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 28:
-#line 352 "ncgen.y" /* yacc.c:1646  */
+#line 354 "ncgen.y" /* yacc.c:1646  */
     {
             (yyvsp[-2].sym)->objectclass=NC_TYPE;
             (yyvsp[-2].sym)->subclass=NC_ECONST;
             (yyvsp[-2].sym)->typ.econst=(yyvsp[0].constant);
 	    (yyval.sym)=(yyvsp[-2].sym);
         }
-#line 1773 "ncgeny.c" /* yacc.c:1646  */
+#line 1775 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 29:
-#line 361 "ncgen.y" /* yacc.c:1646  */
+#line 363 "ncgen.y" /* yacc.c:1646  */
     {
 		    vercheck(NC_OPAQUE);
                     addtogroup((yyvsp[0].sym)); /*sets prefix*/
@@ -1783,11 +1785,11 @@ yyreduce:
                     (yyvsp[0].sym)->typ.size=int32_val;
                     (yyvsp[0].sym)->typ.alignment=ncaux_class_alignment(NC_OPAQUE);
                 }
-#line 1787 "ncgeny.c" /* yacc.c:1646  */
+#line 1789 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 30:
-#line 373 "ncgen.y" /* yacc.c:1646  */
+#line 375 "ncgen.y" /* yacc.c:1646  */
     {
                     Symbol* basetype = (yyvsp[-4].sym);
 		    vercheck(NC_VLEN);
@@ -1799,11 +1801,11 @@ yyreduce:
                     (yyvsp[0].sym)->typ.size=VLENSIZE;
                     (yyvsp[0].sym)->typ.alignment=ncaux_class_alignment(NC_VLEN);
                 }
-#line 1803 "ncgeny.c" /* yacc.c:1646  */
+#line 1805 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 31:
-#line 387 "ncgen.y" /* yacc.c:1646  */
+#line 389 "ncgen.y" /* yacc.c:1646  */
     {
 	    int i,j;
 	    vercheck(NC_COMPOUND);
@@ -1833,23 +1835,23 @@ yyreduce:
 	    }
 	    listsetlength(stack,stackbase);/* remove stack nodes*/
           }
-#line 1837 "ncgeny.c" /* yacc.c:1646  */
+#line 1839 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 32:
-#line 419 "ncgen.y" /* yacc.c:1646  */
+#line 421 "ncgen.y" /* yacc.c:1646  */
     {(yyval.mark)=(yyvsp[-1].mark);}
-#line 1843 "ncgeny.c" /* yacc.c:1646  */
+#line 1845 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 33:
-#line 420 "ncgen.y" /* yacc.c:1646  */
+#line 422 "ncgen.y" /* yacc.c:1646  */
     {(yyval.mark)=(yyvsp[-2].mark);}
-#line 1849 "ncgeny.c" /* yacc.c:1646  */
+#line 1851 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 34:
-#line 424 "ncgen.y" /* yacc.c:1646  */
+#line 426 "ncgen.y" /* yacc.c:1646  */
     {
 	    int i;
 	    (yyval.mark)=(yyvsp[0].mark);
@@ -1861,107 +1863,107 @@ yyreduce:
 		f->typ.basetype = (yyvsp[-1].sym);
             }
         }
-#line 1865 "ncgeny.c" /* yacc.c:1646  */
+#line 1867 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 35:
-#line 437 "ncgen.y" /* yacc.c:1646  */
+#line 439 "ncgen.y" /* yacc.c:1646  */
     { (yyval.sym) = primsymbols[NC_CHAR]; }
-#line 1871 "ncgeny.c" /* yacc.c:1646  */
+#line 1873 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 36:
-#line 438 "ncgen.y" /* yacc.c:1646  */
+#line 440 "ncgen.y" /* yacc.c:1646  */
     { (yyval.sym) = primsymbols[NC_BYTE]; }
-#line 1877 "ncgeny.c" /* yacc.c:1646  */
+#line 1879 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 37:
-#line 439 "ncgen.y" /* yacc.c:1646  */
+#line 441 "ncgen.y" /* yacc.c:1646  */
     { (yyval.sym) = primsymbols[NC_SHORT]; }
-#line 1883 "ncgeny.c" /* yacc.c:1646  */
+#line 1885 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 38:
-#line 440 "ncgen.y" /* yacc.c:1646  */
+#line 442 "ncgen.y" /* yacc.c:1646  */
     { (yyval.sym) = primsymbols[NC_INT]; }
-#line 1889 "ncgeny.c" /* yacc.c:1646  */
+#line 1891 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 39:
-#line 441 "ncgen.y" /* yacc.c:1646  */
+#line 443 "ncgen.y" /* yacc.c:1646  */
     { (yyval.sym) = primsymbols[NC_FLOAT]; }
-#line 1895 "ncgeny.c" /* yacc.c:1646  */
+#line 1897 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 40:
-#line 442 "ncgen.y" /* yacc.c:1646  */
+#line 444 "ncgen.y" /* yacc.c:1646  */
     { (yyval.sym) = primsymbols[NC_DOUBLE]; }
-#line 1901 "ncgeny.c" /* yacc.c:1646  */
+#line 1903 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 41:
-#line 443 "ncgen.y" /* yacc.c:1646  */
+#line 445 "ncgen.y" /* yacc.c:1646  */
     { vercheck(NC_UBYTE); (yyval.sym) = primsymbols[NC_UBYTE]; }
-#line 1907 "ncgeny.c" /* yacc.c:1646  */
+#line 1909 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 42:
-#line 444 "ncgen.y" /* yacc.c:1646  */
+#line 446 "ncgen.y" /* yacc.c:1646  */
     { vercheck(NC_USHORT); (yyval.sym) = primsymbols[NC_USHORT]; }
-#line 1913 "ncgeny.c" /* yacc.c:1646  */
+#line 1915 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 43:
-#line 445 "ncgen.y" /* yacc.c:1646  */
+#line 447 "ncgen.y" /* yacc.c:1646  */
     { vercheck(NC_UINT); (yyval.sym) = primsymbols[NC_UINT]; }
-#line 1919 "ncgeny.c" /* yacc.c:1646  */
+#line 1921 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 44:
-#line 446 "ncgen.y" /* yacc.c:1646  */
+#line 448 "ncgen.y" /* yacc.c:1646  */
     { vercheck(NC_INT64); (yyval.sym) = primsymbols[NC_INT64]; }
-#line 1925 "ncgeny.c" /* yacc.c:1646  */
+#line 1927 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 45:
-#line 447 "ncgen.y" /* yacc.c:1646  */
+#line 449 "ncgen.y" /* yacc.c:1646  */
     { vercheck(NC_UINT64); (yyval.sym) = primsymbols[NC_UINT64]; }
-#line 1931 "ncgeny.c" /* yacc.c:1646  */
+#line 1933 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 46:
-#line 448 "ncgen.y" /* yacc.c:1646  */
+#line 450 "ncgen.y" /* yacc.c:1646  */
     { vercheck(NC_STRING); (yyval.sym) = primsymbols[NC_STRING]; }
-#line 1937 "ncgeny.c" /* yacc.c:1646  */
+#line 1939 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 48:
-#line 452 "ncgen.y" /* yacc.c:1646  */
+#line 454 "ncgen.y" /* yacc.c:1646  */
     {}
-#line 1943 "ncgeny.c" /* yacc.c:1646  */
+#line 1945 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 49:
-#line 453 "ncgen.y" /* yacc.c:1646  */
+#line 455 "ncgen.y" /* yacc.c:1646  */
     {}
-#line 1949 "ncgeny.c" /* yacc.c:1646  */
+#line 1951 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 52:
-#line 460 "ncgen.y" /* yacc.c:1646  */
+#line 462 "ncgen.y" /* yacc.c:1646  */
     {}
-#line 1955 "ncgeny.c" /* yacc.c:1646  */
+#line 1957 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 53:
-#line 460 "ncgen.y" /* yacc.c:1646  */
+#line 462 "ncgen.y" /* yacc.c:1646  */
     {}
-#line 1961 "ncgeny.c" /* yacc.c:1646  */
+#line 1963 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 56:
-#line 468 "ncgen.y" /* yacc.c:1646  */
+#line 470 "ncgen.y" /* yacc.c:1646  */
     {
 		(yyvsp[-2].sym)->dim.declsize = (size_t)extractint((yyvsp[0].constant));
 #ifdef GENDEBUG1
@@ -1969,11 +1971,11 @@ fprintf(stderr,"dimension: %s = %llu\n",(yyvsp[-2].sym)->name,(unsigned long lon
 #endif
 		reclaimconstant((yyvsp[0].constant));
 	      }
-#line 1973 "ncgeny.c" /* yacc.c:1646  */
+#line 1975 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 57:
-#line 476 "ncgen.y" /* yacc.c:1646  */
+#line 478 "ncgen.y" /* yacc.c:1646  */
     {
 		        (yyvsp[-2].sym)->dim.declsize = NC_UNLIMITED;
 		        (yyvsp[-2].sym)->dim.isunlimited = 1;
@@ -1981,11 +1983,11 @@ fprintf(stderr,"dimension: %s = %llu\n",(yyvsp[-2].sym)->name,(unsigned long lon
 fprintf(stderr,"dimension: %s = UNLIMITED\n",(yyvsp[-2].sym)->name);
 #endif
 		   }
-#line 1985 "ncgeny.c" /* yacc.c:1646  */
+#line 1987 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 58:
-#line 486 "ncgen.y" /* yacc.c:1646  */
+#line 488 "ncgen.y" /* yacc.c:1646  */
     {
                      (yyvsp[0].sym)->objectclass=NC_DIM;
                      if(dupobjectcheck(NC_DIM,(yyvsp[0].sym)))
@@ -1995,35 +1997,35 @@ fprintf(stderr,"dimension: %s = UNLIMITED\n",(yyvsp[-2].sym)->name);
 		     (yyval.sym)=(yyvsp[0].sym);
 		     listpush(dimdefs,(void*)(yyvsp[0].sym));
                    }
-#line 1999 "ncgeny.c" /* yacc.c:1646  */
+#line 2001 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 60:
-#line 498 "ncgen.y" /* yacc.c:1646  */
+#line 500 "ncgen.y" /* yacc.c:1646  */
     {}
-#line 2005 "ncgeny.c" /* yacc.c:1646  */
+#line 2007 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 61:
-#line 499 "ncgen.y" /* yacc.c:1646  */
+#line 501 "ncgen.y" /* yacc.c:1646  */
     {}
-#line 2011 "ncgeny.c" /* yacc.c:1646  */
+#line 2013 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 64:
-#line 506 "ncgen.y" /* yacc.c:1646  */
+#line 508 "ncgen.y" /* yacc.c:1646  */
     {}
-#line 2017 "ncgeny.c" /* yacc.c:1646  */
+#line 2019 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 65:
-#line 506 "ncgen.y" /* yacc.c:1646  */
+#line 508 "ncgen.y" /* yacc.c:1646  */
     {}
-#line 2023 "ncgeny.c" /* yacc.c:1646  */
+#line 2025 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 66:
-#line 509 "ncgen.y" /* yacc.c:1646  */
+#line 511 "ncgen.y" /* yacc.c:1646  */
     {
 		    int i;
 		    stackbase=(yyvsp[0].mark);
@@ -2043,25 +2045,25 @@ fprintf(stderr,"dimension: %s = UNLIMITED\n",(yyvsp[-2].sym)->name);
 		    }
 		    listsetlength(stack,stackbase);/* remove stack nodes*/
 		}
-#line 2047 "ncgeny.c" /* yacc.c:1646  */
+#line 2049 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 67:
-#line 531 "ncgen.y" /* yacc.c:1646  */
+#line 533 "ncgen.y" /* yacc.c:1646  */
     {(yyval.mark)=listlength(stack);
                  listpush(stack,(void*)(yyvsp[0].sym));
 		}
-#line 2055 "ncgeny.c" /* yacc.c:1646  */
+#line 2057 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 68:
-#line 535 "ncgen.y" /* yacc.c:1646  */
+#line 537 "ncgen.y" /* yacc.c:1646  */
     {(yyval.mark)=(yyvsp[-2].mark); listpush(stack,(void*)(yyvsp[0].sym));}
-#line 2061 "ncgeny.c" /* yacc.c:1646  */
+#line 2063 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 69:
-#line 539 "ncgen.y" /* yacc.c:1646  */
+#line 541 "ncgen.y" /* yacc.c:1646  */
     {
 		    int i;
 		    Dimset dimset;
@@ -2088,35 +2090,35 @@ fprintf(stderr,"dimension: %s = UNLIMITED\n",(yyvsp[-2].sym)->name);
 		    listsetlength(stack,stackbase);/* remove stack nodes*/
 		    (yyval.sym) = var;
 		    }
-#line 2092 "ncgeny.c" /* yacc.c:1646  */
+#line 2094 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 70:
-#line 567 "ncgen.y" /* yacc.c:1646  */
+#line 569 "ncgen.y" /* yacc.c:1646  */
     {(yyval.mark)=listlength(stack);}
-#line 2098 "ncgeny.c" /* yacc.c:1646  */
+#line 2100 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 71:
-#line 568 "ncgen.y" /* yacc.c:1646  */
+#line 570 "ncgen.y" /* yacc.c:1646  */
     {(yyval.mark)=(yyvsp[-1].mark);}
-#line 2104 "ncgeny.c" /* yacc.c:1646  */
+#line 2106 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 72:
-#line 571 "ncgen.y" /* yacc.c:1646  */
+#line 573 "ncgen.y" /* yacc.c:1646  */
     {(yyval.mark)=listlength(stack); listpush(stack,(void*)(yyvsp[0].sym));}
-#line 2110 "ncgeny.c" /* yacc.c:1646  */
+#line 2112 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 73:
-#line 573 "ncgen.y" /* yacc.c:1646  */
+#line 575 "ncgen.y" /* yacc.c:1646  */
     {(yyval.mark)=(yyvsp[-2].mark); listpush(stack,(void*)(yyvsp[0].sym));}
-#line 2116 "ncgeny.c" /* yacc.c:1646  */
+#line 2118 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 74:
-#line 577 "ncgen.y" /* yacc.c:1646  */
+#line 579 "ncgen.y" /* yacc.c:1646  */
     {Symbol* dimsym = (yyvsp[0].sym);
 		dimsym->objectclass = NC_DIM;
 		/* Find the actual dimension*/
@@ -2127,25 +2129,25 @@ fprintf(stderr,"dimension: %s = UNLIMITED\n",(yyvsp[-2].sym)->name);
 		}
 		(yyval.sym)=dimsym;
 	    }
-#line 2131 "ncgeny.c" /* yacc.c:1646  */
+#line 2133 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 75:
-#line 591 "ncgen.y" /* yacc.c:1646  */
+#line 593 "ncgen.y" /* yacc.c:1646  */
     {(yyval.mark)=listlength(stack);
              listpush(stack,(void*)(yyvsp[0].sym));
 	    }
-#line 2139 "ncgeny.c" /* yacc.c:1646  */
+#line 2141 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 76:
-#line 595 "ncgen.y" /* yacc.c:1646  */
+#line 597 "ncgen.y" /* yacc.c:1646  */
     {(yyval.mark)=(yyvsp[-2].mark); listpush(stack,(void*)(yyvsp[0].sym));}
-#line 2145 "ncgeny.c" /* yacc.c:1646  */
+#line 2147 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 77:
-#line 600 "ncgen.y" /* yacc.c:1646  */
+#line 602 "ncgen.y" /* yacc.c:1646  */
     {
 		int i;
 		Dimset dimset;
@@ -2172,35 +2174,35 @@ fprintf(stderr,"dimension: %s = UNLIMITED\n",(yyvsp[-2].sym)->name);
 		listsetlength(stack,stackbase);/* remove stack nodes*/
 		(yyval.sym) = (yyvsp[-1].sym);
 	    }
-#line 2176 "ncgeny.c" /* yacc.c:1646  */
+#line 2178 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 78:
-#line 628 "ncgen.y" /* yacc.c:1646  */
+#line 630 "ncgen.y" /* yacc.c:1646  */
     {(yyval.mark)=listlength(stack);}
-#line 2182 "ncgeny.c" /* yacc.c:1646  */
+#line 2184 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 79:
-#line 629 "ncgen.y" /* yacc.c:1646  */
+#line 631 "ncgen.y" /* yacc.c:1646  */
     {(yyval.mark)=(yyvsp[-1].mark);}
-#line 2188 "ncgeny.c" /* yacc.c:1646  */
+#line 2190 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 80:
-#line 633 "ncgen.y" /* yacc.c:1646  */
+#line 635 "ncgen.y" /* yacc.c:1646  */
     {(yyval.mark)=listlength(stack); listpush(stack,(void*)(yyvsp[0].sym));}
-#line 2194 "ncgeny.c" /* yacc.c:1646  */
+#line 2196 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 81:
-#line 635 "ncgen.y" /* yacc.c:1646  */
+#line 637 "ncgen.y" /* yacc.c:1646  */
     {(yyval.mark)=(yyvsp[-2].mark); listpush(stack,(void*)(yyvsp[0].sym));}
-#line 2200 "ncgeny.c" /* yacc.c:1646  */
+#line 2202 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 82:
-#line 640 "ncgen.y" /* yacc.c:1646  */
+#line 642 "ncgen.y" /* yacc.c:1646  */
     {  /* Anonymous integer dimension.
 	         Can only occur in type definitions*/
 	     char anon[32];
@@ -2210,11 +2212,11 @@ fprintf(stderr,"dimension: %s = UNLIMITED\n",(yyvsp[-2].sym)->name);
 	     (yyval.sym)->dim.isconstant = 1;
 	     (yyval.sym)->dim.declsize = uint32_val;
 	    }
-#line 2214 "ncgeny.c" /* yacc.c:1646  */
+#line 2216 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 83:
-#line 650 "ncgen.y" /* yacc.c:1646  */
+#line 652 "ncgen.y" /* yacc.c:1646  */
     {  /* Anonymous integer dimension.
 	         Can only occur in type definitions*/
 	     char anon[32];
@@ -2228,11 +2230,11 @@ fprintf(stderr,"dimension: %s = UNLIMITED\n",(yyvsp[-2].sym)->name);
 	     (yyval.sym)->dim.isconstant = 1;
 	     (yyval.sym)->dim.declsize = int32_val;
 	    }
-#line 2232 "ncgeny.c" /* yacc.c:1646  */
+#line 2234 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 84:
-#line 670 "ncgen.y" /* yacc.c:1646  */
+#line 672 "ncgen.y" /* yacc.c:1646  */
     {Symbol* vsym = (yyvsp[0].sym);
 		if(vsym->objectclass != NC_VAR) {
 		    derror("Undefined or forward referenced variable: %s",vsym->name);
@@ -2240,11 +2242,11 @@ fprintf(stderr,"dimension: %s = UNLIMITED\n",(yyvsp[-2].sym)->name);
 		}
 		(yyval.sym)=vsym;
 	    }
-#line 2244 "ncgeny.c" /* yacc.c:1646  */
+#line 2246 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 85:
-#line 681 "ncgen.y" /* yacc.c:1646  */
+#line 683 "ncgen.y" /* yacc.c:1646  */
     {Symbol* tsym = (yyvsp[0].sym);
 		if(tsym->objectclass != NC_TYPE) {
 		    derror("Undefined or forward referenced type: %s",tsym->name);
@@ -2252,11 +2254,11 @@ fprintf(stderr,"dimension: %s = UNLIMITED\n",(yyvsp[-2].sym)->name);
 		}
 		(yyval.sym)=tsym;
 	    }
-#line 2256 "ncgeny.c" /* yacc.c:1646  */
+#line 2258 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 86:
-#line 692 "ncgen.y" /* yacc.c:1646  */
+#line 694 "ncgen.y" /* yacc.c:1646  */
     {Symbol* tvsym = (yyvsp[0].sym); Symbol* sym;
 		/* disambiguate*/
 		tvsym->objectclass = NC_VAR;
@@ -2275,53 +2277,53 @@ fprintf(stderr,"dimension: %s = UNLIMITED\n",(yyvsp[-2].sym)->name);
 		}
 		(yyval.sym)=tvsym;
 	    }
-#line 2279 "ncgeny.c" /* yacc.c:1646  */
+#line 2281 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 87:
-#line 710 "ncgen.y" /* yacc.c:1646  */
+#line 712 "ncgen.y" /* yacc.c:1646  */
     {(yyval.sym)=(yyvsp[0].sym);}
-#line 2285 "ncgeny.c" /* yacc.c:1646  */
+#line 2287 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 88:
-#line 717 "ncgen.y" /* yacc.c:1646  */
+#line 719 "ncgen.y" /* yacc.c:1646  */
     {}
-#line 2291 "ncgeny.c" /* yacc.c:1646  */
+#line 2293 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 89:
-#line 717 "ncgen.y" /* yacc.c:1646  */
+#line 719 "ncgen.y" /* yacc.c:1646  */
     {}
-#line 2297 "ncgeny.c" /* yacc.c:1646  */
+#line 2299 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 90:
-#line 721 "ncgen.y" /* yacc.c:1646  */
+#line 723 "ncgen.y" /* yacc.c:1646  */
     {(yyval.sym) = makespecial(_NCPROPS_FLAG,NULL,NULL,(void*)(yyvsp[0].constant),ISCONST);}
-#line 2303 "ncgeny.c" /* yacc.c:1646  */
+#line 2305 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 91:
-#line 723 "ncgen.y" /* yacc.c:1646  */
+#line 725 "ncgen.y" /* yacc.c:1646  */
     {(yyval.sym) = makespecial(_ISNETCDF4_FLAG,NULL,NULL,(void*)(yyvsp[0].constant),ISCONST);}
-#line 2309 "ncgeny.c" /* yacc.c:1646  */
+#line 2311 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 92:
-#line 725 "ncgen.y" /* yacc.c:1646  */
+#line 727 "ncgen.y" /* yacc.c:1646  */
     {(yyval.sym) = makespecial(_SUPERBLOCK_FLAG,NULL,NULL,(void*)(yyvsp[0].constant),ISCONST);}
-#line 2315 "ncgeny.c" /* yacc.c:1646  */
+#line 2317 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 93:
-#line 727 "ncgen.y" /* yacc.c:1646  */
+#line 729 "ncgen.y" /* yacc.c:1646  */
     { (yyval.sym)=makeattribute((yyvsp[-2].sym),NULL,NULL,(yyvsp[0].datalist),ATTRGLOBAL);}
-#line 2321 "ncgeny.c" /* yacc.c:1646  */
+#line 2323 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 94:
-#line 729 "ncgen.y" /* yacc.c:1646  */
+#line 731 "ncgen.y" /* yacc.c:1646  */
     {Symbol* tsym = (yyvsp[-5].sym); Symbol* vsym = (yyvsp[-4].sym); Symbol* asym = (yyvsp[-2].sym);
 		if(vsym->objectclass == NC_VAR) {
 		    (yyval.sym)=makeattribute(asym,vsym,tsym,(yyvsp[0].datalist),ATTRVAR);
@@ -2330,11 +2332,11 @@ fprintf(stderr,"dimension: %s = UNLIMITED\n",(yyvsp[-2].sym)->name);
 		    YYABORT;
 		}
 	    }
-#line 2334 "ncgeny.c" /* yacc.c:1646  */
+#line 2336 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 95:
-#line 738 "ncgen.y" /* yacc.c:1646  */
+#line 740 "ncgen.y" /* yacc.c:1646  */
     {Symbol* sym = (yyvsp[-4].sym); Symbol* asym = (yyvsp[-2].sym);
 		if(sym->objectclass == NC_VAR) {
 		    (yyval.sym)=makeattribute(asym,sym,NULL,(yyvsp[0].datalist),ATTRVAR);
@@ -2345,345 +2347,345 @@ fprintf(stderr,"dimension: %s = UNLIMITED\n",(yyvsp[-2].sym)->name);
 		    YYABORT;
 		}
 	    }
-#line 2349 "ncgeny.c" /* yacc.c:1646  */
+#line 2351 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 96:
-#line 749 "ncgen.y" /* yacc.c:1646  */
+#line 751 "ncgen.y" /* yacc.c:1646  */
     {(yyval.sym) = makespecial(_FILLVALUE_FLAG,(yyvsp[-4].sym),NULL,(void*)(yyvsp[0].datalist),ISLIST);}
-#line 2355 "ncgeny.c" /* yacc.c:1646  */
+#line 2357 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 97:
-#line 751 "ncgen.y" /* yacc.c:1646  */
+#line 753 "ncgen.y" /* yacc.c:1646  */
     {(yyval.sym) = makespecial(_FILLVALUE_FLAG,(yyvsp[-4].sym),(yyvsp[-5].sym),(void*)(yyvsp[0].datalist),ISLIST);}
-#line 2361 "ncgeny.c" /* yacc.c:1646  */
+#line 2363 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 98:
-#line 753 "ncgen.y" /* yacc.c:1646  */
+#line 755 "ncgen.y" /* yacc.c:1646  */
     {(yyval.sym) = makespecial(_STORAGE_FLAG,(yyvsp[-4].sym),NULL,(void*)(yyvsp[0].constant),ISCONST);}
-#line 2367 "ncgeny.c" /* yacc.c:1646  */
+#line 2369 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 99:
-#line 755 "ncgen.y" /* yacc.c:1646  */
+#line 757 "ncgen.y" /* yacc.c:1646  */
     {(yyval.sym) = makespecial(_CHUNKSIZES_FLAG,(yyvsp[-4].sym),NULL,(void*)(yyvsp[0].datalist),ISLIST);}
-#line 2373 "ncgeny.c" /* yacc.c:1646  */
+#line 2375 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 100:
-#line 757 "ncgen.y" /* yacc.c:1646  */
+#line 759 "ncgen.y" /* yacc.c:1646  */
     {(yyval.sym) = makespecial(_FLETCHER32_FLAG,(yyvsp[-4].sym),NULL,(void*)(yyvsp[0].constant),ISCONST);}
-#line 2379 "ncgeny.c" /* yacc.c:1646  */
+#line 2381 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 101:
-#line 759 "ncgen.y" /* yacc.c:1646  */
+#line 761 "ncgen.y" /* yacc.c:1646  */
     {(yyval.sym) = makespecial(_DEFLATE_FLAG,(yyvsp[-4].sym),NULL,(void*)(yyvsp[0].constant),ISCONST);}
-#line 2385 "ncgeny.c" /* yacc.c:1646  */
+#line 2387 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 102:
-#line 761 "ncgen.y" /* yacc.c:1646  */
+#line 763 "ncgen.y" /* yacc.c:1646  */
     {(yyval.sym) = makespecial(_SHUFFLE_FLAG,(yyvsp[-4].sym),NULL,(void*)(yyvsp[0].constant),ISCONST);}
-#line 2391 "ncgeny.c" /* yacc.c:1646  */
+#line 2393 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 103:
-#line 763 "ncgen.y" /* yacc.c:1646  */
+#line 765 "ncgen.y" /* yacc.c:1646  */
     {(yyval.sym) = makespecial(_ENDIAN_FLAG,(yyvsp[-4].sym),NULL,(void*)(yyvsp[0].constant),ISCONST);}
-#line 2397 "ncgeny.c" /* yacc.c:1646  */
+#line 2399 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 104:
-#line 765 "ncgen.y" /* yacc.c:1646  */
+#line 767 "ncgen.y" /* yacc.c:1646  */
     {(yyval.sym) = makespecial(_FILTER_FLAG,(yyvsp[-4].sym),NULL,(void*)(yyvsp[0].constant),ISCONST);}
-#line 2403 "ncgeny.c" /* yacc.c:1646  */
+#line 2405 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 105:
-#line 767 "ncgen.y" /* yacc.c:1646  */
+#line 769 "ncgen.y" /* yacc.c:1646  */
     {(yyval.sym) = makespecial(_NOFILL_FLAG,(yyvsp[-4].sym),NULL,(void*)(yyvsp[0].constant),ISCONST);}
-#line 2409 "ncgeny.c" /* yacc.c:1646  */
+#line 2411 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 106:
-#line 769 "ncgen.y" /* yacc.c:1646  */
+#line 771 "ncgen.y" /* yacc.c:1646  */
     {(yyval.sym) = makespecial(_FORMAT_FLAG,NULL,NULL,(void*)(yyvsp[0].constant),ISCONST);}
-#line 2415 "ncgeny.c" /* yacc.c:1646  */
+#line 2417 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 107:
-#line 774 "ncgen.y" /* yacc.c:1646  */
+#line 776 "ncgen.y" /* yacc.c:1646  */
     {
 	        (yyval.sym)=(yyvsp[0].sym);
                 (yyvsp[0].sym)->ref.is_ref=1;
                 (yyvsp[0].sym)->is_prefixed=0;
                 setpathcurrent((yyvsp[0].sym));
 	    }
-#line 2426 "ncgeny.c" /* yacc.c:1646  */
+#line 2428 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 108:
-#line 781 "ncgen.y" /* yacc.c:1646  */
+#line 783 "ncgen.y" /* yacc.c:1646  */
     {
 	        (yyval.sym)=(yyvsp[0].sym);
                 (yyvsp[0].sym)->ref.is_ref=1;
                 (yyvsp[0].sym)->is_prefixed=1;
 	        /* path is set in ncgen.l*/
 	    }
-#line 2437 "ncgeny.c" /* yacc.c:1646  */
+#line 2439 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 110:
-#line 790 "ncgen.y" /* yacc.c:1646  */
+#line 792 "ncgen.y" /* yacc.c:1646  */
     {}
-#line 2443 "ncgeny.c" /* yacc.c:1646  */
+#line 2445 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 111:
-#line 791 "ncgen.y" /* yacc.c:1646  */
+#line 793 "ncgen.y" /* yacc.c:1646  */
     {}
-#line 2449 "ncgeny.c" /* yacc.c:1646  */
+#line 2451 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 114:
-#line 799 "ncgen.y" /* yacc.c:1646  */
+#line 801 "ncgen.y" /* yacc.c:1646  */
     {(yyvsp[-2].sym)->data = (yyvsp[0].datalist);}
-#line 2455 "ncgeny.c" /* yacc.c:1646  */
+#line 2457 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 115:
-#line 802 "ncgen.y" /* yacc.c:1646  */
+#line 804 "ncgen.y" /* yacc.c:1646  */
     {(yyval.datalist) = (yyvsp[0].datalist);}
-#line 2461 "ncgeny.c" /* yacc.c:1646  */
+#line 2463 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 116:
-#line 803 "ncgen.y" /* yacc.c:1646  */
+#line 805 "ncgen.y" /* yacc.c:1646  */
     {(yyval.datalist) = (yyvsp[0].datalist);}
-#line 2467 "ncgeny.c" /* yacc.c:1646  */
+#line 2469 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 117:
-#line 807 "ncgen.y" /* yacc.c:1646  */
+#line 809 "ncgen.y" /* yacc.c:1646  */
     {(yyval.datalist) = builddatalist(0);}
-#line 2473 "ncgeny.c" /* yacc.c:1646  */
+#line 2475 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 118:
-#line 811 "ncgen.y" /* yacc.c:1646  */
+#line 813 "ncgen.y" /* yacc.c:1646  */
     {(yyval.datalist) = const2list((yyvsp[0].constant));}
-#line 2479 "ncgeny.c" /* yacc.c:1646  */
+#line 2481 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 119:
-#line 813 "ncgen.y" /* yacc.c:1646  */
+#line 815 "ncgen.y" /* yacc.c:1646  */
     {dlappend((yyvsp[-2].datalist),((yyvsp[0].constant))); (yyval.datalist)=(yyvsp[-2].datalist); }
-#line 2485 "ncgeny.c" /* yacc.c:1646  */
+#line 2487 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 120:
-#line 817 "ncgen.y" /* yacc.c:1646  */
+#line 819 "ncgen.y" /* yacc.c:1646  */
     {(yyval.constant)=(yyvsp[0].constant);}
-#line 2491 "ncgeny.c" /* yacc.c:1646  */
+#line 2493 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 121:
-#line 818 "ncgen.y" /* yacc.c:1646  */
+#line 820 "ncgen.y" /* yacc.c:1646  */
     {(yyval.constant)=builddatasublist((yyvsp[-1].datalist));}
-#line 2497 "ncgeny.c" /* yacc.c:1646  */
+#line 2499 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 122:
-#line 822 "ncgen.y" /* yacc.c:1646  */
+#line 824 "ncgen.y" /* yacc.c:1646  */
     {(yyval.constant)=(yyvsp[0].constant);}
-#line 2503 "ncgeny.c" /* yacc.c:1646  */
+#line 2505 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 123:
-#line 823 "ncgen.y" /* yacc.c:1646  */
+#line 825 "ncgen.y" /* yacc.c:1646  */
     {(yyval.constant)=makeconstdata(NC_OPAQUE);}
-#line 2509 "ncgeny.c" /* yacc.c:1646  */
+#line 2511 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 124:
-#line 824 "ncgen.y" /* yacc.c:1646  */
+#line 826 "ncgen.y" /* yacc.c:1646  */
     {(yyval.constant)=makeconstdata(NC_FILLVALUE);}
-#line 2515 "ncgeny.c" /* yacc.c:1646  */
+#line 2517 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 125:
-#line 825 "ncgen.y" /* yacc.c:1646  */
+#line 827 "ncgen.y" /* yacc.c:1646  */
     {(yyval.constant)=makeconstdata(NC_NIL);}
-#line 2521 "ncgeny.c" /* yacc.c:1646  */
+#line 2523 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 126:
-#line 826 "ncgen.y" /* yacc.c:1646  */
+#line 828 "ncgen.y" /* yacc.c:1646  */
     {(yyval.constant)=(yyvsp[0].constant);}
-#line 2527 "ncgeny.c" /* yacc.c:1646  */
+#line 2529 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 128:
-#line 831 "ncgen.y" /* yacc.c:1646  */
+#line 833 "ncgen.y" /* yacc.c:1646  */
     {(yyval.constant) = makeenumconstref((yyvsp[0].sym));}
-#line 2533 "ncgeny.c" /* yacc.c:1646  */
+#line 2535 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 129:
-#line 835 "ncgen.y" /* yacc.c:1646  */
+#line 837 "ncgen.y" /* yacc.c:1646  */
     {(yyval.constant)=evaluate((yyvsp[-3].sym),(yyvsp[-1].datalist));}
-#line 2539 "ncgeny.c" /* yacc.c:1646  */
+#line 2541 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 130:
-#line 840 "ncgen.y" /* yacc.c:1646  */
+#line 842 "ncgen.y" /* yacc.c:1646  */
     {(yyval.datalist) = const2list((yyvsp[0].constant));}
-#line 2545 "ncgeny.c" /* yacc.c:1646  */
+#line 2547 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 131:
-#line 842 "ncgen.y" /* yacc.c:1646  */
+#line 844 "ncgen.y" /* yacc.c:1646  */
     {dlappend((yyvsp[-2].datalist),((yyvsp[0].constant))); (yyval.datalist)=(yyvsp[-2].datalist);}
-#line 2551 "ncgeny.c" /* yacc.c:1646  */
+#line 2553 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 132:
-#line 846 "ncgen.y" /* yacc.c:1646  */
+#line 848 "ncgen.y" /* yacc.c:1646  */
     {(yyval.constant)=makeconstdata(NC_CHAR);}
-#line 2557 "ncgeny.c" /* yacc.c:1646  */
+#line 2559 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 133:
-#line 847 "ncgen.y" /* yacc.c:1646  */
+#line 849 "ncgen.y" /* yacc.c:1646  */
     {(yyval.constant)=makeconstdata(NC_BYTE);}
-#line 2563 "ncgeny.c" /* yacc.c:1646  */
+#line 2565 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 134:
-#line 848 "ncgen.y" /* yacc.c:1646  */
+#line 850 "ncgen.y" /* yacc.c:1646  */
     {(yyval.constant)=makeconstdata(NC_SHORT);}
-#line 2569 "ncgeny.c" /* yacc.c:1646  */
+#line 2571 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 135:
-#line 849 "ncgen.y" /* yacc.c:1646  */
+#line 851 "ncgen.y" /* yacc.c:1646  */
     {(yyval.constant)=makeconstdata(NC_INT);}
-#line 2575 "ncgeny.c" /* yacc.c:1646  */
+#line 2577 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 136:
-#line 850 "ncgen.y" /* yacc.c:1646  */
+#line 852 "ncgen.y" /* yacc.c:1646  */
     {(yyval.constant)=makeconstdata(NC_INT64);}
-#line 2581 "ncgeny.c" /* yacc.c:1646  */
+#line 2583 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 137:
-#line 851 "ncgen.y" /* yacc.c:1646  */
+#line 853 "ncgen.y" /* yacc.c:1646  */
     {(yyval.constant)=makeconstdata(NC_UBYTE);}
-#line 2587 "ncgeny.c" /* yacc.c:1646  */
+#line 2589 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 138:
-#line 852 "ncgen.y" /* yacc.c:1646  */
+#line 854 "ncgen.y" /* yacc.c:1646  */
     {(yyval.constant)=makeconstdata(NC_USHORT);}
-#line 2593 "ncgeny.c" /* yacc.c:1646  */
+#line 2595 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 139:
-#line 853 "ncgen.y" /* yacc.c:1646  */
+#line 855 "ncgen.y" /* yacc.c:1646  */
     {(yyval.constant)=makeconstdata(NC_UINT);}
-#line 2599 "ncgeny.c" /* yacc.c:1646  */
+#line 2601 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 140:
-#line 854 "ncgen.y" /* yacc.c:1646  */
+#line 856 "ncgen.y" /* yacc.c:1646  */
     {(yyval.constant)=makeconstdata(NC_UINT64);}
-#line 2605 "ncgeny.c" /* yacc.c:1646  */
+#line 2607 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 141:
-#line 855 "ncgen.y" /* yacc.c:1646  */
+#line 857 "ncgen.y" /* yacc.c:1646  */
     {(yyval.constant)=makeconstdata(NC_FLOAT);}
-#line 2611 "ncgeny.c" /* yacc.c:1646  */
+#line 2613 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 142:
-#line 856 "ncgen.y" /* yacc.c:1646  */
+#line 858 "ncgen.y" /* yacc.c:1646  */
     {(yyval.constant)=makeconstdata(NC_DOUBLE);}
-#line 2617 "ncgeny.c" /* yacc.c:1646  */
+#line 2619 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 143:
-#line 857 "ncgen.y" /* yacc.c:1646  */
+#line 859 "ncgen.y" /* yacc.c:1646  */
     {(yyval.constant)=makeconstdata(NC_STRING);}
-#line 2623 "ncgeny.c" /* yacc.c:1646  */
+#line 2625 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 144:
-#line 861 "ncgen.y" /* yacc.c:1646  */
+#line 863 "ncgen.y" /* yacc.c:1646  */
     {(yyval.datalist) = const2list((yyvsp[0].constant));}
-#line 2629 "ncgeny.c" /* yacc.c:1646  */
+#line 2631 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 145:
-#line 862 "ncgen.y" /* yacc.c:1646  */
+#line 864 "ncgen.y" /* yacc.c:1646  */
     {(yyval.datalist)=(yyvsp[-2].datalist); dlappend((yyvsp[-2].datalist),((yyvsp[0].constant)));}
-#line 2635 "ncgeny.c" /* yacc.c:1646  */
+#line 2637 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 146:
-#line 867 "ncgen.y" /* yacc.c:1646  */
+#line 869 "ncgen.y" /* yacc.c:1646  */
     {(yyval.constant)=makeconstdata(NC_INT);}
-#line 2641 "ncgeny.c" /* yacc.c:1646  */
+#line 2643 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 147:
-#line 869 "ncgen.y" /* yacc.c:1646  */
+#line 871 "ncgen.y" /* yacc.c:1646  */
     {(yyval.constant)=makeconstdata(NC_UINT);}
-#line 2647 "ncgeny.c" /* yacc.c:1646  */
+#line 2649 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 148:
-#line 871 "ncgen.y" /* yacc.c:1646  */
+#line 873 "ncgen.y" /* yacc.c:1646  */
     {(yyval.constant)=makeconstdata(NC_INT64);}
-#line 2653 "ncgeny.c" /* yacc.c:1646  */
+#line 2655 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 149:
-#line 873 "ncgen.y" /* yacc.c:1646  */
+#line 875 "ncgen.y" /* yacc.c:1646  */
     {(yyval.constant)=makeconstdata(NC_UINT64);}
-#line 2659 "ncgeny.c" /* yacc.c:1646  */
+#line 2661 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 150:
-#line 877 "ncgen.y" /* yacc.c:1646  */
+#line 879 "ncgen.y" /* yacc.c:1646  */
     {(yyval.constant)=makeconstdata(NC_STRING);}
-#line 2665 "ncgeny.c" /* yacc.c:1646  */
+#line 2667 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 151:
-#line 881 "ncgen.y" /* yacc.c:1646  */
+#line 883 "ncgen.y" /* yacc.c:1646  */
     {(yyval.constant)=(yyvsp[0].constant);}
-#line 2671 "ncgeny.c" /* yacc.c:1646  */
+#line 2673 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 152:
-#line 882 "ncgen.y" /* yacc.c:1646  */
+#line 884 "ncgen.y" /* yacc.c:1646  */
     {(yyval.constant)=(yyvsp[0].constant);}
-#line 2677 "ncgeny.c" /* yacc.c:1646  */
+#line 2679 "ncgeny.c" /* yacc.c:1646  */
     break;
 
   case 153:
-#line 888 "ncgen.y" /* yacc.c:1646  */
+#line 890 "ncgen.y" /* yacc.c:1646  */
     {(yyval.sym)=(yyvsp[0].sym);}
-#line 2683 "ncgeny.c" /* yacc.c:1646  */
+#line 2685 "ncgeny.c" /* yacc.c:1646  */
     break;
 
 
-#line 2687 "ncgeny.c" /* yacc.c:1646  */
+#line 2689 "ncgeny.c" /* yacc.c:1646  */
       default: break;
     }
   /* User semantic actions sometimes alter yychar, and that requires
@@ -2911,7 +2913,7 @@ yyreturn:
 #endif
   return yyresult;
 }
-#line 891 "ncgen.y" /* yacc.c:1906  */
+#line 893 "ncgen.y" /* yacc.c:1906  */
 
 
 #ifndef NO_STDARG
@@ -2991,13 +2993,18 @@ makeprimitivetype(nc_type nctype)
 Symbol*
 install(const char *sname)
 {
+    return installin(sname,currentgroup());
+}
+
+Symbol*
+installin(const char *sname, Symbol* grp)
+{
     Symbol* sp;
     sp = (Symbol*) ecalloc (sizeof (struct Symbol));
     sp->name = nulldup(sname);
     sp->lineno = lineno;
-    sp->location = currentgroup();
-    sp->container = currentgroup();
-    sp->var.special._Storage = NC_CONTIGUOUS;
+    sp->location = grp;
+    sp->container = grp;
     listpush(symlist,sp);
     return sp;
 }
@@ -3269,8 +3276,6 @@ makespecial(int tag, Symbol* vsym, Symbol* tsym, void* data, int isconst)
               globalspecials._Format = kvalue->k_flag;
 	      /*Main.*/format_attribute = 1;
               found = 1;
-	      if(kvalue->deprecated)
-		 fprintf(stderr,"_Format=%s is deprecated; use corresponding _Format=<name>\n",sdata);
               break;
             }
           }
@@ -3593,7 +3598,7 @@ done:
 
 #ifdef GENDEBUG1
 static void
-printfilters(int nfilters, NC_Filterspec** filters)
+printfilters(int nfilters, NC_FilterSpec** filters)
 {
     int i;
     fprintf(stderr,"xxx: nfilters=%lu: ",(unsigned long)nfilters);
@@ -3601,13 +3606,13 @@ printfilters(int nfilters, NC_Filterspec** filters)
 	int k;
 	NC_Filterspec* sp = filters[i];
         fprintf(stderr,"{");
-        fprintf(stderr,"filterid=%s format=%s nparams=%lu params=%p",
+        fprintf(stderr,"filterid=%llu format=%d nparams=%lu params=%p",
 		sp->filterid,sp->format,(unsigned long)sp->nparams,sp->params);
 	if(sp->nparams > 0 && sp->params != NULL) {
             fprintf(stderr," params={");
             for(k=0;k<sp->nparams;k++) {
 	        if(i==0) fprintf(stderr,",");
-	        fprintf(stderr,"%s",sp->params[i]);
+	        fprintf(stderr,"%u",sp->params[i]);
 	    }
             fprintf(stderr,"}");
 	} else

--- a/ncgen/ncgeny.h
+++ b/ncgen/ncgeny.h
@@ -106,7 +106,7 @@ extern int ncgdebug;
 
 union YYSTYPE
 {
-#line 151 "ncgen.y" /* yacc.c:1909  */
+#line 153 "ncgen.y" /* yacc.c:1909  */
 
 Symbol* sym;
 unsigned long  size; /* allow for zero size to indicate e.g. UNLIMITED*/


### PR DESCRIPTION
re: https://github.com/Unidata/netcdf-c/issues/1977

PR https://github.com/Unidata/netcdf-c/pull/1753 changed ncgen to allows certain type names to be used as identifiers in selected situations.

An unwanted side effect was that existing type aliases no longer were accepted by ncgen. Specifically, using the "long" type caused an error.

I was able to figure out a better solution to the original problem (https://github.com/Unidata/netcdf-c/issues/1750) that also fixes this problem as well.

This PR fixes that problem and adds tests to ncdump/test_keywords.sh