### PR TITLE
Fixed various UBSan warnings about invalid bit shifting

### DIFF
--- a/libdispatch/ncexhash.c
+++ b/libdispatch/ncexhash.c
@@ -111,7 +111,7 @@ ncexinit(void)
     int i;
     bitmasks[0] = 0;
     for(i=1;i<NCEXHASHKEYBITS;i++)
-	bitmasks[i] = (1 << i) - 1;
+	bitmasks[i] = (1ULL << i) - 1;
     ncexinitialized = 1;
 }
 
@@ -855,7 +855,7 @@ ncexhashprintstats(NCexhashmap* map)
     fprintf(stderr," |leaf|=%d nactive/nleaves=%g", map->leaflen, leafavg);
     fprintf(stderr," load=%g",leafload);
     fprintf(stderr,"]\n");
-    dirsize = (1<<(map->depth))*((unsigned long long)sizeof(void*));
+    dirsize = (1ULL<<(map->depth))*((unsigned long long)sizeof(void*));
     leafsize = (nleaves)*((unsigned long long)sizeof(NCexleaf));
     total = dirsize + leafsize;
     fprintf(stderr,"\tsizeof(directory)=%llu sizeof(leaves)=%lld total=%lld\n",

--- a/libdispatch/nclistmgr.c
+++ b/libdispatch/nclistmgr.c
@@ -81,8 +81,8 @@ free_NCList(void)
 int
 add_to_NCList(NC* ncp)
 {
-    int i;
-    int new_id;
+    unsigned int i;
+    unsigned int new_id;
     if(nc_filelist == NULL) {
         if (!(nc_filelist = calloc(1, sizeof(NC*)*NCFILELISTLENGTH)))
             return NC_ENOMEM;
@@ -96,7 +96,7 @@ add_to_NCList(NC* ncp)
     if(new_id == 0) return NC_ENOMEM; /* no more slots */
     nc_filelist[new_id] = ncp;
     numfiles++;
-    ncp->ext_ncid = (new_id << ID_SHIFT);
+    ncp->ext_ncid = (int)(new_id << ID_SHIFT);
     return NC_NOERR;
 }
 


### PR DESCRIPTION
Just made sure to use unsigned, so that a bit does not get shifted into a sign bit.