### PR TITLE
Undefined behavior in ncx.m4

### DIFF
--- a/config.h.cmake.in
+++ b/config.h.cmake.in
@@ -118,6 +118,12 @@ are set when opening a binary file on Windows. */
 /* if true, build byte-range Client */
 #cmakedefine ENABLE_BYTERANGE 1
 
+/* if true, enable ERANGE fill */
+#cmakedefine ENABLE_ERANGE_FILL 1
+#ifdef ENABLE_ERANGE_FILL
+#define ERANGE_FILL 1
+#endif
+
 /* if true, use hdf5 S3 virtual file reader */
 #cmakedefine ENABLE_HDF5_ROS3 1
 

--- a/libsrc/ncx.m4
+++ b/libsrc/ncx.m4
@@ -39,7 +39,7 @@ ifdef(`PNETCDF',`
 `#'if HAVE_CONFIG_H
 `#'include <config.h>
 `#'endif')
-
+#include <config.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/libsrc/ncx.m4
+++ b/libsrc/ncx.m4
@@ -760,7 +760,8 @@ APIPrefix`x_put_'NC_TYPE($1)_$2(void *xp, const $2 *ip, void *fillp)
 #endif',
         `$2', `float',  `if (*ip > (double)Xmax($1) || *ip < FXmin($1)) {
         FillValue($1, &xx)
-        DEBUG_ASSIGN_ERROR(err, NC_ERANGE)
+        /* DEBUG_ASSIGN_ERROR(err, NC_ERANGE) */
+		return NC_ERANGE;
     }
 #ifdef ERANGE_FILL
     else

--- a/libsrc/ncx.m4
+++ b/libsrc/ncx.m4
@@ -527,8 +527,10 @@ swapn8b(void *dst, const void *src, IntType nn)
     uint64_t *ip = (uint64_t*) src;
     for (i=0; i<nn; i++) {
         /* copy over, make the below swap in-place */
-        op[i] = ip[i];
-        op[i] = SWAP8(op[i]);
+        uint64_t temp;
+        memcpy(&temp, src + i * sizeof(uint64_t), sizeof(uint64_t));
+        temp = SWAP8(temp);
+        memcpy(dst + i * sizeof(uint64_t), &temp, sizeof(uint64_t));
     }
 #endif
 

--- a/libsrc/ncx.m4
+++ b/libsrc/ncx.m4
@@ -528,9 +528,9 @@ swapn8b(void *dst, const void *src, IntType nn)
     for (i=0; i<nn; i++) {
         /* copy over, make the below swap in-place */
         uint64_t temp;
-        memcpy(&temp, src + i * sizeof(uint64_t), sizeof(uint64_t));
+        memcpy(&temp, (uint64_t*)src + i * sizeof(uint64_t), sizeof(uint64_t));
         temp = SWAP8(temp);
-        memcpy(dst + i * sizeof(uint64_t), &temp, sizeof(uint64_t));
+        memcpy((uint64_t*)dst + i * sizeof(uint64_t), &temp, sizeof(uint64_t));
     }
 #endif
 


### PR DESCRIPTION
* Fixes #2796 

> Closed #2797 because I'm not sure what I was getting at to start with, re-opened under this branch.  

The undefined behavior appears to be a side effect of casting to a narrower data type.  The logic in `ncx.m4` was added way back in 2016, in #319.  Reverting to previous behavior, where we return `NC_ERANGE` when attempting to convert a value too large (or two small) into a narrower data type, fixes the issue.  I need to dig in and figure out if this is the behavior we *want*, or if we want to make broader changes.  

