### PR TITLE
Fix typo "Nan" -> "NaN"

### DIFF
--- a/libnczarr/zcvt.c
+++ b/libnczarr/zcvt.c
@@ -305,7 +305,7 @@ NCZ_stringconvert1(nc_type srctype, size_t len, char* src, NCjson* jvalue)
 #ifdef _WIN32
 	switch (_fpclass(zcvt.float64v)) {
 	case _FPCLASS_SNAN: case _FPCLASS_QNAN:
-	     strcpy(s,"Nan"); break;
+	     strcpy(s,"NaN"); break;
 	case _FPCLASS_NINF:
 	     strcpy(s,"-Infinity"); break;
 	case _FPCLASS_PINF:


### PR DESCRIPTION
re: issue https://github.com/Unidata/netcdf-c/issues/2265

The zarr code is generating "Nan" instead of "NaN" on windows.
This causes failures.
Solution: fix typo.