### PR TITLE
Fix cmake search for Blosc and SZip

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1069,7 +1069,7 @@ ELSE()
 ENDIF()
 
 # See if we have libblosc
-IF(!MSVC)
+IF(NOT MSVC)
 FIND_PACKAGE(Blosc)
 ENDIF()
 # Define a test flag for have blosc library
@@ -1081,7 +1081,7 @@ ELSE()
 ENDIF()
 
 # See if we have libszip
-IF(!MSVC)
+IF(NOT MSVC)
 #FIND_PACKAGE(SZIP)
 #FIND_LIBRARY(SZIP PATH NAMES szip sz)
 SET(SZIP_LIBRARY ${SZIP})


### PR DESCRIPTION
cmake does not search for Blosc or SZip libraries due to use of bang (!) rather
than NOT for negation on lines 1072 and 1084 of CMakeLists.txt. This commit
fixes this issue.

Resolves #2254