### PR TITLE
made nc_perf not build and run benchmarks in parallel, turn off benchmark tst_gfs_data_1.c for HDF5 versions less than 1.10.2

### DIFF
--- a/nc_perf/Makefile.am
+++ b/nc_perf/Makefile.am
@@ -8,6 +8,12 @@
 #
 # Ed Hartnett 3/18/19
 
+# Running these performance tests at the same time is meaningless,
+# since that will saturate I/O channels. Running all benchmarks in
+# parallel can also be really slow on a less-powerful workstation,
+# causing timeouts.
+.NOTPARALLEL:
+
 # Put together AM_CPPFLAGS and AM_LDFLAGS.
 include $(top_srcdir)/lib_flags.am
 

--- a/nc_perf/tst_gfs_data_1.c
+++ b/nc_perf/tst_gfs_data_1.c
@@ -528,6 +528,8 @@ find_filters(int *num_compression_filters, char compression_filter_name[][NC_MAX
 int
 main(int argc, char **argv)
 {
+    /* Parallel I/O with compression was not supported in HDF5 prior to 1.10.2. */
+#if H5_VERSION_GE(1,10,2)    
     /* MPI stuff. */
     int mpi_size, my_rank;
     MPI_Comm comm = MPI_COMM_WORLD;
@@ -722,6 +724,6 @@ main(int argc, char **argv)
 
     if (!my_rank)
         FINAL_RESULTS;
-
+#endif /* HDF5 version > 1.10.2 */
     return 0;
 }

--- a/nc_perf/tst_gfs_data_1.c
+++ b/nc_perf/tst_gfs_data_1.c
@@ -19,6 +19,7 @@
 #include <sys/time.h> /* Extra high precision time info. */
 #include "err_macros.h"
 #include <mpi.h>
+#include <H5public.h>
 
 #include <stdio.h>
 #include <string.h>
@@ -723,7 +724,8 @@ main(int argc, char **argv)
     MPI_Finalize();
 
     if (!my_rank)
-        FINAL_RESULTS;
 #endif /* HDF5 version > 1.10.2 */
+        FINAL_RESULTS;
+
     return 0;
 }


### PR DESCRIPTION
Fixes #2067 

Make nc_perf directory not run test programs in parallel.

Also turn off nc_perf/tst_gfs_data_1.c for HDF5 versions prior to 1.10.2, which parallel writes with compression was introduced.

@WardF it would be great if this could make it in before the release...