### PR TITLE
Avoid redefinition of strcasecmp under mingw-w64

### DIFF
--- a/config.h.cmake.in
+++ b/config.h.cmake.in
@@ -57,7 +57,7 @@ are set when opening a binary file on Windows. */
    #define _OFF_T_DEFINED
    #endif
 
-   #ifdef _WIN32
+   #if defined(_WIN32) && !defined(__MINGW32__)
     #ifndef strcasecmp
       #define strcasecmp _stricmp
     #endif
@@ -656,7 +656,7 @@ with zip */
 #cmakedefine uintptr_t unsigned long
 
 /* Define strcasecmp, strncasecmp, snprintf on Win32 systems. */
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__MINGW32__)
     #ifndef HAVE_STRCASECMP
 	 #define strcasecmp _stricmp
     #endif

--- a/configure.ac
+++ b/configure.ac
@@ -1654,7 +1654,7 @@ AC_SUBST(DO_NCZARR_ZIP_TESTS,[$enable_nczarr_zip])
 #AH_VERBATIM([_WIN32_STRICMP],
 AH_BOTTOM(
 [/* Define strcasecmp, strncasecmp, snprintf on Win32 systems. */
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__MINGW32__)
 	#define strcasecmp _stricmp
 	#define strncasecmp _strnicmp
 	#define snprintf _snprintf

--- a/libdispatch/ncjson.c
+++ b/libdispatch/ncjson.c
@@ -14,7 +14,7 @@ TODO: make utf8 safe
 #include <assert.h>
 #include "ncjson.h"
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__MINGW32__)
 #define strcasecmp _stricmp
 #else
 #include <strings.h>

--- a/libdispatch/nclist.c
+++ b/libdispatch/nclist.c
@@ -6,7 +6,7 @@
 
 #include "nclist.h"
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__MINGW32__)
 #define strcasecmp _stricmp
 #endif
 

--- a/ncgen/ncgen.h
+++ b/ncgen/ncgen.h
@@ -9,7 +9,9 @@
 #ifdef _WIN32
 #include <float.h>
 #include "isnan.h"
+#ifndef __MINGW32__
 #define strcasecmp _stricmp
+#endif
 #endif
 
 #ifdef USE_NETCDF4


### PR DESCRIPTION
Fixes #2083

NetCDF defines `strcasecmp` as a preprocessor macro on Windows platforms. This is probably needed for the Microsoft compilers, but the header files used by mingw-w64 compilers define `strcasecmp` as an inline function.

If both the inline function and the macro definitions are used with gcc at high optimisation levels (specifically the flag `-foptimize-sibling-calls`, which is included by default at `-O2` or higher), the OpenDAP tests hang.

On mingw-w64, the macro `__MINGW32__` is defined in both 32-bit and 64-bit environments. If this macro is defined, the macro definition of `strcasecmp` can be disabled, which avoids the hang when running OpenDAP tests.