### PR TITLE
Fix Mingw versus XGetopt (again)

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -4,7 +4,7 @@
 
 name: Run netCDF Tests
 
-on: [pull_request]
+on: [pull_request,push]
 
 jobs:
 

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -4,7 +4,7 @@
 
 name: Run netCDF Tests
 
-on: [pull_request,push]
+on: [pull_request]
 
 jobs:
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,7 @@ Release Notes       {#RELEASE_NOTES}
 This file contains a high-level description of this package's evolution. Releases are in reverse chronological order (most recent first). Note that, as of netcdf 4.2, the `netcdf-c++` and `netcdf-fortran` libraries have been separated into their own libraries.
 ## 4.8.1 - TBD
 
+* [Bug Fix] Fix bug in use of XGetopt when building under Mingw. See [Github #2009](https://github.com/Unidata/netcdf-c/issues/2009).
 * [Bug Fix] Fix bug in NCclosedir in dpathmgr.c. See [Github #2003](https://github.com/Unidata/netcdf-c/issues/2003).
 * [Bug Fix] Fix bug in ncdump that assumes that there is a relationship between the total number of dimensions and the max dimension id. See [Github #2004](https://github.com/Unidata/netcdf-c/issues/2004).  
 * [Bug Fix] Fix bug in JSON processing of strings with embedded quotes. See [Github #1993](https://github.com/Unidata/netcdf-c/issues/1993).  

--- a/dap4_test/dump.c
+++ b/dap4_test/dump.c
@@ -15,7 +15,7 @@
 #include <getopt.h>
 #endif
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__MINGW32__)
 #include "XGetopt.h"
 #define snprintf _snprintf
 #endif

--- a/ncdump/nccopy.c
+++ b/ncdump/nccopy.c
@@ -13,7 +13,7 @@
 #include <getopt.h>
 #endif
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__MINGW32__)
 #include "XGetopt.h"
 #define snprintf _snprintf
 #endif

--- a/ncdump/ncdump.c
+++ b/ncdump/ncdump.c
@@ -8,7 +8,8 @@ Research/Unidata. See \ref copyright file for more info.  */
 #ifdef HAVE_GETOPT_H
 #include <getopt.h>
 #endif
-#ifdef _WIN32
+
+#if defined(_WIN32) && !defined(__MINGW32__)
 #include "XGetopt.h"
 #define snprintf _snprintf
 #endif

--- a/ncdump/ncvalidator.c
+++ b/ncdump/ncvalidator.c
@@ -73,7 +73,7 @@ THIS SOFTWARE.
 #include <unistd.h>     /* read() getopt() */
 #endif
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__MINGW32__)
 #include <io.h>
 #include "XGetopt.h"
 #define snprintf _snprintf

--- a/ncdump/ocprint.c
+++ b/ncdump/ocprint.c
@@ -31,7 +31,7 @@
 #include "oc.h"
 #include "ocx.h"
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__MINGW32__)
 #include "XGetopt.h"
 #endif
 

--- a/ncgen/main.c
+++ b/ncgen/main.c
@@ -12,7 +12,7 @@
 #include <getopt.h>
 #endif
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__MINGW32__)
 #include "XGetopt.h"
 #endif
 

--- a/ncgen3/main.c
+++ b/ncgen3/main.c
@@ -15,7 +15,7 @@
 #include <getopt.h>
 #endif
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__MINGW32__)
 #include "XGetopt.h"
 #define snprintf _snprintf
 #endif

--- a/nczarr_test/bm_utils.c
+++ b/nczarr_test/bm_utils.c
@@ -15,7 +15,7 @@
 #include <getopt.h>
 #endif
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__MINGW32__)
 #include "XGetopt.h"
 #endif
 

--- a/nczarr_test/ncdumpchunks.c
+++ b/nczarr_test/ncdumpchunks.c
@@ -10,7 +10,7 @@
 #include <getopt.h>
 #endif
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__MINGW32__)
 #include "XGetopt.h"
 #endif
 

--- a/nczarr_test/s3util.c
+++ b/nczarr_test/s3util.c
@@ -13,7 +13,8 @@
 #ifdef HAVE_GETOPT_H
 #include <getopt.h>
 #endif
-#ifdef _WIN32
+
+#if defined(_WIN32) && !defined(__MINGW32__)
 #include "XGetopt.h"
 #endif
 

--- a/nczarr_test/test_nczarr_utils.h
+++ b/nczarr_test/test_nczarr_utils.h
@@ -21,7 +21,7 @@
 #include <getopt.h>
 #endif
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__MINGW32__)
 #include "XGetopt.h"
 #endif
 

--- a/nczarr_test/tst_utils.c
+++ b/nczarr_test/tst_utils.c
@@ -14,7 +14,7 @@
 #include <getopt.h>
 #endif
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__MINGW32__)
 #include "XGetopt.h"
 #endif
 

--- a/nczarr_test/ut_test.c
+++ b/nczarr_test/ut_test.c
@@ -11,7 +11,7 @@ x *      Copyright 2018, University Corporation for Atmospheric Research
 #include <getopt.h>
 #endif
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__MINGW32__)
 #include "XGetopt.h"
 #endif
 

--- a/nczarr_test/zmapio.c
+++ b/nczarr_test/zmapio.c
@@ -13,7 +13,8 @@
 #ifdef HAVE_GETOPT_H
 #include <getopt.h>
 #endif
-#ifdef _WIN32
+
+#if defined(_WIN32) && !defined(__MINGW32__)
 #include "XGetopt.h"
 #endif
 

--- a/nczarr_test/zs3parse.c
+++ b/nczarr_test/zs3parse.c
@@ -13,7 +13,8 @@
 #ifdef HAVE_GETOPT_H
 #include <getopt.h>
 #endif
-#ifdef _WIN32
+
+#if defined(_WIN32) && !defined(__MINGW32__)
 #include "XGetopt.h"
 #endif
 


### PR DESCRIPTION
* Fixes #2003 
* 
re: https://github.com/Unidata/netcdf-c/pull/2003#issuecomment-847637871

Turns out that mingw defines both _WIN32 and also defines getopt.
This means that this test:
````
#ifdef _WIN32
#include "XGetopt.h"
#endif
````
fails on this error:
````
../include/XGetopt.h:38:24: error: conflicting types for 'getopt'
````

Fix is to replace
````
#ifdef _WIN32
with
#if defined(_WIN32) && !defined(__MINGW32__)
````