### PR TITLE
Make dap4 reference dap instead of hard-wired to be disabled.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -609,7 +609,7 @@ fi
 AM_CONDITIONAL(ENABLE_QUANTIZE, [test x$enable_quantize = xyes])
 
 # --enable-dap => enable-dap4
-enable_dap4=no
+enable_dap4=$enable_dap
 AC_MSG_CHECKING([whether dap use of remotetest server should be enabled])
 AC_ARG_ENABLE([dap-remote-tests],
               [AS_HELP_STRING([--disable-dap-remote-tests],


### PR DESCRIPTION
Small fix for an issue that snuck through. 