### PR TITLE
Avoid segfault if opening file failed

### DIFF
--- a/libsrc/posixio.c
+++ b/libsrc/posixio.c
@@ -1634,7 +1634,7 @@ posixio_create(const char *path, int ioflags,
 #endif
 	if(fd < 0)
 	{
-		status = errno;
+		status = errno ? errno : ENOENT;
 		goto unwind_new;
 	}
 	*((int *)&nciop->fd) = fd; /* cast away const */


### PR DESCRIPTION
It looks like on some platforms (e.g., MinGW) errno isn't set
when opening a file failed. That combination of a file id <0
and errno still 0 leads to a segmentation fault later on.

A possible solution to avoid that segfault is to set the status
to ENOENT if errno is unexpectedly 0.
That leads to the error ("No such file or directory") that was
reportedly emitted before version 4.9.0.

See also this report downstream: https://github.com/msys2/MINGW-packages/issues/11918