### PR TITLE
NC_rcfile_insert: save rc in globalstate->rcinfo.triplesNC_rcfile_insert

### DIFF
--- a/libdispatch/drc.c
+++ b/libdispatch/drc.c
@@ -576,7 +576,7 @@ NC_rcfile_insert(const char* key, const char* value, const char* hostport, const
 
     if(rc == NULL) {
 	rc = nclistnew();
-	globalstate->rcinfo.triples = rc;
+	globalstate->rcinfo->entries = rc;
 	if(rc == NULL) {ret = NC_ENOMEM; goto done;}
     }
     entry = rclocate(key,hostport,path);

--- a/libdispatch/drc.c
+++ b/libdispatch/drc.c
@@ -576,6 +576,7 @@ NC_rcfile_insert(const char* key, const char* value, const char* hostport, const
 
     if(rc == NULL) {
 	rc = nclistnew();
+	globalstate->rcinfo.triples = rc;
 	if(rc == NULL) {ret = NC_ENOMEM; goto done;}
     }
     entry = rclocate(key,hostport,path);


### PR DESCRIPTION
This PR solves issue https://github.com/Unidata/netcdf-c/issues/2337

I tested the PR locally with NetCDF 4.8.1 and all test worked except for tst_remote3.sh, which is likely a rounding issue (see below).

The PR is rebased on the current main branch.

```
=============================================
   netCDF 4.8.1: ncdap_test/test-suite.log
=============================================

# TOTAL: 16
# PASS:  15
# SKIP:  0
# XFAIL: 0
# FAIL:  1
# XPASS: 0
# ERROR: 0

.. contents:: :depth: 2

FAIL: tst_remote3
=================

*** Testing DAP to netCDF-3 translation using remote server 
        Base URL: https://remotetest.unidata.ucar.edu/dts
        Client Parameters: [log][netcdf3]
        Caching: on
    Note: The remote tests may be slow or even fail if the server is overloaded
*** Testing: test.01 ; url=[cache][prefetch]https://remotetest.unidata.ucar.edu/dts/test.01
*** Testing: test.02 ; url=[cache][prefetch]https://remotetest.unidata.ucar.edu/dts/test.02
*** Testing: test.04 ; url=[cache][prefetch]https://remotetest.unidata.ucar.edu/dts/test.04
*** Testing: test.05 ; url=[cache][prefetch]https://remotetest.unidata.ucar.edu/dts/test.05
*** Testing: test.07a ; url=[cache][prefetch]https://remotetest.unidata.ucar.edu/dts/test.07a
*** Testing: test.07 ; url=https://remotetest.unidata.ucar.edu/dts/test.07
*** Testing: test.21 ; url=[cache][prefetch]https://remotetest.unidata.ucar.edu/dts/test.21
*** Testing: test.50 ; url=[cache][prefetch]https://remotetest.unidata.ucar.edu/dts/test.50
*** Testing: test.53 ; url=[cache][prefetch]https://remotetest.unidata.ucar.edu/dts/test.53
*** Testing: test.55 ; url=[cache][prefetch]https://remotetest.unidata.ucar.edu/dts/test.55
*** Testing: test.56 ; url=[cache][prefetch]https://remotetest.unidata.ucar.edu/dts/test.56
*** Testing: test.57 ; url=[cache][prefetch]https://remotetest.unidata.ucar.edu/dts/test.57
*** Testing: test.66 ; url=[cache][prefetch]https://remotetest.unidata.ucar.edu/dts/test.66
*** Testing: test.67 ; url=[cache][prefetch]https://remotetest.unidata.ucar.edu/dts/test.67
41c41
<     0.589788025031098, 0.581683089463883, 0.573519986072457, 
---
>     0.589788025031098, 0.581683089463884, 0.573519986072457, 
*** FAIL:  test.67
*** Testing: test.68 ; url=[cache][prefetch]https://remotetest.unidata.ucar.edu/dts/test.68
*** Testing: test.69 ; url=[cache][prefetch]https://remotetest.unidata.ucar.edu/dts/test.69
*** Testing: test.01.1 ; url=[cache][prefetch]https://remotetest.unidata.ucar.edu/dts/test.01?f64
*** Testing: test.02.1 ; url=[cache][prefetch]https://remotetest.unidata.ucar.edu/dts/test.02?b[1:2:10]
*** Testing: test.03.1 ; url=[cache][prefetch]https://remotetest.unidata.ucar.edu/dts/test.03?i32[0:1][1:2][0:2]
*** Testing: test.04.1 ; url=[cache][prefetch]https://remotetest.unidata.ucar.edu/dts/test.04?types.i32
*** Testing: test.05.1 ; url=[cache][prefetch]https://remotetest.unidata.ucar.edu/dts/test.05?types.floats.f32
*** Testing: test.07.1 ; url=[cache][prefetch]https://remotetest.unidata.ucar.edu/dts/test.07?person.age
*** Testing: test.07.3 ; url=[cache][prefetch]https://remotetest.unidata.ucar.edu/dts/test.07?person
*** Testing: test.07.4 ; url=[cache][prefetch]https://remotetest.unidata.ucar.edu/dts/test.07?types.f32
*** FAILED: 23/24 ; 0 expected failures ; 1 unexpected failures
FAIL tst_remote3.sh (exit status: 1)
```