### PR TITLE
libhdf5/H5FDhttp: add missing semicolons to H5Epush_ret

### DIFF
--- a/libhdf5/H5FDhttp.c
+++ b/libhdf5/H5FDhttp.c
@@ -275,7 +275,7 @@ H5Pset_fapl_http(hid_t fapl_id)
     H5Eclear2(H5E_DEFAULT);
 
     if(0 == H5Pisa_class(fapl_id, H5P_FILE_ACCESS))
-        H5Epush_ret(func, H5E_ERR_CLS, H5E_PLIST, H5E_BADTYPE, "not a file access property list", -1)
+        H5Epush_ret(func, H5E_ERR_CLS, H5E_PLIST, H5E_BADTYPE, "not a file access property list", -1);
 
     return H5Pset_driver(fapl_id, H5FD_HTTP, NULL);
 } /* end H5Pset_fapl_http() */
@@ -323,24 +323,24 @@ H5FD_http_open( const char *name, unsigned flags, hid_t /*UNUSED*/ fapl_id,
 
     /* Check arguments */
     if (!name || !*name)
-        H5Epush_ret(func, H5E_ERR_CLS, H5E_ARGS, H5E_BADVALUE, "invalid URL", NULL)
+        H5Epush_ret(func, H5E_ERR_CLS, H5E_ARGS, H5E_BADVALUE, "invalid URL", NULL);
     if (0 == maxaddr || HADDR_UNDEF == maxaddr)
-        H5Epush_ret(func, H5E_ERR_CLS, H5E_ARGS, H5E_BADRANGE, "bogus maxaddr", NULL)
+        H5Epush_ret(func, H5E_ERR_CLS, H5E_ARGS, H5E_BADRANGE, "bogus maxaddr", NULL);
     if (ADDR_OVERFLOW(maxaddr))
-        H5Epush_ret(func, H5E_ERR_CLS, H5E_ARGS, H5E_OVERFLOW, "maxaddr too large", NULL)
+        H5Epush_ret(func, H5E_ERR_CLS, H5E_ARGS, H5E_OVERFLOW, "maxaddr too large", NULL);
 
     /* Always read-only */
     write_access = 0;
 
     /* Open file in read-only mode, to check for existence  and get length */
     if((ncstat = nc_http_open(name,&state,&len))) {
-        H5Epush_ret(func, H5E_ERR_CLS, H5E_IO, H5E_CANTOPENFILE, "cannot access object", NULL)
+        H5Epush_ret(func, H5E_ERR_CLS, H5E_IO, H5E_CANTOPENFILE, "cannot access object", NULL);
     }
 
     /* Build the return value */
     if(NULL == (file = (H5FD_http_t *)H5allocate_memory(sizeof(H5FD_http_t),0))) {
 	nc_http_close(state);
-        H5Epush_ret(func, H5E_ERR_CLS, H5E_RESOURCE, H5E_NOSPACE, "memory allocation failed", NULL)
+        H5Epush_ret(func, H5E_ERR_CLS, H5E_RESOURCE, H5E_NOSPACE, "memory allocation failed", NULL);
     } /* end if */
     memset(file,0,sizeof(H5FD_http_t));
 
@@ -352,7 +352,7 @@ H5FD_http_open( const char *name, unsigned flags, hid_t /*UNUSED*/ fapl_id,
     file->url = H5allocate_memory(strlen(name+1),0);
     if(file->url == NULL) {
 	nc_http_close(state);
-        H5Epush_ret(func, H5E_ERR_CLS, H5E_RESOURCE, H5E_NOSPACE, "memory allocation failed", NULL)
+        H5Epush_ret(func, H5E_ERR_CLS, H5E_RESOURCE, H5E_NOSPACE, "memory allocation failed", NULL);
     }
     memcpy(file->url,name,strlen(name)+1);
 
@@ -637,7 +637,7 @@ H5FD_http_get_handle(H5FD_t *_file, hid_t /*UNUSED*/ fapl, void **file_handle)
 
     *file_handle = file->state;
     if(*file_handle == NULL)
-        H5Epush_ret(func, H5E_ERR_CLS, H5E_IO, H5E_WRITEERROR, "get handle failed", -1)
+        H5Epush_ret(func, H5E_ERR_CLS, H5E_IO, H5E_WRITEERROR, "get handle failed", -1);
 
     return 0;
 } /* end H5FD_http_get_handle() */
@@ -678,9 +678,9 @@ H5FD_http_read(H5FD_t *_file, H5FD_mem_t /*UNUSED*/ type, hid_t /*UNUSED*/ dxpl_
 
     /* Check for overflow */
     if (HADDR_UNDEF==addr)
-        H5Epush_ret (func, H5E_ERR_CLS, H5E_IO, H5E_OVERFLOW, "file address overflowed", -1)
+        H5Epush_ret (func, H5E_ERR_CLS, H5E_IO, H5E_OVERFLOW, "file address overflowed", -1);
     if (REGION_OVERFLOW(addr, size))
-        H5Epush_ret (func, H5E_ERR_CLS, H5E_IO, H5E_OVERFLOW, "file address overflowed", -1)
+        H5Epush_ret (func, H5E_ERR_CLS, H5E_IO, H5E_OVERFLOW, "file address overflowed", -1);
 
     /* Check easy cases */
     if (0 == size)
@@ -697,7 +697,7 @@ H5FD_http_read(H5FD_t *_file, H5FD_mem_t /*UNUSED*/ type, hid_t /*UNUSED*/ dxpl_
         if (file_fseek(file->fp, (file_offset_t)addr, SEEK_SET) < 0) {
             file->op = H5FD_HTTP_OP_UNKNOWN;
             file->pos = HADDR_UNDEF;
-            H5Epush_ret(func, H5E_ERR_CLS, H5E_IO, H5E_SEEKERROR, "fseek failed", -1)
+            H5Epush_ret(func, H5E_ERR_CLS, H5E_IO, H5E_SEEKERROR, "fseek failed", -1);
         }
 #endif
         file->pos = addr;
@@ -716,13 +716,13 @@ H5FD_http_read(H5FD_t *_file, H5FD_mem_t /*UNUSED*/ type, hid_t /*UNUSED*/ dxpl_
             file->op = H5FD_HTTP_OP_UNKNOWN;
             file->pos = HADDR_UNDEF;
 	    ncbytesfree(bbuf); bbuf = NULL;
-            H5Epush_ret(func, H5E_ERR_CLS, H5E_IO, H5E_READERROR, "HTTP byte-range read failed", -1)
+            H5Epush_ret(func, H5E_ERR_CLS, H5E_IO, H5E_READERROR, "HTTP byte-range read failed", -1);
         } /* end if */
 
 	/* Check that proper number of bytes was read */
 	if(ncbyteslength(bbuf) != size) {
 	    ncbytesfree(bbuf); bbuf = NULL;
-            H5Epush_ret(func, H5E_ERR_CLS, H5E_IO, H5E_READERROR, "HTTP byte-range read mismatch ", -1)
+            H5Epush_ret(func, H5E_ERR_CLS, H5E_IO, H5E_READERROR, "HTTP byte-range read mismatch ", -1);
 	}	
 
 	/* Extract the data from buf */
@@ -768,7 +768,7 @@ H5FD_http_write(H5FD_t *_file, H5FD_mem_t /*UNUSED*/ type, hid_t /*UNUSED*/ dxpl
     H5Eclear2(H5E_DEFAULT);
 
     /* Always Fails */
-    H5Epush_ret (func, H5E_ERR_CLS, H5E_IO, H5E_WRITEERROR, "file is read-only", -1)
+    H5Epush_ret (func, H5E_ERR_CLS, H5E_IO, H5E_WRITEERROR, "file is read-only", -1);
 
     return 0;
 }


### PR DESCRIPTION
In HDF5 1.12.1, this was changed from optional to required per the changelog:

>H5Epush_ret() is a function-like macro that has been changed to
>contain a `do {} while(0)` loop. Consequently, a trailing semicolon
>is now required to end the `while` statement. Previously, a trailing
>semi would work, but was not mandatory.

This should be backward compatible with older version of HDF5.

Also fixes https://github.com/Unidata/netcdf-c/issues/2033.