### PR TITLE
CMake: Don't add uninstall target and CPack config if not top-level

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 # Set Project Properties
 ##################################
 
-cmake_minimum_required(VERSION 3.21.0)
+cmake_minimum_required(VERSION 3.12.0)
 
 #Project Name
 project(netCDF
@@ -15,6 +15,14 @@ HOMEPAGE_URL "https://www.unidata.ucar.edu/software/netcdf/"
 DESCRIPTION "NetCDF is a set of software libraries and machine-independent data formats that support the creation, access, and sharing of array-oriented scientific data."
 )
 set(PACKAGE "netCDF" CACHE STRING "")
+
+# Backport of built-in `PROJECT_IS_TOP_LEVEL` from CMake 3.21
+if (NOT DEFINED NETCDF_IS_TOP_LEVEL)
+  set(NETCDF_IS_TOP_LEVEL OFF)
+  if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+    set(NETCDF_IS_TOP_LEVEL ON)
+  endif ()
+endif ()
 
 #####
 # Version Info:
@@ -2787,6 +2795,8 @@ install(
 ####
 
 # CPack inclusion must come last.
-if (PROJECT_IS_TOP_LEVEL)
+option(NETCDF_PACKAGE "Create netCDF-C package " ${NETCDF_IS_TOP_LEVEL})
+
+if (NETCDF_PACKAGE)
   include(CMakeInstallation.cmake)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,9 +6,7 @@
 # Set Project Properties
 ##################################
 
-#Minimum required CMake Version
-cmake_minimum_required(VERSION 3.12.0)
-# CMake 3.12: Use libraries specified in CMAKE_REQUIRED_LIBRARIES for check include macros
+cmake_minimum_required(VERSION 3.21.0)
 
 #Project Name
 project(netCDF
@@ -2789,5 +2787,6 @@ install(
 ####
 
 # CPack inclusion must come last.
-# INCLUDE(CPack)
-INCLUDE(CMakeInstallation.cmake)
+if (PROJECT_IS_TOP_LEVEL)
+  include(CMakeInstallation.cmake)
+endif()


### PR DESCRIPTION
Fixes #2597

CMake 3.21 was released in 2021 and is available in the latest release of all the big distros (see https://pkgs.org/search/?q=cmake). If it's necessary to support older versions of CMake, a reasonable backport is something like:

```cmake
if (${CMAKE_PROJECT_NAME} STREQUAL ${PROJECT_NAME})
  include(CMakeInstallation.cmake)
endif()
```

[`CMAKE_PROJECT_NAME`](https://cmake.org/cmake/help/latest/variable/CMAKE_PROJECT_NAME.html) is the top-level project name  
[`PROJECT_NAME`](https://cmake.org/cmake/help/latest/variable/PROJECT_NAME.html#variable:PROJECT_NAME) is the current project name (i.e. `netCDF`!)

It might also be friendlier to expose an option to allow changing this:

```cmake
if (${CMAKE_PROJECT_NAME} STREQUAL ${PROJECT_NAME})
  set(_default_install_option ON)
else()
  set(_default_install_option OFF)
endif()

option(INSTALL_NETCDF "Install netCDF-C" ${_default_install_option})

if (INSTALL_NETCDF)
  include(CMakeInstallation.cmake)
endif()
```