### PR TITLE
Fixed Clang -Wstrict-prototypes warnings

### DIFF
--- a/include/nc3dispatch.h
+++ b/include/nc3dispatch.h
@@ -174,8 +174,8 @@ extern "C" {
 
 /* End _var */
 
-    extern int NC3_initialize();
-    extern int NC3_finalize();
+    extern int NC3_initialize(void);
+    extern int NC3_finalize(void);
 
 #if defined(__cplusplus)
 }

--- a/libncpoco/cp_unix.c
+++ b/libncpoco/cp_unix.c
@@ -37,7 +37,7 @@ static pthread_mutex_t mutex;
 #endif
 
 int
-ncp_unix_initialize()
+ncp_unix_initialize(void)
 {
     int ret = 1;
 #ifdef USE_MUTEX
@@ -54,7 +54,7 @@ ncp_unix_initialize()
 }
 
 int
-ncp_unix_finalize()
+ncp_unix_finalize(void)
 {
 #ifdef USE_MUTEX
     pthread_mutex_destroy(&mutex);

--- a/libnczarr/zinternal.h
+++ b/libnczarr/zinternal.h
@@ -230,7 +230,7 @@ int ncz_find_grp_var_att(int ncid, int varid, const char *name, int attnum,
                               int use_name, char *norm_name, NC_FILE_INFO_T** file,
                               NC_GRP_INFO_T** grp, NC_VAR_INFO_T** var,
                               NC_ATT_INFO_T** att);
-int NCZ_set_log_level();
+int NCZ_set_log_level(void);
 
 /* zcache.c */
 int ncz_adjust_var_cache(NC_GRP_INFO_T* grp, NC_VAR_INFO_T* var);

--- a/ncdump/dumplib.h
+++ b/ncdump/dumplib.h
@@ -87,7 +87,7 @@ extern int  is_user_defined_type ( nc_type type );
 extern void init_epsilons ( void );
 
 /* Initialize string buffer */
-safebuf_t *sbuf_new();
+safebuf_t *sbuf_new( void );
 
 /* Copy string s2 to buffer in sbuf, growing if necessary */
 void sbuf_cpy(safebuf_t *sbuf, const char *s2);

--- a/ncdump/indent.h
+++ b/ncdump/indent.h
@@ -11,11 +11,11 @@ extern "C" {
 #endif
 
 /* Handle nested group indentation */
-extern void indent_init();	/* initialize indent to zero */
-extern void indent_out();	/* output current indent */
-extern void indent_more();	/* increment current indent */
-extern void indent_less();	/* decrement current indent */
-extern int  indent_get();	/* return current indent */
+extern void indent_init(void);	/* initialize indent to zero */
+extern void indent_out(void);	/* output current indent */
+extern void indent_more(void);	/* increment current indent */
+extern void indent_less(void);	/* decrement current indent */
+extern int  indent_get(void);	/* return current indent */
 
 #ifdef __cplusplus
 }

--- a/ncgen3/ncgen.l
+++ b/ncgen3/ncgen.l
@@ -288,7 +288,7 @@ FloatInf|-?Inff	{ /* missing value (pre-2.4 backward compatibility) */
 
 /* Hack to keep compile quiet */
 void
-ignore()
+ignore(void)
 {
 #ifndef YY_NO_UNPUT
     yyunput(0,NULL);

--- a/ncgen3/ncgen.y
+++ b/ncgen3/ncgen.y
@@ -66,13 +66,13 @@ static void *rec_cur;		/* pointer to where next data value goes */
 static void *rec_start;		/* start of space for data */
 
 /* Forward declarations */
-void defatt();
-void equalatt();
+void defatt(void);
+void equalatt(void);
 
 #ifdef YYLEX_PARAM
 int yylex(YYLEX_PARAM);
 #else
-int yylex();
+int yylex(void);
 #endif
 
 #ifdef vms
@@ -770,7 +770,7 @@ const:         CHAR_CONST
 %%
 
 /* HELPER PROGRAMS */
-void defatt()
+void defatt(void)
 {
     valnum = 0;
     valtype = NC_UNSPECIFIED;
@@ -785,7 +785,7 @@ void defatt()
     double_valp = (double *) att_space;
 }
 
-void equalatt()
+void equalatt(void)
 {
     /* check if duplicate attribute for this var */
     int i;

--- a/ncgen3/ncgenl.c
+++ b/ncgen3/ncgenl.c
@@ -2505,7 +2505,7 @@ void ncgfree (void * ptr )
 
 /* Hack to keep compile quiet */
 void
-ignore()
+ignore(void)
 {
 #ifndef YY_NO_UNPUT
     yyunput(0,NULL);

--- a/ncgen3/ncgeny.c
+++ b/ncgen3/ncgeny.c
@@ -131,13 +131,13 @@ static void *rec_cur;		/* pointer to where next data value goes */
 static void *rec_start;		/* start of space for data */
 
 /* Forward declarations */
-void defatt();
-void equalatt();
+void defatt(void);
+void equalatt(void);
 
 #ifdef YYLEX_PARAM
 int yylex(YYLEX_PARAM);
 #else
-int yylex();
+int yylex(void);
 #endif
 
 #ifdef vms
@@ -2359,7 +2359,7 @@ yyreturn:
 
 
 /* HELPER PROGRAMS */
-void defatt()
+void defatt(void)
 {
     valnum = 0;
     valtype = NC_UNSPECIFIED;
@@ -2374,7 +2374,7 @@ void defatt()
     double_valp = (double *) att_space;
 }
 
-void equalatt()
+void equalatt(void)
 {
     /* check if duplicate attribute for this var */
     int i;

--- a/nctest/tst_rename.c
+++ b/nctest/tst_rename.c
@@ -20,7 +20,7 @@ check_err(const int stat, const int line, const char *file) {
 }
 
 int
-create_file()
+create_file(void)
 {
    int  stat;  /* return status */
    int  ncid;  /* netCDF id */

--- a/oc2/ocinternal.h
+++ b/oc2/ocinternal.h
@@ -235,7 +235,7 @@ extern OCerror ocset_useragent(OCstate* state, const char* agent);
 extern OCerror ocset_netrc(OCstate* state, const char* path);
 
 /* From ocrc.c */
-extern OCerror ocrc_load(); /* find, read, and compile */
+extern OCerror ocrc_load(void); /* find, read, and compile */
 extern OCerror ocrc_process(OCstate* state); /* extract relevant triples */
 extern char* ocrc_lookup(char* key, char* url);
 extern struct OCTriple* ocrc_triple_iterate(char* key, char* url, struct OCTriple* prevp);

--- a/oc2/xxdr.h
+++ b/oc2/xxdr.h
@@ -189,7 +189,7 @@ extern int xxdr_skip_strings(XXDR* xdrs, off_t n);
 
 extern unsigned int xxdr_roundup(off_t n); /* procedural version of RNDUP macro */
 
-extern void xxdr_init();
+extern void xxdr_init(void);
 
 /* Define some inlines */
 #define xxdr_length(xdrs) ((xdrs)->length)


### PR DESCRIPTION
Clang is considering making this warning an error by default: https://discourse.llvm.org/t/rfc-enabling-wstrict-prototypes-by-default-in-c/60521
