### PR TITLE
Fix dll exports for ncxml

### DIFF
--- a/include/ncxml.h
+++ b/include/ncxml.h
@@ -4,7 +4,7 @@
 #ifndef NCXML_H
 #define NCXML_H
 
-#ifdef _WIN32
+#ifdef DLL_NETCDF
   #ifdef DLL_EXPORT /* define when building the library */
     #define DECLSPEC __declspec(dllexport)
   #else


### PR DESCRIPTION
When building netcdf as static libraries and executables on mingw-w64, the build fails while linking `ncgen.exe`, due to numerous undefined references to symbols in ncxml. These symbols are being defined for dll import, which is not appropriate when netcdf is built statically. A minor change to the preprocessor logic solves the problem on mingw-w64, and with this change, the (static) build completes and all tests pass.