### PR TITLE
Use newly assigned Unidata Byte-Range HDF5 VFD Identifier.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,7 +7,7 @@ This file contains a high-level description of this package's evolution. Release
 
 ## 4.9.2 - TBD
 
-* [Ehancement] Update H5FDhttp.c to use the newly registered standard VFD identifier. See [Github #????](https://github.com/Unidata/netcdf-c/pull/????).
+* [Ehancement] Update H5FDhttp.c to use the newly registered standard VFD identifier. See [Github #2629](https://github.com/Unidata/netcdf-c/pull/2629).
 * [Bug Fix] Update H5FDhttp.[ch] to work with HDF5 version 1.14.0. See [Github #2615](https://github.com/Unidata/netcdf-c/pull/2615).
 * [Bug Fix] Update `nc-config` to remove inclusion from automatically-detected `nf-config` and `ncxx-config` files, as the wrong files could be included in the output.  This is in support of [GitHub #2274](https://github.com/Unidata/netcdf-c/issues/2274).
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,9 +7,9 @@ This file contains a high-level description of this package's evolution. Release
 
 ## 4.9.2 - TBD
 
-
-* Update `nc-config` to remove inclusion from automatically-detected `nf-config` and `ncxx-config` files, as the wrong files could be included in the output.  This is in support of [GitHub #2274](https://github.com/Unidata/netcdf-c/issues/2274).
+* [Ehancement] Update H5FDhttp.c to use the newly registered standard VFD identifier. See [Github #????](https://github.com/Unidata/netcdf-c/pull/????).
 * [Bug Fix] Update H5FDhttp.[ch] to work with HDF5 version 1.14.0. See [Github #2615](https://github.com/Unidata/netcdf-c/pull/2615).
+* [Bug Fix] Update `nc-config` to remove inclusion from automatically-detected `nf-config` and `ncxx-config` files, as the wrong files could be included in the output.  This is in support of [GitHub #2274](https://github.com/Unidata/netcdf-c/issues/2274).
 
 ## 4.9.1 - February 2, 2023
 

--- a/libhdf5/H5FDhttp.h
+++ b/libhdf5/H5FDhttp.h
@@ -30,7 +30,7 @@
 #include "H5Ipublic.h"
 
 #if H5_VERSION_GE(1,14,0)
-#define H5_VFD_HTTP     ((H5FD_class_value_t)(H5_VFD_MAX - 2))
+#define H5_VFD_HTTP     ((H5FD_class_value_t)(514))
 #define H5FD_HTTP	(H5FDperform_init(H5FD_http_init))
 #else
 #define H5FD_HTTP	(H5FD_http_init())


### PR DESCRIPTION
re: PR https://github.com/Unidata/netcdf-c/pull/2615
re: Issue https://github.com/Unidata/netcdf-c/issues/2614

H/T to Even Rouault for suggesting that Unidata get an assigned VFD id.

This PR insert the assigned VFD id into H5FDhttp.c.