### PR TITLE
Fix a crash when accessing a corrupted classic file.

### DIFF
--- a/libsrc/posixio.c
+++ b/libsrc/posixio.c
@@ -536,9 +536,8 @@ px_get(ncio *const nciop, ncio_px *const pxp,
 	off_t diff = (size_t)(offset - blkoffset);
 	off_t blkextent = _RNDUP(diff + extent, pxp->blksz);
 
-	assert(extent != 0);
-	assert(extent < X_INT_MAX); /* sanity check */
-	assert(offset >= 0); /* sanity check */
+	if(extent == 0 || extent >= X_INT_MAX || offset >= 0) /* sanity check */
+	    return NC_ENOTNC;
 
 	if(2 * pxp->blksz < blkextent)
 		return E2BIG; /* TODO: temporary kludge */

--- a/libsrc/posixio.c
+++ b/libsrc/posixio.c
@@ -536,7 +536,7 @@ px_get(ncio *const nciop, ncio_px *const pxp,
 	off_t diff = (size_t)(offset - blkoffset);
 	off_t blkextent = _RNDUP(diff + extent, pxp->blksz);
 
-	if(extent == 0 || extent >= X_INT_MAX || offset >= 0) /* sanity check */
+	if(!(extent != 0 && extent < X_INT_MAX && offset >= 0)) /* sanity check */
 	    return NC_ENOTNC;
 
 	if(2 * pxp->blksz < blkextent)

--- a/libsrc/posixio.c
+++ b/libsrc/posixio.c
@@ -63,7 +63,7 @@
 #undef MIN  /* system may define MIN somewhere and complain */
 #define MIN(mm,nn) (((mm) < (nn)) ? (mm) : (nn))
 
-#if !defined(NDEBUG) && !defined(X_INT_MAX)
+#if /*!defined(NDEBUG) &&*/ !defined(X_INT_MAX)
 #define  X_INT_MAX 2147483647
 #endif
 

--- a/nc_test/test_byterange.sh
+++ b/nc_test/test_byterange.sh
@@ -86,7 +86,9 @@ ${NCDUMP} -n nc_enddef "$U" >tmp_${TAG}.cdl
 diff -wb tmp_$TAG.cdl ${srcdir}/nc_enddef.cdl 
 }
 
+if test "x$FEATURE_S3TESTS" = xyes ; then
 testsetup https://s3.us-east-1.amazonaws.com/unidata-zarr-test-data 
+fi
 
 echo "*** Testing reading NetCDF-3 file with http"
 


### PR DESCRIPTION
* Fixes https://github.com/Unidata/netcdf-c/issues/2731

A corrupted classic file is causing the library to crash. Fix so that it returns NC_ENOTNC instead.