### PR TITLE
Fix memory leak

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,7 @@ This file contains a high-level description of this package's evolution. Release
 
 ## 4.9.3 - TBD
 
+* Fix memory leak WRT unreclaimed HDF5 plist. See [Github #????](https://github.com/Unidata/netcdf-c/pull/????).
 * Suppress filters on variables with non-fixed-size types. See [Github #2716](https://github.com/Unidata/netcdf-c/pull/2716).
 * Provide a single option to disable all network access and testing. See [Github #2708](https://github.com/Unidata/netcdf-c/pull/2708).
 * Fix some problems with earthdata authorization and data access. See [Github #2709](https://github.com/Unidata/netcdf-c/pull/2709).

--- a/libhdf5/hdf5open.c
+++ b/libhdf5/hdf5open.c
@@ -959,6 +959,8 @@ nc4_open_file(const char *path, int mode, void* parameters, int ncid)
       if (!(crt_order_flags & H5P_CRT_ORDER_TRACKED)) {
 	  nc4_info->no_attr_create_order = NC_TRUE;
       }
+      if (H5Pclose(pid) < 0)
+	  BAIL(NC_EHDFERR);
     }
 
     /* Now read in all the metadata. Some types and dimscale


### PR DESCRIPTION
re: Issue https://github.com/Unidata/netcdf-c/issues/2723

H/T to Roland Ambs for finding a memory leak where an allocated HDF5 plist is not being reclaimed.