### PR TITLE
Support Windows network paths: \\svc\x\y...

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,7 @@ This file contains a high-level description of this package's evolution. Release
 
 ## 4.8.1 - TBD
 
+* [Enhancement] Support windows network paths (e.g. \\svc\...). See [Github #2065](https://github.com/Unidata/netcdf-c/issues/2065).
 * [Enhancement] Convert to a new representation of the NCZarr meta-data extensions: version 2. Read-only backward compatibility is provided. See [Github #2032](https://github.com/Unidata/netcdf-c/issues/2032).
 * [Bug Fix] Fix dimension_separator bug in libnczarr. See [Github #2035](https://github.com/Unidata/netcdf-c/issues/2035).
 * [Bug Fix] Fix bugs in libdap4. See [Github #2005](https://github.com/Unidata/netcdf-c/issues/2005).

--- a/include/ncpathmgr.h
+++ b/include/ncpathmgr.h
@@ -74,8 +74,12 @@ Assumptions about Input path:
 1. It is a relative or absolute path
 2. It is not a URL
 3. It conforms to the format expected by one of the following:
-       Linux (/x/y/...), Cygwin (/cygdrive/D/...),
-       Windows (D:/...), or MSYS (/D/...), or relative (x/y...)
+       Linux (/x/y/...),
+       Cygwin (/cygdrive/D/...),
+       Windows (D:\...),
+       Windows network path (\\mathworks\...)
+       MSYS (/D/...),
+       or relative (x/y...)
 4. It is encoded in the local platform character set.
    Note that for most systems, this is utf-8. But for Windows,
    the encoding is most likely some form of ANSI code page, probably
@@ -107,13 +111,16 @@ that has some desirable properties:
    the user is responsible for getting this right.
 To this end we choose the linux/cygwin format as our standard canonical form.
 If the path has a windows drive letter, then it is represented
-in the cygwin "/cygdrive/<drive-letter>" form. If it is on *nix* platform,
-then this sequence will never appear and the canonical path will look
-like a standard *nix* path.
+in the cygwin "/cygdrive/<drive-letter>" form.
+If it is a windows network path, then it starts with "//".
+If it is on *nix* platform, then this sequence will never appear
+and the canonical path will look like a standard *nix* path.
 */
 EXTERNL int NCpathcanonical(const char* srcpath, char** canonp);
 
 EXTERNL int NChasdriveletter(const char* path);
+
+EXTERNL int NCisnetworkpath(const char* path);
 
 /* Canonicalize and make absolute by prefixing the current working directory */
 EXTERNL char* NCpathabsolute(const char* name);

--- a/unit_test/test_pathcvt.c
+++ b/unit_test/test_pathcvt.c
@@ -43,6 +43,12 @@ static Test PATHTESTS[] = {
 #ifndef _WIN32
 /* Test utf8 path */
 {"/海/海",{ "/海/海", "/c/海/海", "/cygdrive/c/海/海",  "c:\\海\\海"}},
+/* Test network path */
+{"//git/netcdf-c/dap4_test",{
+    "/@/git/netcdf-c/dap4_test",
+    "/@/git/netcdf-c/dap4_test",
+    "/cygdrive/@/git/netcdf-c/dap4_test",
+    "\\\\git\\netcdf-c\\dap4_test"}},
 #endif
 {NULL, {NULL, NULL, NULL, NULL}}
 };
@@ -62,11 +68,11 @@ main(int argc, char** argv)
 
     nc_initialize();
 
-    /* Test localkind X path kind */
-    for(k=0;k<NKINDS;k++) {
-	int kind = kinds[k];
-	/* Iterate over the test paths */
-        for(test=PATHTESTS;test->test;test++) {
+    /* Test localkind X path-kind */
+    for(test=PATHTESTS;test->test;test++) {
+        /* Iterate over the test paths */
+        for(k=0;k<NKINDS;k++) {
+	    int kind = kinds[k];
 	    /* Compare output for the localkind */
             if(test->expected[k] == NULL) {
 #ifdef DEBUG


### PR DESCRIPTION
* Fixes #2060 

re: Issue https:\\github.com\Unidata\netcdf-c\issues\2060

The path conversion code forgot to consider the case of
windows network paths of the form \\svc\x\y...

I have added support for it, but I can't really test it
since I do not have access to a network drive.