### PR TITLE
Revamping the HDF5_VERSION logic.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -690,17 +690,7 @@ IF(USE_HDF5)
         unset(_hdf5_version_lines)
         MESSAGE(STATUS "Found HDF5 libraries version ${HDF5_VERSION}")
       ENDIF()
-
-    ELSE() # Original HDF5_VERSION blank check.
-      IF(${HDF5_VERSION} VERSION_LESS ${HDF5_VERSION_REQUIRED})
-        MESSAGE(FATAL_ERROR
-	      "netCDF requires at least HDF5 ${HDF5_VERSION_REQUIRED}. Found ${HDF5_VERSION}.")
-      ELSE()
-        MESSAGE(STATUS "Found HDF5 libraries version ${HDF5_VERSION}")
-      ENDIF()
     ENDIF()
-
-
 
     ###
     # If HDF5_VERSION is still empty, we have a problem.
@@ -708,6 +698,15 @@ IF(USE_HDF5)
     ###
     IF("${HDF5_VERSION}" STREQUAL "")
       MESSAGE(FATAL_ERR "Unable to determine HDF5 version.  NetCDF requires at least version ${HDF5_VERSION_REQUIRED}. Please ensure that libhdf5 is installed and accessible.")
+    ENDIF()
+
+    ###
+    # Now that we know HDF5_VERSION isn't empty, we can check for minimum required version,
+    # and toggle various options.
+    ###
+
+    IF(${HDF5_VERSION} VERSION_LESS ${HDF5_VERSION_REQUIRED})
+      MESSAGE(FATAL_ERROR "netCDF requires at least HDF5 ${HDF5_VERSION_REQUIRED}. Found ${HDF5_VERSION}.")
     ENDIF()
 
     ####

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -670,12 +670,28 @@ IF(USE_HDF5)
     ##
     SET(HDF5_VERSION_REQUIRED 1.8.10)
 
+    # Some versions of HDF5 set HDF5_VERSION_STRING instead of HDF5_VERSION
     IF(HDF5_VERSION_STRING AND NOT HDF5_VERSION)
       SET(HDF5_VERSION ${HDF5_VERSION_STRING})
     ENDIF()
+
+
+    ###
+    # If HDF5_VERSION is undefined, attempt to determine it programatically.
+    ###
     IF("${HDF5_VERSION}" STREQUAL "")
-      MESSAGE(STATUS "Unable to determine hdf5 version.  NetCDF requires at least version ${HDF5_VERSION_REQUIRED}")
-    ELSE()
+      MESSAGE(STATUS "HDF5_VERSION not detected. Attempting to determine programatically.")
+      IF (EXISTS "${HDF5_INCLUDE_DIR}/H5pubconf.h")
+        file(READ "${HDF5_INCLUDE_DIR}/H5pubconf.h" _hdf5_version_lines
+          REGEX "#define[ \t]+H5_VERSION")
+        string(REGEX REPLACE ".*H5_VERSION .*\"\(.*\)\".*" "\\1" _hdf5_version "${_hdf5_version_lines}")
+        set(HDF5_VERSION "${_hdf5_version}")
+        unset(_hdf5_version)
+        unset(_hdf5_version_lines)
+        MESSAGE(STATUS "Found HDF5 libraries version ${HDF5_VERSION}")
+      ENDIF()
+
+    ELSE() # Original HDF5_VERSION blank check.
       IF(${HDF5_VERSION} VERSION_LESS ${HDF5_VERSION_REQUIRED})
         MESSAGE(FATAL_ERROR
 	      "netCDF requires at least HDF5 ${HDF5_VERSION_REQUIRED}. Found ${HDF5_VERSION}.")
@@ -683,6 +699,29 @@ IF(USE_HDF5)
         MESSAGE(STATUS "Found HDF5 libraries version ${HDF5_VERSION}")
       ENDIF()
     ENDIF()
+
+
+
+    ###
+    # If HDF5_VERSION is still empty, we have a problem.
+    # Error out.
+    ###
+    IF("${HDF5_VERSION}" STREQUAL "")
+      MESSAGE(FATAL_ERR "Unable to determine HDF5 version.  NetCDF requires at least version ${HDF5_VERSION_REQUIRED}. Please ensure that libhdf5 is installed and accessible.")
+    ENDIF()
+
+    ####
+    # Check to see if HDF5 library is 1.10.6 or greater.
+    # Used to control path name conversion
+    ####
+    IF(${HDF5_VERSION} VERSION_GREATER "1.10.5")
+      SET(HDF5_UTF8_PATHS ON)
+    ELSE()
+      SET(HDF5_UTF8_PATHS OFF)
+    ENDIF()
+
+    MESSAGE("-- HDF5_UTF8_PATHS (HDF5 version 1.10.6+): ${HDF5_UTF8_PATHS}")
+
 
     ##
     # Include the HDF5 include directory.
@@ -718,6 +757,10 @@ IF(USE_HDF5)
       ENDIF(${HDF5_VERSION} VERSION_GREATER "1.8.15")
 
     ELSE(MSVC)
+      ####
+      # Environmental variables in Windows when using MSVC
+      # are a hot mess between versions.
+      ####
 
       IF(HDF5_hdf5_LIBRARY AND NOT HDF5_C_LIBRARY)
         SET(HDF5_C_LIBRARY ${HDF5_hdf5_LIBRARY})
@@ -815,16 +858,6 @@ IF(USE_HDF5)
     SET(HDF5_HAS_PAR_FILTERS FALSE CACHE BOOL "")
     SET(HAS_PAR_FILTERS no CACHE STRING "")
   ENDIF()
-
-  # Check to see if HDF5 library is 1.10.6 or greater.
-  # Used to control path name conversion
-  IF(${HDF5_VERSION} VERSION_GREATER "1.10.5")
-    SET(HDF5_UTF8_PATHS ON)
-  ELSE()
-    SET(HDF5_UTF8_PATHS OFF)
-  ENDIF()
-
-  MESSAGE("-- Checking for HDF5 version 1.10.6 or later: ${HDF5_UTF8_PATHS}")
 
   FIND_PATH(HAVE_HDF5_H hdf5.h PATHS ${HDF5_INCLUDE_DIR} NO_DEFAULT_PATH)
   FIND_PATH(HAVE_HDF5_H hdf5.h)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 #Minimum required CMake Version
 cmake_minimum_required(VERSION 3.6.1)
 
-#Project Name
+#Project Name 
 project(netCDF LANGUAGES C CXX)
 set(PACKAGE "netCDF" CACHE STRING "")
 
@@ -606,11 +606,20 @@ ENDIF(ENABLE_STRICT_NULL_BYTE_HEADER_PADDING)
 ##
 SET(USE_HDF5 ${ENABLE_HDF5})
 IF(USE_HDF5)
+
+  ##
+  # Assert HDF5 version meets minimum required version.
+  ##
+  SET(HDF5_VERSION_REQUIRED 1.8.10)
+
+
   ##
   # Accommodate developers who have hdf5 libraries and
   # headers on their system, but do not have a the hdf
   # .cmake files.  If this is the case, they should
   # specify HDF5_HL_LIBRARY, HDF5_LIBRARY, HDF5_INCLUDE_DIR manually.
+  #
+  # This script will attempt to determine the version of the HDF5 library programatically. 
   ##
   IF(HDF5_C_LIBRARY AND HDF5_HL_LIBRARY AND HDF5_INCLUDE_DIR)
     SET(HDF5_LIBRARIES ${HDF5_C_LIBRARY} ${HDF5_HL_LIBRARY})
@@ -628,6 +637,23 @@ IF(USE_HDF5)
       unset(_hdf5_version)
       unset(_hdf5_version_lines)
     endif ()
+    MESSAGE(STATUS "Found HDF5 libraries version ${HDF5_VERSION}")
+    ###
+    # If HDF5_VERSION is still empty, we have a problem.
+    # Error out.
+    ###
+    IF("${HDF5_VERSION}" STREQUAL "")
+      MESSAGE(FATAL_ERR "Unable to determine HDF5 version.  NetCDF requires at least version ${HDF5_VERSION_REQUIRED}. Please ensure that libhdf5 is installed and accessible.")
+    ENDIF()
+
+    ###
+    # Now that we know HDF5_VERSION isn't empty, we can check for minimum required version,
+    # and toggle various options.
+    ###
+    IF(${HDF5_VERSION} VERSION_LESS ${HDF5_VERSION_REQUIRED})
+      MESSAGE(FATAL_ERROR "netCDF requires at least HDF5 ${HDF5_VERSION_REQUIRED}. Found ${HDF5_VERSION}.")
+    ENDIF()
+
   ELSE(HDF5_C_LIBRARY AND HDF5_HL_LIBRARY AND HDF5_INCLUDE_DIR) # We are seeking out HDF5 with Find Package.
     ###
     # For now we assume that if we are building netcdf
@@ -664,11 +690,6 @@ IF(USE_HDF5)
     # Next, check the HDF5 version. This will inform which
     # HDF5 variables we need to munge.
     ##
-
-    ##
-    # Assert HDF5 version meets minimum required version.
-    ##
-    SET(HDF5_VERSION_REQUIRED 1.8.10)
 
     # Some versions of HDF5 set HDF5_VERSION_STRING instead of HDF5_VERSION
     IF(HDF5_VERSION_STRING AND NOT HDF5_VERSION)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -633,7 +633,7 @@ IF(USE_HDF5)
       file(READ "${HDF5_INCLUDE_DIR}/H5pubconf.h" _hdf5_version_lines
         REGEX "#define[ \t]+H5_VERSION")
       string(REGEX REPLACE ".*H5_VERSION .*\"\(.*\)\".*" "\\1" _hdf5_version "${_hdf5_version_lines}")
-      set(HDF5_VERSION "${_hdf5_version}")
+      set(HDF5_VERSION "${_hdf5_version}" CACHE STRING "")
       unset(_hdf5_version)
       unset(_hdf5_version_lines)
     endif ()
@@ -706,11 +706,13 @@ IF(USE_HDF5)
         file(READ "${HDF5_INCLUDE_DIR}/H5pubconf.h" _hdf5_version_lines
           REGEX "#define[ \t]+H5_VERSION")
         string(REGEX REPLACE ".*H5_VERSION .*\"\(.*\)\".*" "\\1" _hdf5_version "${_hdf5_version_lines}")
-        set(HDF5_VERSION "${_hdf5_version}")
+        set(HDF5_VERSION "${_hdf5_version}" CACHE STRING "")
         unset(_hdf5_version)
         unset(_hdf5_version_lines)
         MESSAGE(STATUS "Found HDF5 libraries version ${HDF5_VERSION}")
       ENDIF()
+    ELSE()
+      SET(HDF5_VERSION ${HDF5_VERSION} CACHE STRING "")
     ENDIF()
 
     ###
@@ -730,18 +732,7 @@ IF(USE_HDF5)
       MESSAGE(FATAL_ERROR "netCDF requires at least HDF5 ${HDF5_VERSION_REQUIRED}. Found ${HDF5_VERSION}.")
     ENDIF()
 
-    ####
-    # Check to see if HDF5 library is 1.10.6 or greater.
-    # Used to control path name conversion
-    ####
-    IF(${HDF5_VERSION} VERSION_GREATER "1.10.5")
-      SET(HDF5_UTF8_PATHS ON)
-    ELSE()
-      SET(HDF5_UTF8_PATHS OFF)
-    ENDIF()
-
-    MESSAGE("-- HDF5_UTF8_PATHS (HDF5 version 1.10.6+): ${HDF5_UTF8_PATHS}")
-
+    
 
     ##
     # Include the HDF5 include directory.
@@ -826,6 +817,18 @@ IF(USE_HDF5)
     SET(CMAKE_REQUIRED_LIBRARIES ${SZIP_LIBRARY} ${CMAKE_REQUIRED_LIBRARIES})
     MESSAGE(STATUS "HDF5 has szip.")
   ENDIF()
+
+  ####
+  # Check to see if HDF5 library is 1.10.6 or greater.
+  # Used to control path name conversion
+  ####
+  IF(${HDF5_VERSION} VERSION_GREATER "1.10.5")
+    SET(HDF5_UTF8_PATHS ON)
+  ELSE()
+    SET(HDF5_UTF8_PATHS OFF)
+  ENDIF()
+
+  MESSAGE("-- HDF5_UTF8_PATHS (HDF5 version 1.10.6+): ${HDF5_UTF8_PATHS}")
 
   # Find out if HDF5 was built with parallel support.
   # Do that by checking for the targets H5Pget_fapl_mpiposx and

--- a/ncdap_test/CMakeLists.txt
+++ b/ncdap_test/CMakeLists.txt
@@ -35,7 +35,11 @@ IF(ENABLE_TESTS)
   IF(BUILD_UTILITIES)
     add_sh_test(ncdap tst_ncdap3)
     add_sh_test(ncdap testpathcvt)
-    SET_TESTS_PROPERTIES(ncdap_tst_ncdap3 ncdap_testpathcvt PROPERTIES RUN_SERIAL TRUE)
+    IF(HAVE_BASH)
+      SET_TESTS_PROPERTIES(ncdap_tst_ncdap3 PROPERTIES RUN_SERIAL TRUE)
+    ENDIF(HAVE_BASH)
+    
+    SET_TESTS_PROPERTIES(ncdap_testpathcvt PROPERTIES RUN_SERIAL TRUE)
 ENDIF()
 
   IF(NOT MSVC)
@@ -49,6 +53,9 @@ ENDIF()
     IF(BUILD_UTILITIES)
       add_sh_test(ncdap tst_ber)
       add_sh_test(ncdap tst_remote3)
+      IF(HAVE_BASH)
+        SET_TESTS_PROPERTIES(ncdap_tst_remote3 PROPERTIES RUN_SERIAL TRUE)
+      ENDIF(HAVE_BASH)
       add_sh_test(ncdap tst_zero_len_var)
       add_sh_test(ncdap tst_encode)
       # not yet      add_sh_test(ncdap tst_hyrax)
@@ -59,7 +66,7 @@ ENDIF()
         SET_TESTS_PROPERTIES(ncdap_tst_longremote3 ncdap_test_manyurls PROPERTIES RUN_SERIAL TRUE)
       ENDIF(ENABLE_DAP_LONG_TESTS)
 
-      SET_TESTS_PROPERTIES(ncdap_tst_remote3 PROPERTIES RUN_SERIAL TRUE)
+      
 
     ENDIF(BUILD_UTILITIES)
 

--- a/ncdap_test/CMakeLists.txt
+++ b/ncdap_test/CMakeLists.txt
@@ -37,10 +37,11 @@ IF(ENABLE_TESTS)
     add_sh_test(ncdap testpathcvt)
     IF(HAVE_BASH)
       SET_TESTS_PROPERTIES(ncdap_tst_ncdap3 PROPERTIES RUN_SERIAL TRUE)
+      SET_TESTS_PROPERTIES(ncdap_testpathcvt PROPERTIES RUN_SERIAL TRUE)
     ENDIF(HAVE_BASH)
     
-    SET_TESTS_PROPERTIES(ncdap_testpathcvt PROPERTIES RUN_SERIAL TRUE)
-ENDIF()
+    
+  ENDIF()
 
   IF(NOT MSVC)
     add_bin_env_test(ncdap t_dap3a)


### PR DESCRIPTION
Revamping HDF5_VERSION logic flow in CMakeLists.txt.  Originally, this information was only used to determine if we had met the minimum supported version threshold.  It has grown since then.  We now check for versions as a cmake-infrastructure provided environmental variable; if that is not available, we attempt to determine the version programmatically using code contributed (I believe) by @edwardhartnett.  If we ultimately cannot determine the HDF5_VERSION through any method, cmake will exit with an error. 