### PR TITLE
Make the fortran cache API always be defined.

### DIFF
--- a/libdispatch/dvar.c
+++ b/libdispatch/dvar.c
@@ -1338,27 +1338,27 @@ nc_get_var_chunk_cache(int ncid, int varid, size_t *sizep, size_t *nelemsp,
 int
 nc_set_chunk_cache_ints(int size, int nelems, int preemption)
 {
-    return NC_ENOTNC4;
+    return NC_ENOTBUILT;
 }
 
 int
 nc_get_chunk_cache_ints(int *sizep, int *nelemsp, int *preemptionp)
 {
-    return NC_ENOTNC4;
+    return NC_ENOTBUILT;
 }
 
 int
 nc_set_var_chunk_cache_ints(int ncid, int varid, int size, int nelems,
 			    int preemption)
 {
-    return NC_NOERR;
+    return NC_ENOTBUILT;
 }
 
 int
 nc_get_var_chunk_cache_ints(int ncid, int varid, int *sizep,
 			    int *nelemsp, int *preemptionp)
 {
-    return NC_ENOTNC4;
+    return NC_ENOTBUILT;
 }
 
 #endif /*USE_NETCDF4*/

--- a/libdispatch/dvar.c
+++ b/libdispatch/dvar.c
@@ -1331,5 +1331,37 @@ nc_get_var_chunk_cache(int ncid, int varid, size_t *sizep, size_t *nelemsp,
     return ncp->dispatch->get_var_chunk_cache(ncid, varid, sizep,
                                               nelemsp, preemptionp);
 }
+
+#ifndef USE_NETCDF4
+/* Make sure the fortran API is defined, even if it only returns errors */
+
+int
+nc_set_chunk_cache_ints(int size, int nelems, int preemption)
+{
+    return NC_ENOTNC4;
+}
+
+int
+nc_get_chunk_cache_ints(int *sizep, int *nelemsp, int *preemptionp)
+{
+    return NC_ENOTNC4;
+}
+
+int
+nc_set_var_chunk_cache_ints(int ncid, int varid, int size, int nelems,
+			    int preemption)
+{
+    return NC_NOERR;
+}
+
+int
+nc_get_var_chunk_cache_ints(int ncid, int varid, int *sizep,
+			    int *nelemsp, int *preemptionp)
+{
+    return NC_ENOTNC4;
+}
+
+#endif /*USE_NETCDF4*/
+
 /** @} */
 /** @} */

--- a/libhdf5/hdf5var.c
+++ b/libhdf5/hdf5var.c
@@ -838,6 +838,7 @@ NC4_def_var_chunking(int ncid, int varid, int storage, const size_t *chunksizesp
 /**
  * @internal Define chunking stuff for a var. This is called by
  * the fortran API.
+ * Note: see libsrc4/nc4cache.c for definition when HDF5 is disabled
  *
  * @param ncid File ID.
  * @param varid Variable ID.
@@ -2147,6 +2148,7 @@ NC4_HDF5_set_var_chunk_cache(int ncid, int varid, size_t size, size_t nelems,
 /**
  * @internal A wrapper for NC4_set_var_chunk_cache(), we need this
  * version for fortran. Negative values leave settings as they are.
+ * Note: see libsrc4/nc4cache.c for definition when HDF5 is disabled
  *
  * @param ncid File ID.
  * @param varid Variable ID.

--- a/libsrc4/nc4cache.c
+++ b/libsrc4/nc4cache.c
@@ -115,6 +115,8 @@ nc_get_chunk_cache(size_t *sizep, size_t *nelemsp, float *preemptionp)
  * but with integers instead of size_t, and with an integer preemption
  * (which is the float preemtion * 100). This was required for fortran
  * to avoid size_t issues.
+ * Note: if netcdf-4 is completely disabled, then the definitions in
+ * libdispatch/dfile.c take effect.
  *
  * @param size Cache size.
  * @param nelems Number of elements.
@@ -139,6 +141,8 @@ nc_set_chunk_cache_ints(int size, int nelems, int preemption)
  * nc_get_chunk_cache() but with integers instead of size_t, and with
  * an integer preemption (which is the float preemtion * 100). This
  * was required for fortran to avoid size_t issues.
+ * Note: if netcdf-4 is completely disabled, then the definitions in
+ * libdispatch/dfile.c take effect.
  *
  * @param sizep Pointer that gets cache size.
  * @param nelemsp Pointer that gets number of elements.
@@ -159,3 +163,25 @@ nc_get_chunk_cache_ints(int *sizep, int *nelemsp, int *preemptionp)
 
     return NC_NOERR;
 }
+
+#ifndef USE_HDF5
+/* See definitions in libhd5/hdf5var.c */
+/* Make sure they are always defined */
+/* Note: if netcdf-4 is completely disabled, then the definitions in
+ * libdispatch/dfile.c take effect.
+ */
+
+int
+nc_set_var_chunk_cache_ints(int ncid, int varid, int size, int nelems,
+                            int preemption)
+{
+    return NC_NOERR;
+}
+
+int
+nc_def_var_chunking_ints(int ncid, int varid, int storage, int *chunksizesp)
+{
+    return NC_NOERR;
+}
+
+#endif /*USE_HDF5*/


### PR DESCRIPTION
* Fixes #2096 

re: Issue https://github.com/Unidata/netcdf-c/issues/2096

The methods nc_set_var_chunk_cache_ints and nc_def_var_chunking_ints
are Fortran entry points for accessing the cache. They are not defined
if netcdf-c is built with --disable-hdf5.

Fix is to create dummy versions that do nothing and return NC_NOERR
when invoked. These dummy versions are defined when USE_HDF5 is false.