### PR TITLE
WIP: attribute creation order on/off

### DIFF
--- a/include/nc4internal.h
+++ b/include/nc4internal.h
@@ -297,6 +297,7 @@ typedef struct  NC_FILE_INFO
     int cmode;      /**< Create mode used to create the file. */
     nc_bool_t parallel;   /**< True if file is open for parallel access */
     nc_bool_t redef;      /**< True if redefining an existing file */
+    nc_bool_t no_attr_creation_order_tracking;
     int fill_mode;        /**< Fill mode for vars - Unused internally currently */
     nc_bool_t no_write;   /**< true if nc_open has mode NC_NOWRITE. */
     NC_GRP_INFO_T *root_grp; /**< Pointer to root group. */

--- a/include/netcdf.h
+++ b/include/netcdf.h
@@ -161,6 +161,8 @@ Use this in mode flags for both nc_create() and nc_open(). */
 #define NC_PERSIST       0x4000  /**< Save diskless contents to disk. Mode flag for nc_open() or nc_create() */
 #define NC_INMEMORY      0x8000  /**< Read from memory. Mode flag for nc_open() or nc_create() */
 
+#define NC_NOATTCREORD   0x20000
+
 #define NC_MAX_MAGIC_NUMBER_LEN 8 /**< Max len of user-defined format magic number. */
 
 /** Format specifier for nc_set_default_format() and returned

--- a/libhdf5/hdf5create.c
+++ b/libhdf5/hdf5create.c
@@ -192,10 +192,15 @@ nc4_create_file(const char *path, int cmode, size_t initialsz,
     if (H5Pset_link_creation_order(fcpl_id, (H5P_CRT_ORDER_TRACKED |
                                              H5P_CRT_ORDER_INDEXED)) < 0)
         BAIL(NC_EHDFERR);
-    if (H5Pset_attr_creation_order(fcpl_id, (H5P_CRT_ORDER_TRACKED |
-                                             H5P_CRT_ORDER_INDEXED)) < 0)
-        BAIL(NC_EHDFERR);
 
+    if (cmode & NC_NOATTCREORD) {
+        nc4_info->no_attr_creation_order_tracking = NC_TRUE;
+    }
+    else {
+      if (H5Pset_attr_creation_order(fcpl_id, (H5P_CRT_ORDER_TRACKED |
+					       H5P_CRT_ORDER_INDEXED)) < 0)
+        BAIL(NC_EHDFERR);
+    }
 #ifdef HDF5_HAS_COLL_METADATA_OPS
     /* If HDF5 supports collective metadata operations, turn them
      * on. This is only relevant for parallel I/O builds of HDF5. */

--- a/libhdf5/nc4hdf.c
+++ b/libhdf5/nc4hdf.c
@@ -969,9 +969,11 @@ var_create_dataset(NC_GRP_INFO_T *grp, NC_VAR_INFO_T *var, nc_bool_t write_dimid
     }
 
     /* Turn on creation order tracking. */
-    if (H5Pset_attr_creation_order(plistid, H5P_CRT_ORDER_TRACKED|
-                                   H5P_CRT_ORDER_INDEXED) < 0)
+    if (!grp->nc4_info->no_attr_creation_order_tracking) {
+      if (H5Pset_attr_creation_order(plistid, H5P_CRT_ORDER_TRACKED|
+				     H5P_CRT_ORDER_INDEXED) < 0)
         BAIL(NC_EHDFERR);
+    }
 
     /* Set per-var chunk cache, for chunked datasets. */
     if (var->storage == NC_CHUNKED && var->chunk_cache_size)
@@ -1327,8 +1329,10 @@ create_group(NC_GRP_INFO_T *grp)
         BAIL(NC_EHDFERR);
 
     /* Tell HDF5 to keep track of attributes in creation order. */
-    if (H5Pset_attr_creation_order(gcpl_id, H5P_CRT_ORDER_TRACKED|H5P_CRT_ORDER_INDEXED) < 0)
+    if (!grp->nc4_info->no_attr_creation_order_tracking) {
+      if (H5Pset_attr_creation_order(gcpl_id, H5P_CRT_ORDER_TRACKED|H5P_CRT_ORDER_INDEXED) < 0)
         BAIL(NC_EHDFERR);
+    }
 
     /* Create the group. */
     if ((hdf5_grp->hdf_grpid = H5Gcreate2(parent_hdf5_grp->hdf_grpid, grp->hdr.name,
@@ -1752,10 +1756,11 @@ nc4_create_dim_wo_var(NC_DIM_INFO_T *dim)
         BAIL(NC_EHDFERR);
 
     /* Turn on creation-order tracking. */
-    if (H5Pset_attr_creation_order(create_propid, H5P_CRT_ORDER_TRACKED|
-                                   H5P_CRT_ORDER_INDEXED) < 0)
+    if (!dim->container->nc4_info->no_attr_creation_order_tracking) {
+      if (H5Pset_attr_creation_order(create_propid, H5P_CRT_ORDER_TRACKED|
+				     H5P_CRT_ORDER_INDEXED) < 0)
         BAIL(NC_EHDFERR);
-
+    }
     /* Create the dataset that will be the dimension scale. */
     LOG((4, "%s: about to H5Dcreate1 a dimscale dataset %s", __func__,
          dim->hdr.name));


### PR DESCRIPTION
Work in progress / Proof of concept:

Add a capability to disable the tracking of attribute creation order.
See #2054 for details.

This PR adds a `NC_NOATTCREORD` define which can be passed int the
`mode` argument to `nc_create`.  If it is present, then the
calls to set the attribute creation order tracking is disabled.
This should only be used for files in which you *know* that the
ordering of the attributes does not matter to *any* potential
readers of this database.