### PR TITLE
Avoid soname version for plugins

### DIFF
--- a/plugins/Makefile.am
+++ b/plugins/Makefile.am
@@ -4,22 +4,7 @@
 # Put Together AM_CPPFLAGS and AM_LDFLAGS
 include $(top_srcdir)/lib_flags.am
 
-# This linker flag specifies libtool version info.
-# See http://www.gnu.org/software/libtool/manual/libtool.html#Libtool-versioning
-# for information regarding incrementing `-version-info`.
-plugin_version_info = -version-info 0:0:0
-
-AM_LDFLAGS += -module -shared -export-dynamic $(NOUNDEFINED)
-
-if ISMINGW
-  AM_LDFLAGS += -avoid-version
-else !ISMINGW
-if ISCYGWIN
-AM_LDFLAGS += -avoid-version
-else !ISCYGWIN
-AM_LDFLAGS += $(plugin_version_info)
-endif !ISCYGWIN
-endif !ISMINGW
+AM_LDFLAGS += -module -avoid-version -shared -export-dynamic $(NOUNDEFINED)
 
 # Create an alternate directory if not installing or for noinst installs.
 ALTPLUGINDIR = ${abs_top_builddir}/plugins/plugindir


### PR DESCRIPTION
- Drop unneeded rpath
- Drop unneeded so version-info
- Handle test plugins by removing them after install

Working on ndfcdf 4.9.0 for Fedora presented a number of issues - the first of which was installing a bunch of plugins into the DESTDIR rpm BUILDROOT in locations like /home/orion/....   After trying a few different things I settled on the scheme of removing the test plugins after install as the simplest.

Next, plugins shouldn't have SO version info so I removed that.

Finally, rpath is generally banned in Fedora so I removed that, and I'm pretty sure it wouldn't be needed elsewhere but perhaps I am mistaken.