### PR TITLE
Fix 'uninitialized variable' Warnings

### DIFF
--- a/include/nctestserver.h
+++ b/include/nctestserver.h
@@ -47,7 +47,7 @@ parseServers(const char* remotetestservers)
     size_t rtslen = strlen(remotetestservers);
 
     /* Keep LGTM quiet */
-    if(rtslen > MAXREMOTETESTSERVERS) goto done;
+    if(rtslen > MAXREMOTETESTSERVERS) return NULL;
     list = (char**)malloc(sizeof(char*) * (int)(rtslen/2));
     if(list == NULL) return NULL;
     rts = strdup(remotetestservers);
@@ -65,8 +65,8 @@ parseServers(const char* remotetestservers)
     *l = NULL;
     servers = list;
     list = NULL;
+    free(rts);
 done:
-    if(rts) free(rts);
     if(list) free(list);
     return servers;
 }

--- a/libdap4/d4dump.c
+++ b/libdap4/d4dump.c
@@ -45,6 +45,8 @@ NCD4_dumpbytes(size_t size, const void* data0, int swap)
         v.i32[0] = *((int*)pos);
         v.u64[0] = *((unsigned long long*)pos);
         v.i64[0] = *((long long*)pos);
+	v.f32[0] = *((float*)pos);
+	v.f64[0] = *((double*)pos);
 	if(swap) {
 	    swapinline16(v.u16);
 	    swapinline32(v.u32);

--- a/libdap4/d4varx.c
+++ b/libdap4/d4varx.c
@@ -135,7 +135,7 @@ getvarx(int ncid, int varid, NCD4INFO** infop, NCD4node** varp,
     size_t instancesize, xsize;
 
     if((ret = NC_check_id(ncid, (NC**)&ncp)) != NC_NOERR)
-	goto done;
+	goto error;
 
     info = getdap(ncp);
     meta = info->substrate.metadata;
@@ -188,6 +188,7 @@ getvarx(int ncid, int varid, NCD4INFO** infop, NCD4node** varp,
 done:
     if(meta->error.message != NULL)
 	NCD4_reporterror(info);    /* Make sure the user sees this */
+error:
     return THROW(ret);    
 }
 

--- a/libdispatch/nctime.c
+++ b/libdispatch/nctime.c
@@ -789,8 +789,8 @@ cdComp2Rel(cdCalenType timetype, cdCompTime comptime, char* relunits, double* re
 	CdTime humantime;
 	CdTimeType old_timetype;
 	cdUnitTime unit;
-	double base_etm, etm, delta;
-	long ndel, hoursInYear;
+	double base_etm, etm, delta = 0.; /* GCC */
+	long ndel = 0, hoursInYear;
 
 					     /* Parse the relunits */
 	if(cdParseRelunits(timetype, relunits, &unit, &base_comptime))
@@ -982,7 +982,7 @@ cdRel2Comp(cdCalenType timetype, char* relunits, double reltime, cdCompTime* com
 	cdCompTime base_comptime;
 	cdUnitTime unit, baseunits;
 	double base_etm, result_etm;
-	double delta;
+	double delta = 0.; /* GCC */
 	long idelta;
 
 					     /* Parse the relunits */

--- a/libhdf5/hdf5internal.c
+++ b/libhdf5/hdf5internal.c
@@ -860,7 +860,7 @@ nc4_hdf5_find_grp_var_att(int ncid, int varid, const char *name, int attnum,
     NC_FILE_INFO_T *my_h5;
     NC_GRP_INFO_T *my_grp;
     NC_VAR_INFO_T *my_var = NULL;
-    NC_ATT_INFO_T *my_att;
+    NC_ATT_INFO_T *my_att = NULL; /* GCC */
     char my_norm_name[NC_MAX_NAME + 1] = "";
     NCindex *attlist = NULL;
     int retval;

--- a/libnczarr/zinternal.c
+++ b/libnczarr/zinternal.c
@@ -572,7 +572,7 @@ ncz_find_grp_var_att(int ncid, int varid, const char *name, int attnum,
     NC_FILE_INFO_T *my_h5;
     NC_GRP_INFO_T *my_grp;
     NC_VAR_INFO_T *my_var = NULL;
-    NC_ATT_INFO_T *my_att;
+    NC_ATT_INFO_T *my_att = NULL; /* GCC */
     char my_norm_name[NC_MAX_NAME + 1] = "";
     NCindex *attlist = NULL;
     int retval;

--- a/libnczarr/zsync.c
+++ b/libnczarr/zsync.c
@@ -298,10 +298,10 @@ ncz_sync_var(NC_FILE_INFO_T* file, NC_VAR_INFO_T* var)
     {	/* Add the type name */
 	const char* dtypename;
 	int endianness = var->type_info->endianness;
-	int islittle;
+	int islittle = 0;
 	switch (endianness) {
 	case NC_ENDIAN_LITTLE: islittle = 1; break;
-	case NC_ENDIAN_BIG: islittle = 0; break;
+	case NC_ENDIAN_BIG: break;
 	case NC_ENDIAN_NATIVE: abort(); /* should never happen */
 	}
 	int atomictype = var->type_info->hdr.id;

--- a/libnczarr/zvar.c
+++ b/libnczarr/zvar.c
@@ -868,7 +868,7 @@ int
 ncz_def_var_chunking_ints(int ncid, int varid, int contiguous, int *chunksizesp)
 {
     NC_VAR_INFO_T *var;
-    size_t *cs;
+    size_t *cs = NULL;
     int i, retval;
 
     /* Get pointer to the var. */

--- a/ncdump/ncdump.c
+++ b/ncdump/ncdump.c
@@ -902,6 +902,7 @@ pr_att(
 		   value = *((uint64_t *)data + i);
 		   break;
 	       default:
+		   value = 0; /* GCC */
 		   error("enum must have an integer base type: %d", base_nc_type);
 	       }
 	       NC_CHECK( nc_inq_enum_ident(ncid, att.type, value,

--- a/ncdump/ncvalidator.c
+++ b/ncdump/ncvalidator.c
@@ -2075,7 +2075,7 @@ val_NC_check_voff(NC *ncp)
 
     if (ncp->begin_rec < prev_off) {
         if (verbose) printf("Error:\n");
-        if (verbose) printf("\tRecord variable section begin offset (%lld) is less than fixed-size variable section end offset (%lld)\n", varp->begin, prev_off);
+        if (verbose) printf("\tRecord variable section begin offset (%lld) is less than fixed-size variable section end offset (%lld)\n", ncp->begin_rec, prev_off);
         nerrs++;
         DEBUG_ASSIGN_ERROR(status, NC_ENOTNC)
     }

--- a/ncgen/bindata.c
+++ b/ncgen/bindata.c
@@ -566,7 +566,7 @@ bin_reclaim_compound(Symbol* tsym, Reclaim* reclaimer)
 {
     int stat = NC_NOERR;
     int nfields;
-    size_t fid, i, arraycount;
+    size_t fid, i;
     ptrdiff_t saveoffset;
 
     reclaimer->offset = read_alignment(reclaimer->offset,tsym->typ.cmpdalign);
@@ -577,6 +577,7 @@ bin_reclaim_compound(Symbol* tsym, Reclaim* reclaimer)
     for(fid=0;fid<nfields;fid++) {
 	Symbol* field = listget(tsym->subnodes,fid);
 	int ndims = field->typ.dimset.ndims;
+	size_t arraycount = ndims > 0 ? 1 : 0;
 	/* compute the total number of elements in the field array */
 	for(i=0;i<ndims;i++) arraycount *= field->typ.dimset.dimsyms[i]->dim.declsize;
 	reclaimer->offset = read_alignment(reclaimer->offset,field->typ.alignment);

--- a/ncgen3/getfill.c
+++ b/ncgen3/getfill.c
@@ -51,11 +51,11 @@ nc_fill(
      void *datp,		/* where to start filling */
      union generic fill_val)	/* value to use */
 {
-    char *char_valp;		/* pointers used to accumulate data values */
-    short *short_valp;
-    int *long_valp;
-    float *float_valp;
-    double *double_valp;
+    char *char_valp = NULL;   /* GCC *//* pointers used to accumulate data values */
+    short *short_valp = NULL; /* GCC */
+    int *long_valp = NULL; /* GCC */
+    float *float_valp = NULL; /* GCC */
+    double *double_valp = NULL; /* GCC */
 
     switch (type) {
       case NC_CHAR:

--- a/ncgen3/load.c
+++ b/ncgen3/load.c
@@ -504,11 +504,11 @@ load_netcdf(
     int stat = NC_NOERR;
     size_t start[NC_MAX_VAR_DIMS];
     size_t count[NC_MAX_VAR_DIMS];
-    char *charvalp;
-    short *shortvalp;
-    int *intvalp;
-    float *floatvalp;
-    double *doublevalp;
+    char *charvalp = NULL; /* GCC */
+    short *shortvalp = NULL; /* GCC */
+    int *intvalp = NULL; /* GCC */
+    float *floatvalp = NULL; /* GCC */
+    double *doublevalp = NULL; /* GCC */
 
     /* load values into variable */
 

--- a/nczarr_test/ncdumpchunks.c
+++ b/nczarr_test/ncdumpchunks.c
@@ -293,7 +293,7 @@ dump(Format* format)
     char sindices[64];
 #ifdef H5
     int i;
-    hid_t fileid, grpid, datasetid;
+    hid_t fileid = H5P_DEFAULT, grpid = H5P_DEFAULT, datasetid = H5P_DEFAULT; /* GCC */
     hid_t dxpl_id = H5P_DEFAULT; /*data transfer property list */
     unsigned int filter_mask = 0;
     hsize_t hoffset[NC_MAX_VAR_DIMS];

--- a/oc2/ocdump.c
+++ b/oc2/ocdump.c
@@ -466,8 +466,8 @@ ocreadfile(FILE* file, off_t datastart, char** memp, size_t* lenp)
 void
 ocdd(OCstate* state, OCnode* root, int xdrencoded, int level)
 {
-    char* mem;
-    size_t len;
+    char* mem = NULL; /* GCC */
+    size_t len = 0; /* GCC */
     if(root->tree->data.file != NULL) {
         if(!ocreadfile(root->tree->data.file,
                        root->tree->data.bod,


### PR DESCRIPTION
While hunting for strict aliasing rule violations we came across warnings about uninitialized variables which were in fact triggered by compiler optimizations applying strict aliasing rules. Looking further, we came across further uninitialized variable warnings which were genuine programming errors and others which were just false positives - in situation where it was not possible for the compiler to determine whether a variable is always initialized on valid code paths.
This set of patches attempts to address all of these - including the false positives: as these tend to reduce the sensitivity for such warnings.
