### PR TITLE
Fix counting of dimensions in ncdump

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,7 @@ Release Notes       {#RELEASE_NOTES}
 This file contains a high-level description of this package's evolution. Releases are in reverse chronological order (most recent first). Note that, as of netcdf 4.2, the `netcdf-c++` and `netcdf-fortran` libraries have been separated into their own libraries.
 ## 4.8.1 - TBD
 
+* [Bug Fix] Fix bug in ncdump that assumes that there is a relationship between the total number of dimensions and the max dimension id. See [Github #2004](https://github.com/Unidata/netcdf-c/issues/2004).  
 * [Bug Fix] Fix bug in JSON processing of strings with embedded quotes. See [Github #1993](https://github.com/Unidata/netcdf-c/issues/1993).  
 * [Enhancement] Add support for the new "dimension_separator" enhancement to Zarr v2. See [Github #1990](https://github.com/Unidata/netcdf-c/pull/1990) for more information.
 * [Bug Fix] Fix hack for handling failure of shell programs to properly handle escape characters. See [Github #1989](https://github.com/Unidata/netcdf-c/issues/1989).  

--- a/ncdump/dumplib.c
+++ b/ncdump/dumplib.c
@@ -1803,6 +1803,7 @@ init_is_unlim(int ncid, int **is_unlim_p)
 {
     int num_grps;	 /* total number of groups */
     int num_dims = 0;    /* total number of dimensions in all groups */
+    int max_dimid = -1;    /* maximum dimid across whole dataset */
     int num_undims = 0;  /* total number of unlimited dimensions in all groups */
     int *grpids = NULL;	 /* temporary list of all grpids */
     int igrp;
@@ -1822,13 +1823,22 @@ init_is_unlim(int ncid, int **is_unlim_p)
     NC_CHECK( nc_inq_grps_full(ncid, &num_grps, grpids) );
 #define DONT_INCLUDE_PARENTS 0
     /* Get all dimensions in groups and info about which ones are unlimited */
+    /* Warning: we cannot assume that the dimension ids are packed */
+    /* Find maximum dimension id */
+    max_dimid = -1;
     for(igrp = 0; igrp < num_grps; igrp++) {
-	int ndims;
+	int i,ndims;
+	int* dimids = NULL;
 	grpid = grpids[igrp];
 	NC_CHECK( nc_inq_dimids(grpid, &ndims, NULL, DONT_INCLUDE_PARENTS) );
 	num_dims += ndims;
+	dimids = (int*)emalloc(ndims*sizeof(int));
+	NC_CHECK( nc_inq_dimids(grpid, &ndims, dimids, DONT_INCLUDE_PARENTS) );
+	for(i=0;i<ndims;i++) {if(dimids[i] > max_dimid) max_dimid = dimids[i];}
+	free(dimids);
     }
-    *is_unlim_p = emalloc((num_dims + 1) * sizeof(int));
+    assert(max_dimid >= 0);
+    *is_unlim_p = emalloc((max_dimid + 1 + 1) * sizeof(int));
     for(igrp = 0; igrp < num_grps; igrp++) {
 	int ndims, idim, *dimids, nundims;
 	grpid = grpids[igrp];
@@ -1837,13 +1847,17 @@ init_is_unlim(int ncid, int **is_unlim_p)
 	NC_CHECK( nc_inq_dimids(grpid, &ndims, dimids, DONT_INCLUDE_PARENTS) );
 	/* mark all dims in this group as fixed-size */
 	for(idim = 0; idim < ndims; idim++) {
-	    (*is_unlim_p)[dimids[idim]] = 0;
+	    int* isunlim = *is_unlim_p;
+	    int did = dimids[idim];
+	    isunlim[did] = 0;
 	}
 	NC_CHECK( nc_inq_unlimdims(grpid, &nundims, dimids) );
 	assert(nundims <= ndims);
 	/* mark the subset of dims in this group that are unlimited */
 	for(idim = 0; idim < nundims; idim++) {
-	    (*is_unlim_p)[dimids[idim]] = 1;
+	    int* isunlim = *is_unlim_p;
+	    int did = dimids[idim];
+	    isunlim[did] = 1;
 	    num_undims++;
 	}
 	if(dimids)


### PR DESCRIPTION
* Fixes #2002 

re: issue https://github.com/Unidata/netcdf-c/issues/2002

It turns out that ncdump has an error where it assumes that the set of all dimension ids has no holes. That is that (maxid+1) = ndims. This is incorrect for a variety of reasons for netcdf-4.

So instead of counting total number of dimensions in a dataset, it is necessary to look for the maximum dimension id and use that when allocating a table of all dimensions.