### PR TITLE
Fix building on macOS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1247,8 +1247,8 @@ if test "x$enable_hdf5" = "xno" ; then
     enable_dap4=no
 fi
 
-if test "x$ISOSX" = xyes && test "x$have_libxml2" = xno ; then
-  AC_MSG_ERROR([Error: OSX requires libxml2 => --disable-dap4.])
+if test "x$ISOSX" = xyes && test "x$have_libxml2" = xno && test "x$enable_dap4" = xyes ; then
+  AC_MSG_WARN([OSX requires libxml2 for DAP4 support; disabling DAP4])
   enable_dap4=no
 fi
 


### PR DESCRIPTION
Currently, the configuration fails on macOS with the `--disable-libxml2` option:
```console
configure: error: Error: OSX requires libxml2 => --disable-dap4.
```
The configuration fails even if we add an extra option `--disable-dap`.

Also, one of the two lines [here](https://github.com/Unidata/netcdf-c/blame/7cb42a673903e9fd80008f9cff0cb0ca8c6f08ed/configure.ac#L1251-L1252) is redundant: the configuration should either fail or override the user's choice and proceed. Although I personally prefer the former, the latter seems to be a common pattern in the configure script. Therefore, this MR switches from `AC_MSG_ERROR` to `AC_MSG_WARN` and modifies the misleading message (there is no option `--disable-dap4`). It also doesn't make sense to emit the message and set `enable_dap4` to `no` if the variable is already set to `no`.

I am not sure, whether the problem fixed with 6d44ec3 is still relevant because I have just managed to build the library with the bundled XML implementation.