### PR TITLE
Removed precision fiddling on OSX

### DIFF
--- a/libdispatch/drc.c
+++ b/libdispatch/drc.c
@@ -576,6 +576,7 @@ NC_rcfile_insert(const char* key, const char* value, const char* hostport, const
 
     if(rc == NULL) {
 	rc = nclistnew();
+        globalstate->rcinfo->entries = rc;
 	if(rc == NULL) {ret = NC_ENOMEM; goto done;}
     }
     entry = rclocate(key,hostport,path);
@@ -1052,7 +1053,7 @@ NC_authgets3profile(const char* profilename, struct AWSprofile** profilep)
     int stat = NC_NOERR;
     int i = -1;
     NCglobalstate* gstate = NC_getglobalstate();
-    
+
     for(i=0;i<nclistlength(gstate->rcinfo->s3profiles);i++) {
 	struct AWSprofile* profile = (struct AWSprofile*)nclistget(gstate->rcinfo->s3profiles,i);
 	if(strcmp(profilename,profile->name)==0)

--- a/ncdap_test/tst_utils.sh
+++ b/ncdap_test/tst_utils.sh
@@ -11,10 +11,7 @@ PARAMS="[log]"
 
 OCLOGFILE=/dev/null
 
-# Reduce the precision
-if test "x$FP_ISOSX" != x ; then
-DUMPFLAGS="-p7,14"
-fi
+DUMPFLAGS=
 
 # Locate directories
 testdata3="${srcdir}/testdata3"


### PR DESCRIPTION
* Fixes #2349 
* Fixes #2347 

Fixes issues that have cropped up with MacOS, also attempts to get around the unexpected issues with merging #2347.