### PR TITLE
CI: Have nc-autotools use source distribution instead of repository

### DIFF
--- a/.github/workflows/run_tests_ubuntu.yml
+++ b/.github/workflows/run_tests_ubuntu.yml
@@ -195,6 +195,19 @@ jobs:
         run: CFLAGS=${CFLAGS} LDFLAGS=${LDFLAGS} LD_LIBRARY_PATH=${LD_LIBRARY_PATH} make check -j
         if: ${{ success() }}
 
+      - name: Create source distribution
+        shell: bash -l {0}
+        if: ${{ success() }}
+        run: make dist -j
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: netcdf-c-autotools-source-distribution
+          path: |
+            *.tar*
+            *.zip
+            *.tgz
+
   ##
   # Parallel
   ##
@@ -448,7 +461,28 @@ jobs:
         use_nczarr: [ nczarr_off, nczarr_on ]
     steps:
 
-      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
+        with:
+          name: netcdf-c-autotools-source-distribution
+
+      - name: Unpack source distribution
+        shell: bash -l {0}
+        run: |
+          if [ -f *.zip ];
+          then
+            unzip *.zip
+          else
+            tar xvzf $(ls *.tar* *.tgz *.zip | head -1)
+          fi
+          ls -d netcdf-c*
+          for name in netcdf-c*;
+          do
+              if [ -d ${name} ];
+              then
+                  cd ${name}
+                  break
+              fi
+          done
 
       - name: Install System dependencies
         shell: bash -l {0}
@@ -497,11 +531,28 @@ jobs:
 
       - name: Run autoconf
         shell: bash -l {0}
-        run: autoreconf -if
+        run: |
+          for name in netcdf-c*;
+          do
+              if [ -d ${name} ];
+              then
+                  cd ${name}
+                  break
+              fi
+          done
+          autoreconf -if
 
       - name: Configure
         shell: bash -l {0}
         run: |
+          for name in netcdf-c*;
+          do
+              if [ -d ${name} ];
+              then
+                  cd ${name}
+                  break
+              fi
+          done
           current_directory="$(pwd)"
           mkdir ../build
           cd ../build && CFLAGS=${CFLAGS} LDFLAGS=${LDFLAGS} LD_LIBRARY_PATH=${LD_LIBRARY_PATH} "${current_directory}/configure" ${ENABLE_HDF5} ${ENABLE_DAP} ${ENABLE_NCZARR}
@@ -509,29 +560,56 @@ jobs:
 
       - name: Look at config.log if error
         shell: bash -l {0}
-        run: cd ../build && cat config.log
+        run: |
+          if [ -d ../build ];
+          then
+              cd ../build
+          else
+              cd build
+          fi && cat config.log
         if: ${{ failure() }}
 
       - name: Print Summary
         shell: bash -l {0}
-        run: cd ../build && cat libnetcdf.settings
+        run: |
+          if [ -d ../build ];
+          then
+              cd ../build
+          else
+              cd build
+          fi && cat libnetcdf.settings
 
       - name: Build Library and Utilities
         shell: bash -l {0}
         run: |
-          cd ../build && CFLAGS=${CFLAGS} LDFLAGS=${LDFLAGS} LD_LIBRARY_PATH=${LD_LIBRARY_PATH} make -j
+          if [ -d ../build ];
+          then
+              cd ../build
+          else
+              cd build
+          fi && CFLAGS=${CFLAGS} LDFLAGS=${LDFLAGS} LD_LIBRARY_PATH=${LD_LIBRARY_PATH} make -j
         if: ${{ success() }}
 
       - name: Build Tests
         shell: bash -l {0}
         run: |
-          cd ../build && CFLAGS=${CFLAGS} LDFLAGS=${LDFLAGS} LD_LIBRARY_PATH=${LD_LIBRARY_PATH} make check TESTS="" -j
+          if [ -d ../build ];
+          then
+              cd ../build
+          else
+              cd build
+          fi && CFLAGS=${CFLAGS} LDFLAGS=${LDFLAGS} LD_LIBRARY_PATH=${LD_LIBRARY_PATH} make check TESTS="" -j
         if: ${{ success() }}
 
       - name: Run Tests
         shell: bash -l {0}
         run: |
-          cd ../build && CFLAGS=${CFLAGS} LDFLAGS=${LDFLAGS} LD_LIBRARY_PATH=${LD_LIBRARY_PATH} make check -j
+          if [ -d ../build ];
+          then
+              cd ../build
+          else
+              cd build
+          fi && CFLAGS=${CFLAGS} LDFLAGS=${LDFLAGS} LD_LIBRARY_PATH=${LD_LIBRARY_PATH} make check -j
         if: ${{ success() }}
 
   nc-cmake:


### PR DESCRIPTION
Instead of a clone of the repository, have the `nc-autotools` job work from a source distribution prepared by a previous autotools CI job.

This should catch most of the "files not included in `EXTRA_DIST`" or similar issues I remember, and probably most of the "netcdf-c does not pass `make distcheck`" errors.

I'm not sure whether this is in scope for a CI job, but the `nc-autotools` jobs should be a fairly complete copy of `make distcheck` now; the only things I can think of not included in that job would be `make install` and `make installcheck`.  I'm only aware of #2431 raising issues with installed files, so that may be less relevant.