### PR TITLE
Support hdf5debug.c compilation with Emscripten

### DIFF
--- a/libhdf5/hdf5debug.c
+++ b/libhdf5/hdf5debug.c
@@ -5,7 +5,7 @@
 #include "config.h"
 #include <stdarg.h>
 #include <stdio.h>
-#if !defined _WIN32 && !defined __CYGWIN__
+#if !defined _WIN32 && !defined __CYGWIN__ && !defined __EMSCRIPTEN__
 #include <execinfo.h>
 #endif
 
@@ -16,7 +16,7 @@
 #define STSIZE 1000
 
 #ifdef H5BACKTRACE
-#  if !defined _WIN32 && !defined __CYGWIN__
+#  if !defined _WIN32 && !defined __CYGWIN__ && !defined __EMSCRIPTEN__
 static void* stacktrace[STSIZE];
 #  endif
 #endif
@@ -25,7 +25,7 @@ int
 nch5breakpoint(int err)
 {
 #ifdef H5BACKTRACE
-#  if !defined _WIN32 && !defined __CYGWIN__
+#  if !defined _WIN32 && !defined __CYGWIN__ && !defined __EMSCRIPTEN__
     int count = 0;
     char** trace = NULL;
     int i;


### PR DESCRIPTION
execinfo.h is not available.
