### PR TITLE
Improve error message when non-existent filter is encountered.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,7 @@ Release Notes       {#RELEASE_NOTES}
 This file contains a high-level description of this package's evolution. Releases are in reverse chronological order (most recent first). Note that, as of netcdf 4.2, the `netcdf-c++` and `netcdf-fortran` libraries have been separated into their own libraries.
 ## 4.8.1 - TBD
 
+* [Enhancement] Improve the error reporting when attempting to use a filter for which no implementation can be found in HDF5_PLUGIN_PATH. See [Github #2000](https://github.com/Unidata/netcdf-c/pull/2000) for more information.
 * [Bug Fix] Fix bug in JSON processing of strings with embedded quotes. See [Github #1993](https://github.com/Unidata/netcdf-c/issues/1993).  
 * [Enhancement] Add support for the new "dimension_separator" enhancement to Zarr v2. See [Github #1990](https://github.com/Unidata/netcdf-c/pull/1990) for more information.
 * [Bug Fix] Fix hack for handling failure of shell programs to properly handle escape characters. See [Github #1989](https://github.com/Unidata/netcdf-c/issues/1989).  

--- a/include/hdf5internal.h
+++ b/include/hdf5internal.h
@@ -95,6 +95,8 @@ typedef struct NC_HDF5_VAR_INFO
     HDF5_OBJID_T *dimscale_hdf5_objids;
     nc_bool_t dimscale;          /**< True if var is a dimscale. */
     nc_bool_t *dimscale_attached;  /**< Array of flags that are true if dimscale is attached for that dim index. */
+    int flags;
+#       define NC_HDF5_VAR_FILTER_MISSING 1 /* if any filter is missing */
 } NC_HDF5_VAR_INFO_T;
 
 /* Struct to hold HDF5-specific info for a field. */
@@ -186,6 +188,7 @@ int NC4_hdf5_inq_var_filter_info(int ncid, int varid, unsigned int filterid, siz
 /* The NC_VAR_INFO_T->filters field is an NClist of this struct */
 struct NC_HDF5_Filter {
     int flags;             /**< Flags describing state of this filter. */
+#       define NC_HDF5_FILTER_MISSING 1 /* Filter implementation is not accessible */
     unsigned int filterid; /**< ID for arbitrary filter. */
     size_t nparams;        /**< nparams for arbitrary filter. */
     unsigned int* params;  /**< Params for arbitrary filter. */
@@ -193,8 +196,9 @@ struct NC_HDF5_Filter {
 
 int NC4_hdf5_filter_remove(NC_VAR_INFO_T* var, unsigned int id);
 int NC4_hdf5_filter_lookup(NC_VAR_INFO_T* var, unsigned int id, struct NC_HDF5_Filter** fi);
-int NC4_hdf5_addfilter(NC_VAR_INFO_T* var, unsigned int id, size_t nparams, const unsigned int* params);
+int NC4_hdf5_addfilter(NC_VAR_INFO_T* var, unsigned int id, size_t nparams, const unsigned int* params, int flags);
 int NC4_hdf5_filter_freelist(NC_VAR_INFO_T* var);
+int NC4_hdf5_find_missing_filter(NC_VAR_INFO_T* var, unsigned int* idp);
 
 /* Support functions for provenance info (defined in nc4hdf.c) */
 extern int NC4_hdf5get_libversion(unsigned*,unsigned*,unsigned*);/*libsrc4/nc4hdf.c*/

--- a/libdispatch/derror.c
+++ b/libdispatch/derror.c
@@ -261,7 +261,7 @@ const char *nc_strerror(int ncerr1)
       case NC_EFILTER:
 	 return "NetCDF: Filter error: bad id or parameters";
       case NC_ENOFILTER:
-	 return "NetCDF: Filter error: filter not defined for variable";
+	 return "NetCDF: Filter error: unimplemented filter encountered";
       case NC_ECANTEXTEND:
 	return "NetCDF: Attempt to extend dataset during NC_INDEPENDENT I/O operation. Use nc_var_par_access to set mode NC_COLLECTIVE before extending variable.";
       case NC_EMPI: return "NetCDF: MPI operation failed.";

--- a/libhdf5/hdf5var.c
+++ b/libhdf5/hdf5var.c
@@ -1375,6 +1375,14 @@ NC4_put_vars(int ncid, int varid, const size_t *startp, const size_t *countp,
         return retval;
     assert(hdf5_var->hdf_datasetid && (!var->ndims || (startp && countp)));
 
+    /* Verify that all the variable's filters are available */
+    if(hdf5_var->flags & NC_HDF5_VAR_FILTER_MISSING) {
+	unsigned id = 0;
+	NC4_hdf5_find_missing_filter(var, &id);
+	LOG((0,"missing filter: variable=%s id=%u",var->hdr.name,id));
+        return NC_ENOFILTER;
+    }
+
     /* Convert from size_t and ptrdiff_t to hssize_t, and hsize_t. */
     /* Also do sanity checks */
     for (i = 0; i < var->ndims; i++)
@@ -1692,6 +1700,14 @@ NC4_get_vars(int ncid, int varid, const size_t *startp, const size_t *countp,
     if ((retval = check_for_vara(&mem_nc_type, var, h5)))
         return retval;
     assert(hdf5_var->hdf_datasetid && (!var->ndims || (startp && countp)));
+
+    /* Verify that all the variable's filters are available */
+    if(hdf5_var->flags & NC_HDF5_VAR_FILTER_MISSING) {
+	unsigned id = 0;
+	NC4_hdf5_find_missing_filter(var, &id);
+	LOG((0,"missing filter: variable=%s id=%u",var->hdr.name,id));
+        return NC_ENOFILTER;
+    }
 
     /* Convert from size_t and ptrdiff_t to hsize_t. Also do sanity
      * checks. */

--- a/libnczarr/zinternal.h
+++ b/libnczarr/zinternal.h
@@ -225,6 +225,7 @@ int ncz_find_default_chunksizes2(NC_GRP_INFO_T *grp, NC_VAR_INFO_T *var);
 /* The NC_VAR_INFO_T->filters field is an NClist of this struct */
 struct NCZ_Filter {
     int flags;             /**< Flags describing state of this filter. */
+#define NCZ_FILTER_MISSING 1 /* Signal filter implementation is not available */
     unsigned int filterid; /**< ID for arbitrary filter. */
     size_t nparams;        /**< nparams for arbitrary filter. */
     unsigned int* params;  /**< Params for arbitrary filter. */

--- a/nc_test4/tst_filter.sh
+++ b/nc_test4/tst_filter.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if test "x$srcdir" = x ; then srcdir=`pwd`; fi
 . ../test_common.sh
@@ -41,10 +41,23 @@ trimleft() {
 sed -e 's/[ 	]*\([^ 	].*\)/\1/' <$1 >$2
 }
 
+# Hide/unhide the bzip2 filter
+hidebzip2() {
+  rm -fr ${HDF5_PLUGIN_PATH}/save
+  mkdir ${HDF5_PLUGIN_PATH}/save
+  mv ${BZIP2PATH} ${HDF5_PLUGIN_PATH}/save
+}
+
+unhidebzip2() {
+  mv ${HDF5_PLUGIN_PATH}/save/${BZIP2LIB} ${HDF5_PLUGIN_PATH}
+  rm -fr ${HDF5_PLUGIN_PATH}/save
+}
+
 # Locate the plugin path and the library names; argument order is critical
 # Find bzip2 and capture
 findplugin h5bzip2
-BZIP2PATH="${HDF5_PLUGIN_PATH}/${HDF5_PLUGIN_LIB}"
+BZIP2LIB="${HDF5_PLUGIN_LIB}"
+BZIP2PATH="${HDF5_PLUGIN_PATH}/${BZIP2LIB}"
 # Find misc and capture
 findplugin misc
 MISCPATH="${HDF5_PLUGIN_PATH}/${HDF5_PLUGIN_LIB}"
@@ -169,23 +182,28 @@ fi
 if test "x$UNK" = x1 ; then
 echo "*** Testing access to filter info when filter dll is not available"
 rm -f bzip2.nc ./tst_filter.txt
-# build bzip2.nc
+# xfail build bzip2.nc 
+hidebzip2
+if ${NCGEN} -lb -4 -o bzip2.nc ${srcdir}/bzip2.cdl ; then
+    echo "*** FAIL: ncgen"
+else
+    echo "*** XFAIL: ncgen"
+fi
+unhidebzip2    
+# build bzip2.nc 
 ${NCGEN} -lb -4 -o bzip2.nc ${srcdir}/bzip2.cdl
-# dump and clean bzip2.nc header only when filter is avail
-${NCDUMP} -hs bzip2.nc > ./tst_filter.txt
-# Remove irrelevant -s output
-sclean ./tst_filter.txt bzip2.dump
 # Now hide the filter code
-mv ${BZIP2PATH} ${BZIP2PATH}.save
-# dump and clean bzip2.nc header only when filter is not avail
+hidebzip2
 rm -f ./tst_filter.txt
-${NCDUMP} -hs bzip2.nc > ./tst_filter.txt
-# Remove irrelevant -s output
-sclean ./tst_filter.txt bzip2x.dump
+# This will xfail
+if ${NCDUMP} -s bzip2.nc > ./tst_filter.txt ; then
+    echo "*** FAIL: ncdump -hs bzip2.nc"
+else
+    echo "*** XFAIL: ncdump -hs bzip2.nc"
+fi
 # Restore the filter code
-mv ${BZIP2PATH}.save ${BZIP2PATH}
-diff -b -w ./bzip2.dump ./bzip2x.dump
-echo "*** Pass: ncgen dynamic filter"
+unhidebzip2
+echo "*** Pass: unknown filter"
 fi
 
 if test "x$NGC" = x1 ; then

--- a/nc_test4/tst_filter.sh
+++ b/nc_test4/tst_filter.sh
@@ -203,6 +203,9 @@ else
 fi
 # Restore the filter code
 unhidebzip2
+# Verify we can see filter when using -h
+rm -f ./tst_filter.txt
+${NCDUMP} -hs bzip2.nc > ./tst_filter.txt
 echo "*** Pass: unknown filter"
 fi
 


### PR DESCRIPTION
* Fixes #1996 

re: https://github.com/Unidata/netcdf-c/issues/1996

Improve the error message and location that is reported when reading a filter with a variable that uses a filter that is not available on the reading platform.

This requires checking the availability of the filter, recording it, and failing when any attempt is made to read or write that variable. A test case was added for this in tst_filter.sh. Also, LOG level 0 message is generated giving the variable and the filter id.

Note that by design if there is no attempt to read or write the variable, then no error is reported; this means that, for example, ncdump -h will list the filter even though it is not actually available. This is important for allowing a user to see the filter details.