### PR TITLE
fixed autoreconf warnings

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -9,7 +9,7 @@ dnl
 AC_DEFUN([UD_CHECK_IEEE],
 [
 AC_MSG_CHECKING(for IEEE floating point format)
-AC_TRY_RUN([#ifndef NO_FLOAT_H
+AC_RUN_IFELSE([AC_LANG_SOURCE[#ifndef NO_FLOAT_H
 #include <float.h>
 #endif
 
@@ -38,7 +38,7 @@ main()
 
 	return EXIT_MAYBEIEEE;
 #endif
-}],ac_cv_c_ieeefloat=yes, ac_cv_c_ieeefloat=no, :)
+}]],ac_cv_c_ieeefloat=yes, ac_cv_c_ieeefloat=no, :)
 AC_MSG_RESULT($ac_cv_c_ieeefloat)
 if test "$ac_cv_c_ieeefloat" = no; then
   AC_DEFINE([NO_IEEE_FLOAT], [], [no IEEE float on this platform])

--- a/configure.ac
+++ b/configure.ac
@@ -7,7 +7,7 @@
 
 # Running autoconf on this file will trigger a warning if
 # autoconf is not at least the specified version.
-AC_PREREQ([2.59])
+AC_PREREQ([2.71])
 
 # Initialize with name, version, and support email address.
 AC_INIT([netCDF],[4.8.2-development],[support-netcdf@unidata.ucar.edu],[netcdf-c])
@@ -1121,8 +1121,6 @@ AC_MSG_NOTICE([checking types, headers, and functions])
 
 AC_CHECK_HEADERS([sys/param.h])
 AC_CHECK_HEADERS([libgen.h])
-#AC_CHECK_HEADERS([locale.h])
-AC_HEADER_STDC
 AC_CHECK_HEADERS([locale.h stdio.h stdarg.h fcntl.h malloc.h stdlib.h string.h strings.h unistd.h sys/stat.h getopt.h sys/time.h sys/types.h time.h dirent.h])
 
 # Do sys/resource.h separately
@@ -1279,7 +1277,6 @@ AC_SUBST(USEPLUGINS, [${enable_plugins}])
 
 AC_FUNC_ALLOCA
 AC_CHECK_DECLS([isnan, isinf, isfinite],,,[#include <math.h>])
-AC_STRUCT_ST_BLKSIZE
 UD_CHECK_IEEE
 AC_CHECK_TYPES([size_t, ssize_t, schar, uchar, longlong, ushort, uint, int64, uint64, size64_t, ssize64_t, _off64_t, uint64_t, ptrdiff_t])
 AC_TYPE_OFF_T
@@ -2085,6 +2082,6 @@ AC_CONFIG_FILES([Makefile
                  plugins/Makefile
 		 nczarr_test/Makefile
                  ])
-AC_OUTPUT()
+AC_OUTPUT
 
 cat libnetcdf.settings

--- a/configure.ac
+++ b/configure.ac
@@ -7,7 +7,7 @@
 
 # Running autoconf on this file will trigger a warning if
 # autoconf is not at least the specified version.
-AC_PREREQ([2.71])
+AC_PREREQ([2.63])
 
 # Initialize with name, version, and support email address.
 AC_INIT([netCDF],[4.8.2-development],[support-netcdf@unidata.ucar.edu],[netcdf-c])


### PR DESCRIPTION
Fixes #2371 

Fixed some autoconf warnings.

This shouldn't be part of the imminent 4.9.0 release, but merged afterwards, to give plenty of time for checking. No need to perturb the build system just before release...