### PR TITLE
Fix typo in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ SET(NC_VERSION ${netCDF_VERSION})
 SET(PACKAGE_VERSION ${VERSION})
 
 # These values should match those in configure.ac
-SET(netCDF_LIB_VERSION 19})
+SET(netCDF_LIB_VERSION 19)
 SET(netCDF_SO_VERSION 19)
 
 # Version of the dispatch table. This must match the value in


### PR DESCRIPTION
At the time generated dynamic library is named `libnetcdf.so.19}` which looks like a typo.