### PR TITLE
Fix a distcheck failure with nczarr_test/run_interop.sh

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-1Release Notes       {#RELEASE_NOTES}
+Release Notes       {#RELEASE_NOTES}
 =============
 
 \brief Release notes file for the netcdf-c package.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-Release Notes       {#RELEASE_NOTES}
+1Release Notes       {#RELEASE_NOTES}
 =============
 
 \brief Release notes file for the netcdf-c package.
@@ -7,9 +7,9 @@ This file contains a high-level description of this package's evolution. Release
 
 ## 4.9.2 - TBD
 
-
+* Fix 'make distcheck' error in run_interop.sh. See [Github #????](https://github.com/Unidata/netcdf-c/pull/????).
 * Update `nc-config` to remove inclusion from automatically-detected `nf-config` and `ncxx-config` files, as the wrong files could be included in the output.  This is in support of [GitHub #2274](https://github.com/Unidata/netcdf-c/issues/2274).
-* [Bug Fix] Update H5FDhttp.[ch] to work with HDF5 version 1.14.0. See [Github #2615](https://github.com/Unidata/netcdf-c/pull/2615).
+* Update H5FDhttp.[ch] to work with HDF5 version 1.14.0. See [Github #2615](https://github.com/Unidata/netcdf-c/pull/2615).
 
 ## 4.9.1 - February 2, 2023
 

--- a/libhdf5/H5FDhttp.h
+++ b/libhdf5/H5FDhttp.h
@@ -30,7 +30,7 @@
 #include "H5Ipublic.h"
 
 #if H5_VERSION_GE(1,14,0)
-#define H5_VFD_HTTP     ((H5FD_class_value_t)(H5_VFD_MAX - 2))
+#define H5_VFD_HTTP     ((H5FD_class_value_t)(514))
 #define H5FD_HTTP	(H5FDperform_init(H5FD_http_init))
 #else
 #define H5FD_HTTP	(H5FD_http_init())

--- a/nczarr_test/Makefile.am
+++ b/nczarr_test/Makefile.am
@@ -164,7 +164,8 @@ ref_string.cdl ref_string_nczarr.baseline ref_string_zarr.baseline ref_scalar.cd
 ref_nulls_nczarr.baseline ref_nulls_zarr.baseline ref_nulls.cdl
 
 # Interoperability files
-EXTRA_DIST += ref_power_901_constants_orig.zip ref_power_901_constants.cdl ref_quotes_orig.zip ref_quotes.cdl 
+EXTRA_DIST += ref_power_901_constants_orig.zip ref_power_901_constants.cdl ref_quotes_orig.zip ref_quotes.cdl \
+ref_zarr_test_data.cdl.gz
 
 CLEANFILES = ut_*.txt ut*.cdl tmp*.nc tmp*.cdl tmp*.txt tmp*.dmp tmp*.zip tmp*.nc tmp*.dump tmp*.tmp tmp_ngc.c ref_zarr_test_data.cdl tst_*.nc.zip ref_quotes.zip ref_power_901_constants.zip
 

--- a/nczarr_test/s3util.c
+++ b/nczarr_test/s3util.c
@@ -128,7 +128,7 @@ main(int argc, char** argv)
 
     dumpoptions.nctype = NC_UBYTE; /* default */
 
-    while ((c = getopt(argc, argv, "df:k:p:t:T:u:v")) != EOF) {
+    while ((c = getopt(argc, argv, "df:hk:p:t:T:u:v")) != EOF) {
 	switch(c) {
 	case 'd': 
 	    dumpoptions.debug = 1;	    
@@ -136,6 +136,9 @@ main(int argc, char** argv)
 	case 'f':
 	    dumpoptions.filename = strdup(optarg);
 	    break;
+	case 'h':
+	    usage();
+	    return 0;
 	case 'k': {
 	    size_t len = strlen(optarg);
 	    dumpoptions.key = (char*)malloc(len+1+1);


### PR DESCRIPTION
The problem was that files were being copied
into the $ {srcdir} rather than $ {builddir} directory.