### PR TITLE
Fix macro usage

### DIFF
--- a/include/nc4internal.h
+++ b/include/nc4internal.h
@@ -288,7 +288,7 @@ typedef struct NC_FILE_INFO
 {
     NC_OBJ hdr;
     NC *controller; /**< Pointer to containing NC. */
-#ifdef USE_PARALLEL4
+#ifdef USE_PARALLEL
     MPI_Comm comm;  /**< Copy of MPI Communicator used to open the file. */
     MPI_Info info;  /**< Copy of MPI Information Object used to open the file. */
 #endif

--- a/libhdf5/hdf5internal.c
+++ b/libhdf5/hdf5internal.c
@@ -163,7 +163,7 @@ find_var_dim_max_length(NC_GRP_INFO_T *grp, int varid, int dimid,
                 if (var->dimids[d] == dimid)
                     *maxlen = *maxlen > h5dimlen[d] ? *maxlen : h5dimlen[d];
 
-#ifdef USE_PARALLEL4
+#ifdef USE_PARALLEL
 	    /* If we are doing parallel I/O in collective mode (with
 	     * either pnetcdf or HDF5), then communicate with all
 	     * other tasks in the collective and find out which has

--- a/libhdf5/hdf5internal.c
+++ b/libhdf5/hdf5internal.c
@@ -163,7 +163,7 @@ find_var_dim_max_length(NC_GRP_INFO_T *grp, int varid, int dimid,
                 if (var->dimids[d] == dimid)
                     *maxlen = *maxlen > h5dimlen[d] ? *maxlen : h5dimlen[d];
 
-#ifdef USE_PARALLEL
+#ifdef USE_PARALLEL4
 	    /* If we are doing parallel I/O in collective mode (with
 	     * either pnetcdf or HDF5), then communicate with all
 	     * other tasks in the collective and find out which has


### PR DESCRIPTION
This fixes configuration with `--disable-parallel4 --enable-pnetcdf`. It looks like `NC_FILE_INFO` has the `comm` member (i.e. `grp->nc4_info->comm` is valid) only if `USE_PARALLEL4` is defined (see [here](https://github.com/Unidata/netcdf-c/blob/b1fd4b840df341dd8be3545c22e2ad15a985e97c/include/nc4internal.h#L291-L294)).