### PR TITLE
Use env variable USERPROFILE instead of HOME for windows and mingw.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1112,7 +1112,7 @@ IF(Bz2_FOUND)
   set_std_filter(Bz2)
 ELSE()
   # The reason we use a local version is to support a more comples test case
-  MESSAGE(WARNING "libbz2 not found using built-in version")
+  MESSAGE("libbz2 not found using built-in version")
   SET(HAVE_LOCAL_BZ2 ON)
   SET(HAVE_BZ2 ON)
   set(STD_FILTERS "${STD_FILTERS} bz2")

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,7 @@ This file contains a high-level description of this package's evolution. Release
 
 ## 4.9.1 - T.B.D.
 
+
 * [Bug Fix] Use env variable USERPROFILE instead of HOME for windows and mingw. See [Github #2405](https://github.com/Unidata/netcdf-c/pull/2405).
 * [Bug Fix] Fix the nc_def_var_fletcher32 code in hdf5 to properly test value of the fletcher32 argument. See [Github #2403](https://github.com/Unidata/netcdf-c/pull/2403).
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,7 +7,7 @@ This file contains a high-level description of this package's evolution. Release
 
 ## 4.9.1 - T.B.D.
 
-* [Bug Fix] Use env variable USERPROFILE instead of HOME for windows and mingw. See [Github #????](https://github.com/Unidata/netcdf-c/pull/????).
+* [Bug Fix] Use env variable USERPROFILE instead of HOME for windows and mingw. See [Github #2405](https://github.com/Unidata/netcdf-c/pull/2405).
 * [Bug Fix] Fix the nc_def_var_fletcher32 code in hdf5 to properly test value of the fletcher32 argument. See [Github #2403](https://github.com/Unidata/netcdf-c/pull/2403).
 
 ## 4.9.0 - June 10, 2022

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,11 +5,15 @@ Release Notes       {#RELEASE_NOTES}
 
 This file contains a high-level description of this package's evolution. Releases are in reverse chronological order (most recent first). Note that, as of netcdf 4.2, the `netcdf-c++` and `netcdf-fortran` libraries have been separated into their own libraries.
 
+## 4.9.1 - T.B.D.
+
+* [Bug Fix] Use env variable USERPROFILE instead of HOME for windows and mingw. See [Github #????](https://github.com/Unidata/netcdf-c/pull/????).
+* [Bug Fix] Fix the nc_def_var_fletcher32 code in hdf5 to properly test value of the fletcher32 argument. See [Github #2403](https://github.com/Unidata/netcdf-c/pull/2403).
+
 ## 4.9.0 - June 10, 2022
 
-* [Bug Fix] Fix the nc_def_var_fletcher32 code in hdf5 to properly test value of the fletcher32 argument. See [Github #2403](https://github.com/Unidata/netcdf-c/pull/2403).
 * [Enhancement] Improve filter installation process to avoid use of an extra shell script. See [Github #2348](https://github.com/Unidata/netcdf-c/pull/2348).
-* [Bug Fix] Get "make distcheck" to work See [Github #/2343](https://github.com/Unidata/netcdf-c/pull/2343).
+* [Bug Fix] Get "make distcheck" to work See [Github #2343](https://github.com/Unidata/netcdf-c/pull/2343).
 * [Enhancement] Allow the read/write of JSON-valued Zarr attributes to allow
 for domain specific info such as used by GDAL/Zarr. See [Github #2278](https://github.com/Unidata/netcdf-c/pull/2278).
 * [Enhancement] Turn on the XArray convention for NCZarr files by default. WARNING, this means that the mode should explicitly specify nczarr" or "zarr" even if "xarray" or "noxarray" is specified. See [Github #2257](https://github.com/Unidata/netcdf-c/pull/2257).

--- a/libdispatch/ddispatch.c
+++ b/libdispatch/ddispatch.c
@@ -32,6 +32,10 @@ See LICENSE.txt for license information.
 #include "ncs3sdk.h"
 #endif
 
+#define MAXPATH 1024
+
+
+
 /* Define vectors of zeros and ones for use with various nc_get_varX functions */
 /* Note, this form of initialization fails under Cygwin */
 size_t NC_coord_zero[NC_MAX_VAR_DIMS] = {0};
@@ -76,15 +80,23 @@ NCDISPATCH_initialize(void)
 
     /* Capture $HOME */
     {
+#if defined(_WIN32) && !defined(__MINGW32__)
         char* home = getenv("HOME");
-
+#else
+        char* home = getenv("USERPROFILE");
+#endif
         if(home == NULL) {
-	    /* use tempdir */
-	    home = globalstate->tempdir;
-	}
-        globalstate->home = strdup(home);
+	    /* use cwd */
+	    home = malloc(MAXPATH+1);
+	    NCgetcwd(home,MAXPATH);
+        } else
+	    home = strdup(home); /* make it always free'able */
+	assert(home != NULL);
+        NCpathcanonical(home,&globalstate->home);
+	nullfree(home);
     }
-
+fprintf(stderr,">>> HOME=|%s|\n",globalstate->home); fflush(stderr);
+ 
     /* Capture $CWD */
     {
         char cwdbuf[4096];

--- a/ncdap_test/t_auth.c
+++ b/ncdap_test/t_auth.c
@@ -112,7 +112,11 @@ fflush(stderr);
 #ifndef NOHOME
     {
         /* Test 1: RC in HOME  */
-	home = getenv("HOME");
+#if defined(_WIN32) && !defined(__MINGW32__)
+        home = getenv("HOME");
+#else
+        home = getenv("USERPROFILE");
+#endif
         fprintf(stderr,"user:pwd in %s/%s\n",home,RC);
 	if(!testrc(home,url2)) {
 	    fprintf(stderr,"user:pwd in %s/%s failed\n",home,RC);

--- a/test_common.in
+++ b/test_common.in
@@ -157,6 +157,14 @@ ncgenc04="${top_srcdir}/ncgen/c0_4.cdl"
 # Set LC_ALL
 if test "x$FP_ISMSVC" = xyes || test "x$FP_ISCYGWIN" = xyes; then export LC_ALL="en_US.utf8"; fi
 
+# Set HOME
+if test "x$FP_ISMSVC" = xyes || test "x$FP_MINGW" = xyes; then
+if test "x$HOME" = x ; then
+HOME=`echo $USERPROFILE |tr '\\\' '/'`
+export HOME
+fi
+fi
+
 # Test for filter availability
 avail() {
 if test yes = `${execdir}/../ncdump/ncfilteravail $1` ; then return 0 ; else echo "filter $1 not available" ; return 1; fi


### PR DESCRIPTION
re: https://github.com/Unidata/netcdf-c/issues/2380
re: https://github.com/Unidata/netcdf-c/issues/2337

This PARTIALLY fixes some HOME problems because under Windows,
the HOME environment variable may not be set. In that case, use the
USERPROFILE environment variable instead.