### PR TITLE
Small fix in nc-config.in

### DIFF
--- a/nc-config.in
+++ b/nc-config.in
@@ -10,7 +10,7 @@ libdir=@libdir@
 includedir=@includedir@
 plugindir=@PLUGIN_INSTALL_DIR@
 
-if test "x@PLUGIN_INSTALL_DIR@" == "xno" ; then
+if test "@PLUGIN_INSTALL_DIR@" == "no" ; then
     plugindir=""
 fi
 

--- a/nc-config.in
+++ b/nc-config.in
@@ -10,7 +10,7 @@ libdir=@libdir@
 includedir=@includedir@
 plugindir=@PLUGIN_INSTALL_DIR@
 
-if test "@PLUGIN_INSTALL_DIR@" == "no" ; then
+if test "@PLUGIN_INSTALL_DIR@" = "no" ; then
     plugindir=""
 fi
 


### PR DESCRIPTION
Darn these C programmer habits. This fixes a small typo in `nc-config.in`.