### PR TITLE
mpi: avoid conflicts with MPI symbols

### DIFF
--- a/docs/known_problems.md
+++ b/docs/known_problems.md
@@ -291,21 +291,6 @@ Known Problems with netCDF 4.0.1
     compilers](#intel_11-ncgen)
 -   ["ncdump -v group/var" reports "group not found"](#ncdump-v)
 
-### Including mpi.h before netcdf.h breaks MPI
-
-Luis Kornblueh reports a subtle bug in netcdf 4.0.1. In the netcdf.h
-header file, the following mpi entities are defined:
-
-     /* These defs added by netCDF configure because parallel HDF5 is not 
-     present. */
-     #define MPI_Comm int
-     #define MPI_Info int
-     #define MPI_COMM_WORLD 0
-     #define MPI_INFO_NULL 0
-
-If mpi.h is included before netcdf.h, these defines (may) break the MPI
-implementation.
-
 ### With Sun C compiler, 64-bit ncdump fails
 
 As identified by Udo Grabowski, using the "-m64" option to build netCDF

--- a/docs/netcdf.m4
+++ b/docs/netcdf.m4
@@ -1395,13 +1395,13 @@ ifelse(PARALLEL_IO,TRUE,
 <<.SH "PARALLEL I/O"
 .LP
 .HP
-FDECL(create_par, (IPATH(), ICMODE(), MPI_Comm comm, MPI_Info info, ONCID()))
+FDECL(create_par, (IPATH(), ICMODE(), nc_MPI_Comm comm, nc_MPI_Info info, ONCID()))
 .sp
 Like FREF(create) but creates for parallel I/O access. The mode must specify a
 netCDF-4/HDF5 dataset.
 .sp
 .HP
-FDECL(open_par, (IPATH(), IMODE(), MPI_Comm comm, MPI_Info info, ONCID()))
+FDECL(open_par, (IPATH(), IMODE(), nc_MPI_Comm comm, nc_MPI_Info info, ONCID()))
 .sp
 Opens for parallel I/O access. Must be a netCDF-4/HDF5 dataset.
 .HP

--- a/docs/old/netcdf-c.texi
+++ b/docs/old/netcdf-c.texi
@@ -847,8 +847,8 @@ main(int argc, char **argv)
     int mpi_namelen;            
     char mpi_name[MPI_MAX_PROCESSOR_NAME];
     int mpi_size, mpi_rank;
-    MPI_Comm comm = MPI_COMM_WORLD;
-    MPI_Info info = MPI_INFO_NULL;
+    nc_MPI_Comm comm = NC_MPI_COMM_WORLD;
+    nc_MPI_Info info = NC_MPI_INFO_NULL;
 
     /* Netcdf-4 stuff. */
     int ncid, v1id, dimids[NDIMS];
@@ -858,8 +858,8 @@ main(int argc, char **argv)
 
     /* Initialize MPI. */
     MPI_Init(&argc,&argv);
-    MPI_Comm_size(MPI_COMM_WORLD, &mpi_size);
-    MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
+    MPI_Comm_size(NC_MPI_COMM_WORLD, &mpi_size);
+    MPI_Comm_rank(NC_MPI_COMM_WORLD, &mpi_rank);
     MPI_Get_processor_name(mpi_name, &mpi_namelen);
     printf("mpi_name: %s size: %d rank: %d\n", mpi_name, 
            mpi_size, mpi_rank);
@@ -1394,8 +1394,8 @@ the default. To use independent access on a variable,
 @heading Usage 
 
 @example
-int nc_create_par(const char *path, int cmode, MPI_Comm comm,
-                  MPI_Info info, int ncidp);
+int nc_create_par(const char *path, int cmode, nc_MPI_Comm comm,
+                  nc_MPI_Info info, int ncidp);
 @end example
 
 @table @code
@@ -1409,10 +1409,10 @@ NC_NETCDF4 flag is used.
 The NC_SHARE flag is ignored.
 
 @item comm
-The MPI_Comm object returned by the MPI layer.
+The nc_MPI_Comm object returned by the MPI layer.
 
 @item info
-The MPI_Info object returned by the MPI layer, if MPI/IO
+The nc_MPI_Info object returned by the MPI layer, if MPI/IO
 is being used, or 0 if MPI/Posix is being used.
 
 @item ncidp
@@ -1684,8 +1684,8 @@ are the default. To use independent access on a variable,
 @heading Usage 
 
 @example
-int nc_open_par(const char *path, int mode, MPI_Comm comm, 
-                MPI_Info info, int *ncidp);
+int nc_open_par(const char *path, int mode, nc_MPI_Comm comm, 
+                nc_MPI_Info info, int *ncidp);
 @end example
 
 @table @code
@@ -1706,10 +1706,10 @@ All other flags are ignored or not allowed. The NC_NETCDF4 flag is not
 required, as the file type is detected when the file is opened.
  
 @item comm
-MPI_Comm object returned by the MPI layer.
+nc_MPI_Comm object returned by the MPI layer.
 
 @item info
-MPI_Info object returned by the MPI layer, or NULL if MPI-POSIX access
+nc_MPI_Info object returned by the MPI layer, or NULL if MPI-POSIX access
 is desired.
 
 @item ncidp

--- a/docs/old/netcdf-f77.texi
+++ b/docs/old/netcdf-f77.texi
@@ -1072,8 +1072,8 @@ This example is from test program nf_test/ftst_parallel.F.
 @example
 !     Create the netCDF file. 
       mode_flag = IOR(nf_netcdf4, nf_classic_model) 
-      retval = nf_create_par(FILE_NAME, mode_flag, MPI_COMM_WORLD, 
-     $     MPI_INFO_NULL, ncid)
+      retval = nf_create_par(FILE_NAME, mode_flag, NC_MPI_COMM_WORLD, 
+     $     NC_MPI_INFO_NULL, ncid)
       if (retval .ne. nf_noerr) stop 2
 @end example
 
@@ -1317,8 +1317,8 @@ This example is from the test program nf_test/ftst_parallel.F.
 
 @example
 !     Reopen the file.
-      retval = nf_open_par(FILE_NAME, nf_nowrite, MPI_COMM_WORLD, 
-     $     MPI_INFO_NULL, ncid)
+      retval = nf_open_par(FILE_NAME, nf_nowrite, NC_MPI_COMM_WORLD, 
+     $     NC_MPI_INFO_NULL, ncid)
       if (retval .ne. nf_noerr) stop 2
 @end example
 

--- a/docs/old/netcdf-f90.texi
+++ b/docs/old/netcdf-f90.texi
@@ -907,13 +907,13 @@ the HDF5 chunk cache.
 @item comm
 If the comm and info parameters are provided the file is created and
 opened for parallel I/O. Set the comm parameter to the MPI
-communicator (of type MPI_Comm). If this parameter is provided the
+communicator (of type nc_MPI_Comm). If this parameter is provided the
 info parameter must also be provided.
 
 @item info
 If the comm and info parameters are provided the file is created and
 opened for parallel I/O. Set the comm parameter to the MPI information
-value (of type MPI_Info). If this parameter is provided the comm
+value (of type nc_MPI_Info). If this parameter is provided the comm
 parameter must also be provided.
 
 @end table
@@ -1042,13 +1042,13 @@ for the HDF5 chunk cache.
 @item comm
 If the comm and info parameters are provided the file is opened for
 parallel I/O. Set the comm parameter to the MPI communicator (of type
-MPI_Comm). If this parameter is provided the info parameter must also
+nc_MPI_Comm). If this parameter is provided the info parameter must also
 be provided.
 
 @item info
 If the comm and info parameters are provided the file is opened for
 parallel I/O. Set the comm parameter to the MPI information value (of
-type MPI_Info). If this parameter is provided the comm parameter must
+type nc_MPI_Info). If this parameter is provided the comm parameter must
 also be provided.
 
 @end table
@@ -1091,8 +1091,8 @@ nf_test/f90tst_parallel.f90.
  integer :: ncid, status
  ...
   ! Reopen the file.
-  call handle_err(nf90_open(FILE_NAME, nf90_nowrite, ncid, comm = MPI_COMM_WORLD, &
-       info = MPI_INFO_NULL))
+  call handle_err(nf90_open(FILE_NAME, nf90_nowrite, ncid, comm = NC_MPI_COMM_WORLD, &
+       info = NC_MPI_INFO_NULL))
 @end example
 
 @node NF90_REDEF, NF90_ENDDEF, NF90_OPEN, Datasets
@@ -6153,8 +6153,8 @@ when configuring netcdf.
 
 @example
   ! Reopen the file.
-  call handle_err(nf90_open(FILE_NAME, nf90_nowrite, ncid, comm = MPI_COMM_WORLD, &
-       info = MPI_INFO_NULL))
+  call handle_err(nf90_open(FILE_NAME, nf90_nowrite, ncid, comm = NC_MPI_COMM_WORLD, &
+       info = NC_MPI_INFO_NULL))
 
   ! Set collective access on this variable. This will cause all
   ! reads/writes to happen together on every processor.

--- a/docs/old/netcdf.texi
+++ b/docs/old/netcdf.texi
@@ -6502,12 +6502,12 @@ following signatures respectively.
 @example
 int (*create)(const char *path, int cmode,
            size_t initialsz, int basepe, size_t *chunksizehintp,
-           int useparallel, MPI_Comm comm, MPI_Info info,
+           int useparallel, nc_MPI_Comm comm, nc_MPI_Info info,
            struct NC_Dispatch*, struct NC** ncp);
 
 int (*open)(const char *path, int mode,
          int basepe, size_t *chunksizehintp,
-         int use_parallel, MPI_Comm comm, MPI_Info info,
+         int use_parallel, nc_MPI_Comm comm, nc_MPI_Info info,
          NC_Dispatch*, NC** ncp);
 @end example
 

--- a/examples/C/parallel_vara.c
+++ b/examples/C/parallel_vara.c
@@ -87,8 +87,8 @@ int main(int argc, char** argv)
     size_t global_ny, global_nx, start[2], count[2];
 
     MPI_Init(&argc, &argv);
-    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-    MPI_Comm_size(MPI_COMM_WORLD, &nprocs);
+    MPI_Comm_rank(NC_MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(NC_MPI_COMM_WORLD, &nprocs);
 
     /* get command-line arguments */
     while ((i = getopt(argc, argv, "hq")) != EOF)
@@ -104,11 +104,11 @@ int main(int argc, char** argv)
     if (argc == 1) strcpy(filename, argv[0]); /* optional argument */
     else strcpy(filename, "testfile.nc");
 
-    MPI_Bcast(filename, 128, MPI_CHAR, 0, MPI_COMM_WORLD);
+    MPI_Bcast(filename, 128, MPI_CHAR, 0, NC_MPI_COMM_WORLD);
 
     /* create a new file for writing ----------------------------------------*/
     cmode = NC_CLOBBER;
-    err = nc_create_par(filename, cmode, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid); FATAL_ERR
+    err = nc_create_par(filename, cmode, NC_MPI_COMM_WORLD, NC_MPI_INFO_NULL, &ncid); FATAL_ERR
 
     /* the global array is NY * (NX * nprocs) */
     global_ny = NY;
@@ -123,7 +123,7 @@ int main(int argc, char** argv)
     asctime_r(localtime(&ltime), str_att);
 
     /* make sure the time string are consistent among all processes */
-    MPI_Bcast(str_att, strlen(str_att), MPI_CHAR, 0, MPI_COMM_WORLD);
+    MPI_Bcast(str_att, strlen(str_att), MPI_CHAR, 0, NC_MPI_COMM_WORLD);
 
     err = nc_put_att_text(ncid, NC_GLOBAL, "history", strlen(str_att),
                           &str_att[0]); ERR
@@ -161,7 +161,7 @@ int main(int argc, char** argv)
     err = nc_close(ncid); ERR
 
     omode = NC_NOWRITE;
-    err = nc_open_par(filename, omode, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid); FATAL_ERR
+    err = nc_open_par(filename, omode, NC_MPI_COMM_WORLD, NC_MPI_INFO_NULL, &ncid); FATAL_ERR
 
     /* inquire dimension IDs and lengths */
     err = nc_inq_dimid(ncid, "Y", &dimid[0]); ERR

--- a/h5_test/tst_h_par.c
+++ b/h5_test/tst_h_par.c
@@ -41,8 +41,8 @@ main(int argc, char **argv)
 #endif /* USE_MPE */
 
     MPI_Init(&argc, &argv);
-    MPI_Comm_rank(MPI_COMM_WORLD, &my_rank);
-    MPI_Comm_size(MPI_COMM_WORLD, &p);
+    MPI_Comm_rank(NC_MPI_COMM_WORLD, &my_rank);
+    MPI_Comm_size(NC_MPI_COMM_WORLD, &p);
 
 #ifdef USE_MPE
     MPE_Init_log();
@@ -88,7 +88,7 @@ main(int argc, char **argv)
 
         /* Create file. */
         if ((fapl_id = H5Pcreate(H5P_FILE_ACCESS)) < 0) ERR;
-        if (H5Pset_fapl_mpio(fapl_id, MPI_COMM_WORLD, MPI_INFO_NULL) < 0) ERR;
+        if (H5Pset_fapl_mpio(fapl_id, NC_MPI_COMM_WORLD, NC_MPI_INFO_NULL) < 0) ERR;
         if ((fileid = H5Fcreate(FILE_NAME, H5F_ACC_TRUNC, H5P_DEFAULT,
                                 fapl_id)) < 0) ERR;
 
@@ -137,7 +137,7 @@ main(int argc, char **argv)
 #endif /* USE_MPE */
         }
         write_us = (MPI_Wtime() - ftime) * MILLION;
-        MPI_Reduce(&write_us, &max_write_us, 1, MPI_INT, MPI_MAX, 0, MPI_COMM_WORLD);
+        MPI_Reduce(&write_us, &max_write_us, 1, MPI_INT, MPI_MAX, 0, NC_MPI_COMM_WORLD);
         if (!my_rank)
         {
             write_rate = (float)(DIM2_LEN * sizeof(int))/(float)max_write_us;
@@ -163,7 +163,7 @@ main(int argc, char **argv)
 
         /* Open the file. */
         if ((fapl_id = H5Pcreate(H5P_FILE_ACCESS)) < 0) ERR;
-        if (H5Pset_fapl_mpio(fapl_id, MPI_COMM_WORLD, MPI_INFO_NULL) < 0) ERR;
+        if (H5Pset_fapl_mpio(fapl_id, NC_MPI_COMM_WORLD, NC_MPI_INFO_NULL) < 0) ERR;
 
 
         if (H5Pset_libver_bounds(fapl_id, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0) ERR;
@@ -208,7 +208,7 @@ main(int argc, char **argv)
                 }
         }
         read_us = (MPI_Wtime() - ftime) * MILLION;
-        MPI_Reduce(&read_us, &max_read_us, 1, MPI_INT, MPI_MAX, 0, MPI_COMM_WORLD);
+        MPI_Reduce(&read_us, &max_read_us, 1, MPI_INT, MPI_MAX, 0, NC_MPI_COMM_WORLD);
         if (!my_rank)
         {
             read_rate = (float)(DIM2_LEN * sizeof(int))/(float)max_read_us;

--- a/h5_test/tst_h_par_compress.c
+++ b/h5_test/tst_h_par_compress.c
@@ -39,8 +39,8 @@ main(int argc, char **argv)
     int p, my_rank;
 
     MPI_Init(&argc, &argv);
-    MPI_Comm_rank(MPI_COMM_WORLD, &my_rank);
-    MPI_Comm_size(MPI_COMM_WORLD, &p);
+    MPI_Comm_rank(NC_MPI_COMM_WORLD, &my_rank);
+    MPI_Comm_size(NC_MPI_COMM_WORLD, &p);
 
     /* For builds with HDF5 prior to 1.10.3, just return success. */
 #ifdef HDF5_SUPPORTS_PAR_FILTERS
@@ -65,7 +65,7 @@ main(int argc, char **argv)
 
 	    /* Create file. */
 	    if ((fapl_id = H5Pcreate(H5P_FILE_ACCESS)) < 0) ERR;
-	    if (H5Pset_fapl_mpio(fapl_id, MPI_COMM_WORLD, MPI_INFO_NULL) < 0) ERR;
+	    if (H5Pset_fapl_mpio(fapl_id, NC_MPI_COMM_WORLD, NC_MPI_INFO_NULL) < 0) ERR;
 	    if ((fileid = H5Fcreate(FILE_NAME, H5F_ACC_TRUNC, H5P_DEFAULT,
 				    fapl_id)) < 0) ERR;
 
@@ -140,7 +140,7 @@ main(int argc, char **argv)
 
 	    /* Open the file. */
 	    if ((fapl_id = H5Pcreate(H5P_FILE_ACCESS)) < 0) ERR;
-	    if (H5Pset_fapl_mpio(fapl_id, MPI_COMM_WORLD, MPI_INFO_NULL) < 0) ERR;
+	    if (H5Pset_fapl_mpio(fapl_id, NC_MPI_COMM_WORLD, NC_MPI_INFO_NULL) < 0) ERR;
 
 
 	    if (H5Pset_libver_bounds(fapl_id, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0) ERR;

--- a/include/nc4internal.h
+++ b/include/nc4internal.h
@@ -291,8 +291,8 @@ typedef struct NC_FILE_INFO
     NC_OBJ hdr;
     NC *controller; /**< Pointer to containing NC. */
 #ifdef USE_PARALLEL4
-    MPI_Comm comm;  /**< Copy of MPI Communicator used to open the file. */
-    MPI_Info info;  /**< Copy of MPI Information Object used to open the file. */
+    nc_MPI_Comm comm;  /**< Copy of MPI Communicator used to open the file. */
+    nc_MPI_Info info;  /**< Copy of MPI Information Object used to open the file. */
 #endif
     int cmode;      /**< Create/Open mode for the file. */
     int flags;      /**< State transition flags . */

--- a/include/ncdispatch.h
+++ b/include/ncdispatch.h
@@ -81,18 +81,23 @@
 #define ATOMICTYPEMAX5 NC_UINT64
 
 #if !defined HDF5_PARALLEL && !defined USE_PNETCDF
-typedef int MPI_Comm;
-typedef int MPI_Info;
-#define MPI_COMM_WORLD 0
-#define MPI_INFO_NULL 0
+typedef int nc_MPI_Comm;
+typedef int nc_MPI_Info;
+#define NC_MPI_COMM_WORLD 0
+#define NC_MPI_INFO_NULL 0
+#else
+typedef MPI_Comm nc_MPI_Comm;
+typedef MPI_Info nc_MPI_Info;
+#define NC_MPI_COMM_WORLD MPI_COMM_WORLD
+#define NC_MPI_INFO_NULL MPI_INFO_NULL
 #endif
 
 /* Define a struct to hold the MPI info so it can be passed down the
  * call stack. This is used internally by the netCDF library. It
  * should not be used by netcdf users. */
 typedef struct NC_MPI_INFO {
-    MPI_Comm comm;
-    MPI_Info info;
+    nc_MPI_Comm comm;
+    nc_MPI_Info info;
 } NC_MPI_INFO;
 
 /* Define known dispatch tables and initializers */

--- a/include/netcdf_par.h
+++ b/include/netcdf_par.h
@@ -33,12 +33,12 @@ extern "C" {
 
 /* Create a file and enable parallel I/O. */
     EXTERNL int
-    nc_create_par(const char *path, int cmode, MPI_Comm comm, MPI_Info info,
+    nc_create_par(const char *path, int cmode, nc_MPI_Comm comm, nc_MPI_Info info,
                   int *ncidp);
 
 /* Open a file and enable parallel I/O. */
     EXTERNL int
-    nc_open_par(const char *path, int mode, MPI_Comm comm, MPI_Info info,
+    nc_open_par(const char *path, int mode, nc_MPI_Comm comm, nc_MPI_Info info,
                 int *ncidp);
 
 /* Change a variable from independent (the default) to collective

--- a/libdap2/obsolete/ncdap4.h
+++ b/libdap2/obsolete/ncdap4.h
@@ -64,7 +64,7 @@ extern int lnc4_close(int ncid);
 
 extern int lnc4_open_file(const char *path, int mode, int basepe,
                           size_t *chunksizehintp, int use_parallel,
-                          MPI_Comm comm, MPI_Info info, int *ncidp);
+                          nc_MPI_Comm comm, nc_MPI_Info info, int *ncidp);
 
 extern int l4nc4_get_vara(NC_FILE_INFO_T *nc, int ncid, int varid, const size_t *startp, const size_t *countp, nc_type mem_nc_type, int is_long, void *data);
 

--- a/libdispatch/dparallel.c
+++ b/libdispatch/dparallel.c
@@ -44,7 +44,7 @@ errors, it simply stops their display to the user through stderr.
 \param comm the MPI communicator specifying the processes participating the
 parallel I/O to this file.
 
-\param info MPI info object containing I/O hints or MPI_INFO_NULL.
+\param info MPI info object containing I/O hints or NC_MPI_INFO_NULL.
 
 \param ncidp Pointer to location where returned netCDF ID is to be
 stored.
@@ -67,14 +67,14 @@ parallel I/O.
 
 \code
     int mpi_size, mpi_rank;
-    MPI_Comm comm = MPI_COMM_WORLD;
-    MPI_Info info = MPI_INFO_NULL;
+    nc_MPI_Comm comm = NC_MPI_COMM_WORLD;
+    nc_MPI_Info info = NC_MPI_INFO_NULL;
     int ncid, v1id, dimids[NDIMS];
     char file_name[NC_MAX_NAME + 1];
 
     MPI_Init(&argc,&argv);
-    MPI_Comm_size(MPI_COMM_WORLD, &mpi_size);
-    MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
+    MPI_Comm_size(NC_MPI_COMM_WORLD, &mpi_size);
+    MPI_Comm_rank(NC_MPI_COMM_WORLD, &mpi_rank);
 
     sprintf(file_name, "%s/%s", TEMP_LARGE, FILE);
     if ((res = nc_create_par(file_name, NC_NETCDF4, comm, info, &ncid))) ERR;
@@ -97,8 +97,8 @@ parallel I/O.
 \author Ed Hartnett, Dennis Heimbigner
 \ingroup datasets
 */
-int nc_create_par(const char *path, int cmode, MPI_Comm comm,
-                  MPI_Info info, int *ncidp)
+int nc_create_par(const char *path, int cmode, nc_MPI_Comm comm,
+                  nc_MPI_Info info, int *ncidp)
 {
 #ifndef USE_PARALLEL
     NC_UNUSED(path);
@@ -167,7 +167,7 @@ access) or NC_NOWRITE (for read-only access).
 \param comm the MPI communicator specifying the processes participating the
 parallel I/O to this file.
 
-\param info MPI info object containing I/O hints or MPI_INFO_NULL.
+\param info MPI info object containing I/O hints or NC_MPI_INFO_NULL.
 
 \param ncidp Pointer to location where returned netCDF ID is to be
 stored.
@@ -199,14 +199,14 @@ Here is an example using nc_open_par() from examples/C/parallel_vara.c.
     char filename[128];
    ...
     omode = NC_NOWRITE;
-    err = nc_open_par(filename, omode, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid); FATAL_ERR
+    err = nc_open_par(filename, omode, NC_MPI_COMM_WORLD, NC_MPI_INFO_NULL, &ncid); FATAL_ERR
 \endcode
 \author Ed Hartnett, Dennis Heimbigner
 \ingroup datasets
 */
 int
-nc_open_par(const char *path, int omode, MPI_Comm comm,
-            MPI_Info info, int *ncidp)
+nc_open_par(const char *path, int omode, nc_MPI_Comm comm,
+            nc_MPI_Info info, int *ncidp)
 {
 #ifndef USE_PARALLEL
     NC_UNUSED(path);
@@ -237,7 +237,7 @@ access) or NC_NOWRITE (for read-only access).
 \param comm the MPI communicator specifying the processes participating the
 parallel I/O to this file.
 
-\param info MPI info object containing I/O hints or MPI_INFO_NULL.
+\param info MPI info object containing I/O hints or NC_MPI_INFO_NULL.
 
 \param ncidp Pointer to location where returned netCDF ID is to be
 stored.
@@ -269,20 +269,20 @@ nc_open_par_fortran(const char *path, int omode, int comm,
     NC_UNUSED(ncidp);
     return NC_ENOPAR;
 #else
-    MPI_Comm comm_c;
-    MPI_Info info_c;
+    nc_MPI_Comm comm_c;
+    nc_MPI_Info info_c;
 
     /* Convert fortran comm and info to C comm and info, if there is a
      * function to do so. Otherwise just pass them. */
 #ifdef HAVE_MPI_COMM_F2C
     comm_c = MPI_Comm_f2c(comm);
 #else
-    comm_c = (MPI_Comm)comm;
+    comm_c = (nc_MPI_Comm)comm;
 #endif
 #ifdef HAVE_MPI_INFO_F2C
     info_c = MPI_Info_f2c(info);
 #else
-    info_c = (MPI_Info)info;
+    info_c = (nc_MPI_Info)info;
 #endif
 
     return nc_open_par(path, omode, comm_c, info_c, ncidp);
@@ -356,7 +356,7 @@ nc_open_par_fortran(const char *path, int omode, int comm,
     global_nx = NX * nprocs;
         ...
     cmode = NC_CLOBBER;
-    err = nc_create_par(filename, cmode, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid); FATAL_ERR
+    err = nc_create_par(filename, cmode, NC_MPI_COMM_WORLD, NC_MPI_INFO_NULL, &ncid); FATAL_ERR
         ...
     err = nc_def_dim(ncid, "Y", global_ny, &dimid[0]); ERR
     err = nc_def_dim(ncid, "X", global_nx, &dimid[1]); ERR
@@ -415,7 +415,7 @@ info from Fortran to C, if necessary.
 \param comm the MPI communicator specifying the processes participating the
 parallel I/O to this file.
 
-\param info MPI info object containing I/O hints or MPI_INFO_NULL.
+\param info MPI info object containing I/O hints or NC_MPI_INFO_NULL.
 
 \param ncidp Pointer to location where returned netCDF ID is to be
 stored.
@@ -446,20 +446,20 @@ nc_create_par_fortran(const char *path, int cmode, int comm,
     NC_UNUSED(ncidp);
     return NC_ENOPAR;
 #else
-    MPI_Comm comm_c;
-    MPI_Info info_c;
+    nc_MPI_Comm comm_c;
+    nc_MPI_Info info_c;
 
     /* Convert fortran comm and info to C comm and info, if there is a
      * function to do so. Otherwise just pass them. */
 #ifdef HAVE_MPI_COMM_F2C
     comm_c = MPI_Comm_f2c(comm);
 #else
-    comm_c = (MPI_Comm)comm;
+    comm_c = (nc_MPI_Comm)comm;
 #endif
 #ifdef HAVE_MPI_INFO_F2C
     info_c = MPI_Info_f2c(info);
 #else
-    info_c = (MPI_Info)info;
+    info_c = (nc_MPI_Info)info;
 #endif
 
     return nc_create_par(path, cmode, comm_c, info_c, ncidp);

--- a/libhdf5/hdf5create.c
+++ b/libhdf5/hdf5create.c
@@ -56,8 +56,8 @@ nc4_create_file(const char *path, int cmode, size_t initialsz,
 
 #ifdef USE_PARALLEL4
     NC_MPI_INFO *mpiinfo = NULL;
-    MPI_Comm comm;
-    MPI_Info info;
+    nc_MPI_Comm comm;
+    nc_MPI_Info info;
     int comm_duped = 0; /* Whether the MPI Communicator was duplicated */
     int info_duped = 0; /* Whether the MPI Info object was duplicated */
 #endif /* !USE_PARALLEL4 */
@@ -139,7 +139,7 @@ nc4_create_file(const char *path, int cmode, size_t initialsz,
         if (MPI_SUCCESS != MPI_Comm_dup(comm, &nc4_info->comm))
             BAIL(NC_EMPI);
         comm_duped++;
-        if (MPI_INFO_NULL != info)
+        if (NC_MPI_INFO_NULL != info)
         {
             if (MPI_SUCCESS != MPI_Info_dup(info, &nc4_info->info))
                 BAIL(NC_EMPI);

--- a/libhdf5/hdf5file.c
+++ b/libhdf5/hdf5file.c
@@ -214,7 +214,7 @@ nc4_close_netcdf4_file(NC_FILE_INFO_T *h5, int abort, NC_memio *memio)
     {
         if (h5->comm != MPI_COMM_NULL)
             MPI_Comm_free(&h5->comm);
-        if (h5->info != MPI_INFO_NULL)
+        if (h5->info != NC_MPI_INFO_NULL)
             MPI_Info_free(&h5->info);
     }
 #endif

--- a/libhdf5/hdf5open.c
+++ b/libhdf5/hdf5open.c
@@ -788,7 +788,7 @@ nc4_open_file(const char *path, int mode, void* parameters, int ncid)
         if (MPI_Comm_dup(mpiinfo->comm, &nc4_info->comm) != MPI_SUCCESS)
             BAIL(NC_EMPI);
         comm_duped++;
-        if (mpiinfo->info != MPI_INFO_NULL)
+        if (mpiinfo->info != NC_MPI_INFO_NULL)
         {
             if (MPI_Info_dup(mpiinfo->info, &nc4_info->info) != MPI_SUCCESS)
                 BAIL(NC_EMPI);

--- a/nc_perf/bm_file.c
+++ b/nc_perf/bm_file.c
@@ -278,11 +278,11 @@ cmp_file(char *file1, char *file2, int *meta_read_us, size_t *data_read_us,
     if (use_par)
     {
 #ifdef USE_PARALLEL
-        if ((ret = nc_open_par(file1, 0, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid1)))
+        if ((ret = nc_open_par(file1, 0, NC_MPI_COMM_WORLD, NC_MPI_INFO_NULL, &ncid1)))
             ERR1(ret);
-        MPI_Barrier(MPI_COMM_WORLD);
+        MPI_Barrier(NC_MPI_COMM_WORLD);
         ftime = MPI_Wtime();
-        if ((ret = nc_open_par(file2, 0, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid2)))
+        if ((ret = nc_open_par(file2, 0, NC_MPI_COMM_WORLD, NC_MPI_INFO_NULL, &ncid2)))
             ERR1(ret);
         *meta_read_us += (MPI_Wtime() - ftime) * MILLION;
 #else
@@ -480,7 +480,7 @@ int copy_file(char *file_name_in, char *file_name_out, int cmode_out,
     {
 #ifdef USE_PARALLEL
         ftime = MPI_Wtime();
-        if ((ret = nc_open_par(file_name_in, 0, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid_in)))
+        if ((ret = nc_open_par(file_name_in, 0, NC_MPI_COMM_WORLD, NC_MPI_INFO_NULL, &ncid_in)))
             ERR1(ret);
         *meta_read_us += (MPI_Wtime() - ftime) * MILLION;
 #else
@@ -510,8 +510,8 @@ int copy_file(char *file_name_in, char *file_name_out, int cmode_out,
         if (use_par)
         {
 #ifdef USE_PARALLEL
-            if ((ret = nc_create_par(file_name_out, cmode_out, MPI_COMM_WORLD,
-                                     MPI_INFO_NULL, &ncid_out)))
+            if ((ret = nc_create_par(file_name_out, cmode_out, NC_MPI_COMM_WORLD,
+                                     NC_MPI_INFO_NULL, &ncid_out)))
                 ERR1(ret);
 #else
             return NC_EPARINIT;
@@ -847,10 +847,10 @@ main(int argc, char **argv)
 
 #ifdef USE_PARALLEL
     MPI_Init(&argc, &argv);
-    MPI_Errhandler_set(MPI_COMM_WORLD, MPI_ERRORS_RETURN);
+    MPI_Errhandler_set(NC_MPI_COMM_WORLD, MPI_ERRORS_RETURN);
 
-    MPI_Comm_rank(MPI_COMM_WORLD, &my_rank);
-    MPI_Comm_size(MPI_COMM_WORLD, &p);
+    MPI_Comm_rank(NC_MPI_COMM_WORLD, &my_rank);
+    MPI_Comm_size(NC_MPI_COMM_WORLD, &p);
 #endif
 
     for (o1 = 0; o1 < MAX_VO; o1++)
@@ -1071,7 +1071,7 @@ main(int argc, char **argv)
         char cmd[NC_MAX_NAME * 3 + 5];
 
 #ifdef USE_PARALLEL
-        MPI_Barrier(MPI_COMM_WORLD);
+        MPI_Barrier(NC_MPI_COMM_WORLD);
 #endif
         /* Create a copy of file_out. This will defeat any buffering
          * that may exist from the fact that we just wrote file_out. */
@@ -1088,11 +1088,11 @@ main(int argc, char **argv)
     if (use_par)
     {
 #ifdef USE_PARALLEL
-        MPI_Reduce(&meta_read_us, &tmeta_read_us, 1, MPI_INT, MPI_MAX, 0, MPI_COMM_WORLD);
-        MPI_Reduce(&meta_write_us, &tmeta_write_us, 1, MPI_INT, MPI_MAX, 0, MPI_COMM_WORLD);
-        MPI_Reduce(&data_read_us, &tdata_read_us, 1, MPI_OFFSET, MPI_MAX, 0, MPI_COMM_WORLD);
-        MPI_Reduce(&data_write_us, &tdata_write_us, 1, MPI_INT, MPI_MAX, 0, MPI_COMM_WORLD);
-        MPI_Reduce(&data_read2_us, &tdata_read2_us, 1, MPI_OFFSET, MPI_MAX, 0, MPI_COMM_WORLD);
+        MPI_Reduce(&meta_read_us, &tmeta_read_us, 1, MPI_INT, MPI_MAX, 0, NC_MPI_COMM_WORLD);
+        MPI_Reduce(&meta_write_us, &tmeta_write_us, 1, MPI_INT, MPI_MAX, 0, NC_MPI_COMM_WORLD);
+        MPI_Reduce(&data_read_us, &tdata_read_us, 1, MPI_OFFSET, MPI_MAX, 0, NC_MPI_COMM_WORLD);
+        MPI_Reduce(&data_write_us, &tdata_write_us, 1, MPI_INT, MPI_MAX, 0, NC_MPI_COMM_WORLD);
+        MPI_Reduce(&data_read2_us, &tdata_read2_us, 1, MPI_OFFSET, MPI_MAX, 0, NC_MPI_COMM_WORLD);
 #else
         return NC_EPARINIT;
 #endif

--- a/nc_perf/tst_compress_par.c
+++ b/nc_perf/tst_compress_par.c
@@ -540,8 +540,8 @@ main(int argc, char **argv)
 #if H5_VERSION_GE(1,10,2)    
     /* MPI stuff. */
     int mpi_size, my_rank;
-    MPI_Comm comm = MPI_COMM_WORLD;
-    MPI_Info info = MPI_INFO_NULL;
+    nc_MPI_Comm comm = NC_MPI_COMM_WORLD;
+    nc_MPI_Info info = NC_MPI_INFO_NULL;
 
     /* For timing. */
     double data_start_time, data_stop_time;
@@ -573,8 +573,8 @@ main(int argc, char **argv)
 
     /* Initialize MPI. */
     MPI_Init(&argc, &argv);
-    MPI_Comm_size(MPI_COMM_WORLD, &mpi_size);
-    MPI_Comm_rank(MPI_COMM_WORLD, &my_rank);
+    MPI_Comm_size(NC_MPI_COMM_WORLD, &mpi_size);
+    MPI_Comm_rank(NC_MPI_COMM_WORLD, &my_rank);
 
     /* Determine what compression filters are present. */
     if ((ret = find_filters(&num_compression_filters, compression_filter_name, deflate_level)))
@@ -655,7 +655,7 @@ main(int argc, char **argv)
 				   latlon_count, lat, lon, my_rank)) ERR;
 
 		    /* Stop the timer for metadata writes. */
-		    MPI_Barrier(MPI_COMM_WORLD);
+		    MPI_Barrier(NC_MPI_COMM_WORLD);
 		    data_start_time = MPI_Wtime();
 
 		    /* Write one record each of the data variables. */
@@ -663,7 +663,7 @@ main(int argc, char **argv)
 		    {
                         /* printf("%d: data_start %ld %ld %ld %ld data_count %ld %ld %ld %ld\n", my_rank, data_start[0], data_start[1], */
                         /*        data_start[2], data_start[3], data_count[0], data_count[1], data_count[2], data_count[3]); */
-                        /* MPI_Barrier(MPI_COMM_WORLD); */
+                        /* MPI_Barrier(NC_MPI_COMM_WORLD); */
                         if (nc_put_vara_float(ncid, data_varid[dv], data_start, data_count,
                                               value_data)) ERR;
 			if (nc_redef(ncid)) ERR;
@@ -673,7 +673,7 @@ main(int argc, char **argv)
 		    if (nc_close(ncid)) ERR;
 
 		    /* Stop the data timer. */
-		    MPI_Barrier(MPI_COMM_WORLD);
+		    MPI_Barrier(NC_MPI_COMM_WORLD);
 		    data_stop_time = MPI_Wtime();
 
 		    /* Get the file size. */
@@ -701,7 +701,7 @@ main(int argc, char **argv)
 			       deflate_level[f][dl], nsd[n], s,
 			       data_rate, (float)file_size/MILLION);
 		    }
-		    MPI_Barrier(MPI_COMM_WORLD);
+		    MPI_Barrier(NC_MPI_COMM_WORLD);
 		} /* next deflate level */
             } /* next nsd */
         } /* next shuffle filter test */

--- a/nc_test/t_nc.c
+++ b/nc_test/t_nc.c
@@ -361,7 +361,7 @@ main(int argc, char *argv[])
 #ifdef ENABLE_CDF5
 	cmode |= (NC_64BIT_DATA);
 #endif
-	ret = nc_create_par(fname,cmode, MPI_COMM_WORLD, MPI_INFO_NULL, &id);
+	ret = nc_create_par(fname,cmode, NC_MPI_COMM_WORLD, NC_MPI_INFO_NULL, &id);
 #else
 	const size_t initialsz = 8192;
 	size_t chunksz = 8192;
@@ -475,7 +475,7 @@ main(int argc, char *argv[])
  */
         omode = NC_NOWRITE;
 #ifdef USE_PNETCDF
-	ret = nc_open_par(fname,omode, MPI_COMM_WORLD, MPI_INFO_NULL, &id);
+	ret = nc_open_par(fname,omode, NC_MPI_COMM_WORLD, NC_MPI_INFO_NULL, &id);
 #else
 	ret = nc__open(fname,omode, &chunksz, &id);
 #endif

--- a/nc_test/t_nc_p5.c
+++ b/nc_test/t_nc_p5.c
@@ -361,7 +361,7 @@ main(int argc, char *argv[])
 
         /* cmode |= NC_64BIT_OFFSET; */
         cmode != NC_64BIT_DATA;
-	ret = nc_create_par(fname,cmode, MPI_COMM_WORLD, MPI_INFO_NULL, &id);
+	ret = nc_create_par(fname,cmode, NC_MPI_COMM_WORLD, NC_MPI_INFO_NULL, &id);
 	if(ret != NC_NOERR)  {
 		fprintf(stderr,"Error %s in file %s at line %d\n",nc_strerror(ret),__FILE__,__LINE__);
 		exit(ret);

--- a/nc_test/tst_atts3.c
+++ b/nc_test/tst_atts3.c
@@ -99,7 +99,7 @@ tst_att_ordering(int cmode)
 
     /* Create a file with some global atts. */
 #ifdef TEST_PNETCDF
-    if (nc_create_par(FILE_NAME, cmode, MPI_COMM_WORLD, MPI_INFO_NULL,&ncid)) ERR;
+    if (nc_create_par(FILE_NAME, cmode, NC_MPI_COMM_WORLD, NC_MPI_INFO_NULL,&ncid)) ERR;
 #else
     if (nc_create(FILE_NAME, cmode, &ncid)) ERR;
 #endif
@@ -115,7 +115,7 @@ tst_att_ordering(int cmode)
 
     /* Reopen the file and check the order. */
 #ifdef TEST_PNETCDF
-    if (nc_open_par(FILE_NAME, 0, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid)) ERR;
+    if (nc_open_par(FILE_NAME, 0, NC_MPI_COMM_WORLD, NC_MPI_INFO_NULL, &ncid)) ERR;
 #else
     if (nc_open(FILE_NAME, 0, &ncid)) ERR;
 #endif
@@ -158,7 +158,7 @@ main(int argc, char **argv)
 
         /* Create a file with some global atts. */
 #ifdef TEST_PNETCDF
-        if (nc_create_par(FILE_NAME, NC_CLOBBER, MPI_COMM_WORLD, MPI_INFO_NULL,&ncid)) ERR;
+        if (nc_create_par(FILE_NAME, NC_CLOBBER, NC_MPI_COMM_WORLD, NC_MPI_INFO_NULL,&ncid)) ERR;
 #else
         if (nc_create(FILE_NAME, NC_CLOBBER, &ncid)) ERR;
 #endif
@@ -168,7 +168,7 @@ main(int argc, char **argv)
 
         /* Reopen the file and check the order. */
 #ifdef TEST_PNETCDF
-        if (nc_open_par(FILE_NAME, 0, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid)) ERR;
+        if (nc_open_par(FILE_NAME, 0, NC_MPI_COMM_WORLD, NC_MPI_INFO_NULL, &ncid)) ERR;
 #else
         if (nc_open(FILE_NAME, 0, &ncid)) ERR;
 #endif
@@ -193,7 +193,7 @@ main(int argc, char **argv)
 
         /* This won't work, because classic files can't create these types. */
 #ifdef TEST_PNETCDF
-        if (nc_create_par(FILE_NAME, NC_CLOBBER, MPI_COMM_WORLD, MPI_INFO_NULL,&ncid)) ERR;
+        if (nc_create_par(FILE_NAME, NC_CLOBBER, NC_MPI_COMM_WORLD, NC_MPI_INFO_NULL,&ncid)) ERR;
 #else
         if (nc_create(FILE_NAME, NC_CLOBBER, &ncid)) ERR;
 #endif
@@ -216,7 +216,7 @@ main(int argc, char **argv)
 
         /* Create a file with a global attribute of each type. */
 #ifdef TEST_PNETCDF
-        if (nc_create_par(FILE_NAME, NC_CLOBBER, MPI_COMM_WORLD, MPI_INFO_NULL,&ncid)) ERR;
+        if (nc_create_par(FILE_NAME, NC_CLOBBER, NC_MPI_COMM_WORLD, NC_MPI_INFO_NULL,&ncid)) ERR;
 #else
         if (nc_create(FILE_NAME, NC_CLOBBER, &ncid)) ERR;
 #endif
@@ -230,7 +230,7 @@ main(int argc, char **argv)
 
         /* Open the file and check attributes. */
 #ifdef TEST_PNETCDF
-        if (nc_open_par(FILE_NAME, 0, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid)) ERR;
+        if (nc_open_par(FILE_NAME, 0, NC_MPI_COMM_WORLD, NC_MPI_INFO_NULL, &ncid)) ERR;
 #else
         if (nc_open(FILE_NAME, 0, &ncid)) ERR;
 #endif
@@ -269,7 +269,7 @@ main(int argc, char **argv)
 
         /* Reopen the file and try different type conversions. */
 #ifdef TEST_PNETCDF
-        if (nc_open_par(FILE_NAME, 0, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid)) ERR;
+        if (nc_open_par(FILE_NAME, 0, NC_MPI_COMM_WORLD, NC_MPI_INFO_NULL, &ncid)) ERR;
 #else
         if (nc_open(FILE_NAME, 0, &ncid)) ERR;
 #endif
@@ -421,7 +421,7 @@ main(int argc, char **argv)
 
         /* Create a file with a global attribute of each type of zero length. */
 #ifdef TEST_PNETCDF
-        if (nc_create_par(FILE_NAME, NC_CLOBBER, MPI_COMM_WORLD, MPI_INFO_NULL,&ncid)) ERR;
+        if (nc_create_par(FILE_NAME, NC_CLOBBER, NC_MPI_COMM_WORLD, NC_MPI_INFO_NULL,&ncid)) ERR;
 #else
         if (nc_create(FILE_NAME, NC_CLOBBER, &ncid)) ERR;
 #endif
@@ -446,7 +446,7 @@ main(int argc, char **argv)
         nc_type xtype;
 
 #ifdef TEST_PNETCDF
-        if (nc_open_par(FILE_NAME, 0, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid)) ERR;
+        if (nc_open_par(FILE_NAME, 0, NC_MPI_COMM_WORLD, NC_MPI_INFO_NULL, &ncid)) ERR;
 #else
         if (nc_open(FILE_NAME, 0, &ncid)) ERR;
 #endif
@@ -489,7 +489,7 @@ main(int argc, char **argv)
 
         /* Create a file with a global attribute of each type of zero length. */
 #ifdef TEST_PNETCDF
-        if (nc_create_par(FILE_NAME, NC_CLOBBER, MPI_COMM_WORLD, MPI_INFO_NULL,&ncid)) ERR;
+        if (nc_create_par(FILE_NAME, NC_CLOBBER, NC_MPI_COMM_WORLD, NC_MPI_INFO_NULL,&ncid)) ERR;
 #else
         if (nc_create(FILE_NAME, NC_CLOBBER, &ncid)) ERR;
 #endif
@@ -506,7 +506,7 @@ main(int argc, char **argv)
         /* Make sure we can read all these zero-length atts added during a
          * redef. */
 #ifdef TEST_PNETCDF
-        if (nc_open_par(FILE_NAME, 0, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid)) ERR;
+        if (nc_open_par(FILE_NAME, 0, NC_MPI_COMM_WORLD, NC_MPI_INFO_NULL, &ncid)) ERR;
 #else
         if (nc_open(FILE_NAME, 0, &ncid)) ERR;
 #endif
@@ -537,7 +537,7 @@ main(int argc, char **argv)
 
         /* Create a file with a global attribute. */
 #ifdef TEST_PNETCDF
-        if (nc_create_par(FILE_NAME, NC_CLOBBER, MPI_COMM_WORLD, MPI_INFO_NULL,&ncid)) ERR;
+        if (nc_create_par(FILE_NAME, NC_CLOBBER, NC_MPI_COMM_WORLD, NC_MPI_INFO_NULL,&ncid)) ERR;
 #else
         if (nc_create(FILE_NAME, NC_CLOBBER, &ncid)) ERR;
 #endif
@@ -547,7 +547,7 @@ main(int argc, char **argv)
 
         /* Rename it. */
 #ifdef TEST_PNETCDF
-        if (nc_open_par(FILE_NAME, NC_WRITE, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid)) ERR;
+        if (nc_open_par(FILE_NAME, NC_WRITE, NC_MPI_COMM_WORLD, NC_MPI_INFO_NULL, &ncid)) ERR;
 #else
         if (nc_open(FILE_NAME, NC_WRITE, &ncid)) ERR;
 #endif
@@ -562,7 +562,7 @@ main(int argc, char **argv)
         if (nc_close(ncid)) ERR;
 
 #ifdef TEST_PNETCDF
-        if (nc_open_par(FILE_NAME, NC_WRITE, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid)) ERR;
+        if (nc_open_par(FILE_NAME, NC_WRITE, NC_MPI_COMM_WORLD, NC_MPI_INFO_NULL, &ncid)) ERR;
 #else
         if (nc_open(FILE_NAME, NC_WRITE, &ncid)) ERR;
 #endif
@@ -577,7 +577,7 @@ main(int argc, char **argv)
 
         /* Now delete the att. */
 #ifdef TEST_PNETCDF
-        if (nc_open_par(FILE_NAME, NC_WRITE, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid)) ERR;
+        if (nc_open_par(FILE_NAME, NC_WRITE, NC_MPI_COMM_WORLD, NC_MPI_INFO_NULL, &ncid)) ERR;
 #else
         if (nc_open(FILE_NAME, NC_WRITE, &ncid)) ERR;
 #endif
@@ -587,7 +587,7 @@ main(int argc, char **argv)
 
         /* Now create a file with a variable, which has an att. */
 #ifdef TEST_PNETCDF
-        if (nc_create_par(FILE_NAME, NC_CLOBBER, MPI_COMM_WORLD, MPI_INFO_NULL,&ncid)) ERR;
+        if (nc_create_par(FILE_NAME, NC_CLOBBER, NC_MPI_COMM_WORLD, NC_MPI_INFO_NULL,&ncid)) ERR;
 #else
         if (nc_create(FILE_NAME, NC_CLOBBER, &ncid)) ERR;
 #endif
@@ -600,7 +600,7 @@ main(int argc, char **argv)
 
         /* Reopen the file and delete it. Make sure it's gone. */
 #ifdef TEST_PNETCDF
-        if (nc_open_par(FILE_NAME, NC_WRITE, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid)) ERR;
+        if (nc_open_par(FILE_NAME, NC_WRITE, NC_MPI_COMM_WORLD, NC_MPI_INFO_NULL, &ncid)) ERR;
 #else
         if (nc_open(FILE_NAME, NC_WRITE, &ncid)) ERR;
 #endif
@@ -611,7 +611,7 @@ main(int argc, char **argv)
         /* Reopen the file and readd the attribute. Enddef and redef,
          * and delete it, then check to make sure it's gone. */
 #ifdef TEST_PNETCDF
-        if (nc_open_par(FILE_NAME, NC_WRITE, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid)) ERR;
+        if (nc_open_par(FILE_NAME, NC_WRITE, NC_MPI_COMM_WORLD, NC_MPI_INFO_NULL, &ncid)) ERR;
 #else
         if (nc_open(FILE_NAME, NC_WRITE, &ncid)) ERR;
 #endif
@@ -637,7 +637,7 @@ main(int argc, char **argv)
 
         /* Create a file with several global attributes. */
 #ifdef TEST_PNETCDF
-        if (nc_create_par(FILE_NAME, NC_CLOBBER, MPI_COMM_WORLD, MPI_INFO_NULL,&ncid)) ERR;
+        if (nc_create_par(FILE_NAME, NC_CLOBBER, NC_MPI_COMM_WORLD, NC_MPI_INFO_NULL,&ncid)) ERR;
 #else
         if (nc_create(FILE_NAME, NC_CLOBBER, &ncid)) ERR;
 #endif
@@ -647,7 +647,7 @@ main(int argc, char **argv)
 
         /* Open it and check the order. */
 #ifdef TEST_PNETCDF
-        if (nc_open_par(FILE_NAME, NC_WRITE, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid)) ERR;
+        if (nc_open_par(FILE_NAME, NC_WRITE, NC_MPI_COMM_WORLD, NC_MPI_INFO_NULL, &ncid)) ERR;
 #else
         if (nc_open(FILE_NAME, NC_WRITE, &ncid)) ERR;
 #endif
@@ -659,7 +659,7 @@ main(int argc, char **argv)
 
         /* Now create a file with a variable, which has two atts. */
 #ifdef TEST_PNETCDF
-        if (nc_create_par(FILE_NAME, NC_CLOBBER, MPI_COMM_WORLD, MPI_INFO_NULL,&ncid)) ERR;
+        if (nc_create_par(FILE_NAME, NC_CLOBBER, NC_MPI_COMM_WORLD, NC_MPI_INFO_NULL,&ncid)) ERR;
 #else
         if (nc_create(FILE_NAME, NC_CLOBBER, &ncid)) ERR;
 #endif
@@ -672,7 +672,7 @@ main(int argc, char **argv)
 
         /* Reopen the file and check the order of the attributes on the var. */
 #ifdef TEST_PNETCDF
-        if (nc_open_par(FILE_NAME, NC_WRITE, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid)) ERR;
+        if (nc_open_par(FILE_NAME, NC_WRITE, NC_MPI_COMM_WORLD, NC_MPI_INFO_NULL, &ncid)) ERR;
 #else
         if (nc_open(FILE_NAME, NC_WRITE, &ncid)) ERR;
 #endif
@@ -701,7 +701,7 @@ main(int argc, char **argv)
 
         /* Create a file with one var, and attach three atts to it. */
 #ifdef TEST_PNETCDF
-        if (nc_create_par(FILE_NAME, NC_CLOBBER, MPI_COMM_WORLD, MPI_INFO_NULL,&ncid)) ERR;
+        if (nc_create_par(FILE_NAME, NC_CLOBBER, NC_MPI_COMM_WORLD, NC_MPI_INFO_NULL,&ncid)) ERR;
 #else
         if (nc_create(FILE_NAME, NC_CLOBBER, &ncid)) ERR;
 #endif
@@ -713,7 +713,7 @@ main(int argc, char **argv)
 
         /* Reopen the file and check. */
 #ifdef TEST_PNETCDF
-        if (nc_open_par(FILE_NAME, 0, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid)) ERR;
+        if (nc_open_par(FILE_NAME, 0, NC_MPI_COMM_WORLD, NC_MPI_INFO_NULL, &ncid)) ERR;
 #else
         if (nc_open(FILE_NAME, 0, &ncid)) ERR;
 #endif
@@ -749,7 +749,7 @@ main(int argc, char **argv)
         int ncid, att = 1;
 
 #ifdef TEST_PNETCDF
-        if (nc_create_par(FILE_NAME, NC_CLOBBER, MPI_COMM_WORLD, MPI_INFO_NULL,&ncid)) ERR;
+        if (nc_create_par(FILE_NAME, NC_CLOBBER, NC_MPI_COMM_WORLD, NC_MPI_INFO_NULL,&ncid)) ERR;
 #else
         if (nc_create(FILE_NAME, NC_CLOBBER, &ncid)) ERR;
 #endif
@@ -762,7 +762,7 @@ main(int argc, char **argv)
         if (nc_close(ncid)) ERR;
 
 #ifdef TEST_PNETCDF
-        if (nc_open_par(FILE_NAME, 0, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid)) ERR;
+        if (nc_open_par(FILE_NAME, 0, NC_MPI_COMM_WORLD, NC_MPI_INFO_NULL, &ncid)) ERR;
 #else
         if (nc_open(FILE_NAME, 0, &ncid)) ERR;
 #endif
@@ -786,7 +786,7 @@ main(int argc, char **argv)
 
         /* Create a file with a global attribute of each type. */
 #ifdef TEST_PNETCDF
-        if (nc_create_par(FILE_NAME, NC_CLOBBER, MPI_COMM_WORLD, MPI_INFO_NULL,&ncid)) ERR;
+        if (nc_create_par(FILE_NAME, NC_CLOBBER, NC_MPI_COMM_WORLD, NC_MPI_INFO_NULL,&ncid)) ERR;
 #else
         if (nc_create(FILE_NAME, NC_CLOBBER, &ncid)) ERR;
 #endif
@@ -799,7 +799,7 @@ main(int argc, char **argv)
 
         /* Create another file and copy all the attributes. */
 #ifdef TEST_PNETCDF
-        if (nc_create_par(FILE_NAME2, NC_CLOBBER, MPI_COMM_WORLD, MPI_INFO_NULL,&ncid2)) ERR;
+        if (nc_create_par(FILE_NAME2, NC_CLOBBER, NC_MPI_COMM_WORLD, NC_MPI_INFO_NULL,&ncid2)) ERR;
 #else
         if (nc_create(FILE_NAME2, NC_CLOBBER, &ncid2)) ERR;
 #endif
@@ -816,7 +816,7 @@ main(int argc, char **argv)
 
         /* Open the file and check attributes. */
 #ifdef TEST_PNETCDF
-        if (nc_open_par(FILE_NAME2, 0, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid)) ERR;
+        if (nc_open_par(FILE_NAME2, 0, NC_MPI_COMM_WORLD, NC_MPI_INFO_NULL, &ncid)) ERR;
 #else
         if (nc_open(FILE_NAME2, 0, &ncid)) ERR;
 #endif

--- a/nc_test/tst_cdf5format.c
+++ b/nc_test/tst_cdf5format.c
@@ -131,12 +131,12 @@ read2(int ncid)
 int main(int argc, char* argv[])
 {
    int rank, nprocs, ncid, cmode;
-   MPI_Comm comm = MPI_COMM_SELF;
-   MPI_Info info = MPI_INFO_NULL;
+   nc_MPI_Comm comm = MPI_COMM_SELF;
+   nc_MPI_Info info = NC_MPI_INFO_NULL;
 
    MPI_Init(&argc, &argv);
-   MPI_Comm_size(MPI_COMM_WORLD, &nprocs);
-   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+   MPI_Comm_size(NC_MPI_COMM_WORLD, &nprocs);
+   MPI_Comm_rank(NC_MPI_COMM_WORLD, &rank);
    if (rank > 0)
       return 2;
 

--- a/nc_test/tst_default_format_pnetcdf.c
+++ b/nc_test/tst_default_format_pnetcdf.c
@@ -60,7 +60,7 @@ create_check_pnetcdf(char *fname, int cmode, int exp_format)
 
     /* create a file */
     cmode |= NC_CLOBBER;
-    err = nc_create_par(fname, cmode, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid); ERR
+    err = nc_create_par(fname, cmode, NC_MPI_COMM_WORLD, NC_MPI_INFO_NULL, &ncid); ERR
     if (exp_err == NC_ENOTBUILT) return 0;
 
     err = nc_close(ncid); ERR
@@ -94,7 +94,7 @@ int main(int argc, char *argv[])
 
     /* check illegal cmode */
     cmode = NC_64BIT_OFFSET | NC_64BIT_DATA;
-    err = nc_create_par(fname, cmode, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid);
+    err = nc_create_par(fname, cmode, NC_MPI_COMM_WORLD, NC_MPI_INFO_NULL, &ncid);
     if (err != NC_EINVAL) {
         printf("Error at %s line %d: expect NC_EINVAL but got %d\n",
                __FILE__, __LINE__, err);
@@ -103,7 +103,7 @@ int main(int argc, char *argv[])
 #ifdef USE_HDF5
     /* check illegal cmode */
     cmode = NC_NETCDF4 | NC_64BIT_OFFSET;
-    err = nc_create_par(fname, cmode, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid);
+    err = nc_create_par(fname, cmode, NC_MPI_COMM_WORLD, NC_MPI_INFO_NULL, &ncid);
     if (err != NC_EINVAL) {
         printf("Error at %s line %d: expect NC_EINVAL but got %d\n",
                __FILE__, __LINE__, err);

--- a/nc_test/tst_formatx_pnetcdf.c
+++ b/nc_test/tst_formatx_pnetcdf.c
@@ -28,14 +28,14 @@ int main(int argc, char* argv[])
     int ncid;
     int cmode, format;
     int nprocs, rank;
-    MPI_Comm comm=MPI_COMM_SELF;
-    MPI_Info info=MPI_INFO_NULL;
+    nc_MPI_Comm comm=MPI_COMM_SELF;
+    nc_MPI_Info info=NC_MPI_INFO_NULL;
 
     printf("\n*** Testing nc_inq_format_extended for PnetCDF...");
 
     MPI_Init(&argc,&argv);
-    MPI_Comm_size(MPI_COMM_WORLD, &nprocs);
-    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(NC_MPI_COMM_WORLD, &nprocs);
+    MPI_Comm_rank(NC_MPI_COMM_WORLD, &rank);
 
     if (nprocs > 1 && rank == 0)
         printf("This test program is intended to run on ONE process\n");

--- a/nc_test/tst_misc.c
+++ b/nc_test/tst_misc.c
@@ -49,7 +49,7 @@ main(int argc, char **argv)
 
 	 /* Make sure that netCDF rejects this file politely. */
 #ifdef TEST_PNETCDF
-        openstat = nc_open_par(FILE_NAME, 0, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid);
+        openstat = nc_open_par(FILE_NAME, 0, NC_MPI_COMM_WORLD, NC_MPI_INFO_NULL, &ncid);
 #else
          openstat = nc_open(FILE_NAME, 0, &ncid);
 #endif

--- a/nc_test/tst_nofill.c
+++ b/nc_test/tst_nofill.c
@@ -106,7 +106,7 @@ create_file(char *file_name, int fill_mode, size_t* sizehintp)
     * nc__create() instead of calling nc_create() and getting the
     * block size reported by fstat */
 #ifdef USE_PNETCDF
-   stat = nc_create_par(file_name, NC_CLOBBER, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid);
+   stat = nc_create_par(file_name, NC_CLOBBER, NC_MPI_COMM_WORLD, NC_MPI_INFO_NULL, &ncid);
    /* PnetCDF does not support fill mode */
 #else
    int old_fill_mode;
@@ -403,8 +403,8 @@ main(int argc, char **argv)
        /* compare data in two files created with nofill mode and fill
 	* mode, which should be identical if all the data were written */
 #ifdef USE_PNETCDF
-       if (nc_open_par(FILE_NAME1, NC_NOWRITE, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid1)) ERR;
-       if (nc_open_par(FILE_NAME2, NC_NOWRITE, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid2)) ERR;
+       if (nc_open_par(FILE_NAME1, NC_NOWRITE, NC_MPI_COMM_WORLD, NC_MPI_INFO_NULL, &ncid1)) ERR;
+       if (nc_open_par(FILE_NAME2, NC_NOWRITE, NC_MPI_COMM_WORLD, NC_MPI_INFO_NULL, &ncid2)) ERR;
 #else
        if (nc_open(FILE_NAME1, NC_NOWRITE, &ncid1)) ERR;
        if (nc_open(FILE_NAME2, NC_NOWRITE, &ncid2)) ERR;

--- a/nc_test/tst_norm.c
+++ b/nc_test/tst_norm.c
@@ -108,7 +108,7 @@ MPI_Init(&argc, &argv);
 #endif
    printf("\n*** testing UTF-8 normalization...");
 #ifdef TEST_PNETCDF
-   if((res = nc_create_par(FILE7_NAME, NC_CLOBBER, MPI_COMM_WORLD, MPI_INFO_NULL,&ncid)))
+   if((res = nc_create_par(FILE7_NAME, NC_CLOBBER, NC_MPI_COMM_WORLD, NC_MPI_INFO_NULL,&ncid)))
 #else
    if((res = nc_create(FILE7_NAME, NC_CLOBBER, &ncid)))
 #endif
@@ -151,7 +151,7 @@ MPI_Init(&argc, &argv);
 
    /* Check it out. */
 #ifdef TEST_PNETCDF
-   if ((res = nc_open_par(FILE7_NAME, NC_NOWRITE, MPI_COMM_WORLD,MPI_INFO_NULL, &ncid)))
+   if ((res = nc_open_par(FILE7_NAME, NC_NOWRITE, NC_MPI_COMM_WORLD,NC_MPI_INFO_NULL, &ncid)))
 #else
    if ((res = nc_open(FILE7_NAME, NC_NOWRITE, &ncid)))
 #endif

--- a/nc_test/tst_parallel2.c
+++ b/nc_test/tst_parallel2.c
@@ -44,8 +44,8 @@ main(int argc, char **argv)
     int mpi_namelen;
     char mpi_name[MPI_MAX_PROCESSOR_NAME];
     int mpi_size, mpi_rank;
-    MPI_Comm comm = MPI_COMM_WORLD;
-    MPI_Info info = MPI_INFO_NULL;
+    nc_MPI_Comm comm = NC_MPI_COMM_WORLD;
+    nc_MPI_Info info = NC_MPI_INFO_NULL;
     double start_time = 0, total_time;
 
     /* Netcdf-4 stuff. */
@@ -64,8 +64,8 @@ main(int argc, char **argv)
 
     /* Initialize MPI. */
     MPI_Init(&argc,&argv);
-    MPI_Comm_size(MPI_COMM_WORLD, &mpi_size);
-    MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
+    MPI_Comm_size(NC_MPI_COMM_WORLD, &mpi_size);
+    MPI_Comm_rank(NC_MPI_COMM_WORLD, &mpi_rank);
     MPI_Get_processor_name(mpi_name, &mpi_namelen);
 #ifdef DEBUG
     printf("mpi_name: %s size: %d rank: %d\n", mpi_name, mpi_size, mpi_rank);
@@ -237,7 +237,7 @@ main(int argc, char **argv)
     MPE_Log_event(e_close, 0, "end close file");
 #endif /* USE_MPE */
 
-    MPI_Barrier(MPI_COMM_WORLD);
+    MPI_Barrier(NC_MPI_COMM_WORLD);
     if (mpi_rank == 0)
 	remove(file_name);
 

--- a/nc_test/tst_pnetcdf.c
+++ b/nc_test/tst_pnetcdf.c
@@ -42,14 +42,14 @@ int main(int argc, char* argv[])
     int st, nerrs=0;
     char str[32];
     size_t start[2], count[2];
-    MPI_Comm comm=MPI_COMM_SELF;
-    MPI_Info info=MPI_INFO_NULL;
+    nc_MPI_Comm comm=MPI_COMM_SELF;
+    nc_MPI_Info info=NC_MPI_INFO_NULL;
 
     printf("\n*** Testing bug fix with changing PnetCDF variable offsets...");
 
     MPI_Init(&argc,&argv);
-    MPI_Comm_size(MPI_COMM_WORLD, &nprocs);
-    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(NC_MPI_COMM_WORLD, &nprocs);
+    MPI_Comm_rank(NC_MPI_COMM_WORLD, &rank);
 
     if (nprocs > 1 && rank == 0)
         printf("This test program is intended to run on ONE process\n");
@@ -106,7 +106,7 @@ int main(int argc, char* argv[])
         }
     }
     st = nc_close(ncid); CHK_ERR(st)
-    if (info != MPI_INFO_NULL) MPI_Info_free(&info);
+    if (info != NC_MPI_INFO_NULL) MPI_Info_free(&info);
 
     /* re-open the file with netCDF (parallel) and enter define mode */
     st = nc_open_par(FILENAME, NC_WRITE, comm, info, &ncid); CHK_ERR(st)

--- a/nc_test/tst_small.c
+++ b/nc_test/tst_small.c
@@ -59,7 +59,7 @@ static int file_create(const char *filename, int cmode, int *ncid)
         || default_format == NC_FORMAT_64BIT_DATA
 #endif
         )
-        err = nc_create_par(filename, cmode, MPI_COMM_WORLD, MPI_INFO_NULL, ncid);
+        err = nc_create_par(filename, cmode, NC_MPI_COMM_WORLD, NC_MPI_INFO_NULL, ncid);
     else
 #endif
         err = nc_create(filename, cmode, ncid);
@@ -81,7 +81,7 @@ static int file_open(const char *filename, int omode, int *ncid)
     if (default_format == NC_FORMAT_CLASSIC ||
         default_format == NC_FORMAT_64BIT_OFFSET ||
         default_format == NC_FORMAT_64BIT_DATA)
-        err = nc_open_par(filename, omode, MPI_COMM_WORLD, MPI_INFO_NULL, ncid);
+        err = nc_open_par(filename, omode, NC_MPI_COMM_WORLD, NC_MPI_INFO_NULL, ncid);
     else
 #endif
         err = nc_open(filename, omode, ncid);

--- a/nc_test/util.c
+++ b/nc_test/util.c
@@ -1155,7 +1155,7 @@ int file_create(const char *filename, int cmode, int *ncid)
     if (default_format == NC_FORMAT_CLASSIC ||
         default_format == NC_FORMAT_64BIT_OFFSET ||
         default_format == NC_FORMAT_64BIT_DATA)
-        err = nc_create_par(filename, cmode, MPI_COMM_WORLD, MPI_INFO_NULL, ncid);
+        err = nc_create_par(filename, cmode, NC_MPI_COMM_WORLD, NC_MPI_INFO_NULL, ncid);
     else
 #endif
         err = nc_create(filename, cmode, ncid);
@@ -1181,7 +1181,7 @@ int file__create(const char *filename,
     if (default_format == NC_FORMAT_CLASSIC ||
         default_format == NC_FORMAT_64BIT_OFFSET ||
         default_format == NC_FORMAT_64BIT_DATA)
-        err = nc_create_par(filename, cmode, MPI_COMM_WORLD, MPI_INFO_NULL, ncid);
+        err = nc_create_par(filename, cmode, NC_MPI_COMM_WORLD, NC_MPI_INFO_NULL, ncid);
     else
 #endif
         err = nc__create(filename, cmode, initialsz, bufrsizehintp, ncid);
@@ -1203,7 +1203,7 @@ int file_open(const char *filename, int omode, int *ncid)
     if (default_format == NC_FORMAT_CLASSIC ||
         default_format == NC_FORMAT_64BIT_OFFSET ||
         default_format == NC_FORMAT_64BIT_DATA)
-        err = nc_open_par(filename, omode, MPI_COMM_WORLD, MPI_INFO_NULL, ncid);
+        err = nc_open_par(filename, omode, NC_MPI_COMM_WORLD, NC_MPI_INFO_NULL, ncid);
     else
 #endif
         err = nc_open(filename, omode, ncid);
@@ -1428,7 +1428,7 @@ test_nc_against_pnetcdf(void)
     IF (err != NC_NOERR) error("nc_close: %s", nc_strerror(err));
 
     /* Using PnetCDF library to check file */
-    err = nc_open_par(scratch, NC_NOWRITE, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid);
+    err = nc_open_par(scratch, NC_NOWRITE, NC_MPI_COMM_WORLD, NC_MPI_INFO_NULL, &ncid);
     IF (err != NC_NOERR) error("nc_open_par: %s", nc_strerror(err));
     check_dims(ncid);
     check_vars(ncid);
@@ -1437,7 +1437,7 @@ test_nc_against_pnetcdf(void)
     IF (err != NC_NOERR) error("nc_close: %s", nc_strerror(err));
 
     /* Using PnetCDF library to create file */
-    err = nc_create_par(scratch, 0, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid);
+    err = nc_create_par(scratch, 0, NC_MPI_COMM_WORLD, NC_MPI_INFO_NULL, &ncid);
     IF (err != NC_NOERR) error("nc_create_par: %s", nc_strerror(err));
     def_dims(ncid);
     def_vars(ncid);

--- a/nc_test4/tst_atts3.c
+++ b/nc_test4/tst_atts3.c
@@ -456,7 +456,7 @@ create_file()
 
     /* enter define mode */
 #ifdef TEST_PNETCDF
-    stat = nc_create_par(FILE_NAME, NC_CLOBBER, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid);
+    stat = nc_create_par(FILE_NAME, NC_CLOBBER, NC_MPI_COMM_WORLD, NC_MPI_INFO_NULL, &ncid);
 #else
     stat = nc_create(FILE_NAME, NC_CLOBBER, &ncid);
 #endif
@@ -2363,7 +2363,7 @@ main(int argc, char **argv)
 
       /* Create a file with a var with two atts. */
 #ifdef TEST_PNETCDF
-      if (nc_create_par(FILE_NAME, NC_CLOBBER, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid)) ERR;
+      if (nc_create_par(FILE_NAME, NC_CLOBBER, NC_MPI_COMM_WORLD, NC_MPI_INFO_NULL, &ncid)) ERR;
 #else
       if (nc_create(FILE_NAME, NC_NETCDF4|NC_CLASSIC_MODEL|NC_CLOBBER, &ncid)) ERR;
 #endif
@@ -2409,7 +2409,7 @@ main(int argc, char **argv)
 
       /* Reopen the file and check it. */
 #ifdef TEST_PNETCDF
-      if (nc_open_par(FILE_NAME, NC_WRITE, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid)) ERR;
+      if (nc_open_par(FILE_NAME, NC_WRITE, NC_MPI_COMM_WORLD, NC_MPI_INFO_NULL, &ncid)) ERR;
 #else
       if (nc_open(FILE_NAME, NC_WRITE, &ncid)) ERR;
 #endif
@@ -2441,7 +2441,7 @@ main(int argc, char **argv)
 
       /* Open the file. */
 #ifdef TEST_PNETCDF
-      if (nc_open_par(FILE_NAME, NC_WRITE, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid)) ERR;
+      if (nc_open_par(FILE_NAME, NC_WRITE, NC_MPI_COMM_WORLD, NC_MPI_INFO_NULL, &ncid)) ERR;
 #else
       if (nc_open(FILE_NAME, NC_WRITE, &ncid)) ERR;
 #endif
@@ -2470,7 +2470,7 @@ main(int argc, char **argv)
 
       /* Reopen the file and check it. */
 #ifdef TEST_PNETCDF
-      if (nc_open_par(FILE_NAME, NC_WRITE, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid)) ERR;
+      if (nc_open_par(FILE_NAME, NC_WRITE, NC_MPI_COMM_WORLD, NC_MPI_INFO_NULL, &ncid)) ERR;
 #else
       if (nc_open(FILE_NAME, NC_WRITE, &ncid)) ERR;
 #endif

--- a/nc_test4/tst_mode.c
+++ b/nc_test4/tst_mode.c
@@ -29,7 +29,7 @@ main(int argc, char** argv)
     MPI_Init(&argc,&argv);
 
     printf("*** Testing create + MPIO + fletcher32\n");
-    if ((retval = nc_create_par(FILE_NAME, NC_CLOBBER|NC_NETCDF4, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid))) ERR;
+    if ((retval = nc_create_par(FILE_NAME, NC_CLOBBER|NC_NETCDF4, NC_MPI_COMM_WORLD, NC_MPI_INFO_NULL, &ncid))) ERR;
     if ((retval = nc_def_dim(ncid,"whatever",10,&dimid))) ERR;
     if ((retval = nc_def_var(ncid,"whatever",NC_INT,1,&dimid,&varid))) ERR;
     retval = nc_def_var_fletcher32(ncid,varid,NC_FLETCHER32);
@@ -46,7 +46,7 @@ main(int argc, char** argv)
     }
 
     printf("*** Testing create + MPIO + deflation\n");
-    if ((retval = nc_create_par(FILE_NAME, NC_CLOBBER|NC_NETCDF4, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid))) ERR;
+    if ((retval = nc_create_par(FILE_NAME, NC_CLOBBER|NC_NETCDF4, NC_MPI_COMM_WORLD, NC_MPI_INFO_NULL, &ncid))) ERR;
     if ((retval = nc_def_dim(ncid,"whatever",10,&dimid))) ERR;
     if ((retval = nc_def_var(ncid,"whatever",NC_INT,1,&dimid,&varid))) ERR;
     retval = nc_def_var_deflate(ncid,varid, NC_NOSHUFFLE, 1, 1);

--- a/nc_test4/tst_mpi_parallel.c
+++ b/nc_test4/tst_mpi_parallel.c
@@ -35,8 +35,8 @@ main(int argc, char **argv)
 
    /* Initialize MPI. */
    MPI_Init(&argc,&argv);
-   MPI_Comm_size(MPI_COMM_WORLD, &mpi_size);
-   MPI_Comm_rank(MPI_COMM_WORLD, &my_rank);
+   MPI_Comm_size(NC_MPI_COMM_WORLD, &mpi_size);
+   MPI_Comm_rank(NC_MPI_COMM_WORLD, &my_rank);
    /*MPI_Get_processor_name(mpi_name, &mpi_namelen);*/
    /*printf("mpi_name: %s size: %d rank: %d\n", mpi_name,
      mpi_size, my_rank);*/
@@ -47,15 +47,15 @@ main(int argc, char **argv)
       printf("*** testing file create with parallel I/O with MPI...");
    }
 
-   if (MPI_File_open(MPI_COMM_WORLD, FILE, MPI_MODE_RDWR | MPI_MODE_CREATE,
-                     MPI_INFO_NULL, &fh) != MPI_SUCCESS) ERR;
+   if (MPI_File_open(NC_MPI_COMM_WORLD, FILE, MPI_MODE_RDWR | MPI_MODE_CREATE,
+                     NC_MPI_INFO_NULL, &fh) != MPI_SUCCESS) ERR;
    if (MPI_File_seek(fh, my_rank * sizeof(int), MPI_SEEK_SET) != MPI_SUCCESS) ERR;
    if (MPI_File_write(fh, &my_rank, 1, MPI_INT, &status) != MPI_SUCCESS) ERR;
    if (MPI_File_close(&fh) != MPI_SUCCESS) ERR;
 
    /* Reopen and check the file. */
-   if (MPI_File_open(MPI_COMM_WORLD, FILE, MPI_MODE_RDONLY,
-                     MPI_INFO_NULL, &fh) != MPI_SUCCESS) ERR;
+   if (MPI_File_open(NC_MPI_COMM_WORLD, FILE, MPI_MODE_RDONLY,
+                     NC_MPI_INFO_NULL, &fh) != MPI_SUCCESS) ERR;
    if (MPI_File_seek(fh, my_rank * sizeof(int), MPI_SEEK_SET) != MPI_SUCCESS) ERR;
    if (MPI_File_read(fh, &data_in, 1, MPI_INT, &status) != MPI_SUCCESS) ERR;
    if (data_in != my_rank) ERR;

--- a/nc_test4/tst_nc4perf.c
+++ b/nc_test4/tst_nc4perf.c
@@ -28,8 +28,8 @@ $Id: tst_nc4perf.c,v 1.4 2009/08/19 15:58:57 ed Exp $
 
 /* This function creates a file with 10 2D variables, no unlimited
  * dimension. */
-int test_pio_2d(size_t cache_size, int access_flag, MPI_Comm comm,
-		MPI_Info info, int mpi_size, int mpi_rank,
+int test_pio_2d(size_t cache_size, int access_flag, nc_MPI_Comm comm,
+		nc_MPI_Info info, int mpi_size, int mpi_rank,
 		size_t *chunk_size)
 {
    double starttime, endtime, write_time = 0, bandwidth = 0;
@@ -135,8 +135,8 @@ int test_pio_2d(size_t cache_size, int access_flag, MPI_Comm comm,
 /* Both read and write will be tested */
 /* Case 2: create four dimensional integer data,
    one dimension is unlimited. */
-int test_pio_4d(size_t cache_size, int access_flag, MPI_Comm comm,
-		MPI_Info info, int mpi_size, int mpi_rank, size_t *chunk_size)
+int test_pio_4d(size_t cache_size, int access_flag, nc_MPI_Comm comm,
+		nc_MPI_Info info, int mpi_size, int mpi_rank, size_t *chunk_size)
 {
    int ncid, dimuids[NDIMS2], varid2[NUMVARS];
    size_t ustart[NDIMS2], ucount[NDIMS2];
@@ -253,8 +253,8 @@ int test_pio_4d(size_t cache_size, int access_flag, MPI_Comm comm,
 
 int main(int argc, char **argv)
 {
-   MPI_Comm comm = MPI_COMM_WORLD;
-   MPI_Info info = MPI_INFO_NULL;
+   nc_MPI_Comm comm = NC_MPI_COMM_WORLD;
+   nc_MPI_Info info = NC_MPI_INFO_NULL;
    int mpi_size, mpi_rank;
    int facc_type[NUM_FACC] = {NC_INDEPENDENT, NC_COLLECTIVE};
    size_t chunk_size_2d[NUM_CHUNK_COMBOS_2D][NDIMS1] = {{0, 0},
@@ -269,8 +269,8 @@ int main(int argc, char **argv)
 
    /* Initialize MPI. */
    MPI_Init(&argc, &argv);
-   MPI_Comm_size(MPI_COMM_WORLD, &mpi_size);
-   MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
+   MPI_Comm_size(NC_MPI_COMM_WORLD, &mpi_size);
+   MPI_Comm_rank(NC_MPI_COMM_WORLD, &mpi_rank);
 
    /* Check for invalid number of processors. */
    if ((float)DIMSIZE1 / mpi_size != (int)(DIMSIZE1 / mpi_size))

--- a/nc_test4/tst_parallel.c
+++ b/nc_test4/tst_parallel.c
@@ -33,8 +33,8 @@ main(int argc, char **argv)
     int mpi_namelen;
     char mpi_name[MPI_MAX_PROCESSOR_NAME];
     int mpi_size, mpi_rank;
-    MPI_Comm comm = MPI_COMM_WORLD;
-    MPI_Info info = MPI_INFO_NULL;
+    nc_MPI_Comm comm = NC_MPI_COMM_WORLD;
+    nc_MPI_Info info = NC_MPI_INFO_NULL;
 
     /* Netcdf-4 stuff. */
     int ncid, v1id, dimids[NDIMS];
@@ -50,8 +50,8 @@ main(int argc, char **argv)
 
     /* Initialize MPI. */
     MPI_Init(&argc,&argv);
-    MPI_Comm_size(MPI_COMM_WORLD, &mpi_size);
-    MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
+    MPI_Comm_size(NC_MPI_COMM_WORLD, &mpi_size);
+    MPI_Comm_rank(NC_MPI_COMM_WORLD, &mpi_rank);
     MPI_Get_processor_name(mpi_name, &mpi_namelen);
     /*printf("mpi_name: %s size: %d rank: %d\n", mpi_name,
       mpi_size, mpi_rank);*/

--- a/nc_test4/tst_parallel3.c
+++ b/nc_test4/tst_parallel3.c
@@ -42,7 +42,7 @@ int test_pio_big(int);
 int test_pio_hyper(int);
 int test_pio_extend(int);
 
-char* getenv_all(MPI_Comm comm, int root, const char* name);
+char* getenv_all(nc_MPI_Comm comm, int root, const char* name);
 int facc_type;
 int facc_type_open;
 char file_name[NC_MAX_NAME + 1];
@@ -59,8 +59,8 @@ int main(int argc, char **argv)
    setbuf(stdout, NULL);
 
    MPI_Init(&argc, &argv);
-   MPI_Comm_size(MPI_COMM_WORLD, &mpi_size);
-   MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
+   MPI_Comm_size(NC_MPI_COMM_WORLD, &mpi_size);
+   MPI_Comm_rank(NC_MPI_COMM_WORLD, &mpi_rank);
 
    if (mpi_rank == 0)
       printf("\n*** Testing more advanced parallel access.\n");
@@ -143,7 +143,7 @@ int main(int argc, char **argv)
    if (mpi_rank == 0)
       SUMMARIZE_ERR;
 
-/*     if(!getenv_all(MPI_COMM_WORLD,0,"NETCDF4_NOCLEANUP")) */
+/*     if(!getenv_all(NC_MPI_COMM_WORLD,0,"NETCDF4_NOCLEANUP")) */
    remove(file_name);
    MPI_Finalize();
 
@@ -157,8 +157,8 @@ int test_pio(int flag)
 {
    /* MPI stuff. */
    int mpi_size, mpi_rank;
-   MPI_Comm comm = MPI_COMM_WORLD;
-   MPI_Info info = MPI_INFO_NULL;
+   nc_MPI_Comm comm = NC_MPI_COMM_WORLD;
+   nc_MPI_Info info = NC_MPI_INFO_NULL;
 
    /* Netcdf-4 stuff. */
    int ncid;
@@ -188,8 +188,8 @@ int test_pio(int flag)
    int *temprudata;
 
    /* Initialize MPI. */
-   MPI_Comm_size(MPI_COMM_WORLD, &mpi_size);
-   MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
+   MPI_Comm_size(NC_MPI_COMM_WORLD, &mpi_size);
+   MPI_Comm_rank(NC_MPI_COMM_WORLD, &mpi_rank);
 
    /* Create a parallel netcdf-4 file. */
    if (nc_create_par(file_name, facc_type, comm, info, &ncid)) ERR;
@@ -362,8 +362,8 @@ int test_pio_attr(int flag)
 {
    /* MPI stuff. */
    int mpi_size, mpi_rank;
-   MPI_Comm comm = MPI_COMM_WORLD;
-   MPI_Info info = MPI_INFO_NULL;
+   nc_MPI_Comm comm = NC_MPI_COMM_WORLD;
+   nc_MPI_Info info = NC_MPI_INFO_NULL;
 
    /* Netcdf-4 stuff. */
    int ncid;
@@ -386,8 +386,8 @@ int test_pio_attr(int flag)
    int *tempdata;
 
    /* Initialize MPI. */
-   MPI_Comm_size(MPI_COMM_WORLD, &mpi_size);
-   MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
+   MPI_Comm_size(NC_MPI_COMM_WORLD, &mpi_size);
+   MPI_Comm_rank(NC_MPI_COMM_WORLD, &mpi_rank);
 
    /* Create a parallel netcdf-4 file. */
 /*    nc_set_log_level(NC_TURN_OFF_LOGGING); */
@@ -547,8 +547,8 @@ int test_pio_hyper(int flag){
    /* MPI stuff. */
    int mpi_size, mpi_rank;
    int res = NC_NOERR;
-   MPI_Comm comm = MPI_COMM_WORLD;
-   MPI_Info info = MPI_INFO_NULL;
+   nc_MPI_Comm comm = NC_MPI_COMM_WORLD;
+   nc_MPI_Info info = NC_MPI_INFO_NULL;
 
    /* Netcdf-4 stuff. */
    int ncid;
@@ -567,8 +567,8 @@ int test_pio_hyper(int flag){
 
 
    /* Initialize MPI. */
-   MPI_Comm_size(MPI_COMM_WORLD, &mpi_size);
-   MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
+   MPI_Comm_size(NC_MPI_COMM_WORLD, &mpi_size);
+   MPI_Comm_rank(NC_MPI_COMM_WORLD, &mpi_rank);
 
    if(mpi_size == 1) return 0;
 
@@ -695,11 +695,11 @@ int test_pio_extend(int flag){
     size_t count[2];
     int vertices[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
 
-    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-    MPI_Comm_size(MPI_COMM_WORLD, &procs);
+    MPI_Comm_rank(NC_MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(NC_MPI_COMM_WORLD, &procs);
 
     /* Create netcdf file */
-    if (nc_create_par("test.nc", NC_NETCDF4, MPI_COMM_WORLD, MPI_INFO_NULL, &ncFile)) ERR;
+    if (nc_create_par("test.nc", NC_NETCDF4, NC_MPI_COMM_WORLD, NC_MPI_INFO_NULL, &ncFile)) ERR;
 
     /* Create netcdf dimensions */
     if (nc_def_dim(ncFile, "partitions", procs, &ncDimPart)) ERR;
@@ -753,7 +753,7 @@ int test_pio_extend(int flag){
  *-------------------------------------------------------------------------
  */
 
-char* getenv_all(MPI_Comm comm, int root, const char* name)
+char* getenv_all(nc_MPI_Comm comm, int root, const char* name)
 {
    int nID;
    int len = -1;

--- a/nc_test4/tst_parallel4.c
+++ b/nc_test4/tst_parallel4.c
@@ -35,8 +35,8 @@ main(int argc, char **argv)
     int mpi_namelen;
     char mpi_name[MPI_MAX_PROCESSOR_NAME];
     int mpi_size, mpi_rank;
-    MPI_Comm comm = MPI_COMM_WORLD;
-    MPI_Info info = MPI_INFO_NULL;
+    nc_MPI_Comm comm = NC_MPI_COMM_WORLD;
+    nc_MPI_Info info = NC_MPI_INFO_NULL;
     double start_time = 0, total_time;
 
     /* Netcdf-4 stuff. */
@@ -55,8 +55,8 @@ main(int argc, char **argv)
 
     /* Initialize MPI. */
     MPI_Init(&argc,&argv);
-    MPI_Comm_size(MPI_COMM_WORLD, &mpi_size);
-    MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
+    MPI_Comm_size(NC_MPI_COMM_WORLD, &mpi_size);
+    MPI_Comm_rank(NC_MPI_COMM_WORLD, &mpi_rank);
     MPI_Get_processor_name(mpi_name, &mpi_namelen);
     /*printf("mpi_name: %s size: %d rank: %d\n", mpi_name, mpi_size, mpi_rank);*/
 

--- a/nc_test4/tst_parallel5.c
+++ b/nc_test4/tst_parallel5.c
@@ -31,8 +31,8 @@ int
 main(int argc, char **argv)
 {
     int mpi_size, mpi_rank;
-    MPI_Comm comm = MPI_COMM_WORLD;
-    MPI_Info info = MPI_INFO_NULL;
+    nc_MPI_Comm comm = NC_MPI_COMM_WORLD;
+    nc_MPI_Info info = NC_MPI_INFO_NULL;
     int ncid, v1id, dimid;
     size_t start[NDIMS1] = {0}, count[NDIMS1] = {0};
     int data = MASTS;
@@ -41,8 +41,8 @@ main(int argc, char **argv)
 
     /* Initialize MPI. */
     MPI_Init(&argc, &argv);
-    MPI_Comm_size(MPI_COMM_WORLD, &mpi_size);
-    MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
+    MPI_Comm_size(NC_MPI_COMM_WORLD, &mpi_size);
+    MPI_Comm_rank(NC_MPI_COMM_WORLD, &mpi_rank);
 
     /* Require exactly 4 tasks. */
     if (mpi_size != NUM_PROC) ERR;
@@ -302,7 +302,7 @@ main(int argc, char **argv)
         signed char test_data_in, test_data = 42;
 
         /* Crate a file with a scalar NC_BYTE value. */
-        if (nc_create_par(FILE, NC_NETCDF4, MPI_COMM_WORLD, MPI_INFO_NULL,
+        if (nc_create_par(FILE, NC_NETCDF4, NC_MPI_COMM_WORLD, NC_MPI_INFO_NULL,
                           &ncid)) ERR;
         if (nc_def_var(ncid, VAR_NAME, NC_BYTE, 0, NULL, &varid)) ERR;
         if (nc_enddef(ncid)) ERR;
@@ -327,7 +327,7 @@ main(int argc, char **argv)
         float preemption;
 
         /* Create a file with parallel I/O and check cache settings. */
-        if (nc_create_par(FILE, NC_NETCDF4|NC_CLOBBER, MPI_COMM_WORLD, MPI_INFO_NULL,
+        if (nc_create_par(FILE, NC_NETCDF4|NC_CLOBBER, NC_MPI_COMM_WORLD, NC_MPI_INFO_NULL,
                           &ncid)) ERR;
         if (nc4_hdf5_get_chunk_cache(ncid, &size, &nelems, &preemption)) ERR;
         if (size != HDF5_DEFAULT_CACHE_SIZE || nelems != HDF5_DEFAULT_NELEMS ||
@@ -394,7 +394,7 @@ main(int argc, char **argv)
             data[i] = mpi_rank + i * 0.1;
 
         /* Crate a file with a scalar NC_BYTE value. */
-        if (nc_create_par(FILE, NC_NETCDF4, MPI_COMM_WORLD, MPI_INFO_NULL,
+        if (nc_create_par(FILE, NC_NETCDF4, NC_MPI_COMM_WORLD, NC_MPI_INFO_NULL,
                           &ncid)) ERR;
         if (nc_def_dim(ncid, SZIP_DIM_NAME, SZIP_DIM_LEN, &dimid)) ERR;
         if (nc_def_var(ncid, SZIP_VAR_NAME, NC_FLOAT, NDIMS1, &dimid, &varid)) ERR;
@@ -445,7 +445,7 @@ main(int argc, char **argv)
             data[i] = mpi_rank + i * 0.1;
 
         /* Crate a file with a scalar NC_BYTE value. */
-        if (nc_create_par(FILE, NC_NETCDF4, MPI_COMM_WORLD, MPI_INFO_NULL,
+        if (nc_create_par(FILE, NC_NETCDF4, NC_MPI_COMM_WORLD, NC_MPI_INFO_NULL,
                           &ncid)) ERR;
         if (nc_def_dim(ncid, SZIP_DIM_NAME, SZIP_DIM_LEN, &dimid)) ERR;
         if (nc_def_var(ncid, SZIP_VAR_NAME, NC_FLOAT, NDIMS1, &dimid, &varid)) ERR;

--- a/nc_test4/tst_parallel_compress.c
+++ b/nc_test4/tst_parallel_compress.c
@@ -36,8 +36,8 @@ main(int argc, char **argv)
 {
     /* MPI stuff. */
     int mpi_size, mpi_rank;
-    MPI_Comm comm = MPI_COMM_WORLD;
-    MPI_Info info = MPI_INFO_NULL;
+    nc_MPI_Comm comm = NC_MPI_COMM_WORLD;
+    nc_MPI_Info info = NC_MPI_INFO_NULL;
 
     /* Netcdf-4 stuff. */
     int ncid, v1id, dimids[NDIMS];
@@ -48,8 +48,8 @@ main(int argc, char **argv)
 
     /* Initialize MPI. */
     MPI_Init(&argc, &argv);
-    MPI_Comm_size(MPI_COMM_WORLD, &mpi_size);
-    MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
+    MPI_Comm_size(NC_MPI_COMM_WORLD, &mpi_size);
+    MPI_Comm_rank(NC_MPI_COMM_WORLD, &mpi_rank);
 
     /* Allocate data. */
     if (!(slab_data = malloc(sizeof(int) * DIMSIZE * DIMSIZE / mpi_size))) ERR;

--- a/nc_test4/tst_parallel_zlib.c
+++ b/nc_test4/tst_parallel_zlib.c
@@ -37,8 +37,8 @@ main(int argc, char **argv)
     int mpi_namelen;
     char mpi_name[MPI_MAX_PROCESSOR_NAME];
     int mpi_size, mpi_rank;
-    MPI_Comm comm = MPI_COMM_WORLD;
-    MPI_Info info = MPI_INFO_NULL;
+    nc_MPI_Comm comm = NC_MPI_COMM_WORLD;
+    nc_MPI_Info info = NC_MPI_INFO_NULL;
 
     /* Netcdf-4 stuff. */
     int ncid, v1id, dimids[NDIMS];
@@ -54,8 +54,8 @@ main(int argc, char **argv)
 
     /* Initialize MPI. */
     MPI_Init(&argc, &argv);
-    MPI_Comm_size(MPI_COMM_WORLD, &mpi_size);
-    MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
+    MPI_Comm_size(NC_MPI_COMM_WORLD, &mpi_size);
+    MPI_Comm_rank(NC_MPI_COMM_WORLD, &mpi_rank);
     MPI_Get_processor_name(mpi_name, &mpi_namelen);
     /*printf("mpi_name: %s size: %d rank: %d\n", mpi_name,
       mpi_size, mpi_rank);*/

--- a/nc_test4/tst_quantize_par.c
+++ b/nc_test4/tst_quantize_par.c
@@ -72,13 +72,13 @@ main(int argc, char **argv)
 {
 
     int mpi_size, mpi_rank;
-    MPI_Comm comm = MPI_COMM_WORLD;
-    MPI_Info info = MPI_INFO_NULL;
+    nc_MPI_Comm comm = NC_MPI_COMM_WORLD;
+    nc_MPI_Info info = NC_MPI_INFO_NULL;
 
     /* Initialize MPI. */
     MPI_Init(&argc, &argv);
-    MPI_Comm_size(MPI_COMM_WORLD, &mpi_size);
-    MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
+    MPI_Comm_size(NC_MPI_COMM_WORLD, &mpi_size);
+    MPI_Comm_rank(NC_MPI_COMM_WORLD, &mpi_rank);
 
     /* Must be run on exactly 4 processors. */
     if (mpi_size != 4)

--- a/nc_test4/tst_simplerw_coll_r.c
+++ b/nc_test4/tst_simplerw_coll_r.c
@@ -29,8 +29,8 @@ main(int argc, char **argv)
    int mpi_namelen;
    char mpi_name[MPI_MAX_PROCESSOR_NAME];
    int mpi_size, mpi_rank;
-   MPI_Comm comm = MPI_COMM_WORLD;
-   MPI_Info info = MPI_INFO_NULL;
+   nc_MPI_Comm comm = NC_MPI_COMM_WORLD;
+   nc_MPI_Info info = NC_MPI_INFO_NULL;
    double start_time = 0, total_time;
    int mpi_size_in;
 #define NUM_TEST_TYPES 11
@@ -41,8 +41,8 @@ main(int argc, char **argv)
 
    /* Initialize MPI. */
    MPI_Init(&argc,&argv);
-   MPI_Comm_size(MPI_COMM_WORLD, &mpi_size);
-   MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
+   MPI_Comm_size(NC_MPI_COMM_WORLD, &mpi_size);
+   MPI_Comm_rank(NC_MPI_COMM_WORLD, &mpi_rank);
    MPI_Get_processor_name(mpi_name, &mpi_namelen);
 
    /* Must be able to evenly divide my slabs between processors. */


### PR DESCRIPTION
Instead of providing MPI names directly just because NetCDF itself is
MPI-unaware, use NetCDF-specific names for these types to avoid any
conflicts.