### PR TITLE
Renamed mmap variable, which conflicts with mmap() function on FreeBSD

### DIFF
--- a/libdispatch/dfile.c
+++ b/libdispatch/dfile.c
@@ -1770,7 +1770,7 @@ static int
 check_create_mode(int mode)
 {
     int mode_format;
-    int mmap = 0;
+    int use_mmap = 0;
     int inmemory = 0;
     int diskless = 0;
 
@@ -1781,17 +1781,17 @@ check_create_mode(int mode)
     if (mode_format && (mode_format & (mode_format - 1)))
         return NC_EINVAL;
 
-    mmap = ((mode & NC_MMAP) == NC_MMAP);
+    use_mmap = ((mode & NC_MMAP) == NC_MMAP);
     inmemory = ((mode & NC_INMEMORY) == NC_INMEMORY);
     diskless = ((mode & NC_DISKLESS) == NC_DISKLESS);
 
     /* NC_INMEMORY and NC_DISKLESS and NC_MMAP are all mutually exclusive */
     if(diskless && inmemory) return NC_EDISKLESS;
-    if(diskless && mmap) return NC_EDISKLESS;
-    if(inmemory && mmap) return NC_EINMEMORY;
+    if(diskless && use_mmap) return NC_EDISKLESS;
+    if(inmemory && use_mmap) return NC_EINMEMORY;
 
     /* mmap is not allowed for netcdf-4 */
-    if(mmap && (mode & NC_NETCDF4)) return NC_EINVAL;
+    if(use_mmap && (mode & NC_NETCDF4)) return NC_EINVAL;
 
 #ifndef USE_NETCDF4
     /* If the user asks for a netCDF-4 file, and the library was built
@@ -1973,7 +1973,7 @@ NC_open(const char *path0, int omode, int basepe, size_t *chunksizehintp,
     const NC_Dispatch* dispatcher = NULL;
     int inmemory = 0;
     int diskless = 0;
-    int mmap = 0;
+    int use_mmap = 0;
     char* path = NULL;
     NCmodel model;
     char* newpath = NULL;
@@ -1989,17 +1989,17 @@ NC_open(const char *path0, int omode, int basepe, size_t *chunksizehintp,
         {stat = NC_EINVAL; goto done;}
 
     /* Capture the inmemory related flags */
-    mmap = ((omode & NC_MMAP) == NC_MMAP);
+    use_mmap = ((omode & NC_MMAP) == NC_MMAP);
     diskless = ((omode & NC_DISKLESS) == NC_DISKLESS);
     inmemory = ((omode & NC_INMEMORY) == NC_INMEMORY);
 
     /* NC_INMEMORY and NC_DISKLESS and NC_MMAP are all mutually exclusive */
     if(diskless && inmemory) {stat = NC_EDISKLESS; goto done;}
-    if(diskless && mmap) {stat = NC_EDISKLESS; goto done;}
-    if(inmemory && mmap) {stat = NC_EINMEMORY; goto done;}
+    if(diskless && use_mmap) {stat = NC_EDISKLESS; goto done;}
+    if(inmemory && use_mmap) {stat = NC_EINMEMORY; goto done;}
 
     /* mmap is not allowed for netcdf-4 */
-    if(mmap && (omode & NC_NETCDF4)) {stat = NC_EINVAL; goto done;}
+    if(use_mmap && (omode & NC_NETCDF4)) {stat = NC_EINVAL; goto done;}
 
     /* Attempt to do file path conversion: note that this will do
        nothing if path is a 'file:...' url, so it will need to be

--- a/nc_test/tst_diskless.c
+++ b/nc_test/tst_diskless.c
@@ -46,7 +46,7 @@ void fail(int line) {
 #endif
 
 /* Control flags  */
-static int flags, persist, usenetcdf4, mmap, diskless;
+static int flags, persist, usenetcdf4, use_mmap, diskless;
 
 char*
 smode(int mode)
@@ -90,13 +90,13 @@ main(int argc, char **argv)
     /* Set defaults */
     persist = 0;
     usenetcdf4 = 0;
-    mmap = 0;
+    use_mmap = 0;
     diskless = 0;
 
     for(i=1;i<argc;i++) {
 	if(strcmp(argv[i],"netcdf4")==0) usenetcdf4=1;
 	else if(strcmp(argv[i],"persist")==0) persist=1;
-	else if(strcmp(argv[i],"mmap")==0) mmap=1;
+	else if(strcmp(argv[i],"mmap")==0) use_mmap=1;
 	else if(strcmp(argv[i],"diskless")==0) diskless=1;
 	else if(strncmp(argv[i],"file:",strlen("file:"))==0) {
 	    filename = argv[i];
@@ -111,12 +111,12 @@ main(int argc, char **argv)
 #endif
 
     /* Invalid combinations */
-    if(mmap && diskless) {fprintf(stderr,"Illegal: mmap+diskless\n"); exit(1);};
-    if(mmap && usenetcdf4) {fprintf(stderr,"Illegal: mmap+netcdf4\n"); exit(1);};
+    if(use_mmap && diskless) {fprintf(stderr,"Illegal: mmap+diskless\n"); exit(1);};
+    if(use_mmap && usenetcdf4) {fprintf(stderr,"Illegal: mmap+netcdf4\n"); exit(1);};
 
     flags = usenetcdf4?FLAGS4:FLAGS3;
     if(persist) flags |= NC_PERSIST;
-    if(mmap) flags |= NC_MMAP;
+    if(use_mmap) flags |= NC_MMAP;
     if(diskless) flags |= NC_DISKLESS;
 
 printf("\n*** Testing the diskless|mmap API.\n");

--- a/nc_test/tst_diskless3.c
+++ b/nc_test/tst_diskless3.c
@@ -47,7 +47,7 @@
 static int status = NC_NOERR;
 
 /* Control flags  */
-static int persist, usenetcdf4, mmap, diskless, file, openfile;
+static int persist, usenetcdf4, use_mmap, diskless, file, openfile;
 static char* filename = NCFILENAME;
 static int diskmode = 0;
 
@@ -211,7 +211,7 @@ parse(int argc, char** argv)
     /* Set defaults */
     persist = 0;
     usenetcdf4 = 0;
-    mmap = 0;
+    use_mmap = 0;
     diskless = 0;
     file = 0;
     diskmode = 0;
@@ -219,7 +219,7 @@ parse(int argc, char** argv)
 
     for(i=1;i<argc;i++) {
 	if(strcmp(argv[i],"diskless")==0) diskless=1;
-	else if(strcmp(argv[i],"mmap")==0) mmap=1;
+	else if(strcmp(argv[i],"mmap")==0) use_mmap=1;
 	else if(strcmp(argv[i],"file")==0) file=1;
 	else if(strcmp(argv[i],"persist")==0) persist=1;
 	else if(strcmp(argv[i],"open")==0) openfile=1;
@@ -231,7 +231,7 @@ parse(int argc, char** argv)
 	/* ignore anything not recognized */
     }
 
-    if(diskless && mmap) {
+    if(diskless && use_mmap) {
 	fprintf(stderr,"NC_DISKLESS and NC_MMAP are mutually exclusive\n");
 	exit(1);
     }
@@ -244,7 +244,7 @@ buildmode(void)
     diskmode = 0;
     if(diskless)
         diskmode |= NC_DISKLESS;
-    if(mmap)
+    if(use_mmap)
         diskmode |= NC_MMAP;
     if(persist)
         diskmode |= NC_PERSIST;
@@ -257,7 +257,7 @@ main(int argc, char **argv)
 {
     parse(argc,argv);
 
-    if(!diskless && !mmap && !file) {
+    if(!diskless && !use_mmap && !file) {
 	fprintf(stderr,"file or diskless or mmap must be specified\n");
 	exit(1);
     }


### PR DESCRIPTION
This fixes compiler errors on FreeBSD 14.