### PR TITLE
Enable compilation with C89 compiler

### DIFF
--- a/nc_test4/tst_virtual_datasets.c
+++ b/nc_test4/tst_virtual_datasets.c
@@ -12,7 +12,8 @@ static void
 create_dataset_a() {
     hsize_t dims[1] = {VARIABLE_SIZE};
     float data[VARIABLE_SIZE];
-    for(size_t i = 0; i < VARIABLE_SIZE; ++i) {
+    size_t i;
+    for(i = 0; i < VARIABLE_SIZE; ++i) {
         data[i] = (float)i;
     }
 
@@ -52,6 +53,7 @@ create_dataset_b() {
 int read_back_contents(const char* filename) {
     int ncid, varid, ndims;
     float data[VARIABLE_SIZE];
+    size_t i;
 
     char var_name[NC_MAX_NAME+1];
     int dimids_var[1], var_type, natts;
@@ -63,7 +65,7 @@ int read_back_contents(const char* filename) {
     if (nc_inq_var(ncid, varid, var_name, &var_type, &ndims, dimids_var, &natts)) ERR;
     if (nc_get_var_float(ncid, varid, data)) ERR;
     printf("\t %s: ", var_name);
-    for (size_t i = 0; i < VARIABLE_SIZE; ++i) {
+    for (i = 0; i < VARIABLE_SIZE; ++i) {
         printf("%f, ", data[i]);
     }
     printf("\n");


### PR DESCRIPTION
Initializing and declaring variable in for loop statement requires C99 mode.  NetCDF is compiled in C89 mode.