### PR TITLE
Fix potential null dereference and source leak

### DIFF
--- a/libdispatch/drc.c
+++ b/libdispatch/drc.c
@@ -1139,9 +1139,12 @@ aws_load_credentials(NCglobalstate* gstate)
     /* add a "none" credentials */
     {
 	struct AWSprofile* noprof = (struct AWSprofile*)calloc(1,sizeof(struct AWSprofile));
+    if(noprof == NULL) {ret = NC_ENOMEM; goto done;}
 	noprof->name = strdup("none");
 	noprof->entries = nclistnew();
-	nclistpush(profiles,noprof); noprof = NULL;
+	nclistpush(profiles,noprof);
+    freeprofile(noprof);
+    noprof = NULL;
     }
 
     if(gstate->rcinfo->s3profiles)
@@ -1166,6 +1169,7 @@ aws_load_credentials(NCglobalstate* gstate)
 done:
     ncbytesfree(buf);
     freeprofilelist(profiles);
+    if(noprof) freeprofile(noprof);
     return stat;
 }
 


### PR DESCRIPTION
**Description**
Fix the null dereference and source leak warning detected by static analyse tool infer@facebook

**Warning Type**
Null Dereference
Source Leak

**Component Name**
netcdf-c/libdispatch/drc.c (line:1141)
netcdf-c/libdispatch/drc.c (line:1144)

**Additional Information**
pointer `noprof` last assigned on line 1141 could be null and is dereferenced at line 1142
resource acquired by call to `open()` at line 1141, is not released after line 1144.

