### PR TITLE
Suppress nczarr_test/tst_unknown filter test

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -16,7 +16,7 @@ This file contains a high-level description of this package's evolution. Release
 
 #### Changes
 
-* [Bug Fix] Fix a race condition when testing missing filters. See [Github #2557](https://github.com/Unidata/netcdf-c/pull/2557).
+* [Bug Fix] Fix a race condition when testing missing filters. See [Github #2557](https://github.com/Unidata/netcdf-c/pull/2557). 
 * [Bug Fix] Fix some race conditions due to use of a common file in multiple shell scripts . See [Github #2552](https://github.com/Unidata/netcdf-c/pull/2552).
 * [Enhancement][Documentation] Add Plugins Quick Start Guide.  See [GitHub #2524](https://github.com/Unidata/netcdf-c/pull/2524) for more information.
 * [Enhancement] Add new entries in `netcdf_meta.h`, `NC_HAS_BLOSC` and `NC_HAS_BZ2`. See [Github #2511](https://github.com/Unidata/netcdf-c/issues/2511) and [Github #2512](https://github.com/Unidata/netcdf-c/issues/2512) for more information.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -16,6 +16,7 @@ This file contains a high-level description of this package's evolution. Release
 
 #### Changes
 
+* [Bug Fix] Fix a race condition when testing missing filters. See [Github #](https://github.com/Unidata/netcdf-c/pull/????).
 * [Bug Fix] Fix some race conditions due to use of a common file in multiple shell scripts . See [Github #2552](https://github.com/Unidata/netcdf-c/pull/2552).
 * [Enhancement][Documentation] Add Plugins Quick Start Guide.  See [GitHub #2524](https://github.com/Unidata/netcdf-c/pull/2524) for more information.
 * [Enhancement] Add new entries in `netcdf_meta.h`, `NC_HAS_BLOSC` and `NC_HAS_BZ2`. See [Github #2511](https://github.com/Unidata/netcdf-c/issues/2511) and [Github #2512](https://github.com/Unidata/netcdf-c/issues/2512) for more information.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -16,7 +16,7 @@ This file contains a high-level description of this package's evolution. Release
 
 #### Changes
 
-* [Bug Fix] Fix a race condition when testing missing filters. See [Github #](https://github.com/Unidata/netcdf-c/pull/????).
+* [Bug Fix] Fix a race condition when testing missing filters. See [Github #2557](https://github.com/Unidata/netcdf-c/pull/2557).
 * [Bug Fix] Fix some race conditions due to use of a common file in multiple shell scripts . See [Github #2552](https://github.com/Unidata/netcdf-c/pull/2552).
 * [Enhancement][Documentation] Add Plugins Quick Start Guide.  See [GitHub #2524](https://github.com/Unidata/netcdf-c/pull/2524) for more information.
 * [Enhancement] Add new entries in `netcdf_meta.h`, `NC_HAS_BLOSC` and `NC_HAS_BZ2`. See [Github #2511](https://github.com/Unidata/netcdf-c/issues/2511) and [Github #2512](https://github.com/Unidata/netcdf-c/issues/2512) for more information.

--- a/nc_test4/CMakeLists.txt
+++ b/nc_test4/CMakeLists.txt
@@ -51,9 +51,13 @@ IF(USE_HDF5 AND ENABLE_FILTER_TESTING)
   build_bin_test(tst_filter_avail)
   build_bin_test(test_filter_vlen)
   ADD_SH_TEST(nc_test4 tst_filter)
-  ADD_SH_TEST(nc_test4 tst_unknown)
   ADD_SH_TEST(nc_test4 tst_specific_filters)
   ADD_SH_TEST(nc_test4 tst_bloscfail)
+  IF(FALSE)
+    # This test is too dangerous to run in a parallel make environment.
+    # It causes race conditions. So suppress and only test by hand.
+    ADD_SH_TEST(nc_test4 tst_unknown)
+  ENDIF(FALSE)
 ENDIF(USE_HDF5 AND ENABLE_FILTER_TESTING)
 
 ENDIF(BUILD_UTILITIES)

--- a/nc_test4/Makefile.am
+++ b/nc_test4/Makefile.am
@@ -84,12 +84,14 @@ extradir =
 check_PROGRAMS += test_filter test_filter_misc test_filter_order test_filter_repeat test_filter_vlen
 check_PROGRAMS += tst_multifilter tst_filter_avail
 TESTS += tst_filter.sh
-TESTS += tst_unknown.sh
 TESTS += tst_specific_filters.sh
 TESTS += tst_bloscfail.sh
 if ISMINGW
 XFAIL_TESTS += tst_filter.sh
 endif # ISMINGW
+# This test is too dangerous to run in a parallel make environment.
+# It causes race conditions. So suppress and only test by hand.
+#TESTS += tst_unknown.sh
 endif # ENABLE_FILTER_TESTING
 endif # USE_HDF5
 endif # BUILD_UTILITIES


### PR DESCRIPTION
The test case nc_test4/tst_unknown.sh deletes and then restores a filter in the plugins directory. The test nczarr_test/run_unknown.sh also does this.  However if both are running at the same time in a parallel environment, they apparently can interfere and can cause a race condition failure.

The solution is to suppress one of them. Since nczarr code is more unstable, we need to run this test. So suppress the corresponding test in nc_test4.