### PR TITLE
Collapse and update the HDF5 versions being tested on Github Actions.

### DIFF
--- a/.github/workflows/run_tests_ubuntu.yml
+++ b/.github/workflows/run_tests_ubuntu.yml
@@ -2,7 +2,7 @@
 # Build hdf4, hdf5 dependencies and cache them in a combined directory.
 ###
 
-name: Run netCDF Tests
+name: Run Ubuntu/Linux netCDF Tests
 
 on: [ pull_request ]
 
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        hdf5: [ 1.8.21, 1.10.1, 1.10.7, 1.12.1 ]
+        hdf5: [ 1.8.21, 1.10.8, 1.12.1 ]
 
     steps:
 
@@ -62,7 +62,7 @@ jobs:
 
     strategy:
       matrix:
-        hdf5: [ 1.8.21, 1.10.1, 1.10.7, 1.12.1 ]
+        hdf5: [ 1.8.21, 1.10.8, 1.12.1 ]
         use_nc4: [ nc3, nc4 ]
         use_dap: [ dap_off, dap_on ]
         use_nczarr: [ nczarr_off, nczarr_on ]
@@ -169,7 +169,7 @@ jobs:
 
     strategy:
       matrix:
-        hdf5: [ 1.8.21, 1.10.1, 1.10.7, 1.12.1 ]
+        hdf5: [ 1.8.21, 1.10.8, 1.12.1 ]
         use_nc4: [ nc3, nc4 ]
         use_dap: [ dap_off, dap_on ]
         use_nczarr: [ nczarr_off, nczarr_on ]
@@ -269,7 +269,7 @@ jobs:
 
     strategy:
       matrix:
-        hdf5: [ 1.10.7 ]
+        hdf5: [ 1.12.1 ]
     steps:
 
       - uses: actions/checkout@v2
@@ -350,7 +350,7 @@ jobs:
 
     strategy:
       matrix:
-        hdf5: [ 1.10.7]
+        hdf5: [ 1.12.1 ]
 
     steps:
 


### PR DESCRIPTION
* Remove HDF5 `1.10.1` from the test matrix, replace `1.10.7` with `1.10.8`.
* For the one-off tests, replace `1.10.7` with `1.12.1`.