### PR TITLE
Fix dll builds under mingw-w64

### DIFF
--- a/nc_test4/tst_udf.c
+++ b/nc_test4/tst_udf.c
@@ -17,7 +17,7 @@
 
 #define FILE_NAME "tst_udf.nc"
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 static int
 NC4_no_show_metadata(int ncid)
 {

--- a/nczarr_test/tst_utils.h
+++ b/nczarr_test/tst_utils.h
@@ -70,7 +70,7 @@ EXTERNL const char* filenamefor(const char* f0);
 EXTERNL const char* printvector(int rank, const size_t* vec);
 EXTERNL const char* printvector64(int rank, const size64_t* vec);
 
-EXTERNL int getoptions(int* argcp, char*** argvp);
+int getoptions(int* argcp, char*** argvp);
 EXTERNL int getmetadata(int create);
 EXTERNL void cleanup(void);
 

--- a/nczarr_test/tst_utils.h
+++ b/nczarr_test/tst_utils.h
@@ -55,28 +55,28 @@ typedef struct Odometer {
   size_t index[NC_MAX_VAR_DIMS]; /* current value of the odometer*/
 } Odometer;
 
-EXTERNL Odometer* odom_new(size_t rank, const size_t* start, const size_t* stop, const size_t* stride, const size_t* max);
-EXTERNL void odom_free(Odometer* odom);
-EXTERNL int odom_more(Odometer* odom);
-EXTERNL int odom_next(Odometer* odom);
-EXTERNL size_t* odom_indices(Odometer* odom);
-EXTERNL size_t odom_offset(Odometer* odom);
-EXTERNL const char* odom_print1(Odometer* odom, int isshort);
-EXTERNL const char* odom_print(Odometer* odom);
-EXTERNL const char* odom_printshort(Odometer* odom);
+extern Odometer* odom_new(size_t rank, const size_t* start, const size_t* stop, const size_t* stride, const size_t* max);
+extern void odom_free(Odometer* odom);
+extern int odom_more(Odometer* odom);
+extern int odom_next(Odometer* odom);
+extern size_t* odom_indices(Odometer* odom);
+extern size_t odom_offset(Odometer* odom);
+extern const char* odom_print1(Odometer* odom, int isshort);
+extern const char* odom_print(Odometer* odom);
+extern const char* odom_printshort(Odometer* odom);
 
-EXTERNL int parsevector(const char* s0, size_t* vec);
-EXTERNL const char* filenamefor(const char* f0);
-EXTERNL const char* printvector(int rank, const size_t* vec);
-EXTERNL const char* printvector64(int rank, const size64_t* vec);
+extern int parsevector(const char* s0, size_t* vec);
+extern const char* filenamefor(const char* f0);
+extern const char* printvector(int rank, const size_t* vec);
+extern const char* printvector64(int rank, const size64_t* vec);
 
-int getoptions(int* argcp, char*** argvp);
-EXTERNL int getmetadata(int create);
-EXTERNL void cleanup(void);
+extern int getoptions(int* argcp, char*** argvp);
+extern int getmetadata(int create);
+extern void cleanup(void);
 
 EXTERNL int nc__testurl(const char*,char**);
 
-EXTERNL const char* ncz_gets3testurl(void);
+extern const char* ncz_gets3testurl(void);
 
 static void
 report(int err, int lineno)
@@ -85,8 +85,8 @@ report(int err, int lineno)
     exit(1);
 }
 
-EXTERNL Options* options;
-EXTERNL Metadata* meta;
-EXTERNL NClist* capture;
+extern Options* options;
+extern Metadata* meta;
+extern NClist* capture;
 
 #endif /*TST_UTILS_H*/


### PR DESCRIPTION
Building the netcdf dll and related executables under mingw-w64 (with `cmake`) fails due to an undefined reference to `NC4_show_metadata'. The code contains a workaround for the MS C compiler, and this can be extended to gcc in mingw-w64.

After that, the build fails again due to undefined references to functions in tst_utils.h, which are declared as `dllimport` when they should be `extern`.

After fixing tst_utils.h, the build completes and all except 4 tests pass. The failed tests are:
         82 - nc_test4_tst_filter (Failed)
         83 - nc_test4_tst_specific_filters (Failed)
        222 - nczarr_test_run_filter (Failed)
        223 - nczarr_test_run_specific_filters (Failed)

All of the failed tests relate to filters, which are not being built under mingw-w64. I think this is because `libdl` is not available by default on mingw-w64, although it can be installed as an optional package. These tests should probably be disabled if the filters are not built.