### PR TITLE
Fix nc_def_var_fletcher32 operation

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,7 @@ This file contains a high-level description of this package's evolution. Release
 
 ## 4.8.2 - TBD
 
+* [Bug Fix] Fix the nc_def_var_fletcher32 code in hdf5 to properly test value of the fletcher32 argument. See [Github #2403](https://github.com/Unidata/netcdf-c/pull/2403).
 * [Enhancement] Improve filter installation process to avoid use of an extra shell script. See [Github #2348](https://github.com/Unidata/netcdf-c/pull/2348).
 * [Bug Fix] Get "make distcheck" to work See [Github #/2343](https://github.com/Unidata/netcdf-c/pull/2343).
 * [Enhancement] Allow the read/write of JSON-valued Zarr attributes to allow

--- a/libhdf5/hdf5var.c
+++ b/libhdf5/hdf5var.c
@@ -542,7 +542,7 @@ nc_def_var_extra(int ncid, int varid, int *shuffle, int *unused1,
     }
 
     /* Fletcher32 checksum error protection? */
-    if (fletcher32 && fletcher32) {
+    if (fletcher32 && *fletcher32) {
 	retval = nc_inq_var_filter_info(ncid,varid,H5Z_FILTER_FLETCHER32,NULL,NULL);
 	if(!retval || retval == NC_ENOFILTER) {
 	    if((retval = nc_def_var_filter(ncid,varid,H5Z_FILTER_FLETCHER32,0,NULL))) return retval;


### PR DESCRIPTION
re: Github Issue https://github.com/Unidata/netcdf-c/issues/2401

The nc_def_var_fletcher32 code in hdf5 is always setting fletcher32 when invoked.
Fix is to properly test value of the fletcher32 argument.