### PR TITLE
Disable by default dap-remote-tests for CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1038,8 +1038,10 @@ IF(NOT WIN32)
 ENDIF()
 
 # Option to Enable DAP long tests, remote tests.
+# Temporarily disable
+OPTION(ENABLE_DAP_REMOTE_TESTS "Enable DAP remote tests." OFF)
+
 OPTION(ENABLE_DAP_LONG_TESTS "Enable DAP long tests." OFF)
-OPTION(ENABLE_DAP_REMOTE_TESTS "Enable DAP remote tests." ON)
 SET(REMOTETESTSERVERS "remotetest.unidata.ucar.edu" CACHE STRING "test servers to use for remote test")
 
 # See if we have zlib


### PR DESCRIPTION
The remotetest server is down for a while
because of the log4j security flaw.
So we default to disabling dap-remote-tests.
This PR adds disable to CMake