### PR TITLE
avoid type redefine of MPI_Comm and MPI_Info

### DIFF
--- a/include/ncdispatch.h
+++ b/include/ncdispatch.h
@@ -80,13 +80,7 @@
 #define ATOMICTYPEMAX3 NC_DOUBLE
 #define ATOMICTYPEMAX5 NC_UINT64
 
-#if !defined HDF5_PARALLEL && !defined USE_PNETCDF
-typedef int MPI_Comm;
-typedef int MPI_Info;
-#define MPI_COMM_WORLD 0
-#define MPI_INFO_NULL 0
-#endif
-
+#ifdef USE_PARALLEL
 /* Define a struct to hold the MPI info so it can be passed down the
  * call stack. This is used internally by the netCDF library. It
  * should not be used by netcdf users. */
@@ -94,6 +88,7 @@ typedef struct NC_MPI_INFO {
     MPI_Comm comm;
     MPI_Info info;
 } NC_MPI_INFO;
+#endif
 
 /* Define known dispatch tables and initializers */
 

--- a/libdispatch/CMakeLists.txt
+++ b/libdispatch/CMakeLists.txt
@@ -4,9 +4,14 @@
 # University Corporation for Atmospheric Research/Unidata.
 
 # See netcdf-c/COPYRIGHT file for more info.
-SET(libdispatch_SOURCES dparallel.c dcopy.c dfile.c ddim.c datt.c dattinq.c dattput.c dattget.c derror.c dvar.c dvarget.c dvarput.c dvarinq.c ddispatch.c nclog.c dstring.c dutf8.c dinternal.c doffsets.c ncuri.c nclist.c ncbytes.c nchashmap.c nctime.c nc.c nclistmgr.c utf8proc.h utf8proc.c dpathmgr.c dutil.c drc.c dauth.c dreadonly.c dnotnc4.c dnotnc3.c dinfermodel.c
+SET(libdispatch_SOURCES dcopy.c dfile.c ddim.c datt.c dattinq.c dattput.c dattget.c derror.c dvar.c dvarget.c dvarput.c dvarinq.c ddispatch.c nclog.c dstring.c dutf8.c dinternal.c doffsets.c ncuri.c nclist.c ncbytes.c nchashmap.c nctime.c nc.c nclistmgr.c utf8proc.h utf8proc.c dpathmgr.c dutil.c drc.c dauth.c dreadonly.c dnotnc4.c dnotnc3.c dinfermodel.c
 daux.c dinstance.c
 dcrc32.c dcrc32.h dcrc64.c ncexhash.c ncxcache.c ncjson.c ds3util.c)
+
+# if parallel I/O is enabled (PnetCDF or/and HDF5)
+IF(ENABLE_PARALLEL)
+  SET(libdispatch_SOURCES ${libdispatch_SOURCES} dparallel.c)
+ENDIF(ENABLE_PARALLEL)
 
 # Netcdf-4 only functions. Must be defined even if not used
 SET(libdispatch_SOURCES ${libdispatch_SOURCES} dgroup.c dvlen.c dcompound.c dtype.c denum.c dopaque.c dfilter.c)

--- a/libdispatch/Makefile.am
+++ b/libdispatch/Makefile.am
@@ -15,13 +15,17 @@ noinst_LTLIBRARIES = libdispatch.la
 libdispatch_la_CPPFLAGS = ${AM_CPPFLAGS}
 
 # The source files.
-libdispatch_la_SOURCES = dparallel.c dcopy.c dfile.c ddim.c datt.c	\
+libdispatch_la_SOURCES = dcopy.c dfile.c ddim.c datt.c	\
 dattinq.c dattput.c dattget.c derror.c dvar.c dvarget.c dvarput.c	\
 dvarinq.c dinternal.c ddispatch.c dutf8.c nclog.c dstring.c ncuri.c	\
 nclist.c ncbytes.c nchashmap.c nctime.c nc.c nclistmgr.c dauth.c	\
 doffsets.c dpathmgr.c dutil.c dreadonly.c dnotnc4.c dnotnc3.c           \
 dinfermodel.c daux.c dinstance.c \
 dcrc32.c dcrc32.h dcrc64.c ncexhash.c ncxcache.c ncjson.c ds3util.c
+
+if ENABLE_PARALLEL
+libdispatch_la_SOURCES += dparallel.c
+endif
 
 # Add the utf8 codebase
 libdispatch_la_SOURCES += utf8proc.c utf8proc.h


### PR DESCRIPTION
MPI_Comm and MPI_Info should only be used when parallel I/O is enabled.
Compiling file libdispatch/dparallel.c is skipped when parallel I/O is disabled.