### PR TITLE
Fix chunk key when using dimension_separator - high priority

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -4,7 +4,7 @@
 
 name: Run netCDF Tests
 
-on: [pull_request,push]
+on: [pull_request]
 
 jobs:
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,7 @@ This file contains a high-level description of this package's evolution. Release
 
 ## 4.8.1 - TBD
 
+* [Bug Fix] Fix dimension_separator bug in libnczarr. See [Github #2035](https://github.com/Unidata/netcdf-c/issues/2035).
 * [Bug Fix] Fix bugs in libdap4. See [Github #2005](https://github.com/Unidata/netcdf-c/issues/2005).
 * [Bug Fix] Store NCZarr fillvalue as a singleton instead of a 1-element array. See [Github #2017](https://github.com/Unidata/netcdf-c/issues/2017).  
 * [Bug Fixes] The netcdf-c library was incorrectly determining the scope of dimension; similar to the type scope problem. See [Github #2012](https://github.com/Unidata/netcdf-c/pull/2012) for more information.

--- a/libnczarr/zutil.c
+++ b/libnczarr/zutil.c
@@ -894,13 +894,11 @@ NCZ_chunkpath(struct ChunkKey key,char dimsep)
 {
     size_t plen = nulllen(key.varkey)+1+nulllen(key.chunkkey);
     char* path = (char*)malloc(plen+1);
-    char sdimsep[2];
     
     if(path == NULL) return NULL;
     path[0] = '\0';
     strlcat(path,key.varkey,plen+1);
-    sdimsep[0] = dimsep; sdimsep[1] = '\0';
-    strlcat(path,sdimsep,plen+1);
+    strlcat(path,"/",plen+1);
     strlcat(path,key.chunkkey,plen+1);
     return path;    
 }


### PR DESCRIPTION
The construction of the chunk key is malformed
when using dimension_separator rather than always
using '/'.

This is a priority bug.
