### PR TITLE
CMake: Find HDF5 header we can safely include for other checks

### DIFF
--- a/cmake/check_hdf5.cmake
+++ b/cmake/check_hdf5.cmake
@@ -1,0 +1,55 @@
+# Work out which HDF5 config header we can safely include
+#
+# We'd like to just use H5public.h, but if HDF5 was built against MPI, this
+# might require us to have found MPI already. The next best file is H5pubconf.h,
+# which actually has all the feature macros we want to check, but some
+# distributions rename this for multiarch, so we've got to check some different
+# names.
+#
+# HDF5_INCLUDE_DIR should already be set before calling this
+function(check_hdf5_feature_header)
+  if (_H5_FEATURE_HEADER)
+    return()
+  endif()
+
+  include(CheckIncludeFile)
+
+  set(CMAKE_REQUIRED_INCLUDES ${HDF5_INCLUDE_DIR})
+
+  message(STATUS "Checking for HDF5 config header")
+  foreach(_h5_header "H5public.h" "H5pubconf.h" "H5pubconf-64.h" "H5pubconf-32.h")
+    check_include_file(${_h5_header} _can_include_h5_header)
+
+    if (_can_include_h5_header)
+      message(STATUS "Using ${_h5_header} to check for feature macros")
+      set(_H5_FEATURE_HEADER ${_h5_header} CACHE INTERNAL "")
+      return()
+    endif()
+  endforeach()
+
+  message(FATAL_ERROR "Could not include any HDF5 config headers")
+endfunction()
+
+
+# Check for an HDF5 feature macro named FEATURE and store the result in VAR
+#
+# This just wraps `check_c_source_compiles` but ensures we use the correct header
+function(check_hdf5_feature VAR FEATURE)
+  if (NOT _H5_FEATURE_HEADER)
+    check_hdf5_feature_header()
+  endif()
+
+  include(CheckCSourceCompiles)
+  set(CMAKE_REQUIRED_INCLUDES ${HDF5_INCLUDE_DIR})
+
+  message(STATUS "Checking for ${FEATURE}")
+  check_c_source_compiles("
+#include <${_H5_FEATURE_HEADER}>
+#if !${FEATURE}
+#error
+#endif
+int main() {}"
+    _has_${FEATURE})
+
+  set(${VAR} ${_has_${FEATURE}} PARENT_SCOPE)
+endfunction()

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -304,18 +304,13 @@ IF(USE_HDF5)
     INCLUDE_DIRECTORIES(${HAVE_HDF5_H})
   ENDIF(NOT HAVE_HDF5_H)
 
-  set (CMAKE_REQUIRED_INCLUDES ${HDF5_INCLUDE_DIR})
+  include(cmake/check_hdf5.cmake)
 
   # Check to ensure that HDF5 was built with zlib.
   # This needs to be near the beginning since we
   # need to know whether to add "-lz" to the symbol
   # tests below.
-  CHECK_C_SOURCE_COMPILES("#include <H5pubconf.h>
-   #if !H5_HAVE_ZLIB_H
-   #error
-   #endif
-   int main() {
-   int x = 1;}" HAVE_HDF5_ZLIB)
+  check_hdf5_feature(HAVE_HDF5_ZLIB H5_HAVE_ZLIB_H)
   IF(NOT HAVE_HDF5_ZLIB)
     MESSAGE(FATAL_ERROR "HDF5 was built without zlib. Rebuild HDF5 with zlib.")
   ELSE()
@@ -332,16 +327,8 @@ IF(USE_HDF5)
     MESSAGE(STATUS "HDF5 has zlib.")
   ENDIF()
 
-  #Check to see if H5Z_SZIP exists in HDF5_Libraries. If so, we must use szip library.
-  CHECK_C_SOURCE_COMPILES("#include <H5pubconf.h>
-   #if !H5_HAVE_FILTER_SZIP
-   #error
-   #endif
-   int main() {
-   int x = 1;}" USE_HDF5_SZIP)
-  IF(USE_HDF5_SZIP)
-    SET(HAVE_H5Z_SZIP yes )
-  ENDIF()
+  # Check to see if H5Z_SZIP exists in HDF5_Libraries. If so, we must use szip library.
+  check_hdf5_feature(HAVE_H5Z_SZIP H5_HAVE_FILTER_SZIP)
 
   ####
   # Check to see if HDF5 library is 1.10.6 or greater.


### PR DESCRIPTION
I was a bit hasty in #2757: some linux distros rename `H5pubconf.h` so we need to potentially check a few headers. I've wrapped this up to keep things clean in the main CMake file.