### PR TITLE
fixed missing szip constants in netcdf.h

### DIFF
--- a/include/netcdf.h
+++ b/include/netcdf.h
@@ -329,6 +329,9 @@ there. */
 #define NC_MIN_DEFLATE_LEVEL 0 /**< Minimum deflate level. */
 #define NC_MAX_DEFLATE_LEVEL 9 /**< Maximum deflate level. */
 
+#define NC_SZIP_NN 32 /**< SZIP NN option mask. */
+#define NC_SZIP_EC 4  /**< SZIP EC option mask. */
+
 #define NC_NOQUANTIZE 0 /**< No quantization in use. */    
 #define NC_QUANTIZE_BITGROOM 1 /**< Use BitGroom quantization. */
 #define NC_QUANTIZE_GRANULARBR 2 /**< Use Granular BitRound quantization. */

--- a/libdispatch/dvar.c
+++ b/libdispatch/dvar.c
@@ -821,8 +821,8 @@ nc_def_var_endian(int ncid, int varid, int endian)
  *
  * To learn the szip settings for a variable, use nc_inq_var_szip().
  *
- * @note The options_mask parameter may be either NC_SZIP_EC (entropy
- * coding) or NC_SZIP_NN (nearest neighbor):
+ * @note The options_mask parameter may be either ::NC_SZIP_EC (entropy
+ * coding) or ::NC_SZIP_NN (nearest neighbor):
  * * The entropy coding method is best suited for data that has been
  * processed. The EC method works best for small numbers.
  * * The nearest neighbor coding method preprocesses the data then the
@@ -835,8 +835,8 @@ nc_def_var_endian(int ncid, int varid, int endian)
  *
  * @param ncid File ID.
  * @param varid Variable ID.
- * @param options_mask The options mask. Can be NC_SZIP_EC or
- * NC_SZIP_NN.
+ * @param options_mask The options mask. Can be ::NC_SZIP_EC or
+ * ::NC_SZIP_NN.
  * @param pixels_per_block Pixels per block. Must be even and not
  * greater than 32, with typical values being 8, 10, 16, or 32. This
  * parameter affects compression ratio; the more pixel values vary,

--- a/nc_test4/tst_vars3.c
+++ b/nc_test4/tst_vars3.c
@@ -13,8 +13,6 @@
 
 #define NC_SZIP_EC_BPP_IN 32  /**< @internal bits per pixel input. */
 #define NC_SZIP_EC_BPP_OUT 64  /**< @internal bits per pixel output. */
-#define NC_SZIP_NN 32 /**< @internal SZIP NN option mask. */
-#define NC_SZIP_EC 4  /**< @internal SZIP EC option mask. */
 
 #define FILE_NAME "tst_vars3.nc"
 #define NDIMS1 1


### PR DESCRIPTION
Fixes #1704.

@WardF since the next release is all about compression, it would be good if this fix could be merged before the release.