### PR TITLE
Add missing files so --enable-benchmarks works again.

### DIFF
--- a/nczarr_test/Makefile.am
+++ b/nczarr_test/Makefile.am
@@ -68,13 +68,16 @@ endif
 if BUILD_BENCHMARKS
 if BUILD_UTILITIES
 
-UTILSRC = bm_utils.c timer_utils.c tst_utils.c
+UTILSRC = bm_utils.c timer_utils.c tst_utils.c bm_utils.h bm_timer.h
 
 bm_chunks3_SOURCES = bm_chunks3.c ${UTILSRC}
 
 check_PROGRAMS += bm_chunks3
 
+# The perf tests need modernization
+if AX_IGNORE
 TESTS += run_perf_chunks1.sh
+endif
 
 endif # BUILD_BENCHMARKS
 

--- a/nczarr_test/bm_timer.h
+++ b/nczarr_test/bm_timer.h
@@ -1,0 +1,73 @@
+/* This is part of the netCDF package. Copyright 2005-2018 University
+   Corporation for Atmospheric Research/Unidata See COPYRIGHT file for
+   conditions of use.
+*/
+
+#ifndef BM_TIMER_H
+#define BM_TIMER_H 1
+
+#undef NOREPEAT
+#undef NOCONTIG
+
+/*
+ * The following timing macros can be used by including the necessary
+ * declarations with
+ *
+ *     TIMING_DECLS(seconds)
+ *
+ * and surrounding sections of code to be timed with the "statements"
+ *
+ *     TIMING_START
+ *     [code to be timed goes here]
+ *     TIMING_END(seconds)
+ *
+ * The macros assume the user has stored a description of what is
+ * being timed in a 100-char string time_mess, and has included
+ * <sys/times.h> and <sys/resource.h>.  The timing message printed by
+ * TIMING_END is not terminated by a new-line, to permit appending
+ * additional text to that line, so user must at least printf("\n")
+ * after that.
+ */
+
+#define TIMING_DECLS(seconds)						       \
+	long TMreps;		/* counts repetitions of timed code */ \
+	long TMrepeats;		/* repetitions needed to exceed 0.1 second */ \
+	Nanotime bnano,enano,delta;	/* start/stop times in nanoseconds */ \
+        double seconds; \
+	NCT_inittimer();
+
+#ifndef NOREPEAT
+#define TIMING_START \
+	TMrepeats = 1; \
+	do { \
+	    NCT_marktime(&bnano); \
+	    for(TMreps=0; TMreps < TMrepeats; TMreps++) {
+
+#define TIMING_END(seconds)				\
+            } \
+	    NCT_marktime(&enano); \
+	    NCT_elapsedtime(&bnano,&enano,&delta); \
+	    TMrepeats *= 2; \
+	} while (NCT_nanoseconds(delta) < 100000000 ); \
+	seconds = ((double)NCT_nanoseconds(delta)) / (1000000000.0 * TMreps); \
+
+#else /*NOREPEAT*/
+
+#define TIMING_START \
+	do { \
+fprintf(stderr,"TIME_START\n"); \
+	    NCT_marktime(&bnano); \
+	    {
+
+#define TIMING_END(time_mess,seconds) \
+	    } \
+	    NCT_marktime(&enano); \
+	    NCT_elapsedtime(&bnano,&enano,&delta); \
+        } while (0); \
+fprintf(stderr,"TIME_END\n"); \
+	seconds = ((double)NCT_nanoseconds(delta)) / (1000000000.0 * TMreps); \
+	printf("%-45.45s %#08.6F sec", time_mess, seconds);
+
+#endif /*NOREPEAT*/
+
+#endif /*BM_TIMER_H*/

--- a/nczarr_test/bm_utils.c
+++ b/nczarr_test/bm_utils.c
@@ -41,7 +41,7 @@ static struct option options[] = {
 {NULL, 0, NULL, 0}
 };
 
-struct Options bmoptions;
+struct BMOptions bmoptions;
 
 static char* dumpintlist(struct IntList* list);
 static int parseintlist(const char* s0, struct IntList* list);
@@ -76,7 +76,7 @@ nc4_timeval_subtract (struct timeval *result, struct timeval *x, struct timeval*
 #endif
 
 int
-nc4_buildpath(struct Options* o, char** pathp)
+nc4_buildpath(struct BMOptions* o, char** pathp)
 {
     char* path = NULL;
     size_t len;
@@ -99,15 +99,15 @@ fprintf(stderr,"buildpath: file=%s\n",path);
 }
 
 EXTERNL int
-getoptions(int* argcp, char*** argvp, struct Options* opt)
+bm_getoptions(int* argcp, char*** argvp, struct BMOptions* opt)
 {
     int stat = NC_NOERR;
     int tag;
     int argc = *argcp;
     char** argv = *argvp;
-    const char* nczarr_s3_test_url = ncz_gets3testurl();
+    const char* nczarr_s3_test_url = "https://stratus.ucar.edu/unidata-netcdf-zarr-testing";
 
-    memset((void*)opt,0,sizeof(struct Options));
+    memset((void*)opt,0,sizeof(struct BMOptions));
     if(argc <= 1) return NC_NOERR;
     while ((tag = getopt_long_only(argc, argv, "", options, NULL)) >= 0) {
 #ifdef DEBUG
@@ -145,13 +145,13 @@ fprintf(stderr,"arg=%s value=%s\n",argv[optind-1],optarg);
 	        opt->pathtemplate = strdup(optarg);
 	        break;
 	    case OPT_FORMAT:
-		if(strcasecmp(optarg,"file")==0)
+		if(strcasecmp(optarg,"file")==0) {
 		    opt->format = NC_FORMATX_NCZARR;
 		    opt->impl = NCZM_FILE;
-		else if(strcasecmp(optarg,"zip")==0)
+		}  else if(strcasecmp(optarg,"zip")==0) {
 		    opt->format = NC_FORMATX_NCZARR;
 		    opt->impl = NCZM_ZIP;
-		else if(strcasecmp(optarg,"s3")==0) {
+		} else if(strcasecmp(optarg,"s3")==0) {
 		    opt->format = NC_FORMATX_NCZARR;
 		    opt->impl = NCZM_S3;
 		} else 
@@ -198,7 +198,7 @@ fprintf(stderr,"arg=%s value=%s\n",argv[optind-1],optarg);
 	    case NCZM_S3:
 		ptlen = strlen(nczarr_s3_test_url) + strlen("/netcdf-c/%s.%s#mode=nczarr,s3");
 	        opt->pathtemplate = (char*)calloc(1,ptlen+1);
-		if(opt->template == NULL) return NC_ENOMEM;
+		if(opt->pathtemplate == NULL) return NC_ENOMEM;
 		strlcat(opt->pathtemplate,nczarr_s3_test_url,ptlen+1);
 		strlcat(opt->pathtemplate,"/netcdf-c/%s.%s#mode=nczarr,s3",ptlen+1);
 		break;
@@ -234,7 +234,7 @@ fprintf(stderr,"arg=%s value=%s\n",argv[optind-1],optarg);
 }
 
 EXTERNL void
-clearoptions(struct Options* o)
+clearoptions(struct BMOptions* o)
 {
     nullfree(o->pathtemplate);
     nullfree(o->filename);
@@ -243,15 +243,16 @@ clearoptions(struct Options* o)
 }
 
 EXTERNL const char*
-formatname(const struct Options* o)
+formatname(const struct BMOptions* o)
 {
     switch (o->format) {
     case NC_FORMATX_NCZARR:
 	switch (o->impl) {
 	case NCZM_S3: return "s3";
-	case NCZM_NC4: return "nz4";
 	case NCZM_FILE: return "file";
 	case NCZM_ZIP: return "zip";
+	default: abort();
+	}
 	break;
     case NC_FORMATX_NC4: /* fall thru */
 	return "nz4";
@@ -263,18 +264,17 @@ formatname(const struct Options* o)
 
 
 EXTERNL void
-reportoptions(struct Options* o)
+reportoptions(struct BMOptions* o)
 {
     fprintf(stderr,"--format=%d\n",o->format);
     fprintf(stderr,"--pathtemplate=%s\n",o->pathtemplate);
     fprintf(stderr,"--filename=%s\n",o->filename);
-    if(o->iss3) fprintf(stderr,"--s3\n");
     fprintf(stderr,"--X=%d\n",o->xvalue);
     fflush(stderr);
 }
 
 EXTERNL void
-reportmetaoptions(struct Meta* o)
+reportmetaoptions(struct BMMeta* o)
 {
     fprintf(stderr,"--treedepth=%d\n",o->treedepth);
     fprintf(stderr,"--ngroups=%d\n",o->ngroups);

--- a/nczarr_test/bm_utils.h
+++ b/nczarr_test/bm_utils.h
@@ -1,0 +1,95 @@
+/*********************************************************************
+ *   Copyright 2018, UCAR/Unidata
+ *   See netcdf/COPYRIGHT file for copying and redistribution conditions.
+ *********************************************************************/
+
+#ifndef BM_UTILS_H
+#define BM_UTILS_H
+
+#include "config.h"
+
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+
+#include "zincludes.h"
+
+#undef DEBUG
+
+/* Define the getopt tags */
+#define OPT_UNKNOWN 0
+#define OPT_TREEDEPTH 1
+#define OPT_NGROUPS 2
+#define OPT_NGROUPATTRS 3
+#define OPT_NDIMS 4
+#define OPT_NTYPES 5
+#define OPT_NVARS 6
+#define OPT_VARRANK 7
+#define OPT_NVARATTRS 8
+#define OPT_FORMAT 9
+#define OPT_PATH 10
+#define OPT_FILE 11
+#define OPT_X 12
+#define OPT_DEBUG 13
+#define OPT_DIMS 14
+#define OPT_CHUNKS 15
+#define OPT_CACHEFACTOR 16
+#define OPT_CACHESIZE 17
+#define OPT_DEFLATELEVEL 18
+#define OPT_WDEBUG 19
+#define OPT_URL 20
+#define OPT_READONLY 21
+#define OPT_WRITEONLY 22
+
+#define X_OPT_MATCH 1
+
+extern struct BMOptions {
+    int format;
+    char* filename;
+    char* url;
+    char* path; /* as sent to e.g. nc_create() */
+    char* pathtemplate;
+    int xvalue;
+    NCZM_IMPL impl;
+    int debug;
+    int wdebug;
+    int readonly;
+    int writeonly;
+    struct BMMeta {
+	int treedepth;
+	int ngroups;
+	int ngroupattrs;
+	int ndims;
+	int ntypes;
+	int nvars;
+	int varrank;
+	int nvarattrs;
+	size_t cachefactor;
+	size_t cachesize;
+	struct IntList {
+	    int count;
+   	    size_t* list;
+	} dims;
+	struct IntList chunks;
+	int deflatelevel;
+    } meta;
+    struct X {
+	int sync;
+    } x;
+} bmoptions;
+
+#define NCCHECK(expr) nccheck((expr),__LINE__)
+
+EXTERNL int bm_buildpath(struct BMOptions*);
+EXTERNL int bm_getoptions(int* argcp, char*** argvp, struct BMOptions*);
+EXTERNL void bm_clearoptions(struct BMOptions*);
+EXTERNL const char* formatname(const struct BMOptions*);
+EXTERNL void bm_reportoptions(struct BMOptions* o);
+EXTERNL void bm_reportmetaoptions(struct BMMeta* o);
+EXTERNL const char* bm_printvector(int rank, const size_t* vec);
+EXTERNL const char* bm_printvectorp(int rank, const ptrdiff_t* vec);
+EXTERNL const char* bm_varasprint(int rank, const size_t* start, const size_t* edges, const ptrdiff_t* stride);
+
+#include "ut_test.h"
+
+#endif /*BM_UTILS_H*/


### PR DESCRIPTION
* Fixes https://github.com/Unidata/netcdf-c/issues/2055

The nczarr_test benchmarks were missing some files and one was
out of date vis-a-vis compilation.