### PR TITLE
turning off tests that depend on ncpathcvt when --disable-utilities is used

### DIFF
--- a/examples/C/Makefile.am
+++ b/examples/C/Makefile.am
@@ -33,10 +33,12 @@ check_PROGRAMS += simple_nc4_wr simple_nc4_rd simple_xy_nc4_wr	\
 simple_xy_nc4_rd
 TESTS += run_examples4.sh
 
+if BUILD_UTILITIES
 if ENABLE_FILTER_TESTING
 # filter_example.c should be same as nc_test4/test_filter.c
 check_PROGRAMS += filter_example
 TESTS += run_filter.sh
+endif
 endif
 
 endif #USE_HDF5

--- a/nctest/Makefile.am
+++ b/nctest/Makefile.am
@@ -30,13 +30,16 @@ nctest_classic.cdl ref_nctest_classic.cdl
 # reference file.
 TESTPROGRAMS = nctest tst_rename
 check_PROGRAMS = $(TESTPROGRAMS)
+
+# This test requires that the utilites also be built.
+if BUILD_UTILITIES
 TESTS = $(TESTPROGRAMS) compare_test_files.sh
+# compare_test_files depends on nctest executing first.
+compare_test_files.log: nctest.log
+endif
 
 # Note which tests depend on other tests. Necessary for make -j check.
 TEST_EXTENSIONS = .sh
-
-# compare_test_files depends on nctest executing first.
-compare_test_files.log: nctest.log
 
 # These are the source files for the nctest program.
 nctest_SOURCES = add.c add.h atttests.c cdftests.c dimtests.c driver.c	\

--- a/nczarr_test/Makefile.am
+++ b/nczarr_test/Makefile.am
@@ -37,13 +37,13 @@ tst_fillonlyz_SOURCES = tst_fillonlyz.c ${tstcommonsrc}
 
 check_PROGRAMS += tst_zchunks tst_zchunks2 tst_zchunks3 tst_fillonlyz test_quantize 
 
-TESTS += run_ut_map.sh
-TESTS += run_ut_mapapi.sh
-TESTS += run_ut_misc.sh
 TESTS += run_ut_chunk.sh
 
 if BUILD_UTILITIES
 
+TESTS += run_ut_map.sh
+TESTS += run_ut_mapapi.sh
+TESTS += run_ut_misc.sh
 TESTS += run_ncgen4.sh
 
 if USE_HDF5


### PR DESCRIPTION
turning off tests that depend on ncpathcvt when --disable-utilities is used

Fixes #2281 
