### PR TITLE
turned off running of run_knmi_bm.sh benchmark with make check (for --enable-benchmark builds)

### DIFF
--- a/nc_perf/Makefile.am
+++ b/nc_perf/Makefile.am
@@ -42,9 +42,12 @@ tst_wrf_reads_SOURCES = tst_wrf_reads.c tst_utils.c
 tst_bm_rando_SOURCES = tst_bm_rando.c tst_utils.c
 
 # Removing tst_mem1 because it sometimes fails on very busy system.
-TESTS = tst_ar4_3d tst_create_files tst_files3 tst_mem run_knmi_bm.sh	\
-tst_wrf_reads tst_attsperf perftest.sh run_tst_chunks.sh		\
-run_bm_elena.sh tst_bm_rando
+# Removing run_knmi_bm.sh because it fetches files from a server and
+# not all HPC systems have easy internet access, plus it's very slow
+# in CI.
+TESTS = tst_ar4_3d tst_create_files tst_files3 tst_mem tst_wrf_reads	\
+tst_attsperf perftest.sh run_tst_chunks.sh run_bm_elena.sh		\
+tst_bm_rando
 
 run_bm_elena.log: tst_create_files.log
 


### PR DESCRIPTION
Fixes #1812 

turned off running of run_knmi_bm.sh benchmark with make check (for --enable-benchmark builds). THis benchmarking script gets some files from Unitdata's ftp site, which presents problems and is slow. So this benchmark will no longer be run by make check.

@WardF it would be great if this could make it into the release...