### PR TITLE
Initialize potentially uninitialized variable

### DIFF
--- a/ncdump/ncpathcvt.c
+++ b/ncdump/ncpathcvt.c
@@ -191,7 +191,7 @@ main(int argc, char** argv)
 {
     int c;
     char* cvtpath = NULL;
-    char* inpath, *canon;
+    char* inpath, *canon = NULL;
 
     memset((void*)&cvtoptions,0,sizeof(cvtoptions));
     cvtoptions.drive = 'c';


### PR DESCRIPTION
If `cvtoptions.pathkind` is true, then `canon` will not be initialized and it is accessed at line 279.