### PR TITLE
Allow building with hdf5-1.12.x without having to set HDF5 compatibility...

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1256,18 +1256,6 @@ if test "x$enable_hdf5" = xyes; then
 
    AC_CHECK_FUNCS([H5Pget_fapl_mpio H5Pset_deflate H5Z_SZIP H5free_memory H5resize_memory H5allocate_memory H5Pset_all_coll_metadata_ops H5Literate])
 
-   # Check to see if HDF5 library has H5Literate (HDF5 1.8.x, 1.10.x)
-   if test "x$ac_cv_func_H5Literate" = xno; then
-      AC_MSG_CHECKING([for H5Literate macro])
-      AC_COMPILE_IFELSE([AC_LANG_PROGRAM([#include "H5public.h"],
-      [[#if !(H5Literate_vers == 1)
-      # error
-      #endif]
-      ])], [], [AC_MSG_RESULT(no); AC_MSG_ERROR([HDF5 was not built with API compatibility version v18. Please recompile your libhdf5 install using '--with-default-api-version=v18'.])])
-      AC_MSG_RESULT(yes)
-   fi
-
-
    # Check to see if HDF5 library has collective metadata APIs, (HDF5 >= 1.10.0)
    if test "x$ac_cv_func_H5Pset_all_coll_metadata_ops" = xyes; then
       AC_DEFINE([HDF5_HAS_COLL_METADATA_OPS], [1], [if true, use collective metadata ops in parallel netCDF-4])

--- a/libhdf5/hdf5open.c
+++ b/libhdf5/hdf5open.c
@@ -2556,7 +2556,12 @@ oinfo_list_add(user_data_t *udata, const hdf5_obj_info_t *oinfo)
  * @author Ed Hartnett
  */
 static int
-read_hdf5_obj(hid_t grpid, const char *name, const H5L_info_t *info,
+read_hdf5_obj(hid_t grpid, const char *name,
+#if H5_VERSION_GE(1,12,0)
+	      const H5L_info2_t *info,
+#else
+	      const H5L_info_t *info,
+#endif
               void *_op_data)
 {
     /* Pointer to user data for callback */


### PR DESCRIPTION
Related to #1965 
Fixes #2026 

This was shockingly easy to fix! Thanks to @ArchangeGabriel for your help on this one.

Once this is done, we will not have to tell anyone to build with any HDF5 API compatibility layer - the vanilla, out of the box, HDF5 build will work. ;-) And we can start taking a better look at some of those sweet new HDF5-1.12.x features...