### PR TITLE
Use canonical path to derive name of dataset on Windows

### DIFF
--- a/ncdump/ncdump.c
+++ b/ncdump/ncdump.c
@@ -155,7 +155,7 @@ name_path(const char *path)
     size_t cplen = 0;
     char* base = NULL;
 
-    if((cvtpath = NCpathcvt(path))==NULL)
+    if (NCpathcanonical(path, &cvtpath) || cvtpath==NULL)
         return NULL;
 
     /* See if this is a url */


### PR DESCRIPTION
If #2084 is merged , netcdf utilities will use Windows paths on mingw-w64. This leads to problems in the output from `ncdump`, such as the following error from `dap4_test/test_meta.sh`:

```
checking: test_anon_dim.2.syn
1c1
< netcdf test_anon_dim.2 {
---
> netcdf .\\results_test_meta\\test_anon_dim.2 {
```

The default name of the dataset is supposed to be the basename of the input file, minus any file extension. The existing function `name_path` which determines the default dataset name assumes that paths have Unix directory separators (`/`), but Windows paths use `\\`. This PR produces a compatible path format using function `NCpathcanonical` instead of `NCpathcvt`.