### PR TITLE
Fix a few memory leaks and erroneous logic in nczarr_test/testfilter_misc

### DIFF
--- a/nc_test4/test_filter_misc.c
+++ b/nc_test4/test_filter_misc.c
@@ -184,22 +184,22 @@ openfile(void)
     }
     if(filterid != TEST_ID) {
         fprintf(stderr,"open: test id mismatch: %d\n",filterid);
+        free(params);
         return NC_EFILTER;
     }
     if(nparams != NPARAMS) {
-	size_t i;
-	unsigned int inqparams[MAXPARAMS];
+        size_t i;
         fprintf(stderr,"nparams  mismatch\n");
         for(nerrs=0,i=0;i<nparams;i++) {
-            if(inqparams[i] != baseline[i]) {
+            if(params[i] != baseline[i]) {
                 fprintf(stderr,"open: testparam mismatch: %ld\n",(unsigned long)i);
-		nerrs++;
-	    }
-	}
+                nerrs++;
+            }
+        }
     }
-    if(nerrs > 0) return NC_EFILTER; 
+    free(params);
 
-    if(params) free(params);
+    if(nerrs > 0) return NC_EFILTER;
 
     /* Verify chunking */
     if(!verifychunks())

--- a/nczarr_test/testfilter_misc.c
+++ b/nczarr_test/testfilter_misc.c
@@ -187,22 +187,21 @@ openfile(void)
     }
     if(filterid != TEST_ID) {
         fprintf(stderr,"open: test id mismatch: %d\n",filterid);
+        free(params);
         return NC_EFILTER;
     }
     if(nparams != NPARAMS) {
-	size_t i;
-	unsigned int inqparams[MAXPARAMS];
+        size_t i;
         fprintf(stderr,"nparams  mismatch\n");
         for(nerrs=0,i=0;i<nparams;i++) {
-            if(inqparams[i] != baseline[i]) {
+            if(params[i] != baseline[i]) {
                 fprintf(stderr,"open: testparam mismatch: %ld\n",(unsigned long)i);
-		nerrs++;
-	    }
-	}
+                nerrs++;
+            }
+        }
     }
-    if(nerrs > 0) return NC_EFILTER; 
-
-    if(params) free(params);
+    free(params);
+    if(nerrs > 0) return NC_EFILTER;
 
     /* Verify chunking */
     if(!verifychunks())


### PR DESCRIPTION
I was just checking to see if the build warnings were meaningful. I feel like some of them are.

This was was "straightforward" to cleanup, but I never saw symptoms of of its "wrongness". 