### PR TITLE
fixed missing NC_HAS_QUANTIZE

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1943,6 +1943,7 @@ AX_SET_META([NC_HAS_BYTERANGE],[$enable_byterange],[yes])
 AX_SET_META([NC_HAS_NCZARR],[$enable_nczarr],[yes])
 AX_SET_META([NC_HAS_MULTIFILTERS],[$has_multifilters],[yes])
 AX_SET_META([NC_HAS_LOGGING],[$enable_logging],[yes])
+AX_SET_META([NC_HAS_QUANTIZE],[yes],[yes])
 AX_SET_META([NC_HAS_SZIP],[$enable_hdf5_szip],[yes])
 
 # This is the version of the dispatch table. If the dispatch table is


### PR DESCRIPTION
fixes #2285 

@WardF this should be merged before the release or many users will start crying when their netcdf_meta.h file breaks their compiles.