### PR TITLE
Address issue with `make dist` generated tarballs, subsequent cmake builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2460,7 +2460,9 @@ IF(ENABLE_TESTS)
     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/ncdap_test/pingurl.c ${CMAKE_CURRENT_BINARY_DIR}/dap4_test/pingurl4.c @ONLY NEWLINE_STYLE LF)
 ENDIF()
 
-add_subdirectory(fuzz)
+if(DEFINED ENV{LIB_FUZZING_ENGINE})
+  add_subdirectory(fuzz)
+endif(DEFINED ENV{LIB_FUZZING_ENGINE})
 
 ####
 # Export files

--- a/Makefile.am
+++ b/Makefile.am
@@ -16,7 +16,7 @@ cmake CMakeLists.txt COMPILE.cmake.txt config.h.cmake.in		\
 cmake_uninstall.cmake.in FixBundle.cmake.in nc-config.cmake.in		\
 RELEASE_NOTES.md CTestCustom.cmake CTestConfig.cmake.in			\
 libnetcdf.settings.in netCDFConfig.cmake.in CMakeInstallation.cmake	\
-test-driver-verbose test_common.in
+test-driver-verbose test_common.in fuzz
 
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = netcdf.pc

--- a/fuzz/CMakeLists.txt
+++ b/fuzz/CMakeLists.txt
@@ -1,3 +1,11 @@
+# This is part of the netCDF package.
+# Copyright 2022 University Corporation for Atmospheric Research/Unidata
+# See COPYRIGHT file for conditions of use.
+#
+# Added for fuzzing in https://github.com/Unidata/netcdf-c/pull/1972
+#
+# @authors Ward Fisher
+
 if(DEFINED ENV{LIB_FUZZING_ENGINE})
   add_executable(fuzz_open fuzz_open.c)
   target_link_libraries(fuzz_open netcdf $ENV{LIB_FUZZING_ENGINE})

--- a/fuzz/Makefile.am
+++ b/fuzz/Makefile.am
@@ -1,0 +1,15 @@
+# This is part of the netCDF package.
+# Copyright 2022 University Corporation for Atmospheric Research/Unidata
+# See COPYRIGHT file for conditions of use.
+#
+# @authors Ward Fisher
+
+# Set AM_CPPFLAGS and AM_LDFLAGS based on user choices.
+include $(top_srcdir)/lib_flags.am
+
+#if(DEFINED ENV{LIB_FUZZING_ENGINE})
+#  add_executable(fuzz_open fuzz_open.c)
+#  target_link_libraries(fuzz_open netcdf $ENV{LIB_FUZZING_ENGINE})
+#endif()
+
+EXTRA_DIST = fuzz.c fuzz_open.c

--- a/libnczarr/Makefile.am
+++ b/libnczarr/Makefile.am
@@ -55,7 +55,6 @@ zarr.h \
 zcache.h \
 zchunking.h \
 zdispatch.h \
-ztracedispatch.h \
 zincludes.h \
 zinternal.h \
 zmap.h \

--- a/nc_test4/Makefile.am
+++ b/nc_test4/Makefile.am
@@ -104,7 +104,8 @@ ref_filteredvv.cdl ref_multi.cdl                                        \
 ref_ncgenF.cdl ref_nccopyF.cdl                                          \
 ref_filter_repeat.txt ref_fillonly.cdl test_fillonly.sh                 \
 ref_filter_order_create.txt ref_filter_order_read.txt			\
-ref_any.cdl tst_specific_filters.sh
+ref_any.cdl tst_specific_filters.sh \
+tst_virtual_datasets.c
 
 CLEANFILES = tst_mpi_parallel.bin cdm_sea_soundings.nc bm_chunking.nc	\
 tst_floats_1D.cdl floats_1D_3.nc floats_1D.cdl tst_*.nc tmp_*.txt       \

--- a/ncdump/cdl/Makefile.am
+++ b/ncdump/cdl/Makefile.am
@@ -25,6 +25,7 @@ ref_solar.cdl unlimtest1.cdl unlimtest2.cdl \
 ref_tst_opaque_data.cdl  \
 ref_tst_vlen_data.cdl ref_tst_vlen_data2.cdl \
 ref_niltest.cdl ref_tst_h_scalar.cdl ref_tst_econst.cdl \
+ref_tst_econst2.cdl \
 ref_tst_nul3.cdl ref_tst_nul4.cdl ref_tst_names.cdl \
 ref_tst_long_charconst.cdl tst_chararray.cdl ref_keyword.cdl \
 CMakeLists.txt

--- a/ncdump/expected/Makefile.am
+++ b/ncdump/expected/Makefile.am
@@ -19,6 +19,7 @@ n3time.dmp ref_tst_special_atts3.dmp ref_tst_chardata.dmp ref_tst_unlim2.dmp \
 ref_solar.dmp unlimtest1.dmp unlimtest2.dmp \
 ref_tst_vlen_data.dmp ref_tst_vlen_data2.dmp \
 ref_niltest.dmp ref_tst_h_scalar.dmp ref_tst_econst.dmp \
+ref_tst_econst2.dmp \
 ref_tst_nul3.dmp ref_tst_nul4.dmp ref_tst_names.dmp \
 ref_tst_long_charconst.dmp tst_chararray.dmp ref_keyword.dmp \
 CMakeLists.txt

--- a/nczarr_test/Makefile.am
+++ b/nczarr_test/Makefile.am
@@ -151,7 +151,7 @@ ref_groups.h5 ref_byte.zarr.zip ref_byte_fill_value_null.zarr.zip \
 ref_groups_regular.cdl ref_byte.cdl ref_byte_fill_value_null.cdl
 
 # Interoperability files
-EXTRA_DIST += ref_power_901_constants.zip ref_power_901_constants.cdl ref_quotes.zip ref_quotes.cdl ref_zarr_test_data.cdl.gz
+EXTRA_DIST += ref_power_901_constants.zip ref_power_901_constants.cdl ref_quotes.zip ref_quotes.cdl 
 
 CLEANFILES = ut_*.txt ut*.cdl tmp*.nc tmp*.cdl tmp*.txt tmp*.dmp tmp*.zip tmp*.nc tmp*.dump tmp*.tmp tmp_ngc.c ref_zarr_test_data.cdl
 


### PR DESCRIPTION
* Fixes #2166 

Clean up some of the issues with `make dist` generated tarballs when used with `cmake`.