### PR TITLE
Correct the accidental removal of NOUNDEFINED in liblib/Makefile.am

### DIFF
--- a/liblib/Makefile.am
+++ b/liblib/Makefile.am
@@ -18,10 +18,10 @@ lib_LTLIBRARIES = libnetcdf.la
 # for information regarding incrementing `-version-info`.
 ##
 
-libnetcdf_la_LDFLAGS = -version-info 19:1:0
+libnetcdf_la_LDFLAGS = -version-info 19:1:0 ${NOUNDEFINED}
 
 libnetcdf_la_CPPFLAGS = ${AM_CPPFLAGS}
-libnetcdf_la_LIBADD = 
+libnetcdf_la_LIBADD =
 CLEANFILES =
 
 # The v2 API...


### PR DESCRIPTION
* Fixes #2196 

Thanks to @matzeri for reporting this apparent accidental removal of `${NOUNDEFINED}`  in `liblib/Makefile.am` in commit 26f8ebda466f64db8d85820413fb445ae97393d9.