### PR TITLE
Refactor Z library detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,9 @@ cmake_minimum_required(VERSION 3.6.1)
 project(netCDF LANGUAGES C CXX)
 set(PACKAGE "netCDF" CACHE STRING "")
 
+# Use libraries specified in CMAKE_REQUIRED_LIBRARIES for check include macros
+cmake_policy(SET CMP0075 NEW)
+
 #####
 # Version Info:
 #
@@ -793,15 +796,38 @@ IF(USE_HDF5)
     ENDIF()
   ENDIF(HDF5_C_LIBRARY AND HDF5_HL_LIBRARY AND HDF5_INCLUDE_DIR)
 
-  FIND_PACKAGE(Threads)
-
   # There is a missing case in the above code so default it
   IF(NOT HDF5_C_LIBRARY_hdf5 OR "${HDF5_C_LIBRARY_hdf5}" STREQUAL "" )
     SET(HDF5_C_LIBRARY_hdf5 "${HDF5_C_LIBRARY}")
   ENDIF()
 
-  #Check to see if H5Z_SZIP exists in HDF5_Libraries. If so, we must use szip library.
+  FIND_PATH(HAVE_HDF5_H hdf5.h PATHS ${HDF5_INCLUDE_DIR} NO_DEFAULT_PATH)
+  FIND_PATH(HAVE_HDF5_H hdf5.h)
+  IF(NOT HAVE_HDF5_H)
+    MESSAGE(FATAL_ERROR "Compiling a test with hdf5 failed. Either hdf5.h cannot be found, or the log messages should be checked for another reason.")
+  ELSE(NOT HAVE_HDF5_H)
+    INCLUDE_DIRECTORIES(${HAVE_HDF5_H})
+  ENDIF(NOT HAVE_HDF5_H)
+
   set (CMAKE_REQUIRED_INCLUDES ${HDF5_INCLUDE_DIR})
+
+  # Check to ensure that HDF5 was built with zlib.
+  # This needs to be near the beginning since we 
+  # need to know whether to add "-lz" to the symbol 
+  # tests below.
+  CHECK_C_SOURCE_COMPILES("#include <H5public.h>
+   #if !H5_HAVE_ZLIB_H
+   #error
+   #endif
+   int main() {
+   int x = 1;}" HAVE_HDF5_ZLIB)
+  IF(NOT HAVE_HDF5_ZLIB)
+    MESSAGE(FATAL_ERROR "HDF5 was built without zlib. Rebuild HDF5 with zlib.")
+  ELSE()
+    set (CMAKE_REQUIRED_LIBRARIES "z" ${CMAKE_REQUIRED_LIBRARIES})
+  ENDIF()
+
+  #Check to see if H5Z_SZIP exists in HDF5_Libraries. If so, we must use szip library.
   CHECK_C_SOURCE_COMPILES("#include <H5public.h>
    #if !H5_HAVE_FILTER_SZIP
    #error
@@ -894,25 +920,12 @@ IF(USE_HDF5)
     INCLUDE_DIRECTORIES(${HAVE_HDF5_H})
   ENDIF(NOT HAVE_HDF5_H)
 
-  # Check to ensure that HDF5 was built with zlib.
-  set (CMAKE_REQUIRED_INCLUDES ${HDF5_INCLUDE_DIR})
-
-
-  CHECK_C_SOURCE_COMPILES("#include <H5public.h>
-   #if !H5_HAVE_ZLIB_H
-   #error
-   #endif
-   int main() {
-   int x = 1;}" HAVE_HDF5_ZLIB)
-  IF(NOT HAVE_HDF5_ZLIB)
-    MESSAGE(FATAL_ERROR "HDF5 was built without zlib. Rebuild HDF5 with zlib.")
-  ENDIF()
-
   #option to include HDF5 High Level header file (hdf5_hl.h) in case we are not doing a make install
   INCLUDE_DIRECTORIES(${HDF5_HL_INCLUDE_DIR})
 
-
 ENDIF(USE_HDF5)
+
+FIND_PACKAGE(Threads)
 
 # See if we have libcurl
 FIND_PACKAGE(CURL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -828,7 +828,7 @@ IF(USE_HDF5)
   ELSE()
     # If user has specified the `ZLIB_LIBRARY`, use it; otherwise try to find...
     IF(NOT ZLIB_LIBRARY)
-      find_package("ZLIB")
+      find_package(ZLIB)
       IF(ZLIB_FOUND)
         SET(ZLIB_LIBRARY ${ZLIB_LIBRARIES})
       ELSE()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -794,10 +794,11 @@ IF(USE_HDF5)
     IF(NOT HDF5_C_LIBRARY)
       SET(HDF5_C_LIBRARY hdf5)
     ENDIF()
-    
-    FIND_PACKAGE(Threads)
+  
   ENDIF(HDF5_C_LIBRARY AND HDF5_HL_LIBRARY AND HDF5_INCLUDE_DIR)
-
+    
+  FIND_PACKAGE(Threads)
+  
   # There is a missing case in the above code so default it
   IF(NOT HDF5_C_LIBRARY_hdf5 OR "${HDF5_C_LIBRARY_hdf5}" STREQUAL "" )
     SET(HDF5_C_LIBRARY_hdf5 "${HDF5_C_LIBRARY}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -826,7 +826,17 @@ IF(USE_HDF5)
   IF(NOT HAVE_HDF5_ZLIB)
     MESSAGE(FATAL_ERROR "HDF5 was built without zlib. Rebuild HDF5 with zlib.")
   ELSE()
-    set (CMAKE_REQUIRED_LIBRARIES "z" ${CMAKE_REQUIRED_LIBRARIES})
+    # If user has specified the `ZLIB_LIBRARY`, use it; otherwise try to find...
+    IF(NOT ZLIB_LIBRARY)
+      find_package("ZLIB")
+      IF(ZLIB_FOUND)
+        SET(ZLIB_LIBRARY ${ZLIB_LIBRARIES})
+      ELSE()
+        MESSAGE(FATAL_ERROR "HDF5 Requires ZLIB, but cannot find libz.")
+      ENDIF()
+    ENDIF()
+    SET(CMAKE_REQUIRED_LIBRARIES ${ZLIB_LIBRARY} ${CMAKE_REQUIRED_LIBRARIES})
+    MESSAGE(STATUS "HDF5 has zlib.")
   ENDIF()
 
   #Check to see if H5Z_SZIP exists in HDF5_Libraries. If so, we must use szip library.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -915,7 +915,6 @@ IF(USE_HDF5)
   ENDIF()
 
   FIND_PATH(HAVE_HDF5_H hdf5.h PATHS ${HDF5_INCLUDE_DIR} NO_DEFAULT_PATH)
-  FIND_PATH(HAVE_HDF5_H hdf5.h)
   IF(NOT HAVE_HDF5_H)
     MESSAGE(FATAL_ERROR "Compiling a test with hdf5 failed. Either hdf5.h cannot be found, or the log messages should be checked for another reason.")
   ELSE(NOT HAVE_HDF5_H)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -805,7 +805,6 @@ IF(USE_HDF5)
   ENDIF()
 
   FIND_PATH(HAVE_HDF5_H hdf5.h PATHS ${HDF5_INCLUDE_DIR} NO_DEFAULT_PATH)
-  FIND_PATH(HAVE_HDF5_H hdf5.h)
   IF(NOT HAVE_HDF5_H)
     MESSAGE(FATAL_ERROR "Compiling a test with hdf5 failed. Either hdf5.h cannot be found, or the log messages should be checked for another reason.")
   ELSE(NOT HAVE_HDF5_H)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -796,9 +796,9 @@ IF(USE_HDF5)
     ENDIF()
   
   ENDIF(HDF5_C_LIBRARY AND HDF5_HL_LIBRARY AND HDF5_INCLUDE_DIR)
-    
+
   FIND_PACKAGE(Threads)
-  
+
   # There is a missing case in the above code so default it
   IF(NOT HDF5_C_LIBRARY_hdf5 OR "${HDF5_C_LIBRARY_hdf5}" STREQUAL "" )
     SET(HDF5_C_LIBRARY_hdf5 "${HDF5_C_LIBRARY}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -794,6 +794,8 @@ IF(USE_HDF5)
     IF(NOT HDF5_C_LIBRARY)
       SET(HDF5_C_LIBRARY hdf5)
     ENDIF()
+    
+    FIND_PACKAGE(Threads)
   ENDIF(HDF5_C_LIBRARY AND HDF5_HL_LIBRARY AND HDF5_INCLUDE_DIR)
 
   # There is a missing case in the above code so default it
@@ -924,8 +926,6 @@ IF(USE_HDF5)
   INCLUDE_DIRECTORIES(${HDF5_HL_INCLUDE_DIR})
 
 ENDIF(USE_HDF5)
-
-FIND_PACKAGE(Threads)
 
 # See if we have libcurl
 FIND_PACKAGE(CURL)


### PR DESCRIPTION
HDF5 can depend on the Z library (in fact required for netCDF).  Moved the detection of whether hdf5 was built with zlib up before any other tests that may require linking of the hdf5 library to determine presence/absence of symbols.  These tests require that the link line include "-lz" if the hdf5 library was built with libz support.  

This is typically handled somewhat automatically if shared libraries are being used, but in the static library case, the explicit dependency needs to be specified.  For internal CMake checks, it uses the `CMAKE_REQUIRED_LIBRARIES` list to specify the libraries that should be used in a `CHECK_C_SOURCE_COMPILE` or a `CHECK_LIBRARY_EXISTS` call.   In the current CMakeLists.txt ordering, the zlib detection is done _after_ the `CHECK_LIBRARY_EXISTS` calls which can cause them to fail and give an incorrect result about whether the function being tested for exists.   With the reordering in this PR, I am able to correctly configure netCDF on a CRAY HPC system that uses static libraries by default.

I moved the `find_package(threads)` out of the HDF5 block since it doesn't seem to be related to HDF5 and nothing is done whether it is found or not...  Maybe it can be removed entirely?