### PR TITLE
Temporarily disable DAP4.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1058,6 +1058,9 @@ ELSE()
   SET(ENABLE_DAP4 OFF CACHE BOOL "")
 ENDIF()
 
+# Temporarily disable DAP4
+SET(ENABLE_DAP4 OFF CACHE BOOL "")
+
 # Option to support byte-range reading of remote datasets
 OPTION(ENABLE_BYTERANGE "Enable byte-range access to remote datasets.." ON)
 if(NOT ENABLE_REMOTE_FUNCTIONALITY)

--- a/configure.ac
+++ b/configure.ac
@@ -611,7 +611,9 @@ fi
 AM_CONDITIONAL(ENABLE_QUANTIZE, [test x$enable_quantize = xyes])
 
 # --enable-dap => enable-dap4
-enable_dap4=$enable_dap
+# Temporarily disable DAP4
+#enable_dap4=$enable_dap
+enable_dap4=no
 AC_MSG_CHECKING([whether dap use of remotetest server should be enabled])
 AC_ARG_ENABLE([dap-remote-tests],
               [AS_HELP_STRING([--disable-dap-remote-tests],


### PR DESCRIPTION
I am making changes to the remotetest server
with respect to how DAP4 checksums are handled.
Until everything is settled, I need to disable DAP4.