### PR TITLE
Cleanup the CMake inter-test dependencies

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -83,11 +83,11 @@ jobs:
       - run: echo "LD_LIBRARY_PATH=${HOME}/environments/${{ matrix.hdf5 }}/lib" >> $GITHUB_ENV
       - run: |
           echo "ENABLE_HDF4=--disable-hdf4" >> $GITHUB_ENV
-          echo "ENABLE_NC4=--disable-hdf5" >> $GITHUB_ENV
+          echo "ENABLE_HDF5=--disable-hdf5" >> $GITHUB_ENV
         if: matrix.use_nc4 == 'nc3'
       - run: |
           echo "ENABLE_HDF4=--enable-hdf4" >> $GITHUB_ENV
-          echo "ENABLE_NC4=--enable-hdf5" >> $GITHUB_ENV
+          echo "ENABLE_HDF5=--enable-hdf5" >> $GITHUB_ENV
         if: matrix.use_nc4 == 'nc4'
       - run: echo "ENABLE_DAP=--disable-dap" >> $GITHUB_ENV
         if: matrix.use_dap == 'dap_off'
@@ -123,7 +123,7 @@ jobs:
 
       - name: Configure
         shell: bash -l {0}
-        run: CFLAGS=${CFLAGS} LDFLAGS=${LDFLAGS} LD_LIBRARY_PATH=${LD_LIBRARY_PATH} ./configure ${ENABLE_HDF4} ${ENABLE_NC4} ${ENABLE_DAP} ${ENABLE_NCZARR}
+        run: CFLAGS=${CFLAGS} LDFLAGS=${LDFLAGS} LD_LIBRARY_PATH=${LD_LIBRARY_PATH} ./configure ${ENABLE_HDF4} ${ENABLE_HDF5} ${ENABLE_DAP} ${ENABLE_NCZARR}
         if: ${{ success() }}
 
       - name: Look at config.log if error
@@ -152,7 +152,7 @@ jobs:
 
      # - name: Make Distcheck
      #   shell: bash -l {0}
-     #   run: CFLAGS=${CFLAGS} LDFLAGS=${LDFLAGS} LD_LIBRARY_PATH=${LD_LIBRARY_PATH} DISTCHECK_CONFIGURE_FLAGS="${ENABLE_HDF4} ${ENABLE_NC4} ${ENABLE_DAP} ${ENABLE_NCZARR}" make distcheck
+     #   run: CFLAGS=${CFLAGS} LDFLAGS=${LDFLAGS} LD_LIBRARY_PATH=${LD_LIBRARY_PATH} DISTCHECK_CONFIGURE_FLAGS="${ENABLE_HDF4} ${ENABLE_HDF5} ${ENABLE_DAP} ${ENABLE_NCZARR}" make distcheck
      #   if: ${{ success() }}
 
       #- name: Start SSH Debug
@@ -189,11 +189,11 @@ jobs:
       - run: echo "LD_LIBRARY_PATH=${HOME}/environments/${{ matrix.hdf5 }}/lib" >> $GITHUB_ENV
       - run: |
           echo "ENABLE_HDF4=OFF" >> $GITHUB_ENV
-          echo "ENABLE_NC4=OFF" >> $GITHUB_ENV
+          echo "ENABLE_HDF5=OFF" >> $GITHUB_ENV
         if: matrix.use_nc4 == 'nc3'
       - run: |
           echo "ENABLE_HDF4=ON" >> $GITHUB_ENV
-          echo "ENABLE_NC4=ON" >> $GITHUB_ENV
+          echo "ENABLE_HDF5=ON" >> $GITHUB_ENV
         if: matrix.use_nc4 == 'nc4'
       - run: echo "ENABLE_DAP=OFF" >> $GITHUB_ENV
         if: matrix.use_dap == 'dap_off'
@@ -229,7 +229,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          LD_LIBRARY_PATH=${LD_LIBRARY_PATH} cmake .. -DENABLE_HDF4=${ENABLE_HDF4} -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH} -DENABLE_DAP=${ENABLE_DAP} -DENABLE_HDF5=${ENABLE_NC4} -DENABLE_NCZARR=${ENABLE_NCZARR}
+          LD_LIBRARY_PATH=${LD_LIBRARY_PATH} cmake .. -DENABLE_HDF4=${ENABLE_HDF4} -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH} -DENABLE_DAP=${ENABLE_DAP} -DENABLE_HDF5=${ENABLE_HDF5} -DENABLE_NCZARR=${ENABLE_NCZARR}
 
       - name: Print Summary
         shell: bash -l {0}

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,7 @@ This file contains a high-level description of this package's evolution. Release
 
 ## 4.8.2 - TBD
 
+* [Bug Fix] Clean up the various inter-test dependencies in ncdump for CMake. See [Github #????](https://github.com/Unidata/netcdf-c/pull/????).
 * [Enhancement] Added options to suppress the new behavior from [Github #2135](https://github.com/Unidata/netcdf-c/pull/2135).  The options for `cmake` and `configure` are, respectively `-DENABLE_LIBXML2` and `--(enable/disable)-libxml2`. Both of these options defaul to 'on/enabled'.  When disabled, the bundled `ezxml` XML interpreter is used regardless of whether `libxml2` is present on the system. 
 * [Enhancement] Support optional use of libxml2, otherwise default to ezxml. See [Github #2135](https://github.com/Unidata/netcdf-c/pull/2135) -- H/T to [Egbert Eich](https://github.com/e4t).
 * [Bug Fix] Fix several os related errors. See [Github #2138](https://github.com/Unidata/netcdf-c/pull/2138).

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,7 +7,7 @@ This file contains a high-level description of this package's evolution. Release
 
 ## 4.8.2 - TBD
 
-* [Bug Fix] Clean up the various inter-test dependencies in ncdump for CMake. See [Github #????](https://github.com/Unidata/netcdf-c/pull/????).
+* [Bug Fix] Clean up the various inter-test dependencies in ncdump for CMake. See [Github #2168](https://github.com/Unidata/netcdf-c/pull/2168).
 * [Enhancement] Added options to suppress the new behavior from [Github #2135](https://github.com/Unidata/netcdf-c/pull/2135).  The options for `cmake` and `configure` are, respectively `-DENABLE_LIBXML2` and `--(enable/disable)-libxml2`. Both of these options defaul to 'on/enabled'.  When disabled, the bundled `ezxml` XML interpreter is used regardless of whether `libxml2` is present on the system. 
 * [Enhancement] Support optional use of libxml2, otherwise default to ezxml. See [Github #2135](https://github.com/Unidata/netcdf-c/pull/2135) -- H/T to [Egbert Eich](https://github.com/e4t).
 * [Bug Fix] Fix several os related errors. See [Github #2138](https://github.com/Unidata/netcdf-c/pull/2138).

--- a/dap4_test/test_hyrax.sh
+++ b/dap4_test/test_hyrax.sh
@@ -26,7 +26,6 @@ failure() {
 }
 
 setresultdir results_test_hyrax
-
 TESTSERVER=`${execdir}/findtestserver4 dap4 opendap test.opendap.org`
 if test "x$TESTSERVER" = x ; then
 echo "***XFAIL: Cannot find test.opendap.org testserver; test skipped"

--- a/ncdap_test/findtestserver.c.in
+++ b/ncdap_test/findtestserver.c.in
@@ -87,7 +87,7 @@ main(int argc, char** argv)
     }
     url = nc_findtestserver(servlet,serverlist);
     if(url == NULL) {
-       url = "";
+       url = strdup("");
        fprintf(stderr,"not found: %s\n",servlet);
     }
     printf("%s",url);

--- a/ncdap_test/tst_urls.sh
+++ b/ncdap_test/tst_urls.sh
@@ -83,11 +83,8 @@ COLUMBIA="http://iridl.ldeo.columbia.edu/SOURCES/.Models/.NMME/.NASA-GMAO/.MONTH
 # Known to fail
 
 XFAILTESTS=
-
-# Suppress some tests if not windows platform.
-if test "x$FP_ISMSVC" != xyes ; then
-    XFAILTESTS="$XFAILTESTS test.67"
-fi
+# Suppress some tests
+XFAILTESTS="$XFAILTESTS test.67"
 
 # Following tests must be run as not cached
 NOCACHETESTS="test.07"

--- a/ncdump/CMakeLists.txt
+++ b/ncdump/CMakeLists.txt
@@ -111,6 +111,7 @@ IF(MSVC)
 ENDIF()
 
 IF(ENABLE_TESTS)
+
   ADD_EXECUTABLE(rewrite-scalar rewrite-scalar.c)
   ADD_EXECUTABLE(bom bom.c)
   ADD_EXECUTABLE(tst_dimsizes tst_dimsizes.c)
@@ -179,29 +180,57 @@ endif()
     ENDIF(USE_HDF5)
   ENDIF(MSVC)
 
+  # Build support programs
+  build_bin_test_no_prefix(tst_utf8)
+  build_bin_test_no_prefix(tst_fillbug)
+  IF(USE_HDF5)
+    build_bin_test_no_prefix(tst_h_rdc0)
+    build_bin_test_no_prefix(tst_unicode)
+    add_bin_test_no_prefix(tst_create_files)
+    add_bin_test_no_prefix(tst_opaque_data)
+    add_bin_test_no_prefix(tst_string_data)
+    add_bin_test_no_prefix(tst_vlen_data)
+    add_bin_test_no_prefix(tst_comp2)
+    add_bin_test_no_prefix(tst_nans)
+    add_bin_test_no_prefix(tst_h_scalar)
+    add_bin_test_no_prefix(tst_compress)
+    add_bin_test_no_prefix(tst_chunking)
+    add_bin_test_no_prefix(tst_group_data)
+    add_bin_test_no_prefix(tst_enum_data)
+    add_bin_test_no_prefix(tst_comp)
+    # Add this test by hand, as it is also called from a script.
+    # Editing the script would break autotools compatibility.
+    add_bin_test_no_prefix(tst_special_atts)
+  ENDIF(USE_HDF5)
+
   # Base tests
   # The tests are set up as a combination of shell scripts and executables that
   # must be run in a particular order. It is painful but will use macros to help
   # keep it from being too bad.
 
+  IF(HAVE_BASH)
+
   ## Start adding tests in the appropriate order
-  add_sh_test(ncdump run_tests)
-  add_sh_test(ncdump tst_64bit)
   add_bin_test_no_prefix(ref_ctest)
   add_bin_test_no_prefix(ref_ctest64)
+
+  add_sh_test(ncdump run_tests)
+  add_sh_test(ncdump tst_64bit)
   add_sh_test(ncdump tst_lengths)
   add_sh_test(ncdump tst_calendars)
-  build_bin_test_no_prefix(tst_utf8)
   add_sh_test(ncdump run_utf8_tests)
-  IF(USE_HDF5)
-    add_sh_test(ncdump run_utf8_nc4_tests)
-    add_sh_test(ncdump tst_fileinfo)
-    add_sh_test(ncdump tst_hdf5_offset)
-  ENDIF(USE_HDF5)
 
-  IF(NOT MSVC AND NOT MINGW)
-      add_sh_test(ncdump tst_output)
-  ENDIF()
+  add_sh_test(ncdump tst_nccopy3_subset)
+  add_sh_test(ncdump tst_charfill)
+  add_sh_test(ncdump tst_formatx3)
+  add_sh_test(ncdump tst_bom)
+  add_sh_test(ncdump tst_dimsizes)
+  add_sh_test(ncdump tst_inmemory_nc3)
+  add_sh_test(ncdump tst_nccopy_w3)
+  add_sh_test(ncdump run_ncgen_tests)
+  add_sh_test(ncdump tst_inttags)
+  add_sh_test(ncdump test_radix)
+  add_sh_test(ncdump tst_ctests)
 
   add_sh_test(ncdump tst_null_byte_padding)
   IF(USE_STRICT_NULL_BYTE_HEADER_PADDING)
@@ -209,18 +238,41 @@ endif()
   ENDIF(USE_STRICT_NULL_BYTE_HEADER_PADDING)
 
   IF(NOT MSVC AND NOT MINGW)
-      add_sh_test(ncdump tst_nccopy3)
-      IF(HAVE_BASH)
-        SET_TESTS_PROPERTIES(ncdump_tst_nccopy3 PROPERTIES RUN_SERIAL TRUE)
-      ENDIF(HAVE_BASH)
+    add_sh_test(ncdump tst_output)
+    add_sh_test(ncdump tst_nccopy3)
+    # Known failure on MSVC; the number of 0's padding
+    # is different, but the result is actually correct.
+    if(USE_HDF5)
+      add_sh_test(ncdump tst_netcdf4)
+    endif()
+
+    SET_TESTS_PROPERTIES(ncdump_tst_nccopy3 PROPERTIES DEPENDS
+        "ncdump_tst_calendars;ncdump_run_utf8_tests;ncdump_tst_output;ncdump_tst_64bit;ncdump_run_tests;ncdump_tst_lengths")
+
   ENDIF()
 
-  add_sh_test(ncdump tst_nccopy3_subset)
-  add_sh_test(ncdump tst_charfill)
+  IF(USE_HDF5)
+    add_sh_test(ncdump tst_formatx4)
+    add_sh_test(ncdump_sh tst_fillbug)
+    add_sh_test(ncdump_shell tst_h_scalar)
+    add_sh_test(ncdump tst_mud)
+    add_sh_test(ncdump tst_grp_spec)
+    add_sh_test(ncdump tst_nccopy5)
+    add_sh_test(ncdump tst_inttags4)
+    add_sh_test(ncdump run_utf8_nc4_tests)
+    add_sh_test(ncdump tst_fileinfo)
+    add_sh_test(ncdump tst_hdf5_offset)
+    add_sh_test(ncdump tst_inmemory_nc4)
+    add_sh_test(ncdump tst_nccopy_w4)
+    add_sh_test(ncdump run_ncgen_nc4_tests)
+    add_sh_test(ncdump tst_ncgen4)
+    add_sh_test(ncdump tst_netcdf4_4)
+    add_sh_test(ncdump tst_nccopy4)
 
-  add_sh_test(ncdump tst_formatx3)
-  add_sh_test(ncdump tst_bom)
-  add_sh_test(ncdump tst_dimsizes)
+    SET_TESTS_PROPERTIES(ncdump_tst_nccopy4 PROPERTIES DEPENDS "ncdump_run_ncgen_tests;ncdump_tst_output;ncdump_tst_ncgen4;ncdump_tst_fillbug;ncdump_tst_netcdf4_4;ncdump_tst_h_scalar;tst_comp;tst_comp2")
+    SET_TESTS_PROPERTIES(ncdump_tst_nccopy5 PROPERTIES DEPENDS "ncdump_tst_nccopy4")
+
+  ENDIF(USE_HDF5)
 
   # The following test script invokes
   # gcc directly.
@@ -230,97 +282,18 @@ endif()
     ENDIF(ENABLE_LARGE_FILE_TESTS)
   ENDIF(CMAKE_COMPILER_IS_GNUCC OR APPLE)
 
-  add_sh_test(ncdump tst_inmemory_nc3)
-  add_sh_test(ncdump tst_nccopy_w3)
-  IF(USE_HDF5)
-      add_sh_test(ncdump tst_inmemory_nc4)
-      add_sh_test(ncdump tst_nccopy_w4)
-  ENDIF(USE_HDF5)
-
-  IF(USE_HDF5)
-    build_bin_test_no_prefix(tst_create_files)
-    build_bin_test_no_prefix(tst_group_data)
-    build_bin_test_no_prefix(tst_enum_data)
-    build_bin_test_no_prefix(tst_opaque_data)
-    build_bin_test_no_prefix(tst_string_data)
-    build_bin_test_no_prefix(tst_vlen_data)
-    build_bin_test_no_prefix(tst_comp)
-    build_bin_test_no_prefix(tst_comp2)
-    build_bin_test_no_prefix(tst_nans)
-    build_bin_test_no_prefix(tst_h_scalar)
-    add_sh_test(ncdump tst_formatx4)
-    # Add this test by hand, as it is also called from a script.
-    # Editing the script would break autotools compatibility.
-    build_bin_test_no_prefix(tst_special_atts)
-    build_bin_test_no_prefix(tst_compress)
-    build_bin_test_no_prefix(tst_chunking)
-
-    ###
-    # This test fails on Visual Studio builds with bash.
-    # It passes, but technically fails because the scientific
-    # formatting omits a 0.
-    ###
-    IF(EXTRA_TESTS)
-      IF(USE_HDF5)
+  ###
+  # This test fails on Visual Studio builds with bash.
+  # It passes, but technically fails because the scientific
+  # formatting omits a 0.
+  ###
+  IF(EXTRA_TESTS)
+    IF(USE_HDF5)
         IF(NOT MSVC AND NOT MINGW)
           add_sh_test(ncdump run_back_comp_tests)
         ENDIF()
       ENDIF()
-    ENDIF(EXTRA_TESTS)
-
-    # Known failure on MSVC; the number of 0's padding
-    # is different, but the result is actually correct.
-    IF(HAVE_BASH)
-      add_sh_test(ncdump tst_netcdf4)
-      build_bin_test_no_prefix(tst_h_rdc0)
-    ENDIF()
-
-    build_bin_test_no_prefix(tst_fillbug)
-    add_sh_test(ncdump_sh tst_fillbug)
-
-    IF(HAVE_BASH)
-      IF(NOT MSVC AND NOT MINGW)
-        add_sh_test(ncdump tst_netcdf4_4)
-      ENDIF()
-    ENDIF(HAVE_BASH)
-
-    ###
-    # Some test reordering was required to ensure these tests
-    # only ran after ncdump was built.
-    ###
-    add_sh_test(ncdump run_ncgen_tests)
-    IF(USE_HDF5)
-      add_sh_test(ncdump run_ncgen_nc4_tests)
-    ENDIF(USE_HDF5)
-
-    add_sh_test(ncdump tst_grp_spec)
-    add_sh_test(ncdump tst_mud)
-    add_sh_test(ncdump_shell tst_h_scalar)
-
-    add_sh_test(ncdump tst_nccopy4)
-    IF(HAVE_BASH)
-      SET_TESTS_PROPERTIES(ncdump_tst_nccopy4 PROPERTIES RUN_SERIAL TRUE)
-    ENDIF(HAVE_BASH)
-
-    add_sh_test(ncdump tst_nccopy5)
-    IF(HAVE_BASH)
-      SET_TESTS_PROPERTIES(ncdump_tst_nccopy5 PROPERTIES RUN_SERIAL TRUE)
-    ENDIF(HAVE_BASH)
-
-    IF(USE_HDF5)
-      add_sh_test(ncdump tst_ncgen4)
-    ENDIF(USE_HDF5)
-
-  ENDIF(USE_HDF5)
-
-  add_sh_test(ncdump tst_inttags)
-  IF(USE_HDF5)
-    add_sh_test(ncdump tst_inttags4)
-  ENDIF(USE_HDF5)
-
-  add_sh_test(ncdump test_radix)
-
-  add_sh_test(ncdump tst_ctests)
+  ENDIF(EXTRA_TESTS)
 
   IF(ENABLE_UNFIXED_MEMORY_LEAKS)
   SET_TESTS_PROPERTIES(ncdump_run_ncgen_nc4_tests.sh ncdump_tst_nccopy4.sh ncdump_tst_ncgen_shared.sh ncdump_tst_netcdf4.sh
@@ -329,27 +302,26 @@ endif()
 
   # The unicode tests are complicated
   IF(USE_HDF5)
-    IF(HAVE_BASH)
-      build_bin_test_no_prefix(tst_unicode)
       IF(NOT MSVC AND NOT MINGW)
         # These tests do not work under windows
         add_sh_test(ncdump test_unicode_directory)
         add_sh_test(ncdump test_unicode_path)
       ENDIF()
-    ENDIF(HAVE_BASH)
   ENDIF(USE_HDF5)
 
   IF(USE_CDF5)
-  add_sh_test(ncdump test_keywords)
+    add_sh_test(ncdump test_keywords)
   ENDIF()
 
   IF(USE_HDF5)
-  add_sh_test(ncdump test_scope)
+    add_sh_test(ncdump test_scope)
   ENDIF()
 
-if(RCMERGE)
-  add_sh_test(ncdump test_rcmerge)
-endif()
+  if(RCMERGE)
+    add_sh_test(ncdump test_rcmerge)
+  endif()
+
+ENDIF(HAVE_BASH)
 
 ENDIF(ENABLE_TESTS)
 

--- a/ncdump/tst_netcdf4_4.sh
+++ b/ncdump/tst_netcdf4_4.sh
@@ -53,15 +53,15 @@ diff -b tst_string_data.tmp ref_tst_string_data.tmp
 #${NCGEN} -v4 -b -o tst_noncoord.nc ${top_srcdir}/ncdump/ref_tst_noncoord.cdl
 
 echo '*** testing reference file ref_tst_compounds2.nc...'
-${NCDUMP} ${top_srcdir}/ncdump/ref_tst_compounds2.nc > tst_compounds2.cdl
+${NCDUMP} -n ref_tst_compounds2 ${top_srcdir}/ncdump/ref_tst_compounds2.nc > tst_compounds2.cdl
 diff -b tst_compounds2.cdl ${top_srcdir}/ncdump/ref_tst_compounds2.cdl
 
 echo '*** testing reference file ref_tst_compounds3.nc...'
-${NCDUMP} ${top_srcdir}/ncdump/ref_tst_compounds3.nc > tst_compounds3.cdl
+${NCDUMP} -n ref_tst_compounds3 ${top_srcdir}/ncdump/ref_tst_compounds3.nc > tst_compounds3.cdl
 diff -b tst_compounds3.cdl ${top_srcdir}/ncdump/ref_tst_compounds3.cdl
 
 echo '*** testing reference file ref_tst_compounds4.nc...'
-${NCDUMP} ${top_srcdir}/ncdump/ref_tst_compounds4.nc > tst_compounds4.cdl
+${NCDUMP} -n ref_tst_compounds4 ${top_srcdir}/ncdump/ref_tst_compounds4.nc > tst_compounds4.cdl
 diff -b tst_compounds4.cdl ${top_srcdir}/ncdump/ref_tst_compounds4.cdl
 
 # Exercise Jira NCF-213 bug fix


### PR DESCRIPTION
The ncdump test set has a number of inter-test dependencies
that are not properly established in ncdump/CMakeLists.txt.

So this PR attempts to:
1. reorder the tests
2. change tests in CMakeLists.txt from build_bin_test_no_prefix to add_bin_test_no_prefix so they get executed

Plus a couple of minor bug fixes.
1. Change ENABLE_NC4 => ENABLE_HDF5 in github action.
2. fix a memory error in findtestserver.c.in
3. fix bug in ncdap_tests/tst_urls.sh
4. fix netcdf file name bug in tst_netcdf4_4.sh