### PR TITLE
Temporarily disable dap remote tests

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -524,9 +524,9 @@ enable_dap4=$enable_dap
 # Default is to do the short remote tests.
 AC_MSG_CHECKING([whether dap remote testing should be enabled])
 AC_ARG_ENABLE([dap-remote-tests],
-              [AS_HELP_STRING([--disable-dap-remote-tests],
-                                 [disable dap remote tests])])
-test "x$enable_dap_remote_tests" = xno || enable_dap_remote_tests=yes
+              [AS_HELP_STRING([--enable-dap-remote-tests],
+                                 [enable dap remote tests])])
+test "x$enable_dap_remote_tests" = xyes || enable_dap_remote_tests=no
 if test "x$enable_dap" = "xno" ; then
   enable_dap_remote_tests=no
 fi


### PR DESCRIPTION
The remotetest server is down for a while
because of the log4j security flaw.
So we default to disabling dap-remote-tests.