### PR TITLE
Fix comment and text of configure option --disable-dap-remote-tests.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -521,12 +521,12 @@ CFLAGS="$SAVECFLAGS"
 
 # --enable-dap => enable-dap4
 enable_dap4=$enable_dap
-# Default is to not do the short remote tests.
-AC_MSG_CHECKING([whether dap remote testing should be enabled (default off)])
+# Default is to do the short remote tests.
+AC_MSG_CHECKING([whether dap remote testing should be enabled])
 AC_ARG_ENABLE([dap-remote-tests],
-              [AS_HELP_STRING([--enable-dap-remote-tests],
-                                 [enable dap remote tests])])
-test "x$enable_dap_remote_tests" = xyes || enable_dap_remote_tests=no
+              [AS_HELP_STRING([--disable-dap-remote-tests],
+                                 [disable dap remote tests])])
+test "x$enable_dap_remote_tests" = xno || enable_dap_remote_tests=yes
 if test "x$enable_dap" = "xno" ; then
   enable_dap_remote_tests=no
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -521,12 +521,12 @@ CFLAGS="$SAVECFLAGS"
 
 # --enable-dap => enable-dap4
 enable_dap4=$enable_dap
-# Default is to do the short remote tests.
+# Default is to not do the short remote tests.
 AC_MSG_CHECKING([whether dap remote testing should be enabled (default off)])
 AC_ARG_ENABLE([dap-remote-tests],
               [AS_HELP_STRING([--enable-dap-remote-tests],
                                  [enable dap remote tests])])
-test "x$enable_dap_remote_tests" = xno || enable_dap_remote_tests=yes
+test "x$enable_dap_remote_tests" = xyes || enable_dap_remote_tests=no
 if test "x$enable_dap" = "xno" ; then
   enable_dap_remote_tests=no
 fi


### PR DESCRIPTION
Fixes #2045 

Fix comment and text of configure option --disable-dap-remote-tests.