### PR TITLE
Revert a change made in d3c2cf236 that is proving confounding in MSYS2 bash

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2250,7 +2250,7 @@ ENDIF(ENABLE_BASH_SCRIPT_TESTING)
 
 MACRO(add_sh_test prefix F)
   IF(HAVE_BASH)
-    ADD_TEST(${prefix}_${F} bash "-c" "export srcdir=${CMAKE_CURRENT_SOURCE_DIR};export TOPSRCDIR=${CMAKE_SOURCE_DIR};bash ${CMAKE_CURRENT_BINARY_DIR}/${F}.sh ${ARGN}")
+    ADD_TEST(${prefix}_${F} bash "-c" "export srcdir=${CMAKE_CURRENT_SOURCE_DIR};export TOPSRCDIR=${CMAKE_SOURCE_DIR};${CMAKE_CURRENT_BINARY_DIR}/${F}.sh ${ARGN}")
   ENDIF()
 ENDMACRO()
 


### PR DESCRIPTION
The original issue may still need to be resolved, but this reverts a change which was causing problems with specific tests in a specific way in a very specific environment.