### PR TITLE
Guard _declspec(dllexport) in support of #2446

### DIFF
--- a/libdispatch/dreg.c
+++ b/libdispatch/dreg.c
@@ -16,7 +16,10 @@
 #include <locale.h>
 //#include <direct.h>
 
+#ifdef _WIN32
 __declspec(dllexport)
+#endif
+
 int
 getmountpoint(char* keyvalue, size_t size)
 {


### PR DESCRIPTION
* Fixes #2446 

Credit to [DWesl](https://github.com/DWesl) and [matzeri](https://github.com/matzeri).