### PR TITLE
Fix potential dead store

### DIFF
--- a/libnczarr/zwalk.c
+++ b/libnczarr/zwalk.c
@@ -411,7 +411,6 @@ NCZ_walk(NCZProjection** projv, NCZOdometer* chunkodom, NCZOdometer* slpodom, NC
 	        nczodom_skipavail(memodom);
 	    } else {
 	        slpavail = 1;
-		memavail = 1;
 	    }
    	    if(slpavail > 0) {
 if(wdebug > 0) wdebug2(common,slpptr0,memptr0,slpavail,laststride,chunkdata);


### PR DESCRIPTION
**Description**
Fix the dead store warning detected by static analyse tool infer@facebook

**Warning Type**
Dead Store

**Component Name**
netcdf-c/libnczarr/zwalk.c (line:414)

**Additional Information**
The value written to &memavail (type unsigned long long) is never used.