### PR TITLE
Restore default enable for enable-dap-remote-testsc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1038,8 +1038,7 @@ IF(NOT WIN32)
 ENDIF()
 
 # Option to Enable DAP long tests, remote tests.
-# Temporarily disable
-OPTION(ENABLE_DAP_REMOTE_TESTS "Enable DAP remote tests." OFF)
+OPTION(ENABLE_DAP_REMOTE_TESTS "Enable DAP remote tests." ON)
 
 OPTION(ENABLE_DAP_LONG_TESTS "Enable DAP long tests." OFF)
 SET(REMOTETESTSERVERS "remotetest.unidata.ucar.edu" CACHE STRING "test servers to use for remote test")

--- a/configure.ac
+++ b/configure.ac
@@ -526,7 +526,7 @@ AC_MSG_CHECKING([whether dap remote testing should be enabled])
 AC_ARG_ENABLE([dap-remote-tests],
               [AS_HELP_STRING([--enable-dap-remote-tests],
                                  [enable dap remote tests])])
-test "x$enable_dap_remote_tests" = xyes || enable_dap_remote_tests=no
+test "x$enable_dap_remote_tests" = xno || enable_dap_remote_tests=yes
 if test "x$enable_dap" = "xno" ; then
   enable_dap_remote_tests=no
 fi

--- a/ncdap_test/tst_urls.sh
+++ b/ncdap_test/tst_urls.sh
@@ -83,13 +83,17 @@ COLUMBIA="http://iridl.ldeo.columbia.edu/SOURCES/.Models/.NMME/.NASA-GMAO/.MONTH
 # Known to fail
 
 XFAILTESTS=
+
 # Suppress some tests if not windows platform.
-if test "x$platform" == xmingw ; then
+if test "x$FP_ISMSVC" != xyes ; then
     XFAILTESTS="$XFAILTESTS test.67"
 fi
 
 # Following tests must be run as not cached
 NOCACHETESTS="test.07"
+
+# Following tests must be run as not prefetch
+NOPREFETCHTESTS="test.07"
 
 # Following tests must be run as not prefetch
 NOPREFETCHTESTS="test.07"
@@ -158,7 +162,7 @@ for x in ${REMOTETESTS} ; do
     if IGNORE=`echo -n " ${XFAILTESTS} " | fgrep " ${name} "`; then isxfail=1; fi
   fi
   ok=1
-  if ${NCDUMP} ${FLAGS} "${url}" | sed 's/\\r//g' > ${name}.dmp ; then ok=$ok; else ok=0; fi
+  if ${NCDUMP} ${DUMPFLAGS} "${url}" | sed 's/\\r//g' > ${name}.dmp ; then ok=$ok; else ok=0; fi
   # compare with expected
   if diff -w ${EXPECTED}/${name}.dmp ${name}.dmp  ; then ok=$ok; else ok=0; fi
    processstatus


### PR DESCRIPTION
The remote test server is up again. So re-enable.
Also do some test cleanup.