### PR TITLE
Adding a workaround for older versions of cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2205,7 +2205,7 @@ MACRO(print_conf_summary)
 
   MESSAGE("")
 ENDMACRO()
-##
+##specific
 # Shell script Macro
 ##
 # Determine if 'bash' is on the system.
@@ -2232,7 +2232,7 @@ ENDIF(ENABLE_BASH_SCRIPT_TESTING)
 
 MACRO(add_sh_test prefix F)
   IF(HAVE_BASH)
-    ADD_TEST(${prefix}_${F} bash "-c" "export srcdir=${CMAKE_CURRENT_SOURCE_DIR};export TOPSRCDIR=${CMAKE_SOURCE_DIR};${CMAKE_CURRENT_BINARY_DIR}/${F}.sh ${ARGN}")
+    ADD_TEST(${prefix}_${F} bash "-c" "export srcdir=${CMAKE_CURRENT_SOURCE_DIR};export TOPSRCDIR=${CMAKE_SOURCE_DIR};bash ${CMAKE_CURRENT_BINARY_DIR}/${F}.sh ${ARGN}")
   ENDIF()
 ENDMACRO()
 

--- a/nczarr_test/CMakeLists.txt
+++ b/nczarr_test/CMakeLists.txt
@@ -21,8 +21,10 @@ FILE(READ ${CMAKE_CURRENT_SOURCE_DIR}/../nc_test4/tst_specific_filters.sh SPSOUR
 STRING(PREPEND SPSOURCE "#!/bin/bash\n")
 STRING(PREPEND SPSOURCE "TESTNCZARR=1\n")
 # Replace with FILE(CONFIGURE) when cmake 3.18 is in common use
+
 FILE(WRITE ${CMAKE_CURRENT_BINARY_DIR}/run_specific_filters.1 "${SPSOURCE}")
 CONFIGURE_FILE(${CMAKE_CURRENT_BINARY_DIR}/run_specific_filters.1 ${CMAKE_CURRENT_BINARY_DIR}/run_specific_filters.sh FILE_PERMISSIONS OWNER_WRITE OWNER_READ OWNER_EXECUTE @ONLY NEWLINE_STYLE LF)
+
 FILE(REMOVE ${CMAKE_CURRENT_BINARY_DIR}/run_specific_filters.1)
 	
 FILE(READ ${CMAKE_CURRENT_SOURCE_DIR}/../nc_test4/tst_unknown.sh SPSOURCE)
@@ -130,26 +132,26 @@ IF(ENABLE_TESTS)
 	add_sh_test(nczarr_test run_s3_cleanup)
     ENDIF()
 
-    IF(ENABLE_FILTER_TESTING)
-	build_bin_test(tst_nczfilter)
-	build_bin_test(testfilter)
-	build_bin_test(testfilter_misc)
-	build_bin_test(testfilter_multi)
-	build_bin_test(testfilter_order)
-	build_bin_test(testfilter_repeat)
-	build_bin_test(test_filter_avail)
-	ADD_SH_TEST(nczarr_test run_nczfilter)
-	ADD_SH_TEST(nczarr_test run_filter)
-	ADD_SH_TEST(nczarr_test run_specific_filters)
-	IF(FALSE)
+  IF(ENABLE_FILTER_TESTING)
+	  build_bin_test(tst_nczfilter)
+	  build_bin_test(testfilter)
+	  build_bin_test(testfilter_misc)
+	  build_bin_test(testfilter_multi)
+	  build_bin_test(testfilter_order)
+	  build_bin_test(testfilter_repeat)
+	  build_bin_test(test_filter_avail)
+	  ADD_SH_TEST(nczarr_test run_nczfilter)
+	  ADD_SH_TEST(nczarr_test run_filter)
+	  ADD_SH_TEST(nczarr_test run_specific_filters)
+	  IF(FALSE)
 	  # This test is too dangerous to run in a parallel make environment.
-          # It causes race conditions. So suppress and only test by hand.
-          ADD_SH_TEST(nczarr_test run_unknown)
-	ENDIF(FALSE)
-    ENDIF(ENABLE_FILTER_TESTING)
-    if(ENABLE_NCZARR_ZIP)
-        add_sh_test(nczarr_test run_newformat)
-    endif()
+    # It causes race conditions. So suppress and only test by hand.
+      ADD_SH_TEST(nczarr_test run_unknown)
+	  ENDIF(FALSE)
+  ENDIF(ENABLE_FILTER_TESTING)
+  if(ENABLE_NCZARR_ZIP)
+      add_sh_test(nczarr_test run_newformat)
+  endif()
 
   ENDIF(BUILD_UTILITIES)
 


### PR DESCRIPTION
Old older, common versions of `cmake` < `3.19`, the `CONFIGURE_FILE` command doesn't accept file permission bit arguments.  Introducing a workaround for this rather than enforce manual upgrades of cmake. 