### PR TITLE
Fix diskless files in mingw-w64

### DIFF
--- a/libsrc/memio.c
+++ b/libsrc/memio.c
@@ -710,7 +710,7 @@ readfile(const char* path, NC_memio* memio)
     char* p = NULL;
 
     /* Open the file for reading */
-#ifdef _MSC_VER
+#ifdef _WIN32
     f = NCfopen(path,"rb");
 #else
     f = NCfopen(path,"r");
@@ -760,7 +760,7 @@ writefile(const char* path, NCMEMIO* memio)
     char* p = NULL;
 
     /* Open/create the file for writing*/
-#ifdef _MSC_VER
+#ifdef _WIN32
     f = NCfopen(path,"wb");
 #else
     f = NCfopen(path,"w");

--- a/nc_test/tst_inmemory.c
+++ b/nc_test/tst_inmemory.c
@@ -168,7 +168,7 @@ readfile(const char* path, NC_memio* memio)
     char* p = NULL;
 
     /* Open the file for reading */
-#ifdef _MSC_VER
+#ifdef _WIN32
     f = fopen(path,"rb");
 #else
     f = fopen(path,"r");
@@ -216,7 +216,7 @@ writefile(const char* path, NC_memio* memio)
     char* p = NULL;
 
     /* Open the file for writing */
-#ifdef _MSC_VER
+#ifdef _WIN32
     f = fopen(path,"wb");
 #else
     f = fopen(path,"w");


### PR DESCRIPTION
This PR fixes the following tests on mingw-w64:

22 - ncdump_tst_nccopy_w3 (Failed)
24 - ncdump_tst_nccopy_w4 (Failed)
67 - nc_test_tst_diskless6 (Failed)
71 - nc_test_run_inmemory (Failed)
