### PR TITLE
CVEs - Issue #2119

### DIFF
--- a/libdispatch/ezxml.c
+++ b/libdispatch/ezxml.c
@@ -225,10 +225,6 @@ ezxml_decode(char* s, char* *ent, char t)
 		    if (!e) { s++; continue; } // bug#18
                 }
 
-                if(c > strlen(s) || strlen(e) > strlen(s + c)) { /* Patch 28 */
-                    fprintf(stderr, "Error: ezxml_decode(): memmove() past end of buffer!");
-                    exit(-1);
-                }
                 memmove(s + c, e + 1, strlen(e)); /* shift rest of string*/
                 strncpy(s, ent[b], c); /* copy in replacement text*/
             }

--- a/libdispatch/ezxml.c
+++ b/libdispatch/ezxml.c
@@ -528,6 +528,7 @@ nc_ezxml_parse_str(char* s, size_t len)
     root->m = s;
     if (! len) return ezxml_err(root, NULL, "root tag missing");
     root->u = ezxml_str2utf8(&s, &len); /* convert utf-16 to utf-8*/
+    if (! s) return ezxml_err(root, NULL, "invalid root tag"); // bug#13 / CVE-2019-20007
     root->e = (root->s = s) + len; /* record start and end of work area*/
 
     e = s[len - 1]; /* save end char*/

--- a/libdispatch/ezxml.c
+++ b/libdispatch/ezxml.c
@@ -831,12 +831,14 @@ ezxml_new(const char* name)
     static const char* entities[] = { "lt;", "&#60;", "gt;", "&#62;", "quot;", "&#34;",
                            "apos;", "&#39;", "amp;", "&#38;", NULL };
     ezxml_root_t root;
+    char **p_ent;
     if (!(root  = malloc(sizeof(struct ezxml_root)))) return NULL;  // bug#21
+    if (!(p_ent = malloc(sizeof(entities)))) { free(root); return NULL; }; // bug#22 CVE-2021-26222
     root = (ezxml_root_t)memset(root, '\0', sizeof(struct ezxml_root));
     root->xml.name = (char* )name;
     root->cur = &root->xml;
     strcpy(root->err, root->xml.txt = "");
-    root->ent = memcpy(malloc(sizeof(entities)), entities, sizeof(entities));
+    root->ent = memcpy(p_ent, entities, sizeof(entities));
     root->attr = root->pi = (char* **)(root->xml.attr = (char**)EZXML_NIL);
     return &root->xml;
 }

--- a/libdispatch/ezxml.c
+++ b/libdispatch/ezxml.c
@@ -187,6 +187,7 @@ ezxml_decode(char* s, char* *ent, char t)
             *(s++) = '\n';
             if (*s == '\n') memmove(s, (s + 1), strlen(s));
         }
+        if (!*s) break; // bug#19 / CVE-2019-20200
     }
 
     for (s = r; ; ) {

--- a/libdispatch/ezxml.c
+++ b/libdispatch/ezxml.c
@@ -218,9 +218,11 @@ ezxml_decode(char* s, char* *ent, char t)
 
             if (ent[b++]) { /* found a match*/
                 if ((c = strlen(ent[b])) - 1 > (e = strchr(s, ';')) - s) {
+                    if (!e) { s++; continue; } // bug#18 / CVE-2019-20199
                     l = (d = (s - r)) + c + strlen(e); /* new length*/
                     r = (r == m) ? strcpy(malloc(l), r) : realloc(r, l);
                     e = strchr((s = r + d), ';'); /* fix up pointers*/
+		    if (!e) { s++; continue; } // bug#18
                 }
 
                 if(c > strlen(s) || strlen(e) > strlen(s + c)) { /* Patch 28 */

--- a/libdispatch/ezxml.c
+++ b/libdispatch/ezxml.c
@@ -202,6 +202,8 @@ ezxml_decode(char* s, char* *ent, char t)
             if (c < 0x80) *(s++) = c; /* US-ASCII subset*/
             else { /* multi-byte UTF-8 sequence*/
                 for (b = 0, d = c; d; d /= 2) b++; /* number of bits in c*/
+                // UTF-8 can ecode max 36 bits (standard says 21) - noop on 32 bit.
+                if (b > 36) { s++; continue; } // bug#15 CVE-2019-20006 / bug#17 CVE-2019-20202
                 b = (b - 2) / 5; /* number of bytes in payload*/
                 *(s++) = (0xFF << (7 - b)) | (c >> (6 * b)); /* head*/
                 while (b) *(s++) = 0x80 | ((c >> (6 * --b)) & 0x3F); /* payload*/

--- a/libdispatch/ezxml.c
+++ b/libdispatch/ezxml.c
@@ -525,6 +525,7 @@ nc_ezxml_parse_str(char* s, size_t len)
     char q, e, *d, **attr, **a = NULL; /* initialize a to avoid compile warning*/
     int l, i, j;
 
+    if (!root) return NULL; // bug#21 / CVE-2021-26221
     root->m = s;
     if (! len) return ezxml_err(root, NULL, "root tag missing");
     root->u = ezxml_str2utf8(&s, &len); /* convert utf-16 to utf-8*/
@@ -829,8 +830,9 @@ ezxml_new(const char* name)
 {
     static const char* entities[] = { "lt;", "&#60;", "gt;", "&#62;", "quot;", "&#34;",
                            "apos;", "&#39;", "amp;", "&#38;", NULL };
-    ezxml_root_t root = (ezxml_root_t)memset(malloc(sizeof(struct ezxml_root)),
-                                             '\0', sizeof(struct ezxml_root));
+    ezxml_root_t root;
+    if (!(root  = malloc(sizeof(struct ezxml_root)))) return NULL;  // bug#21
+    root = (ezxml_root_t)memset(root, '\0', sizeof(struct ezxml_root));
     root->xml.name = (char* )name;
     root->cur = &root->xml;
     strcpy(root->err, root->xml.txt = "");


### PR DESCRIPTION
This series of patches addresses the CVEs mentioned in issue #2119 that have not been addressed by commit b5d4afd1d55b4ead340ed6d1b4eb1c7016e843cc.

- CVE-2021-31598, CVE-2019-20202 and CVE-2019-20006 share the same root cause, however, the fix from [bug#28](https://sourceforge.net/p/ezxml/bugs/28/) was bogus and is therefore backed out and replaced. The reproducers demonstrate one instance of a class of similar issues (not checking the result of str[c]spn()) - so far, only the reproducer is fixed.
- CVE-2019-20198, CVE-2019-20201 and CVE-2021-31229 share the same root cause and are fixed already - the affected code is however not used by netcdf-c.
- CVE-2019-20005 cannot be reproduced with the provided reproducer.
- CVE-2019-20007 fixed
- CVE-2019-20199 fixed
- CVE-2019-20200 fixed
- CVE-2021-26220, CVE-2021-26221 and CVE-2021-26222 belong to the same class of problems: missing checks for failure of (re-)alloc. CVE-2021-26220 covers code not relevant for netcdf-c, the other two are fixed. The provided fix addresses only the provided reproducers.
- CVE-2021-30485, CVE-2021-31348 / CVE-2021-31347 have been fixed already.
