### PR TITLE
CI: Change autotools CI build to out-of-tree build.

### DIFF
--- a/.github/workflows/run_tests_ubuntu.yml
+++ b/.github/workflows/run_tests_ubuntu.yml
@@ -501,31 +501,37 @@ jobs:
 
       - name: Configure
         shell: bash -l {0}
-        run: CFLAGS=${CFLAGS} LDFLAGS=${LDFLAGS} LD_LIBRARY_PATH=${LD_LIBRARY_PATH} ./configure ${ENABLE_HDF5} ${ENABLE_DAP} ${ENABLE_NCZARR}
+        run: |
+          current_directory="$(pwd)"
+          mkdir ../build
+          cd ../build && CFLAGS=${CFLAGS} LDFLAGS=${LDFLAGS} LD_LIBRARY_PATH=${LD_LIBRARY_PATH} "${current_directory}/configure" ${ENABLE_HDF5} ${ENABLE_DAP} ${ENABLE_NCZARR}
         if: ${{ success() }}
 
       - name: Look at config.log if error
         shell: bash -l {0}
-        run: cat config.log
+        run: cd ../build && cat config.log
         if: ${{ failure() }}
 
       - name: Print Summary
         shell: bash -l {0}
-        run: cat libnetcdf.settings
+        run: cd ../build && cat libnetcdf.settings
 
       - name: Build Library and Utilities
         shell: bash -l {0}
-        run: CFLAGS=${CFLAGS} LDFLAGS=${LDFLAGS} LD_LIBRARY_PATH=${LD_LIBRARY_PATH} make -j
+        run: |
+          cd ../build && CFLAGS=${CFLAGS} LDFLAGS=${LDFLAGS} LD_LIBRARY_PATH=${LD_LIBRARY_PATH} make -j
         if: ${{ success() }}
 
       - name: Build Tests
         shell: bash -l {0}
-        run: CFLAGS=${CFLAGS} LDFLAGS=${LDFLAGS} LD_LIBRARY_PATH=${LD_LIBRARY_PATH} make check TESTS="" -j
+        run: |
+          cd ../build && CFLAGS=${CFLAGS} LDFLAGS=${LDFLAGS} LD_LIBRARY_PATH=${LD_LIBRARY_PATH} make check TESTS="" -j
         if: ${{ success() }}
 
       - name: Run Tests
         shell: bash -l {0}
-        run: CFLAGS=${CFLAGS} LDFLAGS=${LDFLAGS} LD_LIBRARY_PATH=${LD_LIBRARY_PATH} make check -j
+        run: |
+          cd ../build && CFLAGS=${CFLAGS} LDFLAGS=${LDFLAGS} LD_LIBRARY_PATH=${LD_LIBRARY_PATH} make check -j
         if: ${{ success() }}
 
   nc-cmake:


### PR DESCRIPTION
This is a reference to an issue (#2547) with how most distribution packagers run Autotools (source in one directory, compile in another, install to a third).  There was a PR (#2546) to catch errors in that kind of build by running `make distcheck` which was turned down due to [a preference for separate compile and test steps](https://github.com/Unidata/netcdf-c/pull/2546#discussion_r1018356480). This PR should test the out-of-tree builds, taking into account the preference for separate build and compile steps.

`make distcheck` would also catch files not being specified in `EXTRA_DIST` (#2548, #2544), though I could change the tests to do that as well (have one of the earlier CI runs make a source archive at the end and upload that, then download that in this step and use the source archive instead of a clone of the git repository as the source for the build step).