### PR TITLE
A small, but meaningful start, to addressing undefined behavior

### DIFF
--- a/libsrc/var.c
+++ b/libsrc/var.c
@@ -175,10 +175,12 @@ dup_NC_var(const NC_var *rvarp)
 		return NULL;
 	}
 
-	(void) memcpy(varp->shape, rvarp->shape,
-			 rvarp->ndims * sizeof(size_t));
-	(void) memcpy(varp->dsizes, rvarp->dsizes,
-			 rvarp->ndims * sizeof(off_t));
+	if(rvarp->shape != NULL)
+		(void) memcpy(varp->shape, rvarp->shape,
+				 rvarp->ndims * sizeof(size_t));
+	if(rvarp->dsizes != NULL)
+		(void) memcpy(varp->dsizes, rvarp->dsizes,
+				 rvarp->ndims * sizeof(off_t));
 	varp->xsz = rvarp->xsz;
 	varp->len = rvarp->len;
 	varp->begin = rvarp->begin;

--- a/nc_test/util.c
+++ b/nc_test/util.c
@@ -413,8 +413,8 @@ int dbl2nc ( const double d, const nc_type xtype, void *p)
 double
 hash( const nc_type xtype, const int rank, const size_t *index )
 {
-    double base;
-    double result;
+    double base = 0;
+    double result = 0;
     int  d;       /* index of dimension */
 
 	/* If vector then elements 0 & 1 are min & max. Elements 2 & 3 are */

--- a/nc_test/util.c
+++ b/nc_test/util.c
@@ -343,7 +343,7 @@ int dbl2nc ( const double d, const nc_type xtype, void *p)
              * reporting it as a range error.
              */
             if ( r < X_CHAR_MIN || r > X_CHAR_MAX ) return 2;
-            *((signed char*) p) = (signed char)r;
+            *((unsigned char*) p) = (unsigned char)r;
             break;
         case NC_BYTE:
             r = floor(0.5+d);
@@ -1006,7 +1006,7 @@ check_vars(int  ncid)
           	err = nc_get_var1_text(ncid, i, index, &text);
             IF (err)
 		    error("nc_get_var1_text: %s", nc_strerror(err));
-            IF (text != (char)expect) {
+            IF ((unsigned char)text != (unsigned char)expect) {
               error("Var %s [%lu] value read %hhd not that expected %g ",
                   var_name[i], j, text, expect);
 		    print_n_size_t(var_rank[i], index);
@@ -1073,7 +1073,7 @@ check_atts(int  ncid)
 		    error("nc_get_att_text: %s", nc_strerror(err));
 		for (k = 0; k < ATT_LEN(i,j); k++) {
 		    expect = hash(xtype, -1, &k);
-		    IF (text[k] != (char)expect) {
+		    IF ((unsigned char)text[k] != (unsigned char)expect) {
 			error("nc_get_att_text: unexpected value");
             	    } else {
               		nok++;

--- a/nc_test/util.c
+++ b/nc_test/util.c
@@ -841,7 +841,7 @@ put_atts(int ncid)
 	for (j = 0; j < NATTS(i); j++) {
 	    if (ATT_TYPE(i,j) == NC_CHAR) {
 		for (k = 0; k < ATT_LEN(i,j); k++) {
-                    catt[k] = (char) hash(ATT_TYPE(i,j), -1, &k);
+                    catt[k] = (unsigned char) hash(ATT_TYPE(i,j), -1, &k);
 		}
 		err = nc_put_att_text(ncid, i, ATT_NAME(i,j),
 		    ATT_LEN(i,j), catt);
@@ -1074,7 +1074,8 @@ check_atts(int  ncid)
 		for (k = 0; k < ATT_LEN(i,j); k++) {
 		    expect = hash(xtype, -1, &k);
 		    IF ((unsigned char)text[k] != (unsigned char)expect) {
-			error("nc_get_att_text: unexpected value");
+            error("Var %s [%lu] value read %hhd not that expected %g ",
+                  var_name[i], j, text, expect);
             	    } else {
               		nok++;
             	    }

--- a/nc_test/util.c
+++ b/nc_test/util.c
@@ -969,7 +969,7 @@ check_dims(int  ncid)
 void
 check_vars(int  ncid)
 {
-    size_t index[MAX_RANK];
+    size_t index[MAX_RANK] = {0};
     char  text, name[NC_MAX_NAME];
     int  i, err;		/* status */
     size_t  j;

--- a/nc_test/util.c
+++ b/nc_test/util.c
@@ -170,8 +170,8 @@ equal(const double x,
         /* because in-memory data type char can be signed or unsigned,
          * type cast the value from external NC_CHAR before the comparison
          */
-        char x2 = (char) x;
-        char y2 = (char) y;
+        char x2 = *(char *)&x;
+        char y2 = *(char *)&y;
         return ABS(x2-y2) <= epsilon * MAX( ABS(x2), ABS(y2));
     }
 
@@ -194,8 +194,8 @@ equal2(const double x,
         /* because in-memory data type char can be signed or unsigned,
          * type cast the value from external NC_CHAR before the comparison
          */
-        char x2 = (char) x;
-        char y2 = (char) y;
+        char x2 = *(char *)&x;
+        char y2 = *(char *)&y;
         return ABS(x2-y2) <= epsilon * MAX( ABS(x2), ABS(y2));
     }
 


### PR DESCRIPTION
* Fixes #1983 

A cast was resulting in undefined behavior, and had to be worked around in a style approximating C++'s 'reinterpret_cast'.  This was discovered using the `-fsanitize=undefined` compiler flag w/ `clang`, and there is a lot of other work to be done.  I am hoping that these fixes, when patched in to `libnetcdf-feedstock`, will also address the issue observed at https://github.com/conda-forge/libnetcdf-feedstock/issues/138.