### PR TITLE
Fix a number of OS specific bugs

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,7 @@ This file contains a high-level description of this package's evolution. Release
 
 ## 4.8.2 - TBD
 
+* [Bug Fix] Fix several mingw related errors. See [Github #????](https://github.com/Unidata/netcdf-c/pull/????).
 * [Enhancement] Support byte-range reading of netcdf-3 files stored in private buckets in S3. See [Github #2134](https://github.com/Unidata/netcdf-c/pull/2134)
 * [Enhancement] Support Amazon S3 access for NCZarr. Also support use of the existing Amazon SDK credentials system. See [Github #2114](https://github.com/Unidata/netcdf-c/pull/2114)
 * [Bug Fix] Fix string allocation error in H5FDhttp.c. See [Github #2127](https://github.com/Unidata/netcdf-c/pull/2127).

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,7 +7,7 @@ This file contains a high-level description of this package's evolution. Release
 
 ## 4.8.2 - TBD
 
-* [Bug Fix] Fix several mingw related errors. See [Github #????](https://github.com/Unidata/netcdf-c/pull/????).
+* [Bug Fix] Fix several os related errors. See [Github #2138](https://github.com/Unidata/netcdf-c/pull/2138).
 * [Enhancement] Support byte-range reading of netcdf-3 files stored in private buckets in S3. See [Github #2134](https://github.com/Unidata/netcdf-c/pull/2134)
 * [Enhancement] Support Amazon S3 access for NCZarr. Also support use of the existing Amazon SDK credentials system. See [Github #2114](https://github.com/Unidata/netcdf-c/pull/2114)
 * [Bug Fix] Fix string allocation error in H5FDhttp.c. See [Github #2127](https://github.com/Unidata/netcdf-c/pull/2127).

--- a/configure.ac
+++ b/configure.ac
@@ -1170,14 +1170,17 @@ case "`uname`" in
   CYGWIN*) ISCYGWIN=yes;;
   Darwin*) ISOSX=yes;;
   WIN*) ISMSVC=yes;;
+  MINGW*) ISMINGW=yes;;
 esac
 AM_CONDITIONAL(ISCYGWIN, [test "x$ISCYGWIN" = xyes])
 AM_CONDITIONAL(ISMSVC, [test "x$ISMSVC" = xyes])
 AM_CONDITIONAL(ISOSX, [test "x$ISOSX" = xyes])
+AM_CONDITIONAL(ISMINGW, [test "x$ISMINGW" = xyes])
 
 AC_SUBST([ISMSVC], [${ISMSVC}])
 AC_SUBST([ISCYGWIN], [${ISCYGWIN}])
 AC_SUBST([ISOSX], [${ISOSX}])
+AC_SUBST([ISMINGW], [${ISMINGW}])
 
 ###
 # Crude hack to work around an issue

--- a/include/ncconfigure.h
+++ b/include/ncconfigure.h
@@ -60,9 +60,6 @@ extern long long int strtoll(const char*, char**, int);
 #ifndef strtoull
 extern unsigned long long int strtoull(const char*, char**, int);
 #endif
-#ifndef fileno
-extern int fileno(FILE*);
-#endif
 
 #endif /*STDC*/
 #endif /*!_WIN32*/

--- a/include/ncrc.h
+++ b/include/ncrc.h
@@ -19,6 +19,7 @@ and accessing rc files (e.g. .daprc).
 /* getenv() keys */
 #define NCRCENVIGNORE "NCRCENV_IGNORE"
 #define NCRCENVRC "NCRCENV_RC"
+#define NCRCENVHOME "NCRCENV_HOME"
 
 /* Known .aws profile keys */
 #define AWS_ACCESS_KEY_ID "aws_access_key_id"
@@ -38,6 +39,7 @@ typedef struct NCRCinfo {
 	int loaded; /* 1 => already loaded */
         NClist* entries; /* the rc file entry store fields*/
         char* rcfile; /* specified rcfile; overrides anything else */
+        char* rchome; /* Overrides $HOME when looking for .rc files */
 } NCRCinfo;
 
 /* Collect global state info in one place */

--- a/libdispatch/dpathmgr.c
+++ b/libdispatch/dpathmgr.c
@@ -871,10 +871,12 @@ getlocalpathkind(void)
     int kind = NCPD_UNKNOWN;
 #ifdef __CYGWIN__
 	kind = NCPD_CYGWIN;
-#elif __MSYS__
-	kind = NCPD_MSYS;
-#elif _MSC_VER /* not _WIN32 */
+#elif defined __MINGW32__
 	kind = NCPD_WIN;
+#elif defined _MSC_VER /* not _WIN32 */
+	kind = NCPD_WIN;
+#elif defined __MSYS__
+	kind = NCPD_MSYS;
 #else
 	kind = NCPD_NIX;
 #endif

--- a/libdispatch/drc.c
+++ b/libdispatch/drc.c
@@ -127,6 +127,18 @@ ncrc_initialize(void)
     }
 }
 
+static void
+ncrc_setrchome(void)
+{
+    const char* tmp = NULL;
+    if(ncrc_globalstate->rcinfo.rchome) return;
+    assert(ncrc_globalstate && ncrc_globalstate->home);
+    tmp = getenv(NCRCENVHOME);
+    if(tmp == NULL || strlen(tmp) == 0)
+	tmp = ncrc_globalstate->home;
+    ncrc_globalstate->rcinfo.rchome = strdup(tmp);
+}
+
 /* Get global state */
 NCRCglobalstate*
 ncrc_getglobalstate(void)
@@ -155,6 +167,7 @@ NC_rcclear(NCRCinfo* info)
 {
     if(info == NULL) return;
     nullfree(info->rcfile);
+    nullfree(info->rchome);
     rcfreeentries(info->entries);
 }
 
@@ -193,9 +206,9 @@ NC_rcload(void)
     /* locate the configuration files in order of use:
        1. Specified by NCRCENV_RC environment variable.
        2. If NCRCENV_RC is not set then merge the set of rc files in this order:
-	  1. $HOME/.ncrc
-  	  2. $HOME/.daprc
-	  3. $HOME/.docsrc
+	  1. $RCHOME/.ncrc
+  	  2. $RCHOME/.daprc
+	  3. $RCHOME/.docsrc
 	  4. $CWD/.ncrc
   	  5. $CWD/.daprc
 	  6. $CWD/.docsrc
@@ -208,7 +221,11 @@ NC_rcload(void)
 	const char* dirnames[3];
 	const char** dir;
 	
-	dirnames[0] = globalstate->home;
+        
+	/* Make sure rcinfo.rchome is defined */
+	ncrc_setrchome();
+	
+	dirnames[0] = globalstate->rcinfo.rchome;
 	dirnames[1] = globalstate->cwd;
 	dirnames[2] = NULL;
 

--- a/libdispatch/dutil.c
+++ b/libdispatch/dutil.c
@@ -256,6 +256,8 @@ NC_writefile(const char* filename, size_t size, void* content)
     void* p;
     size_t remain;
 
+    if(content == NULL) {content = ""; size = 0;}
+
 #ifdef _WIN32
     stream = NCfopen(filename,"wb");
 #else
@@ -343,7 +345,8 @@ done:
     return found;
 }
 
-#ifdef __APPLE__
+#if ! defined __INTEL_COMPILER 
+#if defined __APPLE__ 
 int isinf(double x)
 {
     union { unsigned long long u; double f; } ieee754;
@@ -361,6 +364,8 @@ int isnan(double x)
 }
 
 #endif /*APPLE*/
+#endif /*!_INTEL_COMPILER*/
+
 
 int
 NC_split_delim(const char* arg, char delim, NClist* segments)

--- a/ncdump/CMakeLists.txt
+++ b/ncdump/CMakeLists.txt
@@ -160,13 +160,13 @@ endif()
     SET_TARGET_PROPERTIES(nctrunc PROPERTIES RUNTIME_OUTPUT_DIRECTORY_RELEASE
       ${CMAKE_CURRENT_BINARY_DIR})
 
-IF(RCMERGE)
-    SET_TARGET_PROPERTIES(tst_rcmerge PROPERTIES RUNTIME_OUTPUT_DIRECTORY
-      ${CMAKE_CURRENT_BINARY_DIR})
-    SET_TARGET_PROPERTIES(tst_rcmerge PROPERTIES RUNTIME_OUTPUT_DIRECTORY_DEBUG
-      ${CMAKE_CURRENT_BINARY_DIR})
-    SET_TARGET_PROPERTIES(tst_rcmerge PROPERTIES RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_CURRENT_BINARY_DIR})
-endif()
+    IF(RCMERGE)
+        SET_TARGET_PROPERTIES(tst_rcmerge PROPERTIES RUNTIME_OUTPUT_DIRECTORY
+          ${CMAKE_CURRENT_BINARY_DIR})
+        SET_TARGET_PROPERTIES(tst_rcmerge PROPERTIES RUNTIME_OUTPUT_DIRECTORY_DEBUG
+          ${CMAKE_CURRENT_BINARY_DIR})
+        SET_TARGET_PROPERTIES(tst_rcmerge PROPERTIES RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_CURRENT_BINARY_DIR})
+    endif()
 
     IF(USE_HDF5)
       SET_TARGET_PROPERTIES(tst_fileinfo PROPERTIES RUNTIME_OUTPUT_DIRECTORY
@@ -189,7 +189,6 @@ endif()
   add_sh_test(ncdump tst_64bit)
   add_bin_test_no_prefix(ref_ctest)
   add_bin_test_no_prefix(ref_ctest64)
-  add_sh_test(ncdump tst_output)
   add_sh_test(ncdump tst_lengths)
   add_sh_test(ncdump tst_calendars)
   build_bin_test_no_prefix(tst_utf8)
@@ -200,15 +199,21 @@ endif()
     add_sh_test(ncdump tst_hdf5_offset)
   ENDIF(USE_HDF5)
 
+  IF(NOT MSVC AND NOT MINGW)
+      add_sh_test(ncdump tst_output)
+  ENDIF()
+
   add_sh_test(ncdump tst_null_byte_padding)
   IF(USE_STRICT_NULL_BYTE_HEADER_PADDING)
     SET_TESTS_PROPERTIES(ncdump_tst_null_byte_padding PROPERTIES WILL_FAIL TRUE)
   ENDIF(USE_STRICT_NULL_BYTE_HEADER_PADDING)
 
-  add_sh_test(ncdump tst_nccopy3)
-  IF(HAVE_BASH)
-    SET_TESTS_PROPERTIES(ncdump_tst_nccopy3 PROPERTIES RUN_SERIAL TRUE)
-  ENDIF(HAVE_BASH)
+  IF(NOT MSVC AND NOT MINGW)
+      add_sh_test(ncdump tst_nccopy3)
+      IF(HAVE_BASH)
+        SET_TESTS_PROPERTIES(ncdump_tst_nccopy3 PROPERTIES RUN_SERIAL TRUE)
+      ENDIF(HAVE_BASH)
+  ENDIF()
 
   add_sh_test(ncdump tst_nccopy3_subset)
   add_sh_test(ncdump tst_charfill)
@@ -256,10 +261,11 @@ endif()
     # formatting omits a 0.
     ###
     IF(EXTRA_TESTS)
-      add_sh_test(ncdump run_back_comp_tests)
-      IF(MSVC)
-        SET_TESTS_PROPERTIES(ncdump_run_back_comp_tests PROPERTIES WILL_FAIL TRUE)
-      ENDIF(MSVC)
+      IF(USE_HDF5)
+        IF(NOT MSVC AND NOT MINGW)
+          add_sh_test(ncdump run_back_comp_tests)
+        ENDIF()
+      ENDIF()
     ENDIF(EXTRA_TESTS)
 
     # Known failure on MSVC; the number of 0's padding
@@ -272,10 +278,11 @@ endif()
     build_bin_test_no_prefix(tst_fillbug)
     add_sh_test(ncdump_sh tst_fillbug)
 
-    add_sh_test(ncdump tst_netcdf4_4)
-    IF(MSVC AND HAVE_BASH)
-      SET_TESTS_PROPERTIES(ncdump_tst_netcdf4_4 PROPERTIES WILL_FAIL TRUE)
-    ENDIF(MSVC AND HAVE_BASH)
+    IF(HAVE_BASH)
+      IF(NOT MSVC AND NOT MINGW)
+        add_sh_test(ncdump tst_netcdf4_4)
+      ENDIF()
+    ENDIF(HAVE_BASH)
 
     ###
     # Some test reordering was required to ensure these tests
@@ -324,11 +331,11 @@ endif()
   IF(USE_HDF5)
     IF(HAVE_BASH)
       build_bin_test_no_prefix(tst_unicode)
-      IF(NOT MSVC)
+      IF(NOT MSVC AND NOT MINGW)
         # These tests do not work under windows
         add_sh_test(ncdump test_unicode_directory)
         add_sh_test(ncdump test_unicode_path)
-      ENDIF(NOT MSVC)
+      ENDIF()
     ENDIF(HAVE_BASH)
   ENDIF(USE_HDF5)
 

--- a/ncdump/Makefile.am
+++ b/ncdump/Makefile.am
@@ -76,10 +76,11 @@ bom tst_dimsizes nctrunc tst_rcmerge
 
 # Tests for classic and 64-bit offset files.
 TESTS = tst_inttags.sh run_tests.sh tst_64bit.sh ref_ctest	\
-ref_ctest64 tst_output.sh tst_lengths.sh tst_calendars.sh	\
-run_utf8_tests.sh tst_nccopy3.sh tst_nccopy3_subset.sh		\
+ref_ctest64 tst_lengths.sh tst_calendars.sh	\
+run_utf8_tests.sh tst_nccopy3_subset.sh		\
 tst_charfill.sh tst_iter.sh tst_formatx3.sh tst_bom.sh		\
-tst_dimsizes.sh run_ncgen_tests.sh tst_ncgen4_classic.sh test_radix.sh #test_rcmerge.sh
+tst_dimsizes.sh run_ncgen_tests.sh tst_ncgen4_classic.sh        \
+test_radix.sh test_rcmerge.sh
 
 # The tst_nccopy3.sh test uses output from a bunch of other
 # tests. This records the dependency so parallel builds work.
@@ -89,10 +90,6 @@ tst_64bit.log run_tests.log tst_lengths.log
 TESTS += tst_null_byte_padding.sh
 if USE_STRICT_NULL_BYTE_HEADER_PADDING
 XFAIL_TESTS += tst_null_byte_padding.sh
-endif
-
-if ! ISCYGWIN
-TESTS += test_unicode_directory.sh  test_unicode_path.sh
 endif
 
 if LARGE_FILE_TESTS
@@ -113,9 +110,9 @@ check_PROGRAMS += tst_vlen_demo
 
 # Tests for netCDF-4 behavior.
 TESTS += tst_fileinfo.sh tst_hdf5_offset.sh tst_inttags4.sh		\
-tst_netcdf4.sh tst_fillbug.sh tst_netcdf4_4.sh tst_nccopy4.sh		\
+tst_netcdf4.sh tst_fillbug.sh tst_nccopy4.sh		\
 tst_nccopy5.sh tst_grp_spec.sh tst_mud.sh tst_h_scalar.sh tst_formatx4.sh		\
-run_utf8_nc4_tests.sh run_back_comp_tests.sh run_ncgen_nc4_tests.sh	\
+run_utf8_nc4_tests.sh run_ncgen_nc4_tests.sh	\
 tst_ncgen4.sh test_scope.sh
 
 # Record interscript dependencies so parallel builds work.
@@ -137,6 +134,16 @@ endif
 if ENABLE_CDF5
 # Test for keywords as identifiers
 TESTS += test_keywords.sh
+endif
+
+if ! ISMINGW
+if ! ISCYGWIN
+TESTS += tst_output.sh tst_nccopy3.sh
+TESTS += test_unicode_directory.sh  test_unicode_path.sh
+if USE_HDF5
+TESTS += run_back_comp_tests.sh tst_netcdf4_4.sh
+endif
+endif
 endif
 
 endif BUILD_TESTSETS
@@ -228,4 +235,5 @@ scope_*.nc copy_scope_*.cdl
 
 # Remove directories
 clean-local:
-	rm -fr rcmergedir
+	rm -fr rcmergedir rchome
+

--- a/ncdump/ref_rcmerge1.txt
+++ b/ncdump/ref_rcmerge1.txt
@@ -1,6 +1,6 @@
-|ncrc_home|->|ncrc|
 |daprc_home|->|daprc|
-|dodsrc_home|->|dodsrc|
-|ncrc_local|->|ncrc|
 |daprc_local|->|daprc|
+|dodsrc_home|->|dodsrc|
 |dodsrc_local|->|dodsrc|
+|ncrc_home|->|ncrc|
+|ncrc_local|->|ncrc|

--- a/ncdump/ref_rcmerge2.txt
+++ b/ncdump/ref_rcmerge2.txt
@@ -1,3 +1,3 @@
-|ncrc|->|ncrc|
 |daprc|->|daprc|
 |dodsrc|->|dodsrc|
+|ncrc|->|ncrc|

--- a/ncdump/ref_rcmerge3.txt
+++ b/ncdump/ref_rcmerge3.txt
@@ -1,3 +1,3 @@
+|daprc|->|daprc|
 |ncrc|->|ncrc2|
 |ncrcx|->|ncrcy|
-|daprc|->|daprc|

--- a/ncgen/ncgen.l
+++ b/ncgen/ncgen.l
@@ -671,7 +671,6 @@ Return the value.
 static unsigned long long
 parseULL(int radix, char* text, int* failp)
 {
-    extern int errno;
     char* endptr;
     unsigned long long uint64 = 0;
 

--- a/test_common.in
+++ b/test_common.in
@@ -11,6 +11,7 @@ TOPBUILDDIR='@abs_top_builddir@'
 FP_ISCMAKE=@ISCMAKE@
 FP_ISMSVC=@ISMSVC@
 FP_ISCYGWIN=@ISCYGWIN@
+FP_ISMINGW=@ISMINGW@
 
 # Feature flags
 FEATURE_HDF5=@HAS_HDF5@
@@ -74,6 +75,13 @@ set -e
 
 # Allow global set -x mechanism for debugging.
 if test "x$SETX" = x1 ; then set -x ; fi
+
+# On MINGW, bash and other POSIX utilities use a mounted root directory,
+# but executables compiled for Windows do not recognise the mount point.
+# Here we ensure that Windows paths are used in tests of Windows executables.
+if test "x@ISMINGW@" = xyes; then
+  alias pwd='pwd -W'
+fi
 
 # We assume that TOPSRCDIR and TOPBUILDDIR are defined
 # At the top of this shell script

--- a/unit_test/tst_xcache.c
+++ b/unit_test/tst_xcache.c
@@ -93,7 +93,7 @@ generatestrings(int n, unsigned seed)
 	len = rnd % MAXSTRLEN;
 	/* generate the characters */
 	for(k=0;k<len;k++) {
-	    do {rnd = random() % 127;} while(rnd < ' ');
+	    do {rnd = random() % 127;} while(rnd <= ' ');
 	    assert(rnd > ' ' && rnd < 127);
 	    s[k] = (char)rnd;
 	}


### PR DESCRIPTION
1. Issue https://github.com/Unidata/netcdf-c/issues/2043
   * FreeBSD build fails because of conflicts in defining the fileno() function. So removed all extern declarations of fileno.

2. Issue https://github.com/Unidata/netcdf-c/issues/2124
   * There were a couple of problems here.
     * I was conflating msys with mingw and they need separate handling of paths. So treat mingw like windows.
     * memio.c was not always writing the full content of the memory to file. Untested fix by properly accounting for zero size writes.
     * Fix bug when skipping white space in tst_xcache.c

3. Issue https://github.com/Unidata/netcdf-c/pull/2105
   * On MINGW, bash and other POSIX utilities use a mounted root directory,
     but executables compiled for Windows do not recognise the mount point.
     Ensure that Windows paths are used in tests of Windows executables.

4. Issue https://github.com/Unidata/netcdf-c/issues/2132
   * Apparently the Intel C compiler on OSX defines isnan etc.
     So disable declaration in dutil.c under that condition.

5. Fix and re-enable test_rcmerge.sh by allowing override of where to
   look for .rc files

6. CMakeLists.txt suppresses certain ncdump directory tests because of differences in printing floats/doubles.
   * Extend the list to include those that also fail under mingw.
   * Suppress the mingw tests in ncdump/Makefile.am