### PR TITLE
fix memory leak in genc_netcdf

### DIFF
--- a/ncgen/genc.c
+++ b/ncgen/genc.c
@@ -99,7 +99,10 @@ genc_netcdf(void)
             if(special->flags & _CHUNKSIZES_FLAG) {
                 int i;
                 size_t* chunks = special->_ChunkSizes;
-                if(special->nchunks == 0 || chunks == NULL) continue;
+                if(special->nchunks == 0 || chunks == NULL) {
+                    bbFree(tmp);
+                    continue;
+                }
                 bbClear(tmp);
                 for(i=0;i<special->nchunks;i++) {
                     bbprintf(tmp,"%s%ld",


### PR DESCRIPTION
Found by @Yonah125 with CodeQL

We first have allocation in the loop:
`Bytebuffer* tmp = bbNew();`

And we `continue` on to the next loop execution before having called `bbFree(tmp)`

What do you think of it @DennisHeimbigner ?