### PR TITLE
Remove on-push trigger for OSX-based workflows.

### DIFF
--- a/.github/workflows/run_tests_osx.yml
+++ b/.github/workflows/run_tests_osx.yml
@@ -7,7 +7,7 @@
 name: Run macOS-based netCDF Tests
 
 
-on: [pull_request,push]
+on: [pull_request]
 
 jobs:
 

--- a/.github/workflows/run_tests_ubuntu.yml
+++ b/.github/workflows/run_tests_ubuntu.yml
@@ -82,7 +82,7 @@ jobs:
           key: hdf5-parallel-${{ runner.os }}-${{ matrix.hdf5 }}
 
 
-      - name: Build libhdf5-${{ matrix.hdf5 }}
+      - name: Build libhdf5-${{ matrix.hdf5 }}-pnetcdf-1.12.3
         if: steps.cache-hdf5.outputs.cache-hit != 'true'
         run: |
           set -x


### PR DESCRIPTION
Right on the tin.