### PR TITLE
Fix use of S3 with a non-AWS appliances

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,7 +7,7 @@ This file contains a high-level description of this package's evolution. Release
 
 ## 4.8.2 - TBD
 
-* [Bug Fix] Fix use of non-aws appliances. See [Github #????](https://github.com/Unidata/netcdf-c/pull/????).
+* [Bug Fix] Fix use of non-aws appliances. See [Github #2152](https://github.com/Unidata/netcdf-c/pull/2152).
 * [Enhancement] Added options to suppress the new behavior from [Github #2135](https://github.com/Unidata/netcdf-c/pull/2135).  The options for `cmake` and `configure` are, respectively `-DENABLE_LIBXML2` and `--(enable/disable)-libxml2`. Both of these options defaul to 'on/enabled'.  When disabled, the bundled `ezxml` XML interpreter is used regardless of whether `libxml2` is present on the system. 
 * [Enhancement] Support optional use of libxml2, otherwise default to ezxml. See [Github #2135](https://github.com/Unidata/netcdf-c/pull/2135) -- H/T to [Egbert Eich](https://github.com/e4t).
 * [Bug Fix] Fix several os related errors. See [Github #2138](https://github.com/Unidata/netcdf-c/pull/2138).

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,7 @@ This file contains a high-level description of this package's evolution. Release
 
 ## 4.8.2 - TBD
 
+* [Bug Fix] Fix use of non-aws appliances. See [Github #????](https://github.com/Unidata/netcdf-c/pull/????).
 * [Enhancement] Added options to suppress the new behavior from [Github #2135](https://github.com/Unidata/netcdf-c/pull/2135).  The options for `cmake` and `configure` are, respectively `-DENABLE_LIBXML2` and `--(enable/disable)-libxml2`. Both of these options defaul to 'on/enabled'.  When disabled, the bundled `ezxml` XML interpreter is used regardless of whether `libxml2` is present on the system. 
 * [Enhancement] Support optional use of libxml2, otherwise default to ezxml. See [Github #2135](https://github.com/Unidata/netcdf-c/pull/2135) -- H/T to [Egbert Eich](https://github.com/e4t).
 * [Bug Fix] Fix several os related errors. See [Github #2138](https://github.com/Unidata/netcdf-c/pull/2138).

--- a/include/ncs3sdk.h
+++ b/include/ncs3sdk.h
@@ -10,8 +10,8 @@
 extern "C" {
 #endif
 
-EXTERNL void NC_s3sdkinitialize(void);
-EXTERNL void NC_s3sdkfinalize(void);
+EXTERNL int NC_s3sdkinitialize(void);
+EXTERNL int NC_s3sdkfinalize(void);
 EXTERNL void* NC_s3sdkcreateclient(NCS3INFO* context);
 EXTERNL int NC_s3sdkbucketexists(void* s3client, const char* bucket, int* existsp, char** errmsgp);
 EXTERNL int NC_s3sdkbucketcreate(void* s3client, const char* region, const char* bucket, char** errmsgp);

--- a/libdispatch/ds3util.c
+++ b/libdispatch/ds3util.c
@@ -119,11 +119,12 @@ NC_s3urlrebuild(NCURI* url, NCURI** newurlp, char** bucketp, char** outregionp)
 	if((stat = NC_getdefaults3region(url,&region0))) goto done;
 	region = strdup(region0);
     }
-    /* Construct the revised host */
-    ncbytescat(buf,"s3.");
-    ncbytescat(buf,region);
-    ncbytescat(buf,AWSHOST);
-    host = ncbytesextract(buf);
+    if(host == NULL) { /* Construct the revised host */
+        ncbytescat(buf,"s3.");
+        ncbytescat(buf,region);
+        ncbytescat(buf,AWSHOST);
+        host = ncbytesextract(buf);
+    }
 
     /* Construct the revised path */
     ncbytesclear(buf);

--- a/libdispatch/ncs3sdk.cpp
+++ b/libdispatch/ncs3sdk.cpp
@@ -65,7 +65,7 @@ dumps3info(NCS3INFO* info)
     return text;
 }
 
-EXTERNL void
+EXTERNL int
 NC_s3sdkinitialize(void)
 {
     if(!ncs3_initialized) {
@@ -75,9 +75,10 @@ NC_s3sdkinitialize(void)
 	Aws::InitAPI(ncs3options);
 	NCUNTRACE(NC_NOERR);
     }
+    return 1;
 }
 
-EXTERNL void
+EXTERNL int
 NC_s3sdkfinalize(void)
 {
     if(!ncs3_finalized) {
@@ -87,6 +88,7 @@ NC_s3sdkfinalize(void)
         Aws::ShutdownAPI(ncs3options);
         NCUNTRACE(NC_NOERR);
     }
+    return 1;
 }
 
 static char*

--- a/liblib/nc_initialize.c
+++ b/liblib/nc_initialize.c
@@ -47,8 +47,8 @@ extern int NC_HDF4_finalize(void);
 #endif
 
 #ifdef ENABLE_S3_SDK
-extern int NC_s3sdkinitialize(void);
-extern int NC_s3sdkfinalize(void);
+EXTERNL int NC_s3sdkinitialize(void);
+EXTERNL int NC_s3sdkfinalize(void);
 #endif
 
 #ifdef _MSC_VER

--- a/ncdap_test/Makefile.am
+++ b/ncdap_test/Makefile.am
@@ -7,10 +7,10 @@
 include $(top_srcdir)/lib_flags.am
 
 # Un comment to use a more verbose test driver
-SH_LOG_DRIVER = $(SHELL) $(top_srcdir)/test-driver-verbose
-LOG_DRIVER = $(SHELL) $(top_srcdir)/test-driver-verbose
-TEST_LOG_DRIVER = $(SHELL) $(top_srcdir)/test-driver-verbose
-TESTS_ENVIRONMENT += export SETX=1;
+#SH_LOG_DRIVER = $(SHELL) $(top_srcdir)/test-driver-verbose
+#LOG_DRIVER = $(SHELL) $(top_srcdir)/test-driver-verbose
+#TEST_LOG_DRIVER = $(SHELL) $(top_srcdir)/test-driver-verbose
+#TESTS_ENVIRONMENT += export SETX=1;
 
 # Note which tests depend on other tests. Necessary for make -j check.
 TEST_EXTENSIONS = .sh

--- a/ncdap_test/Makefile.am
+++ b/ncdap_test/Makefile.am
@@ -7,9 +7,10 @@
 include $(top_srcdir)/lib_flags.am
 
 # Un comment to use a more verbose test driver
-#SH_LOG_DRIVER = $(SHELL) $(top_srcdir)/test-driver-verbose
-#LOG_DRIVER = $(SHELL) $(top_srcdir)/test-driver-verbose
-#TEST_LOG_DRIVER = $(SHELL) $(top_srcdir)/test-driver-verbose
+SH_LOG_DRIVER = $(SHELL) $(top_srcdir)/test-driver-verbose
+LOG_DRIVER = $(SHELL) $(top_srcdir)/test-driver-verbose
+TEST_LOG_DRIVER = $(SHELL) $(top_srcdir)/test-driver-verbose
+TESTS_ENVIRONMENT += export SETX=1;
 
 # Note which tests depend on other tests. Necessary for make -j check.
 TEST_EXTENSIONS = .sh

--- a/ncdap_test/findtestserver.c.in
+++ b/ncdap_test/findtestserver.c.in
@@ -87,7 +87,7 @@ main(int argc, char** argv)
     }
     url = nc_findtestserver(servlet,serverlist);
     if(url == NULL) {
-       url = "";
+       url = strdup("");
        fprintf(stderr,"not found: %s\n",servlet);
     }
     printf("%s",url);

--- a/nczarr_test/run_interop.sh
+++ b/nczarr_test/run_interop.sh
@@ -69,19 +69,22 @@ case "$zext" in
 	testcasezip ref_quotes zarr metaonly
 	;;
     s3)
-	# Read a test case created by netcdf-java zarr.
-	# Move into position
-        rm -f ${execdir}/ref_zarr_test_data.cdl
-        if gunzip -c < ${srcdir}/ref_zarr_test_data.cdl.gz > ${execdir}/ref_zarr_test_data.cdl ; then
-            testcases3 zarr_test_data.zarr ref_zarr_test_data xarray
+	# Test file does not exist on stratus
+	if test "x$NCZARR_S3_TEST_HOST" = "xs3.us-east-1.amazonaws.com" ; then
+  	    # Read a test case created by netcdf-java zarr.
+	    # Move into position
+            rm -f ${execdir}/ref_zarr_test_data.cdl
+            if gunzip -c < ${srcdir}/ref_zarr_test_data.cdl.gz > ${execdir}/ref_zarr_test_data.cdl ; then
+                testcases3 zarr_test_data.zarr ref_zarr_test_data xarray
+            fi
         fi
 	;;
     *) echo "unimplemented kind: $1" ; exit 1;;
 esac
 }
 
-#testallcases file
-#if test "x$FEATURE_NCZARR_ZIP" = xyes ; then testallcases zip; fi
+testallcases file
+if test "x$FEATURE_NCZARR_ZIP" = xyes ; then testallcases zip; fi
 if test "x$FEATURE_S3TESTS" = xyes ; then testallcases s3; fi
 exit
 # Cleanup


### PR DESCRIPTION
* Fixes https://github.com/Unidata/netcdf-c/issues/2151

The use of a non-AWS appliance broke during the switch to testing
against Amazon S3.
So make necessary changes to get non-AWS appliances work correctly.