### PR TITLE
Fix a number of bugs in the nczarr code.

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -4,7 +4,7 @@
 
 name: Run netCDF Tests
 
-on: [pull_request]
+on: [pull_request,push]
 
 jobs:
 

--- a/libnczarr/zs3sdk.cpp
+++ b/libnczarr/zs3sdk.cpp
@@ -78,7 +78,9 @@ NCZ_s3sdkcreateconfig(const char* host, const char* region, void** configp)
     if(region) config->region = region;
     if(host) config->endpointOverride = host;
     config->enableEndpointDiscovery = true;
-    config->followRedirects = true;
+#if 0
+    config->followRedirects = Aws::Client::FollowRedirectsPolicy::ALWAYS;
+#endif
     if(configp) * configp = config;
     return ZUNTRACE(stat);
 }

--- a/libnczarr/zutil.c
+++ b/libnczarr/zutil.c
@@ -514,6 +514,7 @@ ncz_dtype2typeinfo(const char* dtype, nc_type* nctypep, int* endianp)
     switch (dtype[0]) {
     case '<': endianness = NC_ENDIAN_LITTLE; break;
     case '>': endianness = NC_ENDIAN_BIG; break;
+    case '|': endianness = NC_ENDIAN_NATIVE; break;
     default: goto zerr;
     }
     /* Decode the type length */


### PR DESCRIPTION
re: Issues https://github.com/Unidata/netcdf-c/issues/2063, https://github.com/Unidata/netcdf-c/issues/2062, https://github.com/Unidata/netcdf-c/issues/2061, https://github.com/Unidata/netcdf-c/issues/2059

1. Support "fill_value: null"  -- 2063.
2. Handle the dtype case "|u1" -- 2062.
3. When writing a pure Zarr format file, some nczarr attributes inadvertently crept in -- 2061.
4. If there is no fill value, then the .zarray fill_value key should have the value null rather than left out -- 2059.

Hat tip: Even Rouault