### PR TITLE
Check for zstd development headers in autotools

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -718,9 +718,23 @@ AC_CHECK_LIB([zstd],[ZSTD_compress],[have_zstd=yes],[have_zstd=no])
 if test "x$have_zstd" = "xyes" ; then
    AC_SEARCH_LIBS([ZSTD_compress],[zstd zstd.dll cygzstd.dll], [], [])
    AC_DEFINE([HAVE_ZSTD], [1], [if true, zstd library is available])
+
 fi
 AC_MSG_CHECKING([whether libzstd library is available])
 AC_MSG_RESULT([${have_zstd}])
+
+##
+# Ensure that the zstd.h dev files are also available.
+##
+if test "x$have_zstd" = "xyes" ; then
+   AC_CHECK_HEADERS([zstd.h], [], [nc_zstd_h_missing=yes])
+   if test "x$nc_zstd_h_missing" = xyes; then
+         AC_MSG_WARN([zstd library detected, but zstd.h development file not found. Ensure that the zstd development files are installed in order to build zstd support.])
+         AC_DEFINE([HAVE_ZSTD], [0], [if true, zstd library is available])
+         have_zstd=no
+   fi
+fi
+
 
 # See if we have libbz2
 AC_CHECK_LIB([bz2],[BZ2_bzCompress],[have_bz2=yes],[have_bz2=no])

--- a/configure.ac
+++ b/configure.ac
@@ -1346,7 +1346,7 @@ AC_STRUCT_ST_BLKSIZE
 UD_CHECK_IEEE
 AC_CHECK_TYPES([size_t, ssize_t, schar, uchar, longlong, ushort, uint, int64, uint64, size64_t, ssize64_t, _off64_t, uint64_t, ptrdiff_t])
 AC_TYPE_OFF_T
-AC_TYPE_UINTPTR_T
+AC_CHECK_TYPES([uintptr_t])
 AC_C_CHAR_UNSIGNED
 AC_C_BIGENDIAN
 

--- a/configure.ac
+++ b/configure.ac
@@ -1186,7 +1186,7 @@ AC_CHECK_HEADERS([sys/param.h])
 AC_CHECK_HEADERS([libgen.h])
 #AC_CHECK_HEADERS([locale.h])
 AC_HEADER_STDC
-AC_CHECK_HEADERS([locale.h stdio.h stdarg.h fcntl.h malloc.h stdlib.h string.h strings.h unistd.h sys/stat.h getopt.h sys/time.h sys/types.h time.h dirent.h])
+AC_CHECK_HEADERS([locale.h stdio.h stdarg.h fcntl.h malloc.h stdlib.h string.h strings.h unistd.h sys/stat.h getopt.h sys/time.h sys/types.h time.h dirent.h stdint.h])
 
 # Do sys/resource.h separately
 #AC_CHECK_HEADERS([sys/resource.h],[havesysresource=1],[havesysresource=0])
@@ -1346,7 +1346,7 @@ AC_STRUCT_ST_BLKSIZE
 UD_CHECK_IEEE
 AC_CHECK_TYPES([size_t, ssize_t, schar, uchar, longlong, ushort, uint, int64, uint64, size64_t, ssize64_t, _off64_t, uint64_t, ptrdiff_t])
 AC_TYPE_OFF_T
-AC_CHECK_TYPES([uintptr_t])
+AC_TYPE_UINTPTR_T
 AC_C_CHAR_UNSIGNED
 AC_C_BIGENDIAN
 


### PR DESCRIPTION
Updated `configure.ac` to check for `zstd.h` in addition to `libzstd` runtime libraries.  This fixes a compile-time error otherwise encountered when the latter is present but the former is missing. 

Also added `stdint.h` to the list of files checked for in `configure.ac`, otherwise a baffling error would sometimes occur due to `uintptr_t` not being detected by some tests, detected in others.  