### PR TITLE
fixing dependency issues in ncdump tests for make -j builds

### DIFF
--- a/ncdump/CMakeLists.txt
+++ b/ncdump/CMakeLists.txt
@@ -256,7 +256,7 @@ endif()
     add_sh_test(ncdump tst_netcdf4_4)
     add_sh_test(ncdump tst_nccopy4)
 
-    SET_TESTS_PROPERTIES(ncdump_tst_nccopy4 PROPERTIES DEPENDS "ncdump_run_ncgen_tests;ncdump_tst_output;ncdump_tst_ncgen4;ncdump_tst_fillbug;ncdump_tst_netcdf4_4;ncdump_tst_h_scalar;tst_comp;tst_comp2")
+    SET_TESTS_PROPERTIES(ncdump_tst_nccopy4 PROPERTIES DEPENDS "ncdump_tst_group_data;ncdump_tst_enum_data;ncdump_run_ncgen_tests;ncdump_tst_output;ncdump_tst_ncgen4;ncdump_tst_fillbug;ncdump_tst_netcdf4_4;ncdump_tst_h_scalar;tst_comp;tst_comp2")
     SET_TESTS_PROPERTIES(ncdump_tst_nccopy5 PROPERTIES DEPENDS "ncdump_tst_nccopy4")
 
   ENDIF(USE_HDF5)

--- a/ncdump/Makefile.am
+++ b/ncdump/Makefile.am
@@ -102,7 +102,8 @@ tst_comp2.log
 # The tst_copy5.sh tests uses output from tst_nccopy4.sh.
 tst_nccopy5.log: tst_nccopy4.log
 
-TESTS += tst_null_byte_padding.sh
+TESTS += tst_null_byte_padding.sh tst_group_data tst_enum_data	\
+tst_comp tst_comp2
 if USE_STRICT_NULL_BYTE_HEADER_PADDING
 XFAIL_TESTS += tst_null_byte_padding.sh
 endif

--- a/ncdump/Makefile.am
+++ b/ncdump/Makefile.am
@@ -94,6 +94,14 @@ test_radix.sh test_rcmerge.sh
 tst_nccopy3.log: tst_calendars.log run_utf8_tests.log tst_output.log	\
                  tst_64bit.log run_tests.log tst_lengths.log
 
+# The tst_nccopy4.sh test uses output from a bunch of other
+# tests. This records the dependency so parallel builds work.
+tst_nccopy4.log: tst_group_data.log tst_enum_data.log tst_comp.log	\
+tst_comp2.log
+
+# The tst_copy5.sh tests uses output from tst_nccopy4.sh.
+tst_nccopy5.log: tst_nccopy4.log
+
 TESTS += tst_null_byte_padding.sh
 if USE_STRICT_NULL_BYTE_HEADER_PADDING
 XFAIL_TESTS += tst_null_byte_padding.sh

--- a/ncdump/tst_nccopy4.sh
+++ b/ncdump/tst_nccopy4.sh
@@ -7,11 +7,6 @@ set -e
 
 # For a netCDF-4 build, test nccopy on netCDF files in this directory
 
-if test -f tst_group_data${ext} ; then ${execdir}/tst_group_data ; fi
-if test -f tst_enum_data${ext} ; then ${execdir}/tst_enum_data ; fi
-if test -f tst_comp${ext} ; then ${execdir}/tst_comp ; fi
-if test -f tst_comp2${ext} ; then ${execdir}/tst_comp2 ; fi
-
 echo ""
 
 # These files are actually in $srcdir in distcheck builds, so they


### PR DESCRIPTION
Fixes #2395