### PR TITLE
Initialize variable

### DIFF
--- a/ncgen/bindata.c
+++ b/ncgen/bindata.c
@@ -410,7 +410,7 @@ bin_generate_data_r(NCConstant* instance, Symbol* tsym, Datalist* fillvalue, Byt
 	    for(i=0;i<ndims;i++) arraycount *= field->typ.dimset.dimsyms[i]->dim.declsize;
 	    write_alignment(field->typ.alignment,databuf);
 	    /* Write the instances */
-	    for(i=0;i<count;i++) {
+	    for(i=0;i<arraycount;i++) {
 	        if((stat = bin_generate_data_r(fieldinstance, field->typ.basetype, NULL, databuf))) goto done;
 	    }
 	}		

--- a/ncgen/bindata.c
+++ b/ncgen/bindata.c
@@ -402,16 +402,15 @@ bin_generate_data_r(NCConstant* instance, Symbol* tsym, Datalist* fillvalue, Byt
 	    Symbol* field = listget(tsym->subnodes,fid);
 	    NCConstant* fieldinstance = datalistith(cmpd,fid);
 	    int ndims = field->typ.dimset.ndims;
-	    size_t arraycount;
+	    size_t arraycount = 1;
 	    if(ndims == 0) {
 	        ndims=1; /* fake the scalar case */
 	    }
   	    /* compute the total number of elements in the field array */
-	    arraycount = 1;
 	    for(i=0;i<ndims;i++) arraycount *= field->typ.dimset.dimsyms[i]->dim.declsize;
 	    write_alignment(field->typ.alignment,databuf);
 	    /* Write the instances */
-	    for(i=0;i<arraycount;i++) {
+	    for(i=0;i<count;i++) {
 	        if((stat = bin_generate_data_r(fieldinstance, field->typ.basetype, NULL, databuf))) goto done;
 	    }
 	}		
@@ -566,7 +565,8 @@ bin_reclaim_compound(Symbol* tsym, Reclaim* reclaimer)
 {
     int stat = NC_NOERR;
     int nfields;
-    size_t fid, i, arraycount;
+    size_t fid, i;
+    size_t arraycount = 1;
     ptrdiff_t saveoffset;
 
     reclaimer->offset = read_alignment(reclaimer->offset,tsym->typ.cmpdalign);


### PR DESCRIPTION
In the second case, `arraycount` is uninitialized. In the first, just initializing at definition instead of a couple lines later...