### PR TITLE
Added stanza to workflow actions so that pushed changes cancel tests

### DIFF
--- a/.github/workflows/run_tests_cdash.yml
+++ b/.github/workflows/run_tests_cdash.yml
@@ -6,7 +6,9 @@ name: Run CDash Ubuntu/Linux netCDF Tests
 
 on: workflow_dispatch
     
-          
+concurrency:  
+  group: ${{ github.workflow}}-${{ github.head_ref }}  
+  cancel-in-progress: true
 
 jobs:
 

--- a/.github/workflows/run_tests_osx.yml
+++ b/.github/workflows/run_tests_osx.yml
@@ -6,8 +6,11 @@
 
 name: Run macOS-based netCDF Tests
 
-
 on: [pull_request,workflow_dispatch]
+
+concurrency:  
+  group: ${{ github.workflow}}-${{ github.head_ref }}  
+  cancel-in-progress: true
 
 jobs:
 

--- a/.github/workflows/run_tests_s3.yml
+++ b/.github/workflows/run_tests_s3.yml
@@ -11,6 +11,10 @@ name: Run S3 netCDF Tests (under Ubuntu Linux)
 
 on: [workflow_dispatch]
 
+concurrency:  
+  group: ${{ github.workflow}}-${{ github.head_ref }}  
+  cancel-in-progress: true
+
 jobs:
 
   build-deps-serial:

--- a/.github/workflows/run_tests_ubuntu.yml
+++ b/.github/workflows/run_tests_ubuntu.yml
@@ -6,6 +6,10 @@ name: Run Ubuntu/Linux netCDF Tests
 
 on: [pull_request, workflow_dispatch]
 
+concurrency:  
+  group: ${{ github.workflow}}-${{ github.head_ref }}  
+  cancel-in-progress: true
+
 jobs:
 
   build-deps-serial:

--- a/.github/workflows/run_tests_win_cygwin.yml
+++ b/.github/workflows/run_tests_win_cygwin.yml
@@ -2,6 +2,10 @@ name: Run Cygwin-based tests
 
 on: [pull_request,workflow_dispatch]
 
+concurrency:  
+  group: ${{ github.workflow}}-${{ github.head_ref }}  
+  cancel-in-progress: true
+
 env:
   SHELLOPTS: igncr
   CHERE_INVOKING: 1

--- a/.github/workflows/run_tests_win_mingw.yml
+++ b/.github/workflows/run_tests_win_mingw.yml
@@ -11,6 +11,10 @@ env:
 
 on: [pull_request,workflow_dispatch]
 
+concurrency:  
+  group: ${{ github.workflow}}-${{ github.head_ref }}  
+  cancel-in-progress: true
+
 jobs:
 
   build-and-test-autotools:


### PR DESCRIPTION
Discovered yesterday that netCDF was clogging up some of the Github Action pipeline for the rest of the Unidata org.  This is because rapid pushes of changes do not cancel existing test runs, as had been my impression. Thanks @dopplershift for pointing this out, and for pointing me in the right direction to ameliorate this.

