### PR TITLE
Fix a stack-read-overflow in ncindexlookup()

### DIFF
--- a/libhdf5/hdf5internal.c
+++ b/libhdf5/hdf5internal.c
@@ -928,7 +928,10 @@ nc4_hdf5_find_grp_var_att(int ncid, int varid, const char *name, int attnum,
 
     /* Give the people what they want. */
     if (norm_name)
+    {
         strncpy(norm_name, my_norm_name, NC_MAX_NAME);
+        norm_name[NC_MAX_NAME] = 0;
+    }
     if (h5)
         *h5 = my_h5;
     if (grp)


### PR DESCRIPTION
Fixes an issue with strlen() reading outside the stack allocated buffer
by NC4_HDF5_inq_att, when reading a name whose length is NC_MAX_NAME.

Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=39189 found
on GDAL

==1895951== Conditional jump or move depends on uninitialised value(s)
==1895951==    at 0x483EF58: strlen (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==1895951==    by 0x48EF73E: ncindexlookup (ncindex.c:60)
==1895951==    by 0x48E81DF: nc4_find_grp_att (nc4internal.c:587)
==1895951==    by 0x48E5B39: nc4_get_att_ptrs (nc4attr.c:72)
==1895951==    by 0x48F98A0: NC4_HDF5_inq_att (hdf5attr.c:818)
==1895951==    by 0x48847F7: nc_inq_att (dattinq.c:91)
==1895951==    by 0x10D693: pr_att (ncdump.c:767)
==1895951==    by 0x110ADB: do_ncdump_rec (ncdump.c:1887)
==1895951==    by 0x1112F1: do_ncdump (ncdump.c:2038)
==1895951==    by 0x11248B: main (ncdump.c:2478)
==1895951==
==1895951== Use of uninitialised value of size 8
==1895951==    at 0x48A24E4: crc64_little (dcrc64.c:173)
==1895951==    by 0x48A27F4: NC_crc64 (dcrc64.c:229)
==1895951==    by 0x4892D49: NC_hashmapkey (nchashmap.c:159)
==1895951==    by 0x489314B: NC_hashmapget (nchashmap.c:263)
==1895951==    by 0x48EF75F: ncindexlookup (ncindex.c:60)
==1895951==    by 0x48E81DF: nc4_find_grp_att (nc4internal.c:587)
==1895951==    by 0x48E5B39: nc4_get_att_ptrs (nc4attr.c:72)
==1895951==    by 0x48F98A0: NC4_HDF5_inq_att (hdf5attr.c:818)
==1895951==    by 0x48847F7: nc_inq_att (dattinq.c:91)
==1895951==    by 0x10D693: pr_att (ncdump.c:767)
==1895951==    by 0x110ADB: do_ncdump_rec (ncdump.c:1887)
==1895951==    by 0x1112F1: do_ncdump (ncdump.c:2038)
==1895951==