### PR TITLE
added ZSTD to netcdf_meta.h and libnetcdf.settings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1125,6 +1125,12 @@ FIND_PACKAGE(Bz2)
 FIND_PACKAGE(Blosc)
 FIND_PACKAGE(Zstd)
 
+IF(Zstd_FOUND)
+  SET(HAVE_ZSTD yes)
+ELSE()
+  SET(HAVE_ZSTD no)
+ENDIF()
+
 # Accumulate standard filters
 set(STD_FILTERS "deflate") # Always have deflate */
 set_std_filter(SZIP)
@@ -2465,6 +2471,7 @@ is_enabled(ENABLE_LOGGING HAS_LOGGING)
 is_enabled(ENABLE_FILTER_TESTING DO_FILTER_TESTS)
 is_enabled(HAVE_SZ HAS_SZIP)
 is_enabled(HAVE_SZ HAS_SZLIB_WRITE)
+is_enabled(HAVE_ZSTD HAS_ZSTD)
 
 # Generate file from template.
 CONFIGURE_FILE("${CMAKE_CURRENT_SOURCE_DIR}/libnetcdf.settings.in"

--- a/configure.ac
+++ b/configure.ac
@@ -1860,6 +1860,7 @@ AC_SUBST(HAS_LOGGING,[$enable_logging])
 AC_SUBST(DO_FILTER_TESTS,[$enable_filter_testing])
 AC_SUBST(HAS_SZLIB,[$have_sz])
 AC_SUBST(HAS_SZLIB_WRITE, [$have_sz])
+AC_SUBST(HAS_ZSTD,[$have_zstd])
 
 # Always available
 std_filters="deflate,bzip2"
@@ -1943,7 +1944,9 @@ AX_SET_META([NC_HAS_BYTERANGE],[$enable_byterange],[yes])
 AX_SET_META([NC_HAS_NCZARR],[$enable_nczarr],[yes])
 AX_SET_META([NC_HAS_MULTIFILTERS],[$has_multifilters],[yes])
 AX_SET_META([NC_HAS_LOGGING],[$enable_logging],[yes])
+AX_SET_META([NC_HAS_QUANTIZE],[yes],[yes])
 AX_SET_META([NC_HAS_SZIP],[$enable_hdf5_szip],[yes])
+AX_SET_META([NC_HAS_ZSTD],[$have_zstd],[yes])
 
 # This is the version of the dispatch table. If the dispatch table is
 # changed, this should be incremented, so that user-defined format

--- a/include/netcdf_meta.h.in
+++ b/include/netcdf_meta.h.in
@@ -64,5 +64,6 @@
 #define NC_HAS_MULTIFILTERS  @NC_HAS_MULTIFILTERS@ /*!< Nczarr support. */
 #define NC_HAS_LOGGING       @NC_HAS_LOGGING@ /*!< Logging support. */
 #define NC_HAS_QUANTIZE      @NC_HAS_QUANTIZE@ /*!< Quantization support. */
+#define NC_HAS_ZSTD          @NC_HAS_ZSTD@ /*!< Zstd support. */
 
 #endif

--- a/libnetcdf.settings.in
+++ b/libnetcdf.settings.in
@@ -48,3 +48,4 @@ Quantization:		@HAS_QUANTIZE@
 Logging:     		@HAS_LOGGING@
 SZIP Write Support:     @HAS_SZLIB_WRITE@
 Standard Filters:       @STD_FILTERS@
+ZSTD Support:           @HAS_ZSTD@


### PR DESCRIPTION
Fixes #2275 

added ZSTD to netcdf_meta.h and libnetcdf.settings

I've checked with both autotools and CMake.

(This PR also incorporates #2286)