### PR TITLE
Fix Compiler Strict Aliasing Rule Violations

### DIFF
--- a/libdap4/d4dump.c
+++ b/libdap4/d4dump.c
@@ -48,12 +48,12 @@ NCD4_dumpbytes(size_t size, const void* data0, int swap)
 	if(swap) {
 	    swapinline16(v.u16);
 	    swapinline32(v.u32);
-	    swapinline32(v.u64);
+	    swapinline64(v.u64);
 	    swapinline16(v.i16);
 	    swapinline32(v.i32);
-	    swapinline32(v.i64);
+	    swapinline64(v.i64);
 	    swapinline32(v.f32);
-	    swapinline32(v.f64);
+	    swapinline64(v.f64);
         }
         if(v.s[0] == '\r') strcpy(v.s,"\\r");
         else if(v.s[0] == '\n') strcpy(v.s,"\\n");

--- a/libdap4/d4util.h
+++ b/libdap4/d4util.h
@@ -25,39 +25,39 @@ typedef struct D4blob {d4size_t size; void* memory;} D4blob;
 /* signature: void swapinline16(void* ip) */
 #define swapinline16(ip) \
 { \
-    union {char b[2]; unsigned short i;} u; \
+    char b[2]; \
     char* src = (char*)(ip); \
-    u.b[0] = src[1]; \
-    u.b[1] = src[0]; \
-    *((unsigned short*)ip) = u.i; \
+    b[0] = src[1]; \
+    b[1] = src[0]; \
+    memcpy(ip, b, 2); \
 }
 
 /* signature: void swapinline32(void* ip) */
 #define swapinline32(ip) \
 { \
-    union {char b[4]; unsigned int i;} u; \
+    char b[4]; \
     char* src = (char*)(ip); \
-    u.b[0] = src[3]; \
-    u.b[1] = src[2]; \
-    u.b[2] = src[1]; \
-    u.b[3] = src[0]; \
-    *((unsigned int*)ip) = u.i; \
+    b[0] = src[3]; \
+    b[1] = src[2]; \
+    b[2] = src[1]; \
+    b[3] = src[0]; \
+    memcpy(ip, b, 4); \
 }
 
 /* signature: void swapinline64(void* ip) */
 #define swapinline64(ip) \
 { \
-    union {char b[8]; unsigned long long i;} u; \
+    char b[8]; \
     char* src = (char*)(ip); \
-    u.b[0] = src[7]; \
-    u.b[1] = src[6]; \
-    u.b[2] = src[5]; \
-    u.b[3] = src[4]; \
-    u.b[4] = src[3]; \
-    u.b[5] = src[2]; \
-    u.b[6] = src[1]; \
-    u.b[7] = src[0]; \
-    *((unsigned long long*)ip) = u.i; \
+    b[0] = src[7]; \
+    b[1] = src[6]; \
+    b[2] = src[5]; \
+    b[3] = src[4]; \
+    b[4] = src[3]; \
+    b[5] = src[2]; \
+    b[6] = src[1]; \
+    b[7] = src[0]; \
+    memcpy(ip, b, 8); \
 }
 
 /***************************************************/

--- a/libdispatch/daux.c
+++ b/libdispatch/daux.c
@@ -900,7 +900,8 @@ filterspec_cvt(const char* txt, size_t* nparamsp, unsigned int* params)
         sstat = sscanf(p,"%lf",&vald);
         if(sstat != 1) {stat = NC_EINVAL; goto done;}
         valf = (float)vald;
-        params[nparams++] = *(unsigned int*)&valf;
+	/* avoid type punning */
+	memcpy(&params[nparams++], &valf, sizeof(unsigned int));
         break;
     /* The following are 8-byte values, so we must swap pieces if this
     is a little endian machine */        

--- a/libsrc/ncx.m4
+++ b/libsrc/ncx.m4
@@ -348,7 +348,9 @@ inline static void
 swap4b(void *dst, const void *src)
 {
     /* copy over, make the below swap in-place */
-    uint32_t tmp = *(uint32_t*)src;
+    uint32_t tmp;
+    /* use memcpy to avoid type punning */
+    memcpy(&tmp, src, sizeof(tmp));
     tmp = SWAP4(tmp);
     memcpy(dst, &tmp, 4);
 
@@ -464,7 +466,9 @@ swap8b(void *dst, const void *src)
     op = (uint32_t*)((char*)dst+4);
     *op = SWAP4(*op);
 #else
-    uint64_t tmp = *(uint64_t*)src;
+    uint64_t tmp;
+    /* use memcpy to avoid type punning */
+    memcpy(&tmp, src, sizeof(tmp));
     tmp = SWAP8(tmp);
     memcpy(dst, &tmp, 8);
 

--- a/oc2/xxdr.c
+++ b/oc2/xxdr.c
@@ -502,7 +502,8 @@ xxdrntohdouble(char* c8, double* dp)
 	ii[0] = ii[1];
 	ii[1] = tmp;
     }
-    if(dp) *dp = *(double*)ii;
+    /* use memcpy avoid type punning */
+    if(dp) memcpy(dp, ii, sizeof(double));
 }
 
 void


### PR DESCRIPTION
With the introduction of GCC v.11 numerous test cases in nc_test started to fail on x86_64. This was mostly due to improved optimizations applying aliasing rules more strictly. Recently, this issue has been mitigated by setting -fno-strict-aliasing  where available.
This set of patches attempts to fix all cases where strict aliasing violations were either flagged as warnings by GCC directly or where another warning (ie a warning about an uninitialized variable) was the result of a strict aliasing violation.

These fixes resolved all detected test failures.
