### PR TITLE
Fix bug with displaying log messages

### DIFF
--- a/libdispatch/nclog.c
+++ b/libdispatch/nclog.c
@@ -82,9 +82,11 @@ ncloginit(void)
 }
 
 /*!
-Enable/Disable logging.
+Enable logging messages to a given level. Set to NCLOGOFF to disable
+all messages, NCLOGERR for errors only, NCLOGWARN for warnings and
+errors, and so on
 
-\param[in] tf If 1, then turn on logging, if 0, then turn off logging.
+\param[in] level Messages above this level are ignored
 
 \return The previous value of the logging flag.
 */
@@ -136,8 +138,9 @@ ncvlog(int level, const char* fmt, va_list ap)
     const char* prefix;
 
     if(!nclogginginitialized) ncloginit();
-    if(nclog_global.loglevel > level || nclog_global.nclogstream == NULL)
-	return;
+    if(nclog_global.loglevel < level || nclog_global.nclogstream == NULL) {
+        return;
+    }
     prefix = nctagname(level);
     fprintf(nclog_global.nclogstream,"%s: ",prefix);
     if(fmt != NULL) {


### PR DESCRIPTION
* Fixes #2773 

One of the changes in df3636b introduced the ability to filter log messages by level. This fixes a typo that flipped the intended filtering, so that `NCLOGOFF` _enabled_ all messages instead of _disabling_ them.