### PR TITLE
Silence conversion warnings from `malloc` arguments

### DIFF
--- a/h5_test/tst_h_vl.c
+++ b/h5_test/tst_h_vl.c
@@ -7,6 +7,7 @@
 
 #include "h5_err_macros.h"
 #include <hdf5.h>
+#include <stddef.h>
 
 #define FILE_NAME "tst_h_vl.h5"
 #define DIM1_LEN 3
@@ -23,7 +24,7 @@ main()
       hsize_t dims[1] = {DIM1_LEN};
       hvl_t data[DIM1_LEN], data_in[DIM1_LEN];
       int *phoney;
-      int i, j;
+      size_t i, j;
       size_t size;
       
       /* Create some phoney data, an array of struct s1, which holds a

--- a/include/nctestserver.h
+++ b/include/nctestserver.h
@@ -52,7 +52,7 @@ parseServers(const char* remotetestservers)
 
     /* Keep LGTM quiet */
     if(rtslen > MAXREMOTETESTSERVERS) goto done;
-    list = (char**)malloc(sizeof(char*) * (int)(rtslen/2));
+    list = (char**)malloc(sizeof(char*) * (rtslen/2));
     if(list == NULL) return NULL;
     rts = strdup(remotetestservers);
     if(rts == NULL) goto done;

--- a/libdap2/dapdump.c
+++ b/libdap2/dapdump.c
@@ -38,7 +38,7 @@ dumpmetadata(int ncid, NChdr** hdrp)
         fprintf(stdout,"ncid=%d ngatts=%d ndims=%d nvars=%d unlimid=%d\n",
 		hdr->ncid,hdr->ngatts,hdr->ndims,hdr->nvars,hdr->unlimid);
 #endif
-    hdr->gatts = (NCattribute*)calloc(1,hdr->ngatts*sizeof(NCattribute));
+    hdr->gatts = (NCattribute*)calloc(1, (size_t)hdr->ngatts*sizeof(NCattribute));
     MEMCHECK(hdr->gatts,NC_ENOMEM);
     if(hdr->ngatts > 0)
 	fprintf(stdout,"global attributes:\n");
@@ -81,7 +81,7 @@ dumpmetadata(int ncid, NChdr** hdrp)
 	fprintf(stdout,"\n");
     }
 
-    hdr->dims = (Dim*)malloc(hdr->ndims*sizeof(Dim));
+    hdr->dims = (Dim*)malloc((size_t)hdr->ndims*sizeof(Dim));
     MEMCHECK(hdr->dims,NC_ENOMEM);
     for(i=0;i<hdr->ndims;i++) {
 	hdr->dims[i].dimid = i;
@@ -93,7 +93,7 @@ dumpmetadata(int ncid, NChdr** hdrp)
 	fprintf(stdout,"dim[%d]: name=%s size=%lu\n",
 		i,hdr->dims[i].name,(unsigned long)hdr->dims[i].size);
     }
-    hdr->vars = (Var*)malloc(hdr->nvars*sizeof(Var));
+    hdr->vars = (Var*)malloc((size_t)hdr->nvars*sizeof(Var));
     MEMCHECK(hdr->vars,NC_ENOMEM);
     for(i=0;i<hdr->nvars;i++) {
 	Var* var = &hdr->vars[i];
@@ -118,7 +118,7 @@ dumpmetadata(int ncid, NChdr** hdrp)
 	    fprintf(stdout," %d",var->dimids[j]);
 	}
 	fprintf(stdout,"}\n");
-	var->atts = (NCattribute*)malloc(var->natts*sizeof(NCattribute));
+	var->atts = (NCattribute*)malloc((size_t)var->natts*sizeof(NCattribute));
         MEMCHECK(var->atts,NC_ENOMEM);
         for(j=0;j<var->natts;j++) {
 	    NCattribute* att = &var->atts[j];

--- a/libdap2/daputil.c
+++ b/libdap2/daputil.c
@@ -4,6 +4,7 @@
  *********************************************************************/
 
 #include "config.h"
+#include <stddef.h>
 
 #ifdef HAVE_SYS_TIME_H
 #include <sys/time.h>
@@ -763,7 +764,7 @@ repairname(const char* name, const char* badchars)
     const char *p;
     char *q;
     int c;
-    int nnlen = 0;
+    size_t nnlen = 0;
 
     if(name == NULL) return NULL;
     nnlen = (3*strlen(name)); /* max needed */

--- a/libdap4/d4file.c
+++ b/libdap4/d4file.c
@@ -7,6 +7,7 @@
 #include "ncd4dispatch.h"
 #include "d4includes.h"
 #include "d4curlfunctions.h"
+#include <stddef.h>
 
 #ifdef _MSC_VER
 #include <process.h>
@@ -301,7 +302,7 @@ set_curl_properties(NCD4INFO* d4info)
 	/* If no cookie file was defined, define a default */
         char* path = NULL;
         char* newpath = NULL;
-        int len;
+        size_t len;
 	errno = 0;
 	NCglobalstate* globalstate = NC_getglobalstate();
 

--- a/libdap4/d4meta.c
+++ b/libdap4/d4meta.c
@@ -5,6 +5,7 @@
 
 #include "d4includes.h"
 #include <stdarg.h>
+#include <stddef.h>
 #include "nc4internal.h"
 #include "ncoffsets.h"
 
@@ -603,8 +604,8 @@ savevarbyid(NCD4node* group, NCD4node* var)
 {
     if(group->group.varbyid == NULL)
         group->group.varbyid = nclistnew();
-    nclistsetalloc(group->group.varbyid,var->meta.id);
-    nclistinsert(group->group.varbyid,var->meta.id,var);
+    nclistsetalloc(group->group.varbyid, (size_t)var->meta.id);
+    nclistinsert(group->group.varbyid, (size_t)var->meta.id,var);
 }
 
 /* Collect FQN path from var node up to and including
@@ -730,7 +731,7 @@ compileAttrValues(NCD4meta* builder, NCD4node* attr, void** memoryp, NClist* blo
     NCD4node* container = attr->container;
     NCD4node* basetype = attr->basetype;
     NClist* values = attr->attr.values;
-    int count = nclistlength(values);
+    size_t count = nclistlength(values);
 
     memset((void*)&converter,0,sizeof(converter));
 

--- a/libdispatch/dinfermodel.c
+++ b/libdispatch/dinfermodel.c
@@ -320,8 +320,8 @@ parsepair(const char* pair, char** keyp, char** valuep)
 	key = strdup(pair);
     } else {
 	ptrdiff_t len = (p-pair);
-	if((key = malloc(len+1))==NULL) return NC_ENOMEM;
-	memcpy(key,pair,len);
+	if((key = malloc((size_t)len+1))==NULL) return NC_ENOMEM;
+	memcpy(key,pair,(size_t)len);
 	key[len] = '\0';
 	if(p[1] == '\0')
 	    value = NULL;
@@ -383,8 +383,8 @@ parseonchar(const char* s, int ch, NClist* segments)
 	endp = strchr(p,ch);
 	if(endp == NULL) endp = p + strlen(p);
 	slen = (endp - p);
-	if((q = malloc(slen+1)) == NULL) {stat = NC_ENOMEM; goto done;}
-	memcpy(q,p,slen);
+	if((q = malloc((size_t)slen+1)) == NULL) {stat = NC_ENOMEM; goto done;}
+	memcpy(q,p,(size_t)slen);
 	q[slen] = '\0';
 	nclistpush(segments,q);
 	if(*endp == '\0') break;

--- a/libdispatch/dutil.c
+++ b/libdispatch/dutil.c
@@ -448,9 +448,9 @@ NC_split_delim(const char* arg, char delim, NClist* segments)
         len = (q - p);
 	if(len == 0)
 	    {stat = NC_EURL; goto done;}
-	if((seg = malloc(len+1)) == NULL)
+	if((seg = malloc((size_t)len+1)) == NULL)
 	    {stat = NC_ENOMEM; goto done;}
-	memcpy(seg,p,len);
+	memcpy(seg,p,(size_t)len);
 	seg[len] = '\0';
 	nclistpush(segments,seg);
 	seg = NULL; /* avoid mem errors */

--- a/libdispatch/dv2i.c
+++ b/libdispatch/dv2i.c
@@ -1254,7 +1254,7 @@ ncvarputg(
 		ret = nc_inq_vartype(ncid, varid, &type);
 		if(ret) return ret;
 				el_size = nctypelen(type);
-		imp = (ptrdiff_t*) malloc(ndims * sizeof(ptrdiff_t));
+		imp = (ptrdiff_t*) malloc((size_t)ndims * sizeof(ptrdiff_t));
 		for (i=0; i<ndims; i++) imp[i] = map[i] / el_size;
 	}
 
@@ -1327,7 +1327,7 @@ ncvargetg(
 		ret = nc_inq_vartype(ncid, varid, &type);
 		if(ret) return ret;
 		el_size = nctypelen(type);
-		imp = (ptrdiff_t*) malloc(ndims * sizeof(ptrdiff_t));
+		imp = (ptrdiff_t*) malloc((size_t)ndims * sizeof(ptrdiff_t));
 		for (i=0; i<ndims; i++) imp[i] = map[i] / el_size;
 	}
 

--- a/libdispatch/dvar.c
+++ b/libdispatch/dvar.c
@@ -1034,7 +1034,7 @@ NC_inq_recvar(int ncid, int varid, int* nrecdimsp, int *is_recdim)
         if(status != NC_NOERR) return status;
         if(nunlimdims == 0) return status;
 
-        if (!(unlimids = malloc(nunlimdims * sizeof(int))))
+        if (!(unlimids = malloc((size_t)nunlimdims * sizeof(int))))
             return NC_ENOMEM;
         status = nc_inq_unlimdims(ncid, &nunlimdims, unlimids); /* for group or file, not variable */
         if(status != NC_NOERR) {
@@ -1263,7 +1263,7 @@ NC_check_nulls(int ncid, int varid, const size_t *start, size_t **count,
     /* If count is NULL, assume full extent of var. */
     if (!*count)
     {
-        if (!(*count = malloc(varndims * sizeof(size_t))))
+        if (!(*count = malloc((size_t)varndims * sizeof(size_t))))
             return NC_ENOMEM;
         if ((stat = NC_getshape(ncid, varid, varndims, *count)))
         {
@@ -1279,7 +1279,7 @@ NC_check_nulls(int ncid, int varid, const size_t *start, size_t **count,
     {
         int i;
 
-        if (!(*stride = malloc(varndims * sizeof(ptrdiff_t))))
+        if (!(*stride = malloc((size_t)varndims * sizeof(ptrdiff_t))))
             return NC_ENOMEM;
         for (i = 0; i < varndims; i++)
             (*stride)[i] = 1;

--- a/libdispatch/ncexhash.c
+++ b/libdispatch/ncexhash.c
@@ -386,7 +386,7 @@ exhashsplit(NCexhashmap* map, ncexhashkey_t hkey, NCexleaf* leaf)
     }
     
     /* Re-build the old leaf; keep same uid */
-    if((leaf->entries = (NCexentry*)calloc(map->leaflen,sizeof(NCexentry))) == NULL)
+    if((leaf->entries = (NCexentry*)calloc((size_t)map->leaflen, sizeof(NCexentry))) == NULL)
 	{stat = NC_ENOMEM; goto done;}
     leaf->active = 0;
 
@@ -588,7 +588,7 @@ exhashnewleaf(NCexhashmap* map, NCexleaf** leafp)
         if((leaf = calloc(1,sizeof(NCexleaf))) == NULL)
 	    goto done;
 	assert(map->leaflen > 0);
-        if((leaf->entries = calloc(map->leaflen,sizeof(NCexentry))) == NULL)
+        if((leaf->entries = calloc((size_t)map->leaflen, sizeof(NCexentry))) == NULL)
 	    goto done;	
         leaf->uid = map->uid++;
 	*leafp = leaf; leaf = NULL;

--- a/libdispatch/ncjson.c
+++ b/libdispatch/ncjson.c
@@ -798,9 +798,9 @@ listappend(struct NCjlist* list, NCjson* json)
 	list->contents[0] = json;
 	list->len++;
     } else {
-        if((newcontents = (NCjson**)calloc((2*list->len)+1,sizeof(NCjson*)))==NULL)
+        if((newcontents = (NCjson**)calloc((size_t)(2*list->len)+1,sizeof(NCjson*)))==NULL)
             {stat = NCJTHROW(NCJ_ERR); goto done;}
-        memcpy(newcontents,list->contents,list->len*sizeof(NCjson*));
+        memcpy(newcontents,list->contents, (size_t)list->len*sizeof(NCjson*));
 	newcontents[list->len] = json;
 	list->len++;
 	free(list->contents);

--- a/libdispatch/utf8proc.c
+++ b/libdispatch/utf8proc.c
@@ -713,7 +713,7 @@ static nc_utf8proc_ssize_t nc_seqindex_write_char_decomposed(nc_utf8proc_uint16_
   *dstptr = NULL;
   result = nc_utf8proc_decompose_custom(str, strlen, NULL, 0, options, custom_func, custom_data);
   if (result < 0) return result;
-  buffer = (nc_utf8proc_int32_t *) malloc(result * sizeof(nc_utf8proc_int32_t) + 1);
+  buffer = (nc_utf8proc_int32_t *) malloc((size_t)result * sizeof(nc_utf8proc_int32_t) + 1);
   if (!buffer) return UTF8PROC_ERROR_NOMEM;
   result = nc_utf8proc_decompose_custom(str, strlen, buffer, result, options, custom_func, custom_data);
   if (result < 0) {

--- a/libhdf5/hdf5internal.c
+++ b/libhdf5/hdf5internal.c
@@ -150,9 +150,9 @@ find_var_dim_max_length(NC_GRP_INFO_T *grp, int varid, int dimid,
                 BAIL(NC_EHDFERR);
             if (dataset_ndims != var->ndims)
                 BAIL(NC_EHDFERR);
-            if (!(h5dimlen = malloc(dataset_ndims * sizeof(hsize_t))))
+            if (!(h5dimlen = malloc((size_t)dataset_ndims * sizeof(hsize_t))))
                 BAIL(NC_ENOMEM);
-            if (!(h5dimlenmax = malloc(dataset_ndims * sizeof(hsize_t))))
+            if (!(h5dimlenmax = malloc((size_t)dataset_ndims * sizeof(hsize_t))))
                 BAIL(NC_ENOMEM);
             if ((dataset_ndims = H5Sget_simple_extent_dims(spaceid,
                                                            h5dimlen, h5dimlenmax)) < 0)

--- a/libhdf5/hdf5open.c
+++ b/libhdf5/hdf5open.c
@@ -1365,9 +1365,9 @@ get_attached_info(NC_VAR_INFO_T *var, NC_HDF5_VAR_INFO_T *hdf5_var, int ndims,
          * attached for each dimension, and the HDF5 object IDs of the
          * scale(s). */
         assert(!hdf5_var->dimscale_hdf5_objids);
-        if (!(hdf5_var->dimscale_attached = calloc(ndims, sizeof(nc_bool_t))))
+        if (!(hdf5_var->dimscale_attached = calloc((size_t)ndims, sizeof(nc_bool_t))))
             return NC_ENOMEM;
-        if (!(hdf5_var->dimscale_hdf5_objids = malloc(ndims *
+        if (!(hdf5_var->dimscale_hdf5_objids = malloc((size_t)ndims *
                                                       sizeof(struct hdf5_objid))))
             return NC_ENOMEM;
 
@@ -1886,7 +1886,7 @@ read_hdf5_att(NC_GRP_INFO_T *grp, hid_t attid, NC_ATT_INFO_T *att)
                                           &type_size)))
             return retval;
         {
-            if (!(att->data = malloc((unsigned int)(att->len * type_size))))
+            if (!(att->data = malloc((unsigned int)((size_t)att->len * type_size))))
                 BAIL(NC_ENOMEM);
 
             /* For a fixed length HDF5 string, the read requires
@@ -1907,7 +1907,7 @@ read_hdf5_att(NC_GRP_INFO_T *grp, hid_t attid, NC_ATT_INFO_T *att)
 		char** dst = NULL;
 
                 /* Alloc space for the contiguous memory read. */
-                if (!(contig_buf = malloc(att->len * fixed_size * sizeof(char))))
+                if (!(contig_buf = malloc((size_t)att->len * fixed_size * sizeof(char))))
                     BAIL(NC_ENOMEM);
 
                 /* Read the fixed-len strings as one big block. */
@@ -2088,7 +2088,7 @@ read_type(NC_GRP_INFO_T *grp, hid_t hdf_typeid, char *type_name)
             return NC_EHDFERR;
         LOG((5, "compound type has %d members", nmembers));
         type->u.c.field = nclistnew();
-        nclistsetalloc(type->u.c.field,nmembers);
+        nclistsetalloc(type->u.c.field, (size_t)nmembers);
 
         for (m = 0; m < nmembers; m++)
         {
@@ -2253,7 +2253,7 @@ read_type(NC_GRP_INFO_T *grp, hid_t hdf_typeid, char *type_name)
         if ((nmembers = H5Tget_nmembers(hdf_typeid)) < 0)
             return NC_EHDFERR;
         type->u.e.enum_member = nclistnew();
-        nclistsetalloc(type->u.e.enum_member,nmembers);
+        nclistsetalloc(type->u.e.enum_member, (size_t)nmembers);
 
         /* Allocate space for one value. */
         if (!(value = calloc(1, type_size)))

--- a/libhdf5/hdf5var.c
+++ b/libhdf5/hdf5var.c
@@ -433,7 +433,7 @@ NC4_def_var(int ncid, const char *name, nc_type xtype, int ndims,
      * remember whether dimension scales have been attached to each
      * dimension. */
     if (!hdf5_var->dimscale && ndims)
-        if (!(hdf5_var->dimscale_attached = calloc(ndims, sizeof(nc_bool_t))))
+        if (!(hdf5_var->dimscale_attached = calloc((size_t)ndims, sizeof(nc_bool_t))))
             BAIL(NC_ENOMEM);
 
     /* Return the varid. */

--- a/libncxml/ncxml_xml2.c
+++ b/libncxml/ncxml_xml2.c
@@ -1,5 +1,6 @@
 /* Copyright 2018-2018 University Corporation for Atmospheric  Research/Unidata. */
 
+#include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
 #include <libxml2/libxml/parser.h>
@@ -139,7 +140,8 @@ ncxml_attr_pairs(ncxml_t xml0, char*** pairsp)
     char** pairs = NULL;
     xmlNode* xml = (xmlNode*)xml0;
     xmlAttr* attr = NULL;
-    int i,count = 0;
+    int i;
+    size_t count = 0;
 
     if(xml == NULL) return 0;
     /* First count */

--- a/libnczarr/zmap.c
+++ b/libnczarr/zmap.c
@@ -322,8 +322,8 @@ nczm_divide_at(const char* key, int nsegs, char** prefixp, char** suffixp)
     /* p should point at the presegs+1 start point */
     delta = (p-key);    
     if(prefixp) {
-        prefix = malloc(delta+1);
-        memcpy(prefix,key,delta);
+        prefix = malloc((size_t)delta+1);
+        memcpy(prefix,key,(size_t)delta);
         prefix[delta] = '\0';
         *prefixp = prefix;
     } 
@@ -436,7 +436,7 @@ nczm_segment1(const char* path, char** seg1p)
     q = strchr(p,'/');
     if(q == NULL) q = p+strlen(p); /* point to stop character */
     delta = (q-p);
-    if((seg1 = (char*)malloc(delta+1))==NULL)
+    if((seg1 = (char*)malloc((size_t)delta+1))==NULL)
         {ret = NC_ENOMEM; goto done;}
     memcpy(seg1,p,delta);
     seg1[delta] = '\0';
@@ -489,9 +489,9 @@ nczm_basename(const char* path, char** basep)
     p = strrchr(last,'.');
     if(p == NULL) p = last+strlen(last);
     delta = (p - last);
-    if((base = (char*)malloc(delta+1))==NULL)
+    if((base = (char*)malloc((size_t)delta+1))==NULL)
         {stat = NC_ENOMEM; goto done;}
-    memcpy(base,last,delta);
+    memcpy(base,last,(size_t)delta);
     base[delta] = '\0';
     if(basep) {*basep = base; base = NULL;}
 done:

--- a/libnczarr/zodom.c
+++ b/libnczarr/zodom.c
@@ -131,11 +131,11 @@ buildodom(int rank, NCZOdometer** odomp)
         if((odom = calloc(1,sizeof(NCZOdometer))) == NULL)
 	    goto done;   
         odom->rank = rank;
-        if((odom->start=calloc(1,(sizeof(size64_t)*rank)))==NULL) goto nomem;
-        if((odom->stop=calloc(1,(sizeof(size64_t)*rank)))==NULL) goto nomem;
-        if((odom->stride=calloc(1,(sizeof(size64_t)*rank)))==NULL) goto nomem;
-        if((odom->len=calloc(1,(sizeof(size64_t)*rank)))==NULL) goto nomem;
-        if((odom->index=calloc(1,(sizeof(size64_t)*rank)))==NULL) goto nomem;
+        if((odom->start=calloc(1,(sizeof(size64_t)*(size_t)rank)))==NULL) goto nomem;
+        if((odom->stop=calloc(1,(sizeof(size64_t)*(size_t)rank)))==NULL) goto nomem;
+        if((odom->stride=calloc(1,(sizeof(size64_t)*(size_t)rank)))==NULL) goto nomem;
+        if((odom->len=calloc(1,(sizeof(size64_t)*(size_t)rank)))==NULL) goto nomem;
+        if((odom->index=calloc(1,(sizeof(size64_t)*(size_t)rank)))==NULL) goto nomem;
         *odomp = odom; odom = NULL;
     }
 done:

--- a/libnczarr/zsync.c
+++ b/libnczarr/zsync.c
@@ -1676,7 +1676,7 @@ define_vars(NC_FILE_INFO_T* file, NC_GRP_INFO_T* grp, NClist* varnames)
   	        /* Save the rank of the variable */
 	        if((stat = nc4_var_set_ndims(var, rank))) goto done;
 	        /* extract the shapes */
-	        if((shapes = (size64_t*)malloc(sizeof(size64_t)*zarr_rank)) == NULL)
+	        if((shapes = (size64_t*)malloc(sizeof(size64_t)*(size_t)zarr_rank)) == NULL)
 	            {stat = (THROW(NC_ENOMEM)); goto done;}
 	        if((stat = decodeints(jvalue, shapes))) goto done;
 	    }
@@ -1702,7 +1702,7 @@ define_vars(NC_FILE_INFO_T* file, NC_GRP_INFO_T* grp, NClist* varnames)
 		var->storage = NC_CHUNKED;
 		if(var->ndims != rank)
 		    {stat = (THROW(NC_ENCZARR)); goto done;}
-		if((var->chunksizes = malloc(sizeof(size_t)*zarr_rank)) == NULL)
+		if((var->chunksizes = malloc(sizeof(size_t)*(size_t)zarr_rank)) == NULL)
 		    {stat = NC_ENOMEM; goto done;}
 		if((stat = decodeints(jvalue, chunks))) goto done;
 		/* validate the chunk sizes */

--- a/libnczarr/zutil.c
+++ b/libnczarr/zutil.c
@@ -801,8 +801,8 @@ NCZ_comma_parse(const char* s, NClist* list)
 	endp = strchr(p,',');
 	if(endp == NULL) endp = p + strlen(p);
 	slen = (endp - p);
-	if((s = malloc(slen+1)) == NULL) {stat = NC_ENOMEM; goto done;}
-	memcpy(s,p,slen);
+	if((s = malloc((size_t)slen+1)) == NULL) {stat = NC_ENOMEM; goto done;}
+	memcpy(s,p,(size_t)slen);
 	s[slen] = '\0';
 	if(nclistmatch(list,s,0)) {
 	    nullfree(s); /* duplicate */
@@ -1013,9 +1013,9 @@ NCZ_fixed2char(const void* fixed, char** charp, size_t count, int maxstrlen)
 	if(p[0] == '\0') {
 	    sp = NULL;
 	} else {
-	    if((sp = (unsigned char*)malloc(maxstrlen+1))==NULL) /* ensure null terminated */
+	    if((sp = (unsigned char*)malloc((size_t)maxstrlen+1))==NULL) /* ensure null terminated */
 	        return NC_ENOMEM; 
-	    memcpy(sp,p,maxstrlen);
+	    memcpy(sp,p,(size_t)maxstrlen);
 	    sp[maxstrlen] = '\0';
 	}
 	charp[i] = (char*)sp;

--- a/libnczarr/zwalk.c
+++ b/libnczarr/zwalk.c
@@ -586,7 +586,7 @@ NCZ_projectslices(struct Common* common,
     size64_t stride[NC_MAX_VAR_DIMS];
     size64_t len[NC_MAX_VAR_DIMS];
 
-    if((allprojections = calloc(common->rank,sizeof(NCZSliceProjections))) == NULL)
+    if((allprojections = calloc((size_t)common->rank, sizeof(NCZSliceProjections))) == NULL)
         {stat = NC_ENOMEM; goto done;}
     memset(ranges,0,sizeof(ranges));
 

--- a/libnczarr/zxcache.c
+++ b/libnczarr/zxcache.c
@@ -14,6 +14,7 @@
 #include "zcache.h"
 #include "ncxcache.h"
 #include "zfilter.h"
+#include <stddef.h>
 
 #undef DEBUG
 
@@ -662,7 +663,7 @@ put_chunk(NCZChunkCache* cache, NCZCacheEntry* entry)
         /* Convert from char* to char[strlen] format */
         int maxstrlen = NCZ_get_maxstrlen((NC_OBJ*)cache->var);
         assert(maxstrlen > 0);
-        if((strchunk = malloc(cache->chunkcount*maxstrlen))==NULL) {stat = NC_ENOMEM; goto done;}
+        if((strchunk = malloc((size_t)cache->chunkcount * (size_t)maxstrlen))==NULL) {stat = NC_ENOMEM; goto done;}
         /* copy char* to char[] format */
         if((stat = NCZ_char2fixed((const char**)entry->data,strchunk,cache->chunkcount,maxstrlen))) goto done;
         /* Reclaim the old chunk */

--- a/libsrc4/nc4attr.c
+++ b/libsrc4/nc4attr.c
@@ -111,7 +111,7 @@ nc4_get_att_ptrs(NC_FILE_INFO_T *h5, NC_GRP_INFO_T *grp, NC_VAR_INFO_T *var,
         !(mem_type == NC_CHAR &&
           (att->nc_typeid == NC_UBYTE || att->nc_typeid == NC_BYTE)))
     {
-        if (!(bufr = malloc((size_t)(att->len * type_size))))
+        if (!(bufr = malloc((size_t)(att->len) * type_size)))
             BAIL(NC_ENOMEM);
         need_to_convert++;
         if ((retval = nc4_convert_type(att->data, bufr, att->nc_typeid,

--- a/libsrc4/nc4grp.c
+++ b/libsrc4/nc4grp.c
@@ -177,9 +177,9 @@ NC4_inq_grpname_full(int ncid, size_t *lenp, char *full_name)
         ;
 
     /* Allocate storage. */
-    if (!(name = malloc((g + 1) * (NC_MAX_NAME + 1) + 1)))
+    if (!(name = malloc((size_t)(g + 1) * (NC_MAX_NAME + 1) + 1)))
         return NC_ENOMEM;
-    if (!(gid = malloc((g + 1) * sizeof(int))))
+    if (!(gid = malloc((size_t)(g + 1) * sizeof(int))))
     {
         free(name);
         return NC_ENOMEM;

--- a/libsrc4/nc4internal.c
+++ b/libsrc4/nc4internal.c
@@ -24,6 +24,7 @@
 #include "ncdispatch.h" /* from libdispatch */
 #include "ncutf8.h"
 #include <stdarg.h>
+#include <stddef.h>
 #include "ncrc.h"
 
 /** @internal Number of reserved attributes. These attributes are
@@ -788,14 +789,14 @@ nc4_var_set_ndims(NC_VAR_INFO_T *var, int ndims)
     /* Allocate space for dimension information. */
     if (ndims)
     {
-        if (!(var->dim = calloc(ndims, sizeof(NC_DIM_INFO_T *))))
+      if (!(var->dim = calloc((size_t)ndims, sizeof(NC_DIM_INFO_T *))))
             return NC_ENOMEM;
-        if (!(var->dimids = calloc(ndims, sizeof(int))))
+      if (!(var->dimids = calloc((size_t)ndims, sizeof(int))))
             return NC_ENOMEM;
 
         /* Initialize dimids to illegal values (-1). See the comment
            in nc4_rec_match_dimscales(). */
-        memset(var->dimids, -1, ndims * sizeof(int));
+      memset(var->dimids, -1, (size_t)ndims * sizeof(int));
     }
 
     return NC_NOERR;
@@ -1159,7 +1160,7 @@ nc4_field_list_add(NC_TYPE_INFO_T *parent, const char *name,
     if (ndims)
     {
         int i;
-        if (!(field->dim_size = malloc(ndims * sizeof(int))))
+        if (!(field->dim_size = malloc((size_t)ndims * sizeof(int))))
         {
             free(field->hdr.name);
             free(field);

--- a/nc_test/tst_formats.c
+++ b/nc_test/tst_formats.c
@@ -9,6 +9,7 @@
 
 #include "config.h"
 #include <nc_tests.h>
+#include <stddef.h>
 #include "err_macros.h"
 
 #define FILE_NAME_BASE "tst_formats"
@@ -281,7 +282,7 @@ main(int argc, char **argv)
                 char var_name[NC_MAX_NAME + 1];
                 int dimid[NDIM2];
                 int xtype[NTYPE] = {NC_BYTE, NC_CHAR, NC_SHORT, NC_INT, NC_FLOAT, NC_DOUBLE};
-                int type_size[NTYPE] = {1, 1, 2, 4, 4, 8};
+                size_t type_size[NTYPE] = {1, 1, 2, 4, 4, 8};
                 int varid[NTYPE];
                 size_t start[NDIM2] = {0, 0};
                 size_t count[NDIM2] = {2, 2};

--- a/nc_test/tst_global_fillval.c
+++ b/nc_test/tst_global_fillval.c
@@ -16,6 +16,7 @@
 
 #include "config.h"
 #include <nc_tests.h>
+#include <stddef.h>
 #include "err_macros.h"
 
 #define FILE_NAME "tst_global_fillval.nc"
@@ -28,8 +29,8 @@ main(int argc, char **argv)
     {
 
 	int n = 0;
-    int i;
-    int num_formats = 2;
+    size_t i;
+    size_t num_formats = 2;
     int *formats = NULL;
 	/* Determine how many formats are in use. */
 

--- a/nc_test/tst_nofill.c
+++ b/nc_test/tst_nofill.c
@@ -421,7 +421,7 @@ main(int argc, char **argv)
 	   char varname2[NC_MAX_NAME];
 	   /* How many values in this variable to compare? */
 	   if (nc_inq_varndims(ncid1, varid, &ndims)) ERR;
-	   dimids = malloc((ndims + 1) * sizeof(int));
+	   dimids = malloc((size_t)(ndims + 1) * sizeof(int));
 	   if (!dimids) ERR;
 	   if (nc_inq_vardimid (ncid1, varid, dimids)) ERR;
 	   nvals = 1;

--- a/nc_test4/tst_chunks2.c
+++ b/nc_test4/tst_chunks2.c
@@ -24,7 +24,7 @@ calculate_waste(int ndims, size_t *dimlen, size_t *chunksize, float *waste)
    size_t chunk_size = 1;
 
    assert(waste && dimlen && chunksize && ndims);
-   if (!(num_chunks = calloc(ndims, sizeof(size_t)))) ERR;
+   if (!(num_chunks = calloc((size_t)ndims, sizeof(size_t)))) ERR;
 
 #ifdef PRINT_CHUNK_WASTE_REPORT
    printf("\n");

--- a/nc_test4/tst_h_strbug.c
+++ b/nc_test4/tst_h_strbug.c
@@ -14,6 +14,7 @@
 #include <nc_tests.h>
 #include <err_macros.h>
 #include <hdf5.h>
+#include <stddef.h>
 
 #define FILE_NAME "tst_h_strbug.h5"
 #define VS_ATT_NAME "vsatt"
@@ -173,7 +174,7 @@ main()
     	if (type != NC_STRING) ERR;
     	if (nc_inq_varndims(ncid, varid, &ndims )) ERR;
     	if (ndims != RANK) ERR;
-	if (!(dimids = malloc(ndims * sizeof(int)))) ERR;
+	if (!(dimids = malloc((size_t)ndims * sizeof(int)))) ERR;
     	if (nc_inq_vardimid(ncid, varid, dimids)) ERR;
 	if (nc_inq_dimlen(ncid, dimids[0], &nstrings)) ERR;
 	if (!(data_in = (char **)malloc(nstrings * sizeof(char *)))) ERR;

--- a/nc_test4/tst_vl.c
+++ b/nc_test4/tst_vl.c
@@ -8,6 +8,7 @@
 */
 
 #include <nc_tests.h>
+#include <stddef.h>
 #include "err_macros.h"
 #include "netcdf.h"
 
@@ -38,7 +39,7 @@ main(int argc, char **argv)
       char name_in[NC_MAX_NAME + 1];
       int *phony, class_in;
       size_t len_in;
-      int i, j;
+      size_t i, j;
 
       /* Create phony data. */
       for (i=0; i<DIM_LEN; i++)
@@ -77,7 +78,7 @@ main(int argc, char **argv)
 	 for (j = 0; j < data_in[i].len; j++)
 	    if (*((int *)data_in[i].p) != PHONY_VAL)
 	    {
-	       printf("*((int *)data_in[%d].p = %d (0x%x)\n", i, *((int *)data_in[i].p),
+	       printf("*((int *)data_in[%zu].p = %d (0x%x)\n", i, *((int *)data_in[i].p),
 		      *((int *)data_in[i].p));
 	       ERR;
 	       return 2;
@@ -110,7 +111,7 @@ main(int argc, char **argv)
       int ncid, typeid;
       nc_vlen_t data[DIM_LEN], data_in[DIM_LEN];
       int *phony;
-      int i, j;
+      size_t i, j;
 
       /* Create phony data. */
       for (i=0; i<DIM_LEN; i++)
@@ -142,7 +143,7 @@ main(int argc, char **argv)
 	 for (j=0; j<data_in[i].len; j++)
 	    if (*((int *)data_in[i].p) != *((int *)data[i].p))
 	    {
-	       printf("*((int *)data_in[%d].p = %d (0x%x)\n", i, *((int *)data_in[i].p),
+	       printf("*((int *)data_in[%zu].p = %d (0x%x)\n", i, *((int *)data_in[i].p),
 		      *((int *)data_in[i].p));
 	       ERR;
 	       return 2;
@@ -164,7 +165,7 @@ main(int argc, char **argv)
       char name_in[NC_MAX_NAME + 1];
       int *phony, class_in;
       size_t len_in;
-      int i, j;
+      size_t i, j;
 
       /* Create phony data. */
       for (i=0; i<DIM_LEN; i++)
@@ -201,7 +202,7 @@ main(int argc, char **argv)
 	 for (j = 0; j < data_in[i].len; j++)
 	    if (*((int *)data_in[i].p) != PHONY_VAL)
 	    {
-	       printf("*((int *)data_in[%d].p = %d (0x%x)\n", i, *((int *)data_in[i].p),
+	       printf("*((int *)data_in[%zu].p = %d (0x%x)\n", i, *((int *)data_in[i].p),
 		      *((int *)data_in[i].p));
 	       ERR;
 	       return 2;

--- a/nc_test4/tst_vlenstr.c
+++ b/nc_test4/tst_vlenstr.c
@@ -1,3 +1,4 @@
+#include <stddef.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -34,7 +35,7 @@ checkErrorCode(int status, const char* message)
 
 
 void
-writeVariable(int dimlength, int ncid, nc_type vlen_typeID)
+writeVariable(size_t dimlength, int ncid, nc_type vlen_typeID)
 {
     int retval = NC_NOERR;
     int dimid;
@@ -99,12 +100,12 @@ createFruitsData(int elemno, int vlensize, int* stringIndexp, nc_vlen_t* data)
 }
 
 void
-writeAttribute(int len, int ncid, nc_type vlen_typeID)
+writeAttribute(size_t len, int ncid, nc_type vlen_typeID)
 {
     int retval = NC_NOERR;
     
     /* Setup data */
-    nc_vlen_t* data = calloc(sizeof(nc_vlen_t),len);
+    nc_vlen_t* data = calloc(sizeof(nc_vlen_t), len);
 
     /* create six variable length arrays of strings */
     int stringIndex = 0;

--- a/ncdap_test/test_nstride_cached.c
+++ b/ncdap_test/test_nstride_cached.c
@@ -99,7 +99,7 @@ main()
     int pass = 1;
     int nelems = XSIZE*YSIZE;
     int idim, ndim;
-    float *dat = (float*)malloc(sizeof(float)*nelems);
+    float *dat = (float*)malloc(sizeof(float)*(size_t)nelems);
     float sdat[10];
     char* svc;
 

--- a/ncdap_test/test_vara.c
+++ b/ncdap_test/test_vara.c
@@ -158,10 +158,10 @@ static Odom* odom_create(int rank)
     Odom* odom = (Odom*)malloc(sizeof(Odom));
     /* Init the odometer */
     odom->rank = rank;
-    odom->index = (size_t*)calloc(sizeof(size_t)*rank,1);
-    odom->stop = (size_t*)calloc(sizeof(size_t)*rank,1);
-    odom->start = (size_t*)calloc(sizeof(size_t)*rank,1);
-    odom->count = (size_t*)calloc(sizeof(size_t)*rank,1);
+    odom->index = (size_t*)calloc(sizeof(size_t)*(size_t)rank,1);
+    odom->stop = (size_t*)calloc(sizeof(size_t)*(size_t)rank,1);
+    odom->start = (size_t*)calloc(sizeof(size_t)*(size_t)rank,1);
+    odom->count = (size_t*)calloc(sizeof(size_t)*(size_t)rank,1);
     return odom;
 }
 

--- a/ncdump/chunkspec.c
+++ b/ncdump/chunkspec.c
@@ -136,7 +136,7 @@ dimchunkspec_parse(int igrp, const char *spec)
 		goto done;
 	    }
 	    /* extract dimension name */
-	    dimname = (char *) emalloc(pp - np + 1);
+	    dimname = (char *) emalloc((size_t)(pp - np + 1));
 	    dp = dimname;
 	    while(np < pp) {
 		*dp++ = *np++;

--- a/ncdump/dumplib.c
+++ b/ncdump/dumplib.c
@@ -415,7 +415,7 @@ count_udtypes(int ncid) {
 	/* Get number of types in this group */
 	NC_CHECK( nc_inq_typeids(ncid, &ntypes, NULL) ) ;
 	NC_CHECK( nc_inq_grps(ncid, &numgrps, NULL) ) ;
-	ncids = (int *) emalloc(sizeof(int) * (numgrps + 1));
+	ncids = (int *) emalloc(sizeof(int) * (size_t)(numgrps + 1));
 	NC_CHECK( nc_inq_grps(ncid, NULL, ncids) ) ;
 	/* Add number of types in each subgroup, if any */
 	for (i=0; i < numgrps; i++) {
@@ -1520,7 +1520,7 @@ init_types(int ncid) {
     if (max_type == 0) {	/* if called for first time */
 	int maxtype = max_typeid(ncid);
 	int i;
-	nctypes = (nctype_t **) emalloc((maxtype + 2) * sizeof(nctype_t *));
+	nctypes = (nctype_t **) emalloc((size_t)(maxtype + 2) * sizeof(nctype_t *));
 	for(i=0; i < maxtype+1; i++)
 	    nctypes[i] = NULL;	/* so can later skip over unused type slots */
 	init_prim_types(ncid);
@@ -1532,7 +1532,7 @@ init_types(int ncid) {
    if (ntypes)
    {
       int t;
-      int *typeids = emalloc((ntypes + 1) * sizeof(int));
+      int *typeids = emalloc((size_t)(ntypes + 1) * sizeof(int));
       NC_CHECK( nc_inq_typeids(ncid, NULL, typeids) );
       for (t = 0; t < ntypes; t++) {
 	  nctype_t *tinfo;	/* details about the type */
@@ -1587,14 +1587,14 @@ init_types(int ncid) {
 		  NC_CHECK( nc_inq_compound_field(ncid, tinfo->tid, fidx, NULL,
 						  &offset, &ftype, &rank,
 						  sides) );
-		  if(rank > 0) sides = (int *) emalloc(rank * sizeof(int));
+		  if(rank > 0) sides = (int *) emalloc((size_t)rank * sizeof(int));
 		  NC_CHECK( nc_inq_compound_field(ncid, tinfo->tid, fidx, NULL,
 						  NULL, NULL, NULL, sides) );
 		  tinfo->fids[fidx] = ftype;
 		  tinfo->offsets[fidx] = offset;
 		  tinfo->ranks[fidx] = rank;
 		  if (rank > 0)
-		      tinfo->sides[fidx] = (int *) emalloc(rank * sizeof(int));
+		      tinfo->sides[fidx] = (int *) emalloc((size_t)rank * sizeof(int));
 		  tinfo->nvals[fidx] = 1;
 		  for(i = 0; i < rank; i++) {
 		      tinfo->sides[fidx][i] = sides[i];
@@ -1629,7 +1629,7 @@ init_types(int ncid) {
       /* See how many groups there are. */
       NC_CHECK( nc_inq_grps(ncid, &numgrps, NULL) );
       if (numgrps > 0) {
-	  ncids = (int *) emalloc(numgrps * sizeof(int));
+	  ncids = (int *) emalloc((size_t)numgrps * sizeof(int));
 	  /* Get the list of group ids. */
 	  NC_CHECK( nc_inq_grps(ncid, NULL, ncids) );
 	  /* Call this function for each group. */
@@ -1670,10 +1670,10 @@ iscoordvar(int ncid, int varid)
 #endif
 	if (dims)
 	    free(dims);
-	dims = (ncdim_t *) emalloc((ndims + 1) * sizeof(ncdim_t));
+	dims = (ncdim_t *) emalloc((size_t)(ndims + 1) * sizeof(ncdim_t));
 	if (dimids)
 	    free(dimids);
-	dimids = (int *) emalloc((ndims + 1) * sizeof(int));
+	dimids = (int *) emalloc((size_t)(ndims + 1) * sizeof(int));
 #ifdef USE_NETCDF4
 	NC_CHECK( nc_inq_dimids(ncid, &ndims1, dimids, include_parents ) );
 #else
@@ -1767,7 +1767,7 @@ print_type_name(int locid, int typeid) {
 	    curlocid = parent_groupid;
 	    NC_CHECK( nc_inq_typeids(curlocid, &ntypes, NULL) );
 	    if(ntypes > 0) {
-		int *typeids = (int *) emalloc((ntypes + 1) * sizeof(int));
+		int *typeids = (int *) emalloc((size_t)(ntypes + 1) * sizeof(int));
 		int i;
 		NC_CHECK( nc_inq_typeids(curlocid, &ntypes, typeids) );
 		for(i = 0; i < ntypes; i++) {
@@ -1822,7 +1822,7 @@ init_is_unlim(int ncid, int **is_unlim_p)
 	return NC_EBADGRPID;
     /* Now ncid is root group.  Get total number of groups and their ids */
     NC_CHECK( nc_inq_grps_full(ncid, &num_grps, NULL) );
-    grpids = emalloc((num_grps + 1) * sizeof(int));
+    grpids = emalloc((size_t)(num_grps + 1) * sizeof(int));
     NC_CHECK( nc_inq_grps_full(ncid, &num_grps, grpids) );
 #define DONT_INCLUDE_PARENTS 0
     /* Get all dimensions in groups and info about which ones are unlimited */
@@ -1835,18 +1835,18 @@ init_is_unlim(int ncid, int **is_unlim_p)
 	grpid = grpids[igrp];
 	NC_CHECK( nc_inq_dimids(grpid, &ndims, NULL, DONT_INCLUDE_PARENTS) );
 	num_dims += ndims;
-	dimids = (int*)emalloc(ndims*sizeof(int));
+	dimids = (int*)emalloc((size_t)ndims*sizeof(int));
 	NC_CHECK( nc_inq_dimids(grpid, &ndims, dimids, DONT_INCLUDE_PARENTS) );
 	for(i=0;i<ndims;i++) {if(dimids[i] > max_dimid) max_dimid = dimids[i];}
 	free(dimids);
     }
     assert(max_dimid >= 0);
-    *is_unlim_p = emalloc((max_dimid + 1 + 1) * sizeof(int));
+    *is_unlim_p = emalloc((size_t)(max_dimid + 1 + 1) * sizeof(int));
     for(igrp = 0; igrp < num_grps; igrp++) {
 	int ndims, idim, *dimids, nundims;
 	grpid = grpids[igrp];
 	NC_CHECK( nc_inq_dimids(grpid, &ndims, NULL, DONT_INCLUDE_PARENTS) );
-	dimids = emalloc((ndims + 1) * sizeof(int));
+	dimids = emalloc((size_t)(ndims + 1) * sizeof(int));
 	NC_CHECK( nc_inq_dimids(grpid, &ndims, dimids, DONT_INCLUDE_PARENTS) );
 	/* mark all dims in this group as fixed-size */
 	for(idim = 0; idim < ndims; idim++) {

--- a/ncdump/nc4printer.c
+++ b/ncdump/nc4printer.c
@@ -657,18 +657,18 @@ record(NC4printer* out, NCID* node)
     switch (node->sort) {
     case DIM:
         if(nclistlength(out->dims) <= node->id) {
-            nclistsetalloc(out->dims,node->id+1);
-            nclistsetlength(out->dims,node->id+1);
+            nclistsetalloc(out->dims, (size_t)node->id+1);
+            nclistsetlength(out->dims, (size_t)node->id+1);
         }
-        nclistset(out->dims,node->id,node);
+        nclistset(out->dims, (size_t)node->id, node);
         break;
     case ATOMTYPE:
     case USERTYPE:
         if(nclistlength(out->types) <= node->id) {
-            nclistsetalloc(out->types,node->id+1);
-            nclistsetlength(out->types,node->id+1);
+            nclistsetalloc(out->types, (size_t)node->id+1);
+            nclistsetlength(out->types, (size_t)node->id+1);
         }
-        nclistset(out->types,node->id,node);
+        nclistset(out->types, (size_t)node->id, node);
         break;
     default: break;
     }

--- a/ncdump/nccopy.c
+++ b/ncdump/nccopy.c
@@ -432,7 +432,7 @@ inq_var_chunksize(int igrp, int varid, size_t* chunksizep) {
     NC_CHECK(nc_inq_type(igrp, vartype, NULL, &value_size));
     prod = value_size;
     NC_CHECK(nc_inq_varndims(igrp, varid, &ndims));
-    chunksizes = (size_t *) emalloc((ndims + 1) * sizeof(size_t));
+    chunksizes = (size_t *) emalloc((size_t)(ndims + 1) * sizeof(size_t));
     contig = NC_CHUNKED;
     NC_CHECK(nc_inq_var_chunking(igrp, varid, &contig, NULL));
     if(contig != NC_CHUNKED) {
@@ -493,7 +493,7 @@ inq_var_chunking_params(int igrp, int ivarid, int ogrp, int ovarid,
 	return stat;
     }
 
-    ichunksizes = (size_t *) emalloc((ndims + 1) * sizeof(size_t));
+    ichunksizes = (size_t *) emalloc((size_t)(ndims + 1) * sizeof(size_t));
     if(icontig != NC_CHUNKED) { /* if input contiguous|compact, treat as if chunked on
 			* first dimension */
 	ichunksizes[0] = 1;
@@ -505,7 +505,7 @@ inq_var_chunking_params(int igrp, int ivarid, int ogrp, int ovarid,
     }
 
     /* now can pretend chunking in both input and output */
-    ochunksizes = (size_t *) emalloc((ndims + 1) * sizeof(size_t));
+    ochunksizes = (size_t *) emalloc((size_t)(ndims + 1) * sizeof(size_t));
     NC_CHECK(nc_inq_var_chunking(ogrp, ovarid, &ocontig, ochunksizes));
 
     nelems = 1;
@@ -632,7 +632,7 @@ copy_compound_type(int igrp, nc_type itype, int ogrp)
 	    NC_CHECK(nc_insert_compound(ogrp, otype, fname, foff, oftype));
 	} else {		/* field is array type */
 	    int *fdimsizes;
-	    fdimsizes = (int *) emalloc((fndims + 1) * sizeof(int));
+	    fdimsizes = (int *) emalloc((size_t)(fndims + 1) * sizeof(int));
 	    stat = nc_inq_compound_field(igrp, itype, fid, NULL, NULL, NULL,
 					 NULL, fdimsizes);
 	    NC_CHECK(nc_insert_array_compound(ogrp, otype, fname, foff, oftype, fndims, fdimsizes));
@@ -688,7 +688,7 @@ copy_groups(int iroot, int oroot)
     /* get total number of groups and their ids, including all descendants */
     NC_CHECK(nc_inq_grps_full(iroot, &numgrps, NULL));
     if(numgrps > 1) {		/* there's always 1 root group */
-	grpids = emalloc(numgrps * sizeof(int));
+	grpids = emalloc((size_t)numgrps * sizeof(int));
 	NC_CHECK(nc_inq_grps_full(iroot, NULL, grpids));
 	/* create corresponding new groups in ogrp, except for root group */
 	for(i = 1; i < numgrps; i++) {
@@ -741,7 +741,7 @@ copy_types(int igrp, int ogrp)
     NC_CHECK(nc_inq_typeids(igrp, &ntypes, NULL));
 
     if(ntypes > 0) {
-	types = (nc_type *) emalloc(ntypes * sizeof(nc_type));
+	types = (nc_type *) emalloc((size_t)ntypes * sizeof(nc_type));
 	NC_CHECK(nc_inq_typeids(igrp, &ntypes, types));
 	for (i = 0; i < ntypes; i++) {
 	    NC_CHECK(copy_type(igrp, types[i], ogrp));
@@ -752,7 +752,7 @@ copy_types(int igrp, int ogrp)
     /* Copy types from subgroups */
     NC_CHECK(nc_inq_grps(igrp, &numgrps, NULL));
     if(numgrps > 0) {
-	grpids = (int *)emalloc(sizeof(int) * numgrps);
+	grpids = (int *)emalloc(sizeof(int) * (size_t)numgrps);
 	NC_CHECK(nc_inq_grps(igrp, &numgrps, grpids));
 	for(i = 0; i < numgrps; i++) {
 	    if (option_grpstruct || group_wanted(grpids[i], option_nlgrps, option_grpids)) {
@@ -1329,11 +1329,11 @@ copy_dims(int igrp, int ogrp)
     * may be defined in various groups, and we are only looking at one
     * group at a time. */
     /* Find the dimension ids in this group, don't include parents. */
-    dimids = (int *) emalloc((ndims + 1) * sizeof(int));
+    dimids = (int *) emalloc((size_t)(ndims + 1) * sizeof(int));
     NC_CHECK(nc_inq_dimids(igrp, NULL, dimids, 0));
     /* Find the number of unlimited dimensions and get their IDs */
     NC_CHECK(nc_inq_unlimdims(igrp, &nunlims, NULL));
-    unlimids = (int *) emalloc((nunlims + 1) * sizeof(int));
+    unlimids = (int *) emalloc((size_t)(nunlims + 1) * sizeof(int));
     NC_CHECK(nc_inq_unlimdims(igrp, NULL, unlimids));
 #else
     NC_CHECK(nc_inq_unlimdim(igrp, &unlimid));
@@ -1426,7 +1426,7 @@ copy_var(int igrp, int varid, int ogrp)
     int o_varid;
 
     NC_CHECK(nc_inq_varndims(igrp, varid, &ndims));
-    idimids = (int *) emalloc((ndims + 1) * sizeof(int));
+    idimids = (int *) emalloc((size_t)(ndims + 1) * sizeof(int));
     NC_CHECK(nc_inq_var(igrp, varid, name, &typeid, NULL, idimids, &natts));
     o_typeid = typeid;
 #ifdef USE_NETCDF4
@@ -1441,7 +1441,7 @@ copy_var(int igrp, int varid, int ogrp)
 #endif	/* USE_NETCDF4 */
 
     /* get the corresponding dimids in the output file */
-    odimids = (int *) emalloc((ndims + 1) * sizeof(int));
+    odimids = (int *) emalloc((size_t)(ndims + 1) * sizeof(int));
     for(i = 0; i < ndims; i++) {
 	odimids[i] = dimmap_odimid(idimids[i]);
 	if(odimids[i] == -1) {
@@ -1550,7 +1550,7 @@ copy_schema(int igrp, int ogrp)
 	int i;
 	/* Copy schema from subgroups */
 	stat = nc_inq_grps(igrp, &numgrps, NULL);
-	grpids = (int *)emalloc((numgrps + 1) * sizeof(int));
+	grpids = (int *)emalloc((size_t)(numgrps + 1) * sizeof(int));
 	NC_CHECK(nc_inq_grps(igrp, &numgrps, grpids));
 
 	for(i = 0; i < numgrps; i++) {
@@ -1574,7 +1574,7 @@ inq_nvals(int igrp, int varid, long long *nvalsp) {
     long long nvals = 1;
 
     NC_CHECK(nc_inq_varndims(igrp, varid, &ndims));
-    dimids = (int *) emalloc((ndims + 1) * sizeof(int));
+    dimids = (int *) emalloc((size_t)(ndims + 1) * sizeof(int));
     NC_CHECK(nc_inq_vardimid (igrp, varid, dimids));
     for(dim = 0; dim < ndims; dim++) {
 	size_t len;
@@ -1673,8 +1673,8 @@ copy_var_data(int igrp, int varid, int ogrp)
     /* initialize variable iteration */
     NC_CHECK(nc_get_iter(igrp, varid, option_copy_buffer_size, &iterp));
 
-    start = (size_t *) emalloc((iterp->rank + 1) * sizeof(size_t));
-    count = (size_t *) emalloc((iterp->rank + 1) * sizeof(size_t));
+    start = (size_t *) emalloc((size_t)(iterp->rank + 1) * sizeof(size_t));
+    count = (size_t *) emalloc((size_t)(iterp->rank + 1) * sizeof(size_t));
     /* nc_next_iter() initializes start and count on first call,
      * changes start and count to iterate through whole variable on
      * subsequent calls. */
@@ -1757,7 +1757,7 @@ copy_data(int igrp, int ogrp)
 #ifdef USE_NETCDF4
     /* Copy data from subgroups */
     stat = nc_inq_grps(igrp, &numgrps, NULL);
-    grpids = (int *)emalloc((numgrps + 1) * sizeof(int));
+    grpids = (int *)emalloc((size_t)(numgrps + 1) * sizeof(int));
     NC_CHECK(nc_inq_grps(igrp, &numgrps, grpids));
 
     for(i = 0; i < numgrps; i++) {
@@ -1786,7 +1786,7 @@ count_dims(int ncid) {
     NC_CHECK(nc_inq_grps(ncid, &numgrps, NULL));
     if(numgrps > 0) {
 	int igrp;
-	int *grpids = emalloc(numgrps * sizeof(int));
+	int *grpids = emalloc((size_t)numgrps * sizeof(int));
 	NC_CHECK(nc_inq_grps(ncid, &numgrps, grpids));
 	for(igrp = 0; igrp < numgrps; igrp++) {
 	    ndims += count_dims(grpids[igrp]);
@@ -1820,7 +1820,7 @@ nc3_special_case(int ncid, int kind) {
 		NC_CHECK( nc_inq_varndims(ncid, varid, &ndims) );
 		if (ndims > 0) {
 		    int dimids0;
-		    dimids = (int *) emalloc((ndims + 1) * sizeof(int));
+		    dimids = (int *) emalloc((size_t)(ndims + 1) * sizeof(int));
 		    NC_CHECK( nc_inq_vardimid(ncid, varid, dimids) );
 		    dimids0 = dimids[0];
 		    free(dimids);
@@ -1850,9 +1850,9 @@ classify_vars(
     int nvars;
     NC_CHECK(nc_inq_nvars(ncid, &nvars));
     *nf = 0;
-    *fvars = (int *) emalloc(nvars * sizeof(int));
+    *fvars = (int *) emalloc((size_t)nvars * sizeof(int));
     *nr = 0;
-    *rvars = (int *) emalloc(nvars * sizeof(int));
+    *rvars = (int *) emalloc((size_t)nvars * sizeof(int));
 
     if(option_nlvars > 0) {
       for (varindex = 0; varindex < option_nlvars; varindex++) {
@@ -1940,9 +1940,9 @@ copy_record_data(int ncid, int ogrp, size_t nrec_vars, int *rec_varids) {
 	char varname[NC_MAX_NAME];
 	varid = rec_varids[ivar];
 	NC_CHECK(nc_inq_varndims(ncid, varid, &ndims));
-	dimids = (int *) emalloc((1 + ndims) * sizeof(int));
-	start[ivar] = (size_t *) emalloc(ndims * sizeof(size_t));
-	count[ivar] = (size_t *) emalloc(ndims * sizeof(size_t));
+	dimids = (int *) emalloc((size_t)(1 + ndims) * sizeof(int));
+	start[ivar] = (size_t *) emalloc((size_t)ndims * sizeof(size_t));
+	count[ivar] = (size_t *) emalloc((size_t)ndims * sizeof(size_t));
 	NC_CHECK(nc_inq_vardimid (ncid, varid, dimids));
 	value_size = val_size(ncid, varid);
 	nvals = 1;

--- a/ncdump/ncdump.c
+++ b/ncdump/ncdump.c
@@ -4,6 +4,7 @@ Copyright 2018 University Corporation for Atmospheric
 Research/Unidata. See \ref copyright file for more info.  */
 
 #include "config.h"
+#include <stddef.h>
 #include <stdio.h>
 #ifdef HAVE_GETOPT_H
 #include <getopt.h>
@@ -997,7 +998,7 @@ pr_att_specials(
 	   int i;
 	    pr_att_name(ncid, varp->name, NC_ATT_STORAGE);
 	    printf(" = \"chunked\" ;\n");
-	    chunkp = (size_t *) emalloc(sizeof(size_t) * (varp->ndims + 1) );
+	    chunkp = (size_t *) emalloc(sizeof(size_t) * (size_t)(varp->ndims + 1) );
 	    NC_CHECK( nc_inq_var_chunking(ncid, varid, NULL, chunkp) );
 	    /* print chunking, even if it is default */
 	    pr_att_name(ncid, varp->name, NC_ATT_CHUNKING);
@@ -1224,7 +1225,7 @@ pr_attx(
 {
     ncatt_t att;			/* attribute */
     char *attvals = NULL;
-    int attvalslen = 0;
+    size_t attvalslen = 0;
 
     NC_CHECK( nc_inq_attname(ncid, varid, ia, att.name) );
 #ifdef USE_NETCDF4
@@ -1308,7 +1309,7 @@ static void
 pr_shape(ncvar_t* varp, ncdim_t *dims)
 {
     char *shape;
-    int shapelen = 0;
+    size_t shapelen = 0;
     int id;
 
     if (varp->ndims == 0)
@@ -1472,7 +1473,7 @@ print_ud_type(int ncid, nc_type typeid) {
 		    printf(" ");
 		    print_name(field_name);
 		    if (field_ndims > 0) {
-			int *field_dim_sizes = (int *) emalloc((field_ndims + 1) * sizeof(int));
+			int *field_dim_sizes = (int *) emalloc((size_t)(field_ndims + 1) * sizeof(int));
 			NC_CHECK( nc_inq_compound_field(ncid, typeid, f, NULL,
 							NULL, NULL, NULL,
 							field_dim_sizes) );
@@ -1647,7 +1648,7 @@ do_ncdump_rec(int ncid, const char *path)
    {
       int t;
 
-      typeids = emalloc((ntypes + 1) * sizeof(int));
+      typeids = emalloc((size_t)(ntypes + 1) * sizeof(int));
       NC_CHECK( nc_inq_typeids(ncid, &ntypes, typeids) );
       indent_out();
       printf("types:\n");
@@ -1667,7 +1668,7 @@ do_ncdump_rec(int ncid, const char *path)
     */
    NC_CHECK( nc_inq(ncid, &ndims, &nvars, &ngatts, &xdimid) );
    /* get dimension info */
-   dims = (ncdim_t *) emalloc((ndims + 1) * sizeof(ncdim_t));
+   dims = (ncdim_t *) emalloc((size_t)(ndims + 1) * sizeof(ncdim_t));
    if (ndims > 0) {
        indent_out();
        printf ("dimensions:\n");
@@ -1680,14 +1681,14 @@ do_ncdump_rec(int ncid, const char *path)
 
    /* Find the number of dimids defined in this group. */
    NC_CHECK( nc_inq_ndims(ncid, &ndims_grp) );
-   dimids_grp = (int *)emalloc((ndims_grp + 1) * sizeof(int));
+   dimids_grp = (int *)emalloc((size_t)(ndims_grp + 1) * sizeof(int));
 
    /* Find the dimension ids in this group. */
    NC_CHECK( nc_inq_dimids(ncid, 0, dimids_grp, 0) );
 
    /* Find the number of unlimited dimensions and get their IDs */
    NC_CHECK( nc_inq_unlimdims(ncid, &nunlim, NULL) );
-   unlimids = (int *)emalloc((nunlim + 1) * sizeof(int));
+   unlimids = (int *)emalloc((size_t)(nunlim + 1) * sizeof(int));
    NC_CHECK( nc_inq_unlimdims(ncid, &nunlim, unlimids) );
 
    /* For each dimension defined in this group, get and print out info. */
@@ -1767,7 +1768,7 @@ do_ncdump_rec(int ncid, const char *path)
 
    for (varid = 0; varid < nvars; varid++) {
       NC_CHECK( nc_inq_varndims(ncid, varid, &var.ndims) );
-      var.dims = (int *) emalloc((var.ndims + 1) * sizeof(int));
+      var.dims = (int *) emalloc((size_t)(var.ndims + 1) * sizeof(int));
       NC_CHECK( nc_inq_var(ncid, varid, var.name, &var.type, 0,
 			   var.dims, &var.natts) );
       /* TODO: don't bother if type name not needed here */
@@ -1928,7 +1929,7 @@ do_ncdump_rec(int ncid, const char *path)
 	    continue;
 	 NC_CHECK( nc_inq_varndims(ncid, varid, &var.ndims) );
 	 if(var.dims != NULL) {free(var.dims); var.dims = NULL;}
-	 var.dims = (int *) emalloc((var.ndims + 1) * sizeof(int));
+	 var.dims = (int *) emalloc((size_t)(var.ndims + 1) * sizeof(int));
 	 NC_CHECK( nc_inq_var(ncid, varid, var.name, &var.type, 0,
 			      var.dims, &var.natts) );
 	 var.tinfo = get_typeinfo(var.type);
@@ -1942,7 +1943,7 @@ do_ncdump_rec(int ncid, const char *path)
 	     free(vdims);
 	     vdims = 0;
 	 }
-	 vdims = (size_t *) emalloc((var.ndims + 1) * SIZEOF_SIZE_T);
+	 vdims = (size_t *) emalloc((size_t)(var.ndims + 1) * SIZEOF_SIZE_T);
 	 no_data = 0;
 	 for (id = 0; id < var.ndims; id++) {
 	     size_t len;
@@ -1995,7 +1996,7 @@ do_ncdump_rec(int ncid, const char *path)
       NC_CHECK( nc_inq_grps(ncid, &numgrps, NULL) );
 
       /* Allocate memory to hold the list of group ids. */
-      ncids = emalloc((numgrps + 1) * sizeof(int));
+      ncids = emalloc((size_t)(numgrps + 1) * sizeof(int));
 
       /* Get the list of group ids. */
       NC_CHECK( nc_inq_grps(ncid, NULL, ncids) );
@@ -2095,7 +2096,7 @@ do_ncdumpx(int ncid, const char *path)
     /* TODO: print names with XML-ish escapes fopr special chars */
     NC_CHECK( nc_inq(ncid, &ndims, &nvars, &ngatts, &xdimid) );
     /* get dimension info */
-    dims = (ncdim_t *) emalloc((ndims + 1) * sizeof(ncdim_t));
+    dims = (ncdim_t *) emalloc((size_t)(ndims + 1) * sizeof(ncdim_t));
     for (dimid = 0; dimid < ndims; dimid++) {
 	NC_CHECK( nc_inq_dim(ncid, dimid, dims[dimid].name, &dims[dimid].size) );
 	if (dimid == xdimid)
@@ -2115,7 +2116,7 @@ do_ncdumpx(int ncid, const char *path)
     for (varid = 0; varid < nvars; varid++) {
 	NC_CHECK( nc_inq_varndims(ncid, varid, &var.ndims) );
 	if(var.dims != NULL) free(var.dims);
-	var.dims = (int *) emalloc((var.ndims + 1) * sizeof(int));
+	var.dims = (int *) emalloc((size_t)(var.ndims + 1) * sizeof(int));
 	NC_CHECK( nc_inq_var(ncid, varid, var.name, &var.type, 0,
 			     var.dims, &var.natts) );
 	printf ("  <variable name=\"%s\"", var.name);

--- a/ncdump/nciter.c
+++ b/ncdump/nciter.c
@@ -5,6 +5,7 @@
  *********************************************************************/
 
 #include "config.h"		/* for USE_NETCDF4 macro */
+#include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -193,10 +194,10 @@ nc_get_iter(int ncid,
 
     NC_CHECK(nc_inq_varndims(ncid, varid, &ndims));
 
-    dimids = (int *) emalloc((ndims + 1) * sizeof(int));
+    dimids = (int *) emalloc((size_t)(ndims + 1) * sizeof(int));
 
-    iterp->dimsizes = (size_t *) emalloc((ndims + 1) * sizeof(size_t));
-    iterp->chunksizes = (size_t *) emalloc((ndims + 1) * sizeof(size_t));
+    iterp->dimsizes = (size_t *) emalloc((size_t)(ndims + 1) * sizeof(size_t));
+    iterp->chunksizes = (size_t *) emalloc((size_t)(ndims + 1) * sizeof(size_t));
 
     NC_CHECK(nc_inq_vardimid (ncid, varid, dimids));
     for(dim = 0; dim < ndims; dim++) {

--- a/ncdump/ncvalidator.c
+++ b/ncdump/ncvalidator.c
@@ -1622,9 +1622,9 @@ val_new_NC_var(char *name, int ndims)
     if (varp == NULL) return NULL;
 
     if (ndims > 0) {
-        varp->shape  = (long long*)calloc(ndims, sizeof(long long));
-        varp->dsizes = (long long*)calloc(ndims, sizeof(long long));
-        varp->dimids = (int *)     calloc(ndims, sizeof(int));
+        varp->shape  = (long long*)calloc((size_t)ndims, sizeof(long long));
+        varp->dsizes = (long long*)calloc((size_t)ndims, sizeof(long long));
+        varp->dimids = (int *)     calloc((size_t)ndims, sizeof(int));
     }
 
     varp->name     = name;

--- a/ncdump/tst_create_files.c
+++ b/ncdump/tst_create_files.c
@@ -11,6 +11,7 @@
 #include <nc_tests.h>
 #include "err_macros.h"
 #include <netcdf.h>
+#include <stddef.h>
 #include <stdlib.h>
 
 #define FILE_NAME_1 "tst_solar_1.nc"
@@ -188,7 +189,7 @@ main(int argc, char **argv)
 #define ATT_NAME3 "for_testing_unsigned_short_attribute_bug"
    {
       int ncid;
-      int i, j;
+      size_t i, j;
       nc_type typeid;
       nc_vlen_t data[DIM_LEN];
       int *phoney;

--- a/ncdump/tst_fillbug.c
+++ b/ncdump/tst_fillbug.c
@@ -191,7 +191,7 @@ count_udtypes(int ncid) {
 	/* Get number of types in this group */
 	if( nc_inq_typeids(ncid, &ntypes, NULL) ) ERR;
 	if( nc_inq_grps(ncid, &numgrps, NULL) ) ERR;
-	ncids = (int *) malloc(sizeof(int) * numgrps);
+	ncids = (int *) malloc(sizeof(int) * (size_t)numgrps);
 	if( nc_inq_grps(ncid, NULL, ncids) ) ERR;
 	/* Add number of types in each subgroup, if any */
 	for (i=0; i < numgrps; i++) {

--- a/ncdump/tst_vlen_data.c
+++ b/ncdump/tst_vlen_data.c
@@ -88,7 +88,7 @@ main(int argc, char **argv)
    if(array == NULL) ERR;
    for (i = 0; i < NROWS; i++) {
        int ncolumns = NROWS - i;
-       array[i] = (float *) malloc(ncolumns * sizeof(float));
+       array[i] = (float *) malloc((size_t)ncolumns * sizeof(float));
        if(array[i] == NULL) ERR;
        for (j = 0; j < ncolumns; j++) {
 	   array[i][j] = 10.0f * (float)(i + 1) + (float)j;

--- a/ncdump/utils.c
+++ b/ncdump/utils.c
@@ -350,10 +350,10 @@ isrecvar(int ncid, int varid)
 	int nunlimdims;
 	int *recdimids;
 	int dim, recdim;
-	dimids = (int *) emalloc((ndims + 1) * sizeof(int));
+	dimids = (int *) emalloc((size_t)(ndims + 1) * sizeof(int));
 	NC_CHECK( nc_inq_vardimid(ncid, varid, dimids) );
 	NC_CHECK( nc_inq_unlimdims(ncid, &nunlimdims, NULL) );
-	recdimids = (int *) emalloc((nunlimdims + 1) * sizeof(int));
+	recdimids = (int *) emalloc((size_t)(nunlimdims + 1) * sizeof(int));
 	NC_CHECK( nc_inq_unlimdims(ncid, NULL, recdimids) );
 	for (dim = 0; dim < ndims && is_recvar == 0; dim++) {
 	    for(recdim = 0; recdim < nunlimdims; recdim++) {
@@ -504,7 +504,7 @@ nc_inq_grpname_count(int ncid, int igrp, char **lgrps, idnode_t *grpids) {
     NC_CHECK( nc_inq_grps(ncid, &numgrps, NULL) );
     if(numgrps > 0) {
 	/* Allocate memory to hold the list of group ids. */
-	ncids = emalloc(numgrps * sizeof(int));
+	ncids = emalloc((size_t)numgrps * sizeof(int));
 	/* Get the list of group ids. */
 	NC_CHECK( nc_inq_grps(ncid, NULL, ncids) );
 	/* Call this function recursively for each group. */
@@ -649,7 +649,7 @@ nc_inq_varname_count(int ncid, char *varname) {
     NC_CHECK( nc_inq_grps(ncid, &numgrps, NULL) );
 	 
     /* Allocate memory to hold the list of group ids. */
-    ncids = emalloc((numgrps + 1) * sizeof(int));
+    ncids = emalloc((size_t)(numgrps + 1) * sizeof(int));
 	
     /* Get the list of group ids. */
     NC_CHECK( nc_inq_grps(ncid, NULL, ncids) );
@@ -691,7 +691,7 @@ make_lvars(char *optarg, int *nlvarsp, char ***lvarsp)
       if (*cp == ',')
  	nvars++;
     *nlvarsp = nvars;
-    *lvarsp = (char **) emalloc(nvars * sizeof(char*));
+    *lvarsp = (char **) emalloc((size_t)nvars * sizeof(char*));
     cpp = *lvarsp;
     /* copy variable names into list */
     for (cp = strtok(optarg, ","); cp != NULL; cp = strtok((char *) NULL, ",")) {
@@ -712,7 +712,7 @@ make_lgrps(char *optarg, int *nlgrps, char ***lgrpsp, idnode_t **grpidsp)
       if (*cp == ',')
  	ngrps++;
     *nlgrps = ngrps;
-    *lgrpsp = (char **) emalloc(ngrps * sizeof(char*));
+    *lgrpsp = (char **) emalloc((size_t)ngrps * sizeof(char*));
     cpp = *lgrpsp;
     /* copy group names into list */
     for (cp = strtok(optarg, ","); cp != NULL; cp = strtok((char *) NULL, ",")) {
@@ -852,7 +852,7 @@ nc_next_giter(ncgiter_t *iterp, int *grpidp) {
 	*grpidp = gs_pop(iterp);
 	NC_CHECK(nc_inq_grps2(*grpidp, &numgrps, NULL));
 	if(numgrps > 0) {
-	    grpids = (int *)emalloc(sizeof(int) * numgrps);
+	    grpids = (int *)emalloc(sizeof(int) * (size_t)numgrps);
 	    NC_CHECK(nc_inq_grps2(*grpidp, &numgrps, grpids));
 	    for(i = numgrps - 1; i >= 0; i--) { /* push ids on stack in reverse order */
 		gs_push(iterp, grpids[i]);

--- a/ncdump/vardata.c
+++ b/ncdump/vardata.c
@@ -451,8 +451,8 @@ print_rows(
 	marks_pending++;	/* matching "}"s to emit after last "row" */
     }
     if(rank - level > 1) {     	/* this level is just d0 next levels */
-	size_t *local_cor = emalloc((rank + 1) * sizeof(size_t));
-	size_t *local_edg = emalloc((rank + 1) * sizeof(size_t));
+	size_t *local_cor = emalloc((size_t)(rank + 1) * sizeof(size_t));
+	size_t *local_edg = emalloc((size_t)(rank + 1) * sizeof(size_t));
 	for(i = 0; i < rank; i++) {
 	    local_cor[i] = cor[i];
 	    local_edg[i] = edg[i];
@@ -546,9 +546,9 @@ vardata(
     int level = 0;
     int marks_pending = 0;
 
-    cor = (size_t *) emalloc((1 + vrank) * sizeof(size_t));
-    edg = (size_t *) emalloc((1 + vrank) * sizeof(size_t));
-    add = (size_t *) emalloc((1 + vrank) * sizeof(size_t));
+    cor = (size_t *) emalloc((size_t)(1 + vrank) * sizeof(size_t));
+    edg = (size_t *) emalloc((size_t)(1 + vrank) * sizeof(size_t));
+    add = (size_t *) emalloc((size_t)(1 + vrank) * sizeof(size_t));
 
     nels = 1;
     if(vrank == 0) { /*scalar*/
@@ -733,9 +733,9 @@ vardatax(
     size_t nrows;
     int vrank = vp->ndims;
 
-    cor = (size_t *) emalloc((vrank + 1) * sizeof(size_t));
-    edg = (size_t *) emalloc((vrank + 1) * sizeof(size_t));
-    add = (size_t *) emalloc((vrank + 1) * sizeof(size_t));
+    cor = (size_t *) emalloc((size_t)(vrank + 1) * sizeof(size_t));
+    edg = (size_t *) emalloc((size_t)(vrank + 1) * sizeof(size_t));
+    add = (size_t *) emalloc((size_t)(vrank + 1) * sizeof(size_t));
 
     nels = 1;
     for (id = 0; id < vrank; id++) {

--- a/ncgen/bindata.c
+++ b/ncgen/bindata.c
@@ -5,6 +5,7 @@
 
 #include "includes.h"
 #include "nclog.h"
+#include <stddef.h>
 
 #ifdef ENABLE_BINARY
 
@@ -81,7 +82,7 @@ bin_constant(Generator* generator, Symbol* sym, NCConstant* con, Bytebuffer* buf
         } break;
     case NC_NIL:
     case NC_STRING: {
-        int len = (size_t)con->value.stringv.len;
+        size_t len = (size_t)con->value.stringv.len;
 	if(len == 0 && con->value.stringv.stringv == NULL) {
 	    char* nil = NULL;
             bbAppendn(buf,(void*)&nil,sizeof(nil));
@@ -351,8 +352,8 @@ bin_generate_data_r(NCConstant* instance, Symbol* tsym, Datalist* fillvalue, Byt
             NCConstant* tmp = nullconst();
             tmp->nctype = NC_STRING;
             convert1(instance,tmp);
-            p = emalloc(tmp->value.stringv.len+1);
-	    memcpy(p,tmp->value.stringv.stringv,tmp->value.stringv.len);
+            p = emalloc((size_t)tmp->value.stringv.len+1);
+	    memcpy(p,tmp->value.stringv.stringv, (size_t)tmp->value.stringv.len);
 	    p[tmp->value.stringv.len] = '\0';
             bbAppendn(databuf,&p,sizeof(char*));
             reclaimconstant(tmp);

--- a/ncgen/cdata.c
+++ b/ncgen/cdata.c
@@ -4,6 +4,7 @@
  *********************************************************************/
 
 #include "includes.h"
+#include <stddef.h>
 
 #ifdef ENABLE_C
 
@@ -98,8 +99,7 @@ c_constant(Generator* generator, Symbol* sym, NCConstant* con, Bytebuffer* buf,.
 	} break;
     case NC_OPAQUE: {
 	char* p;
-	int bslen;
-	bslen=(4*con->value.opaquev.len);
+	size_t bslen = (size_t)(4*con->value.opaquev.len);
 	special = poolalloc(bslen+2+1);
 	strcpy(special,"\"");
 	p = con->value.opaquev.stringv;

--- a/ncgen/cvt.c
+++ b/ncgen/cvt.c
@@ -450,10 +450,10 @@ case CASE(NC_STRING,NC_CHAR):
 case CASE(NC_STRING,NC_STRING):
     /* Need to watch out for embedded NULs */
     tmp.stringv.len = src->value.stringv.len;
-    tmp.stringv.stringv = (char*)ecalloc(src->value.stringv.len+1);
+    tmp.stringv.stringv = (char*)ecalloc((size_t)src->value.stringv.len+1);
     memcpy((void*)tmp.stringv.stringv,
            (void*)src->value.stringv.stringv,
-           tmp.stringv.len);
+           (size_t)tmp.stringv.len);
     tmp.stringv.stringv[tmp.stringv.len] = '\0';
     break;
 
@@ -559,8 +559,8 @@ case CASE(NC_OPAQUE,NC_DOUBLE):
     tmp.doublev = *(double*)bytes;
   break;
 case CASE(NC_OPAQUE,NC_OPAQUE):
-    tmp.opaquev.stringv = (char*)ecalloc(src->value.opaquev.len+1);
-    memcpy(tmp.opaquev.stringv,src->value.opaquev.stringv,src->value.opaquev.len);
+    tmp.opaquev.stringv = (char*)ecalloc((size_t)src->value.opaquev.len+1);
+    memcpy(tmp.opaquev.stringv,src->value.opaquev.stringv, (size_t)src->value.opaquev.len);
     tmp.opaquev.len = src->value.opaquev.len;
     tmp.opaquev.stringv[tmp.opaquev.len] = '\0';
     break;

--- a/ncgen/data.c
+++ b/ncgen/data.c
@@ -9,6 +9,7 @@
 #include        "ncoffsets.h"
 #include        "netcdf_aux.h"
 #include        "dump.h"
+#include <stddef.h>
 
 #undef VERIFY
 #ifndef __MINGW32__
@@ -147,17 +148,17 @@ cloneconstant(NCConstant* con)
 	if(newcon->value.stringv.len == 0)
 	    s = NULL;
 	else {
-	    s = (char*)ecalloc(newcon->value.stringv.len+1);
+	    s = (char*)ecalloc((size_t)newcon->value.stringv.len+1);
 	    if(newcon->value.stringv.len > 0)
-	        memcpy(s,newcon->value.stringv.stringv,newcon->value.stringv.len);
+	        memcpy(s,newcon->value.stringv.stringv, (size_t)newcon->value.stringv.len);
 	    s[newcon->value.stringv.len] = '\0';
 	}
 	newcon->value.stringv.stringv = s;
 	break;
     case NC_OPAQUE:
-	s = (char*)ecalloc(newcon->value.opaquev.len+1);
+	s = (char*)ecalloc((size_t)newcon->value.opaquev.len+1);
 	if(newcon->value.opaquev.len > 0)
-	    memcpy(s,newcon->value.opaquev.stringv,newcon->value.opaquev.len);
+	    memcpy(s,newcon->value.opaquev.stringv, (size_t)newcon->value.opaquev.len);
 	s[newcon->value.opaquev.len] = '\0';
 	newcon->value.opaquev.stringv = s;
 	break;
@@ -603,8 +604,8 @@ builddatalist(int initial)
     initial++; /* for header*/
     ci = (Datalist*)ecalloc(sizeof(Datalist));
     if(ci == NULL) semerror(0,"out of memory\n");
-    ci->data = (NCConstant**)ecalloc(sizeof(NCConstant*)*initial);
-    ci->alloc = initial;
+    ci->data = (NCConstant**)ecalloc(sizeof(NCConstant*) * (size_t)initial);
+    ci->alloc = (size_t)initial;
     ci->length = 0;
     return ci;
 }
@@ -645,12 +646,12 @@ dlinsert(Datalist* dl, size_t pos, Datalist* insertion)
     int len1 = datalistlen(dl);
     int len2 = datalistlen(insertion);
     int delta = len1 - pos;
-    dlsetalloc(dl,len2+len1+1);
+    dlsetalloc(dl, len2+len1+1);
 
    
     /* move contents of dl up to make room for insertion */
     if(delta > 0)
-        memmove(&dl->data[pos+len2],&dl->data[pos],delta*sizeof(NCConstant*));
+        memmove(&dl->data[pos+len2],&dl->data[pos], (size_t)delta*sizeof(NCConstant*));
     dl->length += len2;
     for(i=0;i<len2;i++) {
 	NCConstant* con = insertion->data[i];

--- a/ncgen/escapes.c
+++ b/ncgen/escapes.c
@@ -6,6 +6,7 @@
 
 #include "includes.h"
 #include "ncutf8.h"
+#include <stddef.h>
 
 #define HEXCHARS "0123456789abcdefABCDEF"
 #define OCTCHARS "01234567"
@@ -155,7 +156,7 @@ static struct {
  	{'/', "_SLASH_"},
 };
 static int idtlen;
-static int hexlen;
+static size_t hexlen;
 static Bytebuffer* newname;
 
 static void
@@ -508,7 +509,7 @@ fqnescape(const char* s)
     const char* p;
     char* q;
     int c;
-    int l = strlen(s);
+    size_t l = strlen(s);
 
 /*
 1234567
@@ -617,8 +618,8 @@ unescape(
     char* p;
     int b;
 
-    s = (char*)emalloc(yyleng+1);
-    memcpy(s,yytext,yyleng);
+    s = (char*)emalloc((size_t)yyleng+1);
+    memcpy(s,yytext, (size_t)yyleng);
     s[yyleng] = '\0';
 
     /* translate "\" escapes, e.g. "\t" to tab character  */

--- a/ncgen/genchar.c
+++ b/ncgen/genchar.c
@@ -245,8 +245,8 @@ makeconst(int lineno, int len, char* str)
     con->filled = 0;
     con->value.stringv.len = len;
     /* We cannot use strdup because str might have embedded nuls */
-    con->value.stringv.stringv = (char*)ecalloc(len+1);
-    memcpy((void*)con->value.stringv.stringv,(void*)str,len);
+    con->value.stringv.stringv = (char*)ecalloc((size_t)len+1);
+    memcpy((void*)con->value.stringv.stringv,(void*)str, (size_t)len);
     con->value.stringv.stringv[len] = '\0';
     return con;
 }

--- a/ncgen/generate.c
+++ b/ncgen/generate.c
@@ -6,6 +6,7 @@
 #include "includes.h"
 #include "ncoffsets.h"
 #include "netcdf_aux.h"
+#include <stddef.h>
 
 /**************************************************/
 /* Code for generating data lists*/
@@ -251,22 +252,22 @@ generate_fieldarray(Symbol* basetype, NCConstant* con, Dimset* dimset,
 static void
 normalizeopaquelength(NCConstant* prim, unsigned long nbytes)
 {
-    int nnibs = 2*nbytes;
+    size_t nnibs = 2*nbytes;
     ASSERT(prim->nctype==NC_OPAQUE);
     if(prim->value.opaquev.len == nnibs) {
         /* do nothing*/
     } else if(prim->value.opaquev.len > nnibs) { /* truncate*/
         prim->value.opaquev.stringv[nnibs] = '\0';
-        prim->value.opaquev.len = nnibs;
+        prim->value.opaquev.len = (int)nnibs;
     } else {/* prim->value.opaquev.len < nnibs => expand*/
         char* s;
         s = (char*)ecalloc(nnibs+1);
         memset(s,'0',nnibs);    /* Fill with '0' characters */
-        memcpy(s,prim->value.opaquev.stringv,prim->value.opaquev.len);
+        memcpy(s,prim->value.opaquev.stringv, (size_t)prim->value.opaquev.len);
         s[nnibs] = '\0';
         efree(prim->value.opaquev.stringv);
         prim->value.opaquev.stringv=s;
-        prim->value.opaquev.len = nnibs;
+        prim->value.opaquev.len = (int)nnibs;
     }
 }
 

--- a/ncgen/ncgeny.c
+++ b/ncgen/ncgeny.c
@@ -3318,13 +3318,12 @@ makeconstdata(nc_type nctype)
 #ifdef USE_NETCDF4
 	case NC_OPAQUE: {
 	    char* s;
-	    int len;
-	    len = bbLength(lextext);
+	    size_t len = bbLength(lextext);
 	    s = (char*)ecalloc(len+1);
 	    strncpy(s,bbContents(lextext),len);
 	    s[len] = '\0';
 	    con->value.opaquev.stringv = s;
-	    con->value.opaquev.len = len;
+	    con->value.opaquev.len = (int)len;
 	    } break;
 
 	case NC_NIL:

--- a/ncgen/util.c
+++ b/ncgen/util.c
@@ -5,6 +5,7 @@
  *********************************************************************/
 
 #include "includes.h"
+#include <stddef.h>
 
 /* Track primitive symbol instances (initialized in ncgen.y) */
 Symbol* primsymbols[PRIMNO];
@@ -12,7 +13,7 @@ Symbol* primsymbols[PRIMNO];
 char*
 append(const char* s1, const char* s2)
 {
-    int len = (s1?strlen(s1):0)+(s2?strlen(s2):0);
+    size_t len = (s1?strlen(s1):0)+(s2?strlen(s2):0);
     char* result = (char*)ecalloc(len+1);
     result[0] = '\0';
     if(s1) strcat(result,s1);
@@ -369,7 +370,7 @@ collectpath(Symbol* grp, List* grpstack)
 char*
 prefixtostring(List* prefix, char* separator)
 {
-    int slen=0;
+    size_t slen=0;
     int plen;
     int i;
     char* result;
@@ -439,7 +440,7 @@ prefixdup(List* prefix)
     int i;
     if(prefix == NULL) return listnew();
     dupseq = listnew();
-    listsetalloc(dupseq,listlength(prefix));
+    listsetalloc(dupseq, (size_t)listlength(prefix));
     for(i=0;i<listlength(prefix);i++) listpush(dupseq,listget(prefix,i));
     return dupseq;
 }
@@ -486,7 +487,7 @@ pooldup(const char* s)
 char*
 poolcat(const char* s1, const char* s2)
 {
-    int len1, len2;
+    size_t len1, len2;
     char* cat;
     if(s1 == NULL && s2 == NULL) return NULL;
     len1 = (s1?strlen(s1):0);

--- a/ncgen3/genlib.c
+++ b/ncgen3/genlib.c
@@ -5,6 +5,7 @@
  *********************************************************************/
 
 #include "config.h"
+#include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <assert.h>
@@ -1756,7 +1757,7 @@ grow_iarray(
   }
   if (! pow2(nar))		/* return unless nar is a power of two */
     return;
-  *arpp = (int *) erealloc(*arpp, 2 * nar * sizeof(int));
+  *arpp = (int *) erealloc(*arpp, 2 * (size_t)nar * sizeof(int));
 }
 
 
@@ -1782,7 +1783,7 @@ grow_varray(
   }
   if (! pow2(nar))		/* return unless nar is a power of two */
     return;
-  *arpp = (struct vars *) erealloc(*arpp, 2 * nar * sizeof(struct vars));
+  *arpp = (struct vars *) erealloc(*arpp, 2 * (size_t)nar * sizeof(struct vars));
 }
 
 
@@ -1808,7 +1809,7 @@ grow_darray(
   }
   if (! pow2(nar))		/* return unless nar is a power of two */
     return;
-  *arpp = (struct dims *) erealloc(*arpp, 2 * nar * sizeof(struct dims));
+  *arpp = (struct dims *) erealloc(*arpp, 2 * (size_t)nar * sizeof(struct dims));
 }
 
 
@@ -1834,7 +1835,7 @@ grow_aarray(
   }
   if (! pow2(nar))		/* return unless nar is a power of two */
     return;
-  *arpp = (struct atts *) erealloc(*arpp, 2 * nar * sizeof(struct atts));
+  *arpp = (struct atts *) erealloc(*arpp, 2 * (size_t)nar * sizeof(struct atts));
 }
 
 
@@ -1899,9 +1900,9 @@ decodify (
 /* 	{'_', "_UNDERSCORE_"} */
     };
     static int idtlen;
-    static int hexlen;
+    static size_t hexlen;
     int nctable = (sizeof(ctable))/(sizeof(ctable[0]));
-    int newlen;
+    size_t newlen;
 
     idtlen = strlen("DIGIT_n_"); /* initial digit template */
     hexlen = 1+strlen("_XHH"); /* template for hex of non-ASCII bytes */

--- a/nctest/add.c
+++ b/nctest/add.c
@@ -60,7 +60,7 @@ add_var (test, ivar)		/* add the variable ivar to the netcdf test */
     (void) strcpy(test->vars[test->nvars].name, ivar->name);
     test->vars[test->nvars].type = ivar->type;
     test->vars[test->nvars].ndims = ivar->ndims;
-    test->vars[test->nvars].dims = (int *) emalloc(sizeof(int)*ivar->ndims);
+    test->vars[test->nvars].dims = (int *) emalloc(sizeof(int)*(size_t)ivar->ndims);
     for (i = 0; i < ivar->ndims; i++)
       test->vars[test->nvars].dims[i] = ivar->dims[i];
     test->vars[test->nvars].natts = 0;

--- a/nctest/atttests.c
+++ b/nctest/atttests.c
@@ -125,7 +125,7 @@ test_ncattput(path)
 	    ncclose(cdfid); return ++nerrs;
 	}
 	/* allocate space to hold the attribute value to be retrieved */
-	tmp.val = emalloc(atts[ia].len * nctypelen(atts[ia].type));
+	tmp.val = emalloc((size_t)(atts[ia].len * nctypelen(atts[ia].type)));
 	if (ncattget(cdfid, NC_GLOBAL, atts[ia].name, tmp.val) == -1) {
 	    error("%s: ncattget of variable attribute failed", pname);
 	    ncclose(cdfid); return ++nerrs;
@@ -138,7 +138,7 @@ test_ncattput(path)
 	free (tmp.val);
     }
     /* add a variable, then variable attributes of every type */
-    ww.dims = (int *) emalloc(sizeof(int) * ww.ndims);
+    ww.dims = (int *) emalloc(sizeof(int) * (size_t)ww.ndims);
     for (id = 0; id < ww.ndims; id++)
       ww.dims[id] = id;
     if ((ww_id = ncvardef(cdfid,
@@ -169,7 +169,7 @@ test_ncattput(path)
 	    ncclose(cdfid); return ++nerrs;
 	}
 	/* allocate space to hold the attribute value to be retrieved */
-	tmp.val = emalloc(atts[ia].len * nctypelen(atts[ia].type));
+	tmp.val = emalloc((size_t)(atts[ia].len * nctypelen(atts[ia].type)));
 	if (ncattget(cdfid, ww_id, atts[ia].name, tmp.val) == -1) {
 	    error("%s: ncattget of variable attribute failed", pname);
 	    ncclose(cdfid); return ++nerrs;
@@ -213,7 +213,7 @@ test_ncattput(path)
 	    ncclose(cdfid); return ++nerrs;
 	}
 	/* allocate space to hold the attribute value to be retrieved */
-	tmp.val = emalloc(atts[ia].len * nctypelen(atts[ia].type));
+	tmp.val = emalloc((size_t)(atts[ia].len * nctypelen(atts[ia].type)));
 	if (ncattget(cdfid, ww_id, atts[ia-1].name, tmp.val) == -1) {
 	    error("%s: ncattget of variable attribute failed", pname);
 	    ncclose(cdfid); return ++nerrs;
@@ -294,7 +294,7 @@ test_ncattput(path)
 	    ncclose(cdfid); return ++nerrs;
 	}
 	/* allocate space to hold the attribute value to be retrieved */
-	tmp.val = emalloc(atts[ia].len * nctypelen(atts[ia].type));
+	tmp.val = emalloc((size_t)(atts[ia].len * nctypelen(atts[ia].type)));
 	if (ncattget(cdfid, ww_id, atts[ia+1].name, tmp.val) == -1) {
 	    error("%s: ncattget of variable attribute failed in data mode",
 		  pname);
@@ -386,7 +386,7 @@ test_ncattinq(path)
 	ncclose(cdfid); return ++nerrs;
     }
     /* in define mode, add a variable */
-    vv.dims = (int *) emalloc(sizeof(int) * vv.ndims);
+    vv.dims = (int *) emalloc(sizeof(int) * (size_t)vv.ndims);
     for (id = 0; id < vv.ndims; id++)
       vv.dims[id] = id;		/* assumes vv.ndims <= test.ndims */
     if ((vv_id = ncvardef(cdfid, vv.name, vv.type, vv.ndims, vv.dims))
@@ -484,7 +484,7 @@ test_ncattget(path)
 	ncclose(cdfid); return ++nerrs;
     }
     /* add a variable */
-    uu.dims = (int *) emalloc(sizeof(int) * uu.ndims);
+    uu.dims = (int *) emalloc(sizeof(int) * (size_t)uu.ndims);
     for (id = 0; id < uu.ndims; id++)
       uu.dims[id] = id;
     if ((uu_id = ncvardef(cdfid,
@@ -520,7 +520,7 @@ test_ncattget(path)
 	    ncclose(cdfid); return ++nerrs;
 	}
 	/* allocate space to hold the attribute value to be retrieved */
-	tmp.val = emalloc(tmp.len * nctypelen(tmp.type));
+	tmp.val = emalloc((size_t)(tmp.len * nctypelen(tmp.type)));
 	if (ncattget(cdfid, test.atts[ia].var, test.atts[ia].name, tmp.val)
 	    == -1) {
 	    error("%s: ncattget of variable attribute failed in define mode",
@@ -565,7 +565,7 @@ test_ncattget(path)
 	    return ++nerrs;
 	}
 	/* allocate space to hold the attribute value to be retrieved */
-	tmp.val = emalloc(tmp.len * nctypelen(tmp.type));
+	tmp.val = emalloc((size_t)(tmp.len * nctypelen(tmp.type)));
 	if (ncattget(cdfid, test.atts[ia].var, test.atts[ia].name, tmp.val)
 	    == -1) {
 	    error("%s: ncattget of variable attribute failed in data mode",
@@ -667,7 +667,7 @@ test_ncattcopy(path1, path2)
 	ncclose(cdfid); return ++nerrs;
     }
     add_att(&test, NC_GLOBAL, &att); /* keep in-memory netcdf consistent */
-    tt.dims = (int *) emalloc(sizeof(int) * tt.ndims);
+    tt.dims = (int *) emalloc(sizeof(int) * (size_t)tt.ndims);
     for (id=0; id < tt.ndims; id++)
       tt.dims[0] = id;
     if ((tt_id=ncvardef(cdfid, tt.name, tt.type, tt.ndims, tt.dims)) == -1) {
@@ -681,7 +681,7 @@ test_ncattcopy(path1, path2)
     }
     add_att(&test, tt_id, &att); /* keep in-memory netcdf consistent */
 
-    tu.dims = (int *) emalloc(sizeof(int) * tu.ndims);
+    tu.dims = (int *) emalloc(sizeof(int) * (size_t)tu.ndims);
     for (id = 0; id < tu.ndims; id++)
 	tu.dims[id] = id;
     if ((tu_id=ncvardef(cdfid, tu.name, tu.type, tu.ndims, tu.dims)) == -1) {
@@ -732,7 +732,7 @@ test_ncattcopy(path1, path2)
 	ncclose(cdfid); ncclose(cdfid2); return ++nerrs;
     }
     /* allocate space to hold the attribute value to be retrieved */
-    tmp.val = emalloc(att.len * nctypelen(att.type));
+    tmp.val = emalloc((size_t)(att.len * nctypelen(att.type)));
     if (ncattget(cdfid2, NC_GLOBAL, att.name, tmp.val) == -1) {
 	error("%s: ncattget of variable attribute failed", pname);
 	ncclose(cdfid); ncclose(cdfid2); return ++nerrs;
@@ -758,7 +758,7 @@ test_ncattcopy(path1, path2)
 	ncclose(cdfid); ncclose(cdfid2); return ++nerrs;
     }
     /* allocate space to hold the attribute value to be retrieved */
-    tmp.val = emalloc(att.len * nctypelen(att.type));
+    tmp.val = emalloc((size_t)(att.len * nctypelen(att.type)));
     if (ncattget(cdfid2, tu2_id, att.name, tmp.val) == -1) {
 	error("%s: ncattget of variable attribute failed", pname);
 	ncclose(cdfid); ncclose(cdfid2); return ++nerrs;
@@ -801,7 +801,7 @@ test_ncattcopy(path1, path2)
 	ncclose(cdfid); ncclose(cdfid2); return ++nerrs;
     }
     /* allocate space to hold the attribute value to be retrieved */
-    tmp.val = emalloc(att2.len * nctypelen(att2.type));
+    tmp.val = emalloc((size_t)(att2.len * nctypelen(att2.type)));
     if (ncattget(cdfid2, tu2_id, att2.name, tmp.val) == -1) {
 	error("%s: ncattget of variable attribute failed", pname);
 	ncclose(cdfid); ncclose(cdfid2); return ++nerrs;
@@ -830,7 +830,7 @@ test_ncattcopy(path1, path2)
 	ncclose(cdfid); ncclose(cdfid2); return ++nerrs;
     }
     /* allocate space to hold the attribute value to be retrieved */
-    tmp.val = emalloc(att2.len * nctypelen(att2.type));
+    tmp.val = emalloc((size_t)(att2.len * nctypelen(att2.type)));
     if (ncattget(cdfid, tu_id, att2.name, tmp.val) == -1) {
 	error("%s: ncattget of variable attribute failed", pname);
 	ncclose(cdfid); ncclose(cdfid2); return ++nerrs;
@@ -1149,7 +1149,7 @@ test_ncattrename(path)
 	ncclose(cdfid); return ++nerrs;
     }
     /* allocate space to hold the attribute value to be retrieved */
-    tmp.val = emalloc(atty.len * nctypelen(atty.type));
+    tmp.val = emalloc((size_t)(atty.len * nctypelen(atty.type)));
     if (ncattget(cdfid, NC_GLOBAL, newname, tmp.val) == -1) {
 	error("%s: ncattget of variable attribute failed", pname);
 	ncclose(cdfid); return ++nerrs;
@@ -1273,7 +1273,7 @@ test_ncattdel(path)
 	ncclose(cdfid); return ++nerrs;
     }
     add_att(&test, NC_GLOBAL, &yaa); /* keep in-memory netcdf in sync */
-    yav.dims = (int *) emalloc(sizeof(int) * yav.ndims);
+    yav.dims = (int *) emalloc(sizeof(int) * (size_t)yav.ndims);
     for (id = 0; id < yav.ndims; id++)
 	yav.dims[id] = id;
     if ((yav_id=ncvardef(cdfid, yav.name, yav.type, yav.ndims, yav.dims))

--- a/nctest/cdftests.c
+++ b/nctest/cdftests.c
@@ -275,7 +275,7 @@ test_ncredef(path)
     add_dim(&test, &ii);	/* keep in-memory netcdf in sync */
 
     /* dimension added OK, add a variable */
-    aa.dims = (int *)emalloc(sizeof(int) * aa.ndims);
+    aa.dims = (int *)emalloc(sizeof(int) * (size_t)aa.ndims);
     aa.dims[0] = ii_dim;
     if ((aa_id = ncvardef(ncid, aa.name, aa.type,
 			   aa.ndims, aa.dims)) == -1) {
@@ -367,7 +367,7 @@ test_ncendef(path)
     add_dim(&test, &kk);	/* keep in-memory netcdf in sync */
     
     /* dimensions added OK, add a variable */
-    bb.dims = (int *) emalloc(sizeof(int) * bb.ndims);
+    bb.dims = (int *) emalloc(sizeof(int) * (size_t)bb.ndims);
     bb.dims[0] = kk_dim;
     bb.dims[1] = jj_dim;
     if ((bb_id = ncvardef(ncid, bb.name, bb.type,
@@ -562,7 +562,7 @@ test_ncinquire(path)
 
     /* add some record variables */
     for (iv = 0; iv < nv; iv++) {
-	cc[iv].dims = (int *) emalloc(sizeof(int) * cc[iv].ndims);
+	cc[iv].dims = (int *) emalloc(sizeof(int) * (size_t)cc[iv].ndims);
 	cc[iv].dims[0] = rec_dim; /* first dimension unlimited */
 	for (id = 1; id < cc[iv].ndims; id++)
 	  cc[iv].dims[id] = dimids[id];
@@ -676,7 +676,7 @@ test_ncsync(path)
     }
     add_dim(&test, &ll);
 
-    dd.dims = (int *) emalloc(sizeof(int) * dd.ndims);
+    dd.dims = (int *) emalloc(sizeof(int) * (size_t)dd.ndims);
     dd.dims[0] = ll_dim;
     if ((dd_id=ncvardef(ncid0, dd.name, dd.type, dd.ndims, dd.dims)) == -1) {
 	error("%s: ncvardef failed", pname);

--- a/nctest/rec.c
+++ b/nctest/rec.c
@@ -359,8 +359,8 @@ test_ncrecput(path)
 
     /* get a block of data of the right type for each record variable */
     for (iv = 0; iv < nrvars; iv++) {
-	datap[iv] = emalloc(rvarsizes[iv]);
-	datar[iv] = emalloc(rvarsizes[iv]); /* for comparison values */
+	datap[iv] = emalloc((size_t)rvarsizes[iv]);
+	datar[iv] = emalloc((size_t)rvarsizes[iv]); /* for comparison values */
 	if (ncvarinq(ncid, rvarids[iv], 0, &vartype[iv], 0, 0, 0) == -1) {
 	    error("%s: ncvarinq failed", pname);
 	    ncclose(ncid);
@@ -517,8 +517,8 @@ test_ncrecget(path)
 
     /* get a block of data of the right type for each record variable */
     for (iv = 0; iv < nrvars; iv++) {
-	datap[iv] = emalloc(rvarsizes[iv]);
-	datar[iv] = emalloc(rvarsizes[iv]); /* for comparison values */
+	datap[iv] = emalloc((size_t)rvarsizes[iv]);
+	datar[iv] = emalloc((size_t)rvarsizes[iv]); /* for comparison values */
 	if (ncvarinq(ncid, rvarids[iv], 0, &vartype[iv], 0, 0, 0) == -1) {
 	    error("%s: ncvarinq failed", pname);
 	    ncclose(ncid);

--- a/nctest/slabs.c
+++ b/nctest/slabs.c
@@ -157,7 +157,7 @@ test_slabs(cdfid)
     /* define a multi-dimensional variable of each type */
 
     for (iv = 0; iv < NVARS; iv++) {
-	va[iv].dims = (int *) emalloc(sizeof(int) * va[iv].ndims);
+	va[iv].dims = (int *) emalloc(sizeof(int) * (size_t)va[iv].ndims);
 	for (idim = 0; idim < va[iv].ndims; idim++)
 	  va[iv].dims[idim] = dimids[idim];
 	varid[iv] = ncvardef(cdfid, va[iv].name, va[iv].type, va[iv].ndims,
@@ -177,7 +177,7 @@ test_slabs(cdfid)
 
     for (iv = 0; iv < NVARS; iv++) { /* test each type of variable */
 
-	v = emalloc(WSIZE*XSIZE*YSIZE*ZSIZE * nctypelen(va[iv].type));
+	v = emalloc(WSIZE*XSIZE*YSIZE*ZSIZE * (size_t)nctypelen(va[iv].type));
 
 	/* fill it with values using a function of dimension indices */
 	ii = 0;

--- a/nctest/vardef.c
+++ b/nctest/vardef.c
@@ -166,7 +166,7 @@ test_ncvardef(path)
     /* in define mode, add variables of each type with various shapes */
     for (iv = 0; iv < nv; iv++) {
 	/* set shape to use subset of dimensions previously defined */
-	va[iv].dims = (int *) emalloc(sizeof(int) * va[iv].ndims);
+	va[iv].dims = (int *) emalloc(sizeof(int) * (size_t)va[iv].ndims);
 	for (id = 0; id < va[iv].ndims; id++)
 	  va[iv].dims[id] = di_id[id];
 	if ((va_id[iv] = ncvardef(cdfid, va[iv].name, va[iv].type,

--- a/nctest/varget.c
+++ b/nctest/varget.c
@@ -62,7 +62,7 @@ test_ncvarget(path)
 	    hc.edg[id] = 1;
 	}
 	/* get space for vals */
-	hc.vals = emalloc(nctypelen(test.vars[iv].type) + 8);
+	hc.vals = emalloc((size_t)nctypelen(test.vars[iv].type) + 8);
 
 	id = test.vars[iv].ndims - 1;
 	tmp = hc.cor[id];

--- a/nctest/vargetg.c
+++ b/nctest/vargetg.c
@@ -64,7 +64,7 @@ test_ncvargetg(path)
 	}
 
 	/* get space for vals */
-	hc.vals = emalloc(nctypelen(test.vars[iv].type) + 8);
+	hc.vals = emalloc((size_t)nctypelen(test.vars[iv].type) + 8);
 
 #	define TEST_FAILS(varid) \
 	    (ncvarputg(cdfid, varid, hc.cor, hc.edg, \

--- a/nctest/varput.c
+++ b/nctest/varput.c
@@ -66,7 +66,7 @@ test_ncvarput(path)
 	    hc.edg[id] = 1;
 	}
 	/* fill in vals with value of appropriate type */
-	hc.vals = emalloc(nctypelen(test.vars[iv].type));
+	hc.vals = emalloc((size_t)nctypelen(test.vars[iv].type));
 	val_fill(test.vars[iv].type, 1, hc.vals);
 
 	id = test.vars[iv].ndims - 1;

--- a/nctest/varputg.c
+++ b/nctest/varputg.c
@@ -66,7 +66,7 @@ test_ncvarputg(path)
 	}
 
 	/* fill in vals with value of appropriate type */
-	hc.vals = emalloc(nctypelen(test.vars[iv].type));
+	hc.vals = emalloc((size_t)nctypelen(test.vars[iv].type));
 	val_fill(test.vars[iv].type, 1, hc.vals);
 
 #	define TEST_FAILS(varid) \

--- a/nctest/vartests.c
+++ b/nctest/vartests.c
@@ -48,7 +48,7 @@ test_ncvarid(path)
 	ncclose(cdfid); return ++nerrs;
     }
     /* in define mode, add a variable */
-    xx.dims = (int *) emalloc(sizeof(int) * xx.ndims);
+    xx.dims = (int *) emalloc(sizeof(int) * (size_t)xx.ndims);
     for (id = 0; id < xx.ndims; id++)
       xx.dims[id] = id;
     if ((varid = ncvardef(cdfid,
@@ -584,7 +584,7 @@ test_ncvarrename(path)
 	ncclose(cdfid); return ++nerrs;
     }
     /* in define mode, add two variables */
-    yy.dims = (int *) emalloc(sizeof(int) * yy.ndims);
+    yy.dims = (int *) emalloc(sizeof(int) * (size_t)yy.ndims);
     for (id = 0; id < yy.ndims; id++)
       yy.dims[id] = id;
     if ((yy_id = ncvardef(cdfid,
@@ -593,7 +593,7 @@ test_ncvarrename(path)
 	ncclose(cdfid); return ++nerrs;
     }
     add_var(&test, &yy);	/* keep in-memory netcdf in sync */
-    zz.dims = (int *) emalloc(sizeof(int) * zz.ndims);
+    zz.dims = (int *) emalloc(sizeof(int) * (size_t)zz.ndims);
     for (id = 0; id < zz.ndims; id++)
       zz.dims[id] = id;
     if (ncvardef(cdfid, zz.name, zz.type, zz.ndims, zz.dims) == -1) {

--- a/nctest/vputget.c
+++ b/nctest/vputget.c
@@ -77,8 +77,8 @@ test_varputget(cdfid)
 	for (ie = 0; ie < ne; ie++) { /* for each of ne points */
 
 	    /* allocate space for the cube of values */
-	    hc[ie].vals = emalloc(nel[ie]*nctypelen(test.vars[iv].type) + 8);
-	    tmp.vals = emalloc(nel[ie]*nctypelen(test.vars[iv].type) + 8);
+	    hc[ie].vals = emalloc((size_t)(nel[ie]*nctypelen(test.vars[iv].type) + 8));
+	    tmp.vals = emalloc((size_t)(nel[ie]*nctypelen(test.vars[iv].type) + 8));
 
 	    /* fill allocated space with different values of right type */
 	    val_fill(test.vars[iv].type, nel[ie], hc[ie].vals);

--- a/nctest/vputgetg.c
+++ b/nctest/vputgetg.c
@@ -5,6 +5,7 @@
  *********************************************************************/
 
 #include <config.h>
+#include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>		/* for free() */
 #include "netcdf.h"
@@ -109,7 +110,7 @@ test_varputgetg(cdfid)
 	}
 
 	for (ie = 0; ie < ne; ie++) { /* for each test */
-	    int nelms = (int)nel[ie]*nctypelen(test.vars[iv].type) + 8;
+	    size_t nelms = (size_t)(nel[ie]*nctypelen(test.vars[iv].type) + 8);
 	    /* allocate space for the cube of values */
 	    hc[ie].vals	= emalloc(nelms);
 	    tmp.vals = emalloc(nelms);

--- a/nczarr_test/test_zchunks2.c
+++ b/nczarr_test/test_zchunks2.c
@@ -26,7 +26,7 @@ calculate_waste(int ndims, size_t *dimlen, size_t *chunksize, float *waste)
    size_t chunk_size = 1;
 
    assert(waste && dimlen && chunksize && ndims);
-   if (!(num_chunks = calloc(ndims, sizeof(size_t)))) ERR;
+   if (!(num_chunks = calloc((size_t)ndims, sizeof(size_t)))) ERR;
 
 #ifdef PRINT_CHUNK_WASTE_REPORT
    printf("\n");

--- a/nczarr_test/ut_util.c
+++ b/nczarr_test/ut_util.c
@@ -4,6 +4,7 @@
  */
 
 #include "ut_includes.h"
+#include <stddef.h>
 
 #undef DEBUG
 
@@ -81,8 +82,8 @@ parsedimdef(const char* s0, Dimdef** defp)
     s = s0;
     if((p = strchr(s,'=')) == NULL) abort();
     if((count = (p - s)) == 0) return THROW(NC_EINVAL);
-    def->name = malloc(count+1);
-    memcpy(def->name,s,count);
+    def->name = malloc((size_t)count+1);
+    memcpy(def->name,s,(size_t)count);
     def->name[count] = '\0';
     s = p+1;
     sscanf(s,"%u%n",&l,&nchars);
@@ -115,7 +116,7 @@ parsevardef(const char* s0, NClist* dimdefs, Vardef** varp)
     if(p == NULL) return THROW(NC_EINVAL);
     len = (p - s);  
     if(len == 0) return THROW(NC_EINVAL);
-    memcpy(name,s,len);
+    memcpy(name,s,(size_t)len);
     name[len] = '\0';
     vd->typeid = ut_typeforname(name);
     vd->typesize = ut_typesize(vd->typeid);
@@ -127,7 +128,7 @@ parsevardef(const char* s0, NClist* dimdefs, Vardef** varp)
     if(p == NULL) return THROW(NC_EINVAL);
     len = (p - s);  
     if(len == 0) return THROW(NC_EINVAL);
-    memcpy(name,s,len);
+    memcpy(name,s,(size_t)len);
     name[len] = '\0';
     vd->name = strdup(name);     
     /* parse a vector of dimnames and chunksizes and convert */
@@ -178,7 +179,7 @@ parsestringvector(const char* s0, int stopchar, char*** namesp)
     /* First, compute number of elements */
     for(s=s0,nelems=1;*s;s++) {if(*s == ',') nelems++; if(*s == stopchar) break;}
     if(nelems == 0) return THROW(NC_EINVAL);
-    names = calloc(nelems+1,sizeof(char*));
+    names = calloc((size_t)nelems+1,sizeof(char*));
     for(s=s0,i=0;i<nelems;i++) {
         ptrdiff_t len;
         const char* p = strchr(s,',');
@@ -187,8 +188,8 @@ parsestringvector(const char* s0, int stopchar, char*** namesp)
         if(names[i] == NULL) {
             char* q;
             len = (p - s);
-            q = malloc(1+len);
-            memcpy(q,s,len);
+            q = malloc(1+(size_t)len);
+            memcpy(q,s,(size_t)len);
             q[len] = '\0';
             names[i] = q;
         }
@@ -211,7 +212,7 @@ parseintvector(const char* s0, int typelen, void** vectorp)
         if(*s == ',') nelems++;
     }
 
-    vector = calloc(nelems,typelen);
+    vector = calloc((size_t)nelems, (size_t)typelen);
 
     /* Extract the elements of the vector */
     /* Skip any leading bracketchar */
@@ -508,8 +509,8 @@ fillcommon(struct Common* common, Vardef* var)
     common->typesize = sizeof(int);
     if(var != NULL) {
         common->rank = var->rank;
-        memcpy(common->dimlens,var->dimsizes,sizeof(size64_t)*common->rank);
-        memcpy(common->chunklens,var->chunksizes,sizeof(size64_t)*common->rank);
-        memcpy(common->memshape,common->dimlens,sizeof(size64_t)*common->rank); /* fake it */
+        memcpy(common->dimlens,var->dimsizes,sizeof(size64_t)*(size_t)common->rank);
+        memcpy(common->chunklens,var->chunksizes,sizeof(size64_t)*(size_t)common->rank);
+        memcpy(common->memshape,common->dimlens,sizeof(size64_t)*(size_t)common->rank); /* fake it */
     }
 }

--- a/oc2/ocinternal.c
+++ b/oc2/ocinternal.c
@@ -2,6 +2,7 @@
    See the COPYRIGHT file for more information. */
 
 #include "config.h"
+#include <stddef.h>
 #include <stdio.h>
 
 #ifdef HAVE_STDINT_H
@@ -320,7 +321,7 @@ createtempfile(OCstate* state, OCtree* tree)
     int stat = OC_NOERR;
     char* path = NULL;
     char* tmppath = NULL;
-    int len;
+    size_t len;
     NCglobalstate* globalstate = NC_getglobalstate();
 
     len =
@@ -552,7 +553,7 @@ ocset_curlproperties(OCstate* state)
         int stat = NC_NOERR;
         char* path = NULL;
         char* tmppath = NULL;
-        int len;
+        size_t len;
         errno = 0;
         /* Create the unique cookie file name */
         len =

--- a/oc2/ocutil.c
+++ b/oc2/ocutil.c
@@ -3,6 +3,7 @@
 
 #include "config.h"
 #include <errno.h>
+#include <stddef.h>
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
@@ -695,7 +696,7 @@ done:
 char**
 ocmerge(const char** list1, const char** list2)
 {
-    int l1, l2;
+    size_t l1, l2;
     char** merge;
     const char** p;
     for(l1=0,p=list1;*p;p++) {l1++;}

--- a/unit_test/tst_xcache.c
+++ b/unit_test/tst_xcache.c
@@ -84,7 +84,7 @@ generatestrings(int n, unsigned seed)
     char* s = NULL;
 
     srandom(seed);
-    strings = (NCXSTR*)calloc(sizeof(NCXSTR),(n+1));
+    strings = (NCXSTR*)calloc(sizeof(NCXSTR),((size_t)n+1));
     if(strings == NULL) abort();
     for(i=0;i<n;i++) {
         /* Generate one random string */


### PR DESCRIPTION
Mostly just add an explicit cast when calling `malloc` and its variants. Sometimes instead change the type of a local variable if this would silence multiple warnings.

Silences more than 300 warnings on GCC.