### PR TITLE
hdf5: try and fill in HDF5_C_LIBRARY from HDF5_hdf5_LIBRARY if possible

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -711,6 +711,10 @@ IF(USE_HDF5)
 
     ELSE(MSVC)
 
+      IF(HDF5_hdf5_LIBRARY AND NOT HDF5_C_LIBRARY)
+        SET(HDF5_C_LIBRARY ${HDF5_hdf5_LIBRARY})
+      ENDIF()
+
       # Depending on the install, either HDF5_hdf_library or
       # HDF5_C_LIBRARIES may be defined.  We must check for either.
       IF(HDF5_C_LIBRARIES AND NOT HDF5_hdf5_LIBRARY)


### PR DESCRIPTION
A fairly vanilla build of 1.12.1 into a non-default directory ends up
with `HDF5_C_LIBRARY` set to `hdf5` which ends up failing all of the
`try_compile` checks because `-lhdf5` cannot be found.

---
No idea if this breaks anything else. Or if this is generalizable. It fixed my problem and that's about the extent I like interacting with `FindHDF5` at this point :) .