### PR TITLE
Make variable easier to compress

### DIFF
--- a/ncdump/tst_compress.c
+++ b/ncdump/tst_compress.c
@@ -36,7 +36,7 @@ main(int argc, char **argv) { /* create a compressible file, for testing */
     if (nc_def_var(ncid, "var1", NC_INT, VAR1_RANK, var1_dims, &varid)) ERR;
     if (nc_enddef (ncid)) ERR;
     for(i=0; i < DIM1_LEN; i++) {
-	var1_data[i] = i;
+	var1_data[i] = i / 3;
     }
     if (nc_put_var(ncid, varid, var1_data)) ERR;
     if (nc_close(ncid)) ERR;
@@ -47,7 +47,7 @@ main(int argc, char **argv) { /* create a compressible file, for testing */
     if (nc_def_var(ncid, "var1", NC_INT, VAR1_RANK, var1_dims, &varid)) ERR;
     if (nc_enddef (ncid)) ERR;
     for(i=0; i < DIM1_LEN; i++) {
-	var1_data[i] = i;
+	var1_data[i] = i / 3;
     }
     if (nc_put_var(ncid, varid, var1_data)) ERR;
     if (nc_close(ncid)) ERR;

--- a/ncdump/tst_compress.c
+++ b/ncdump/tst_compress.c
@@ -36,7 +36,7 @@ main(int argc, char **argv) { /* create a compressible file, for testing */
     if (nc_def_var(ncid, "var1", NC_INT, VAR1_RANK, var1_dims, &varid)) ERR;
     if (nc_enddef (ncid)) ERR;
     for(i=0; i < DIM1_LEN; i++) {
-	var1_data[i] = i / 3;
+	var1_data[i] = i / 3;  /* Want integer division / truncation */
     }
     if (nc_put_var(ncid, varid, var1_data)) ERR;
     if (nc_close(ncid)) ERR;
@@ -47,7 +47,7 @@ main(int argc, char **argv) { /* create a compressible file, for testing */
     if (nc_def_var(ncid, "var1", NC_INT, VAR1_RANK, var1_dims, &varid)) ERR;
     if (nc_enddef (ncid)) ERR;
     for(i=0; i < DIM1_LEN; i++) {
-	var1_data[i] = i / 3;
+	var1_data[i] = i / 3; /* Want integer division / truncation */
     }
     if (nc_put_var(ncid, varid, var1_data)) ERR;
     if (nc_close(ncid)) ERR;


### PR DESCRIPTION
Make the data in the variable `var1` easier to compress so that the compression tests will be more robust.  The zlib_ng library, for example, at level 1 does not compress a sequence of integers very well which resulted in the NetCDF-4 compressed file being larger than the uncompressed NetCDF-3 file.  With the change above, the variable contains `0,0,0,1,1,1,2,2,2,...,` which compresses at level 1 and the compression test is more robust.