### PR TITLE
CI: Update HDF5 testing 1.8.21 --> 1.8.22

### DIFF
--- a/.github/workflows/run_tests_ubuntu.yml
+++ b/.github/workflows/run_tests_ubuntu.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        hdf5: [ 1.8.21, 1.10.8, 1.12.1 ]
+        hdf5: [ 1.8.22, 1.10.8, 1.12.1 ]
 
     steps:
 
@@ -61,7 +61,7 @@ jobs:
 
     strategy:
       matrix:
-        hdf5: [ 1.8.21, 1.10.8, 1.12.1 ]
+        hdf5: [ 1.8.22, 1.10.8, 1.12.1 ]
         use_nc4: [ nc3, nc4 ]
         use_dap: [ dap_off, dap_on ]
         use_nczarr: [ nczarr_off, nczarr_on ]
@@ -168,7 +168,7 @@ jobs:
 
     strategy:
       matrix:
-        hdf5: [ 1.8.21, 1.10.8, 1.12.1 ]
+        hdf5: [ 1.8.22, 1.10.8, 1.12.1 ]
         use_nc4: [ nc3, nc4 ]
         use_dap: [ dap_off, dap_on ]
         use_nczarr: [ nczarr_off, nczarr_on ]


### PR DESCRIPTION
* Update test matrix for latest HDF5, replace `1.8.21` with `1.8.22`.

1.8.22 was released 2021 February 5.
https://portal.hdfgroup.org/display/support/HDF5%201.8.22

This follows another recent matrix update in #2194.
This would depend on the latest `HDF5 1.8.22` being available in CI.
This is untested by me.  Let's just see what CI does with it.