### PR TITLE
allow to test tst_cdf5format when PnetCDF is enabled

### DIFF
--- a/nc_test/Makefile.am
+++ b/nc_test/Makefile.am
@@ -38,11 +38,9 @@ check_PROGRAMS += tst_parallel2 tst_pnetcdf tst_addvar	\
 tst_formatx_pnetcdf tst_default_format_pnetcdf
 endif
 
-if TEST_PARALLEL4
 if USE_PNETCDF
 if ENABLE_CDF5
 check_PROGRAMS += tst_cdf5format
-endif
 endif
 endif
 


### PR DESCRIPTION
When using configure options --enable-pnetcdf --disable-hdf5,
I got error message below when running make check.
```
HYDU_create_process: execvp error on file ./tst_cdf5format (No such file or directory)
FAIL run_pnetcdf_tests.sh (exit status: 255)
```

I suggest to add in github actions a test option of --enable-pnetcdf --disable-hdf5 

