### PR TITLE
Silence sign conversion warnings from `NClist` functions

### DIFF
--- a/include/nclist.h
+++ b/include/nclist.h
@@ -4,6 +4,7 @@
 #define NCLIST_H 1
 
 #include "ncexternl.h"
+#include <stddef.h>
 
 /* Define the type of the elements in the list*/
 

--- a/libdap2/cache.c
+++ b/libdap2/cache.c
@@ -25,7 +25,9 @@ static int iscacheableconstraint(DCEconstraint* con);
 int
 iscached(NCDAPCOMMON* nccomm, CDFnode* target, NCcachenode** cachenodep)
 {
-    int i,j,found,index;
+    int i, found;
+    size_t j;
+    size_t index;
     NCcache* cache;
     NCcachenode* cachenode;
 

--- a/libdap2/cache.c
+++ b/libdap2/cache.c
@@ -5,6 +5,7 @@
 
 #include "dapincludes.h"
 #include "dapdump.h"
+#include <stddef.h>
 
 /*
 Grads servers always require a constraint,
@@ -92,7 +93,7 @@ else
 NCerror
 prefetchdata(NCDAPCOMMON* nccomm)
 {
-    int i;
+    size_t i;
     NCFLAGS flags;
     NCerror ncstat = NC_NOERR;
     NClist* allvars = nccomm->cdf.ddsroot->tree->varnodes;
@@ -341,7 +342,7 @@ fprintf(stderr,"freecachenode: %s\n",
 void
 freenccache(NCDAPCOMMON* nccomm, NCcache* cache)
 {
-    int i;
+    size_t i;
     if(cache == NULL) return;
     freenccachenode(nccomm,cache->prefetch);
     for(i=0;i<nclistlength(cache->nodes);i++) {
@@ -367,7 +368,8 @@ createnccache(void)
 static int
 iscacheableprojection(DCEprojection* proj)
 {
-    int i,cacheable;
+    size_t i;
+    int cacheable;
     if(proj->discrim != CES_VAR) return 0;
     cacheable = 1; /* assume so */
     for(i=0;i<nclistlength(proj->var->segments);i++) {
@@ -380,7 +382,7 @@ iscacheableprojection(DCEprojection* proj)
 static int
 iscacheableconstraint(DCEconstraint* con)
 {
-    int i;
+    size_t i;
     if(con == NULL) return 1;
     if(con->selections != NULL && nclistlength(con->selections) > 0)
 	return 0; /* can't deal with selections */
@@ -400,7 +402,7 @@ A variable is prefetchable if
 NCerror
 markprefetch(NCDAPCOMMON* nccomm)
 {
-    int i,j;
+    size_t i,j;
     NClist* allvars = nccomm->cdf.fullddsroot->tree->varnodes;
     assert(allvars != NULL);
     /* mark those variables of sufficiently small size */

--- a/libdap2/cdf.c
+++ b/libdap2/cdf.c
@@ -6,6 +6,7 @@
 #include "dapincludes.h"
 #include "daputil.h"
 #include "dapdump.h"
+#include <stddef.h>
 
 #ifdef DAPDEBUG
 extern char* ocfqn(OCddsnode);
@@ -433,7 +434,7 @@ we expected a grid.
 static int
 restructr(NCDAPCOMMON* ncc, CDFnode* dxdparent, CDFnode* patternparent, NClist* repairlist)
 {
-    int index, i, j, match;
+    size_t index, i, j, match;
 
 #ifdef DEBUG
 fprintf(stderr,"restruct: matched: %s -> %s\n",
@@ -501,7 +502,7 @@ static NCerror
 repairgrids(NCDAPCOMMON* ncc, NClist* repairlist)
 {
     NCerror ncstat = NC_NOERR;
-    int i;
+    size_t i;
     assert(nclistlength(repairlist) % 2 == 0);
     for(i=0;i<nclistlength(repairlist);i+=2) {
 	CDFnode* node = (CDFnode*)nclistget(repairlist,i);
@@ -541,7 +542,7 @@ structwrap(NCDAPCOMMON* ncc, CDFnode* node, CDFnode* parent, int parentindex,
 static int
 findin(CDFnode* parent, CDFnode* child)
 {
-    int i;
+    size_t i;
     NClist* subnodes = parent->subnodes;
     for(i=0;i<nclistlength(subnodes);i++) {
 	if(nclistget(subnodes,i) == child)
@@ -674,13 +675,13 @@ dimimprint(NCDAPCOMMON* nccomm)
 {
     NCerror ncstat = NC_NOERR;
     NClist* allnodes;
-    int i,j;
+    size_t i,j;
     CDFnode* basenode;
 
     allnodes = nccomm->cdf.ddsroot->tree->nodes;
     for(i=0;i<nclistlength(allnodes);i++) {
 	CDFnode* node = (CDFnode*)nclistget(allnodes,i);
-	int noderank, baserank;
+	size_t noderank, baserank;
         /* Do dimension imprinting */
 	basenode = node->basenode;
 	if(basenode == NULL) continue;
@@ -689,7 +690,7 @@ dimimprint(NCDAPCOMMON* nccomm)
 	if(noderank == 0) continue;
         ASSERT(noderank == baserank);
 #ifdef DEBUG
-fprintf(stderr,"dimimprint %s/%d -> %s/%d\n",
+fprintf(stderr,"dimimprint %s/%zu -> %s/%zu\n",
 	makecdfpathstring(basenode,"."),
 	noderank,
 	makecdfpathstring(node,"."),
@@ -725,7 +726,7 @@ static NClist*
 clonedimset(NCDAPCOMMON* nccomm, NClist* dimset, CDFnode* var)
 {
     NClist* result = NULL;
-    int i;
+    size_t i;
 
     for(i=0;i<nclistlength(dimset);i++) {
         CDFnode *dim = NULL;
@@ -768,7 +769,7 @@ definedimsetplus(NCDAPCOMMON* nccomm/*notused*/, CDFnode* node)
 static NCerror
 definedimsetall(NCDAPCOMMON* nccomm/*notused*/, CDFnode* node)
 {
-    int i;
+    size_t i;
     int ncstat = NC_NOERR;
     NClist* dimsetall = NULL;
 
@@ -795,7 +796,7 @@ fprintf(stderr,"dimsetall: |%s|=%d\n",node->ocname,(int)nclistlength(dimsetall))
 static NCerror
 definetransdimset(NCDAPCOMMON* nccomm/*notused*/, CDFnode* node)
 {
-    int i;
+    size_t i;
     int ncstat = NC_NOERR;
     NClist* dimsettrans = NULL;
 
@@ -842,7 +843,7 @@ Recursive helper for definedimsettrans3
 static NCerror
 definedimsettransR(NCDAPCOMMON* nccomm, CDFnode* node)
 {
-    int i;
+    size_t i;
     int ncstat = NC_NOERR;
 
     definetransdimset(nccomm,node);
@@ -882,7 +883,7 @@ Recursive helper
 static NCerror
 definedimsetsR(NCDAPCOMMON* nccomm, CDFnode* node)
 {
-    int i;
+    size_t i;
     int ncstat = NC_NOERR;
 
     definedimsetplus(nccomm,node);
@@ -1057,7 +1058,7 @@ buildcdftreer(NCDAPCOMMON* nccomm, OCddsnode ocnode, CDFnode* container,
 void
 freecdfroot(CDFnode* root)
 {
-    int i;
+    size_t i;
     CDFtree* tree;
     NCDAPCOMMON* nccomm;
     if(root == NULL) return;
@@ -1187,7 +1188,7 @@ fix1node(NCDAPCOMMON* nccomm, CDFnode* node)
 static NCerror
 fixnodes(NCDAPCOMMON* nccomm, NClist* cdfnodes)
 {
-    int i;
+    size_t i;
     for(i=0;i<nclistlength(cdfnodes);i++) {
 	CDFnode* node = (CDFnode*)nclistget(cdfnodes,i);
 	NCerror err = fix1node(nccomm,node);

--- a/libdap2/cdf.c
+++ b/libdap2/cdf.c
@@ -71,7 +71,7 @@ computecdfnodesets(NCDAPCOMMON* nccomm, CDFtree* tree)
 NCerror
 computevarnodes(NCDAPCOMMON* nccomm, NClist* allnodes, NClist* varnodes)
 {
-    unsigned int i,len;
+    size_t i, len;
     NClist* allvarnodes = nclistnew();
     for(i=0;i<nclistlength(allnodes);i++) {
 	CDFnode* node = (CDFnode*)nclistget(allnodes,i);

--- a/libdap2/constraints.c
+++ b/libdap2/constraints.c
@@ -296,7 +296,7 @@ matchnode->ncfullname,dumpsegments(segments));
 	break;
     default: {
 	CDFnode* minnode = NULL;
-	int minpath = 0;
+	size_t minpath = 0;
 	int nmin = 0; /* to catch multiple ones with same short path */
 	/* ok, see if one of the matches has a path that is shorter
            then all the others */

--- a/libdap2/constraints.c
+++ b/libdap2/constraints.c
@@ -7,6 +7,7 @@
 #include "dceparselex.h"
 #include "dceconstraints.h"
 #include "dapdump.h"
+#include <stddef.h>
 
 static void completesegments(NClist* fullpath, NClist* segments);
 static NCerror qualifyprojectionnames(DCEprojection* proj);
@@ -338,7 +339,8 @@ done:
 static int
 matchsuffix(NClist* matchpath, NClist* segments)
 {
-    int i,pathstart;
+    size_t i;
+    int pathstart;
     int nsegs = nclistlength(segments);
     int pathlen = nclistlength(matchpath);
     int segmatch;
@@ -356,7 +358,7 @@ matchsuffix(NClist* matchpath, NClist* segments)
        matching as we go
     */
     for(i=0;i<nsegs;i++) {
-	CDFnode* node = (CDFnode*)nclistget(matchpath,pathstart+i);
+	CDFnode* node = (CDFnode*)nclistget(matchpath, (size_t)pathstart+i);
 	DCEsegment* seg = (DCEsegment*)nclistget(segments,i);
 	int rank = seg->rank;
 	segmatch = 1; /* until proven otherwise */
@@ -386,12 +388,12 @@ dapbuildvaraprojection(CDFnode* var,
 		     const size_t* startp, const size_t* countp, const ptrdiff_t* stridep,
 		     DCEprojection** projectionp)
 {
-    int i,j;
+    size_t i,j;
     NCerror ncstat = NC_NOERR;
     DCEprojection* projection = NULL;
     NClist* path = nclistnew();
     NClist* segments = NULL;
-    int dimindex;
+    size_t dimindex;
 
     /* Build a skeleton projection that has 1 segment for
        every cdfnode from root to the variable of interest.
@@ -463,9 +465,10 @@ dapiswholeslice(DCEslice* slice, CDFnode* dim)
 int
 dapiswholesegment(DCEsegment* seg)
 {
-    int i,whole;
+    size_t i;
+    int whole;
     NClist* dimset = NULL;
-    unsigned int rank;
+    size_t rank;
 
     if(seg->rank == 0) return 1;
     if(!seg->slicesdefined) return 0;
@@ -483,7 +486,8 @@ dapiswholesegment(DCEsegment* seg)
 int
 dapiswholeprojection(DCEprojection* proj)
 {
-    int i,whole;
+    size_t i;
+    int whole;
 
     ASSERT((proj->discrim == CES_VAR));
 
@@ -498,7 +502,7 @@ dapiswholeprojection(DCEprojection* proj)
 int
 dapiswholeconstraint(DCEconstraint* con)
 {
-    int i;
+    size_t i;
     if(con == NULL) return 1;
     if(con->projections != NULL) {
 	for(i=0;i<nclistlength(con->projections);i++) {
@@ -528,7 +532,7 @@ The term "expanded" means
 NCerror
 dapfixprojections(NClist* list)
 {
-    int i,j,k;
+    size_t i,j,k;
     NCerror ncstat = NC_NOERR;
     NClist* tmp = nclistnew(); /* misc. uses */
 
@@ -619,12 +623,12 @@ next:   continue;
     } /*for(;;)*/
 
     /* remove all NULL elements */
-    for(i=nclistlength(list)-1;i>=0;i--) {
-        DCEprojection* target = (DCEprojection*)nclistget(list,i);
+    int n;
+    for(n=nclistlength(list)-1;n>=0;n--) {
+        DCEprojection* target = (DCEprojection*)nclistget(list,n);
 	if(target == NULL)
-	    nclistremove(list,i);
+	    nclistremove(list,n);
     }
-
 done:
 #ifdef DEBUG
 fprintf(stderr,"fixprojection: exploded = %s\n",dumpprojections(list));
@@ -661,7 +665,7 @@ projectify(CDFnode* field, DCEprojection* container)
 static int
 slicematch(NClist* seglist1, NClist* seglist2)
 {
-    int i,j;
+    size_t i,j;
     if((seglist1 == NULL || seglist2 == NULL) && seglist1 != seglist2)
 	return 0;
     if(nclistlength(seglist1) != nclistlength(seglist2))
@@ -691,7 +695,7 @@ slicematch(NClist* seglist1, NClist* seglist2)
 int
 dapvar2projection(CDFnode* var, DCEprojection** projectionp)
 {
-    int i,j;
+    size_t i,j;
     int ncstat = NC_NOERR;
     NClist* path = nclistnew();
     NClist* segments;
@@ -707,7 +711,7 @@ dapvar2projection(CDFnode* var, DCEprojection** projectionp)
     for(i=0;i<nclistlength(path);i++) {
 	DCEsegment* segment = (DCEsegment*)dcecreate(CES_SEGMENT);
 	CDFnode* n = (CDFnode*)nclistget(path,i);
-	int localrank;
+	size_t localrank;
         NClist* dimset;
 
 	segment->annotation = (void*)n;
@@ -757,7 +761,7 @@ int
 daprestrictprojection(NClist* projections, DCEprojection* var, DCEprojection** resultp)
 {
     int ncstat = NC_NOERR;
-    int i;
+    size_t i;
     DCEprojection* result = NULL;
 #ifdef DEBUG1
 fprintf(stderr,"restrictprojection.before: constraints=|%s| vara=|%s|\n",
@@ -817,7 +821,7 @@ int
 dapshiftprojection(DCEprojection* projection)
 {
     int ncstat = NC_NOERR;
-    int i,j;
+    size_t i,j;
     NClist* segments;
 
 #ifdef DEBUG1
@@ -849,7 +853,7 @@ dapcomputeprojectedvars(NCDAPCOMMON* dapcomm, DCEconstraint* constraint)
 {
     NCerror ncstat = NC_NOERR;
     NClist* vars = NULL;
-    int i;
+    size_t i;
 
     vars = nclistnew();
 

--- a/libdap2/dapattr.c
+++ b/libdap2/dapattr.c
@@ -4,6 +4,7 @@
  *********************************************************************/
 
 #include "dapincludes.h"
+#include <stddef.h>
 
 #define OCCHECK(exp) if((ocstat = (exp))) {THROWCHK(ocstat); goto done;}
 
@@ -18,7 +19,7 @@ and stuff from DODS_EXTRA.
 int
 dapmerge(NCDAPCOMMON* nccomm, CDFnode* ddsroot, OCddsnode dasroot)
 {
-    int i,j;
+    size_t i,j;
     NCerror ncstat = NC_NOERR;
     OCerror ocstat = OC_NOERR;
     NClist* allnodes;

--- a/libdap2/dapcvt.c
+++ b/libdap2/dapcvt.c
@@ -4,6 +4,7 @@
  *********************************************************************/
 #include "config.h"
 #include "dapincludes.h"
+#include <stddef.h>
 
 #ifdef _WIN32
 #include <crtdbg.h>
@@ -215,10 +216,10 @@ If we need an int and the string value is out of range, return NC_ERANGE.
 NCerror
 dapcvtattrval(nc_type etype, void* dst, NClist* src, NCattribute* att)
 {
-    int i;
+    size_t i;
     NCerror  ncstat = NC_NOERR;
-    unsigned int memsize = nctypesizeof(etype);
-    unsigned int nvalues = nclistlength(src);
+    size_t memsize = nctypesizeof(etype);
+    size_t nvalues = nclistlength(src);
     char* dstmem = (char*)dst;
 
     for(i=0;i<nvalues;i++) {

--- a/libdap2/dapdump.c
+++ b/libdap2/dapdump.c
@@ -5,6 +5,7 @@
 
 #include "config.h"
 #include "netcdf.h"
+#include <stddef.h>
 #ifdef USE_PARALLEL
 #include "netcdf_par.h"
 #endif
@@ -247,7 +248,7 @@ dumppath(CDFnode* leaf)
     NClist* path = nclistnew();
     NCbytes* buf = ncbytesnew();
     char* result;
-    int i;
+    size_t i;
 
     if(leaf == NULL) return nulldup("");
     collectnodepath(leaf,path,!WITHDATASET);
@@ -272,7 +273,7 @@ dumpindent(int indent, NCbytes* buf)
 static void
 dumptreer1(CDFnode* root, NCbytes* buf, int indent, char* tag, int visible)
 {
-    int i;
+    size_t i;
     dumpindent(indent,buf);
     ncbytescat(buf,tag);
     ncbytescat(buf," {\n");
@@ -300,7 +301,7 @@ dumptreer1(CDFnode* root, NCbytes* buf, int indent, char* tag, int visible)
 static void
 dumptreer(CDFnode* root, NCbytes* buf, int indent, int visible)
 {
-    int i;
+    size_t i;
     char* primtype = NULL;
     NClist* dimset = NULL;
 
@@ -389,7 +390,7 @@ dumpnode(CDFnode* node)
 {
     NCbytes* buf = ncbytesnew();
     char* result;
-    int i;
+    size_t i;
     char* nctype = NULL;
     char* primtype = NULL;
     char tmp[1024];
@@ -456,7 +457,7 @@ dumpnode(CDFnode* node)
     ncbytescat(buf,tmp);
     for(i=0;i<nclistlength(node->array.dimset0);i++) {
 	CDFnode* dim = (CDFnode*)nclistget(node->array.dimset0,i);
-        snprintf(tmp,sizeof(tmp),"dims[%d]={\n",i);
+        snprintf(tmp,sizeof(tmp),"dims[%zu]={\n",i);
         ncbytescat(buf,tmp);
 	snprintf(tmp,sizeof(tmp),"    ocname=%s\n",dim->ocname);
         ncbytescat(buf,tmp);
@@ -497,7 +498,7 @@ dumpcachenode(NCcachenode* node)
 {
     char* result = NULL;
     char tmp[8192];
-    int i;
+    size_t i;
     NCbytes* buf;
 
     if(node == NULL) return strdup("cachenode{null}");
@@ -527,7 +528,7 @@ dumpcache(NCcache* cache)
 {
     char* result = NULL;
     char tmp[8192];
-    int i;
+    size_t i;
     NCbytes* buf;
 
     if(cache == NULL) return strdup("cache{null}");
@@ -619,10 +620,10 @@ dumplistraw(NClist* l)
 void
 dumpstringlist(NClist* l)
 {
-    int i;
+    size_t i;
     for(i=0;i<nclistlength(l);i++) {
 	const char* s = (const char*)nclistget(l,i);
-	fprintf(stderr,"[%d]: |%s|\n",i,s);
+	fprintf(stderr,"[%zu]: |%s|\n",i,s);
     }
     fflush(stderr);
 }

--- a/libdap2/daputil.c
+++ b/libdap2/daputil.c
@@ -4,6 +4,7 @@
  *********************************************************************/
 
 #include "config.h"
+#include <stddef.h>
 
 #ifdef HAVE_SYS_TIME_H
 #include <sys/time.h>
@@ -312,7 +313,7 @@ collectocpath(OClink conn, OCddsnode node, NClist* path)
 char*
 makeocpathstring(OClink conn, OCddsnode node, const char* sep)
 {
-    int i,len,first;
+    size_t i,len,first;
     char* result;
     char* name;
     OCtype octype;
@@ -353,7 +354,7 @@ makeocpathstring(OClink conn, OCddsnode node, const char* sep)
 char*
 makepathstring(NClist* path, const char* separator, int flags)
 {
-    int i,len,first;
+    size_t i,len,first;
     NCbytes* pathname = NULL;
     char* result;
     CDFnode* node;
@@ -412,7 +413,7 @@ clonenodenamepath(CDFnode* node, NClist* path, int withdataset)
 char*
 simplepathstring(NClist* names,  char* separator)
 {
-    int i;
+    size_t i;
     size_t len;
     char* result;
     if(nclistlength(names) == 0) return nulldup("");

--- a/libdap2/daputil.c
+++ b/libdap2/daputil.c
@@ -255,7 +255,8 @@ nclistconcat(NClist* l1, NClist* l2)
 int
 nclistminus(NClist* l1, NClist* l2)
 {
-    unsigned int i,len,found;
+    size_t i, len;
+    int found;
     len = nclistlength(l2);
     found = 0;
     for(i=0;i<len;i++) {

--- a/libdap2/dceconstraints.c
+++ b/libdap2/dceconstraints.c
@@ -5,6 +5,7 @@
 
 #include "config.h"
 
+#include <stddef.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -218,7 +219,7 @@ Dst will be modified.
 int
 dcemergeprojectionlists(NClist* dst, NClist* src)
 {
-    int i;
+    size_t i;
     NClist* cat = nclistnew();
     int ncstat = NC_NOERR;
 
@@ -272,7 +273,7 @@ int
 dcemergeprojections(DCEprojection* merged, DCEprojection* addition)
 {
     int ncstat = NC_NOERR;
-    int i,j;
+    size_t i,j;
 
     ASSERT((merged->discrim == CES_VAR && addition->discrim == CES_VAR));
     ASSERT((nclistlength(merged->var->segments) == nclistlength(addition->var->segments)));    
@@ -432,7 +433,7 @@ done:
 NClist*
 dceclonelist(NClist* list)
 {
-    int i;
+    size_t i;
     NClist* clone;
     if(list == NULL) return NULL;
     clone = nclistnew();
@@ -519,7 +520,7 @@ dcefree(DCEnode* node)
 void
 dcefreelist(NClist* list)
 {
-    int i;
+    size_t i;
     if(list == NULL) return;
     for(i=0;i<nclistlength(list);i++) {
 	DCEnode* node = (DCEnode*)nclistget(list,i);
@@ -717,7 +718,7 @@ dcelisttostring(NClist* list, char* sep)
 void
 dcelisttobuffer(NClist* list, NCbytes* buf, char* sep)
 {
-    int i;
+    size_t i;
     if(list == NULL || buf == NULL) return;
     if(sep == NULL) sep = ",";
     for(i=0;i<nclistlength(list);i++) {
@@ -741,7 +742,7 @@ dceallnodes(DCEnode* node, CEsort which)
 static void
 ceallnodesr(DCEnode* node, NClist* allnodes, CEsort which)
 {
-    int i;
+    size_t i;
     if(node == NULL) return;
     if(nclistcontains(allnodes,(void*)node)) return;
     if(which == CES_NIL || node->sort == which)
@@ -920,8 +921,8 @@ dcemakewholeprojection(DCEprojection* p)
 int
 dcesamepath(NClist* list1, NClist* list2)
 {
-    int i;
-    int len = nclistlength(list1);
+    size_t i;
+    size_t len = nclistlength(list1);
     if(len != nclistlength(list2)) return 0;
     for(i=0;i<len;i++) {
 	DCEsegment* s1 = (DCEsegment*)nclistget(list1,i);
@@ -1162,7 +1163,7 @@ dcedumpraw(DCEnode* node, NCbytes* buf)
 static void
 dcedumprawlist(NClist* list, NCbytes* buf)
 {
-    int i;
+    size_t i;
     if(list == NULL || buf == NULL) return;
     ncbytescat(buf,"(");
     for(i=0;i<nclistlength(list);i++) {

--- a/libdap2/dceparse.c
+++ b/libdap2/dceparse.c
@@ -8,6 +8,7 @@
 */
 
 #include "config.h"
+#include <stddef.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -91,7 +92,7 @@ segmentlist(DCEparsestate* state, Object var0, Object decl)
 Object
 segment(DCEparsestate* state, Object name, Object slices0)
 {
-    int i;
+    size_t i;
     DCEsegment* segment = (DCEsegment*)dcecreate(CES_SEGMENT);
     NClist* slices = (NClist*)slices0;
     segment->name = strdup((char*)name);
@@ -222,7 +223,7 @@ array_indices(DCEparsestate* state, Object list0, Object indexno)
 Object
 indexer(DCEparsestate* state, Object name, Object indices)
 {
-    int i;
+    size_t i;
     NClist* list = (NClist*)indices;
     DCEsegment* seg = (DCEsegment*)dcecreate(CES_SEGMENT);
     seg->name = strdup((char*)name);

--- a/libdap2/getvara.c
+++ b/libdap2/getvara.c
@@ -9,6 +9,7 @@
 #include "dapdump.h"
 #include "ncd2dispatch.h"
 #include "ocx.h"
+#include <stddef.h>
 
 #define NEWVARM
 
@@ -95,7 +96,7 @@ nc3d_getvarx(int ncid, int varid,
 {
     NCerror ncstat = NC_NOERR;
     OCerror ocstat = OC_NOERR;
-    int i;
+    size_t i;
     NC* drno;
     NC* substrate;
     NCDAPCOMMON* dapcomm;
@@ -426,7 +427,7 @@ fail:
 static NCerror
 removepseudodims(DCEprojection* proj)
 {
-    int i;
+    size_t i;
 #ifdef DEBUG1
 fprintf(stderr,"removesequencedims.before: %s\n",dumpprojection(proj));
 #endif
@@ -935,7 +936,7 @@ extractstring(
 {
     NCerror ncstat = NC_NOERR;
     OCerror ocstat = OC_NOERR;
-    int i;
+    size_t i;
     size_t rank0;
     NClist* strings = NULL;
     Dapodometer* odom = NULL;
@@ -1056,9 +1057,9 @@ It is assumed that both trees have been re-struct'ed if necessary.
 */
 
 static NCerror
-attachr(CDFnode* xnode, NClist* patternpath, int depth)
+attachr(CDFnode* xnode, NClist* patternpath, size_t depth)
 {
-    unsigned int i,plen,lastnode,gridable;
+    size_t i,plen,lastnode,gridable;
     NCerror ncstat = NC_NOERR;
     CDFnode* patternpathnode;
     CDFnode* patternpathnext;
@@ -1129,7 +1130,7 @@ attachsubsetr(CDFnode* target, CDFnode* pattern)
 {
     unsigned int i;
     NCerror ncstat = NC_NOERR;
-    int fieldindex;
+    size_t fieldindex;
 
 #ifdef DEBUG2
 fprintf(stderr,"attachsubsetr: attach: target=%s pattern=%s\n",

--- a/libdap4/d4data.c
+++ b/libdap4/d4data.c
@@ -6,6 +6,7 @@
 #include "d4includes.h"
 #include <stdarg.h>
 #include <assert.h>
+#include <stddef.h>
 #include "d4includes.h"
 #include "d4odom.h"
 #include "nccrc.h"
@@ -58,7 +59,7 @@ int
 NCD4_parcelvars(NCD4meta* meta, NCD4response* resp)
 {
     int ret = NC_NOERR;
-    int i;
+    size_t i;
     NClist* toplevel = NULL;
     NCD4node* root = meta->root;
     NCD4offset* offset = NULL;
@@ -88,7 +89,7 @@ int
 NCD4_processdata(NCD4meta* meta, NCD4response* resp)
 {
     int ret = NC_NOERR;
-    int i;
+    size_t i;
     NClist* toplevel = NULL;
     NCD4node* root = meta->root;
     NCD4offset* offset = NULL;
@@ -203,7 +204,8 @@ done:
 static int
 fillstruct(NCD4meta* meta, NCD4node* type, NCD4offset* offset, void** dstp, NClist* blobs)
 {
-    int i,ret = NC_NOERR;
+    size_t i;
+    int ret = NC_NOERR;
     void* dst = *dstp;
  
 #ifdef CLEARSTRUCT
@@ -370,7 +372,7 @@ int
 NCD4_getToplevelVars(NCD4meta* meta, NCD4node* group, NClist* toplevel)
 {
     int ret = NC_NOERR;
-    int i;
+    size_t i;
 
     if(group == NULL)
 	group = meta->root;
@@ -397,7 +399,8 @@ int
 NCD4_inferChecksums(NCD4meta* meta, NCD4response* resp)
 {
     int ret = NC_NOERR;
-    int i, attrfound;
+    size_t i;
+    int attrfound;
     NClist* toplevel = NULL;
  
     /* Get the toplevel vars */
@@ -407,7 +410,7 @@ NCD4_inferChecksums(NCD4meta* meta, NCD4response* resp)
     /* First, look thru the DMR to see if there is a checksum attribute */
     attrfound = 0;
     for(i=0;i<nclistlength(toplevel);i++) {
-	int a;
+	size_t a;
         NCD4node* node = (NCD4node*)nclistget(toplevel,i);
 	for(a=0;a<nclistlength(node->attributes);a++) {	
             NCD4node* attr = (NCD4node*)nclistget(node->attributes,a);

--- a/libdap4/d4debug.c
+++ b/libdap4/d4debug.c
@@ -4,6 +4,7 @@
  *********************************************************************/
 #include "config.h"
 #include <stdarg.h>
+#include <stddef.h>
 #include <stdio.h>
 
 #include "d4includes.h"
@@ -96,7 +97,8 @@ bv inserting the data into the substrate and then writing it out.
 int
 NCD4_debugcopy(NCD4INFO* info)
 {
-    int i,ret=NC_NOERR;
+    size_t i;
+    int ret = NC_NOERR;
     NCD4meta* meta = info->dmrmetadata;
     NClist* topvars = nclistnew();
     NC* ncp = info->controller;
@@ -134,7 +136,7 @@ NCD4_debugcopy(NCD4INFO* info)
 	*/
 	{	
 	    size_t edges[NC_MAX_VAR_DIMS];
-	    int d;
+	    size_t d;
 	    for(d=0;d<nclistlength(var->dims);d++) {
 		NCD4node* dim = (NCD4node*)nclistget(var->dims,d);
 		edges[d] = (size_t)dim->dim.size;

--- a/libdap4/d4dump.c
+++ b/libdap4/d4dump.c
@@ -3,6 +3,7 @@
 */
 
 #include "d4includes.h"
+#include <stddef.h>
 
 /*
 Provide a simple dump of binary data
@@ -87,7 +88,7 @@ NCD4_tagdump(size_t size, const void* data0, int swap, const char* tag)
 void
 NCD4_dumpvars(NCD4node* group)
 {
-    int i;
+    size_t i;
     fprintf(stderr,"%s.vars:\n",group->name);
     for(i=0;i<nclistlength(group->vars);i++) {
 	NCD4node* var = (NCD4node*)nclistget(group->vars,i);

--- a/libdap4/d4file.c
+++ b/libdap4/d4file.c
@@ -7,6 +7,7 @@
 #include "ncd4dispatch.h"
 #include "d4includes.h"
 #include "d4curlfunctions.h"
+#include <stddef.h>
 
 #ifdef _MSC_VER
 #include <process.h>
@@ -678,7 +679,7 @@ NCD4_newMeta(NCD4INFO* info, NCD4meta** metap)
 void
 NCD4_reclaimMeta(NCD4meta* dataset)
 {
-    int i;
+    size_t i;
     if(dataset == NULL) return;
 
     for(i=0;i<nclistlength(dataset->allnodes);i++) {

--- a/libdap4/d4fix.c
+++ b/libdap4/d4fix.c
@@ -5,6 +5,7 @@
 
 #include <stdarg.h>
 #include <assert.h>
+#include <stddef.h>
 
 #include "d4includes.h"
 
@@ -120,7 +121,7 @@ Do depth first search
 static void
 walk(NCD4node* node, NClist* sorted)
 {
-    int i;
+    size_t i;
 
     if(node->visited) return;
     node->visited = 1;
@@ -310,7 +311,7 @@ static int
 delimitStruct(NCD4meta* compiler, NCD4node* basetype, NCD4offset* offset)
 {
     int ret = NC_NOERR;
-    int i;
+    size_t i;
 
     /* The fields are associated with the basetype struct */
     for(i=0;i<nclistlength(basetype->vars);i++) {

--- a/libdap4/d4meta.c
+++ b/libdap4/d4meta.c
@@ -496,15 +496,14 @@ buildCompound(NCD4meta* builder, NCD4node* cmpdtype, NCD4node* group, char* name
 
     /* Step 3: add the fields to type */
     for(i=0;i<nclistlength(cmpdtype->vars);i++) {
-	int rank;
 	int dimsizes[NC_MAX_VAR_DIMS];
         NCD4node* field = (NCD4node*)nclistget(cmpdtype->vars,i);
-	rank = nclistlength(field->dims);
+	size_t rank = nclistlength(field->dims);
         if(rank == 0) { /* scalar */
             NCCHECK((nc_insert_compound(group->meta.id, cmpdtype->meta.id,
 					field->name, field->meta.offset,
 					field->basetype->meta.id)));
-        } else if(rank > 0) { /* array  */
+        } else { /* array  */
   	    int idimsizes[NC_MAX_VAR_DIMS];
 	    int j;
 	    getDimsizes(field,dimsizes);
@@ -513,7 +512,7 @@ buildCompound(NCD4meta* builder, NCD4node* cmpdtype, NCD4node* group, char* name
             NCCHECK((nc_insert_array_compound(group->meta.id, cmpdtype->meta.id,
 					      field->name, field->meta.offset,
 					      field->basetype->meta.id,
-					      rank, idimsizes)));
+					      (int)rank, idimsizes)));
 	}
     }
 
@@ -551,14 +550,13 @@ buildStructure(NCD4meta* builder, NCD4node* structvar)
 {
     int ret = NC_NOERR;
     NCD4node* group;
-    int rank;
     int dimids[NC_MAX_VAR_DIMS];
 
     /* Step 1: define the variable */
-    rank = nclistlength(structvar->dims);
+    size_t rank = nclistlength(structvar->dims);
     getDimrefs(structvar,dimids);
     group = NCD4_groupFor(structvar);
-    NCCHECK((nc_def_var(group->meta.id,structvar->name,structvar->basetype->meta.id,rank,dimids,&structvar->meta.id)));
+    NCCHECK((nc_def_var(group->meta.id,structvar->name,structvar->basetype->meta.id,(int)rank,dimids,&structvar->meta.id)));
     /* Tag the var */
     savevarbyid(group,structvar);
 
@@ -575,13 +573,12 @@ buildSequence(NCD4meta* builder, NCD4node* seq)
 
     int ret = NC_NOERR;
     NCD4node* group;
-    int rank;
     int dimids[NC_MAX_VAR_DIMS];
 
-    rank = nclistlength(seq->dims);
+    size_t rank = nclistlength(seq->dims);
     getDimrefs(seq,dimids);
     group = NCD4_groupFor(seq);
-    NCCHECK((nc_def_var(group->meta.id,seq->name,seq->basetype->meta.id,rank,dimids,&seq->meta.id)));
+    NCCHECK((nc_def_var(group->meta.id,seq->name,seq->basetype->meta.id,(int)rank,dimids,&seq->meta.id)));
     savevarbyid(group,seq);
 
     /* Build attributes and map attributes WRT the variable */

--- a/libdap4/d4meta.c
+++ b/libdap4/d4meta.c
@@ -5,6 +5,7 @@
 
 #include "d4includes.h"
 #include <stdarg.h>
+#include <stddef.h>
 #include "nc4internal.h"
 #include "ncoffsets.h"
 
@@ -58,7 +59,7 @@ int
 NCD4_metabuild(NCD4meta* metadata, int ncid)
 {
     int ret = NC_NOERR;
-    int i;
+    size_t i;
 
     metadata->ncid = ncid;
     metadata->root->meta.id = ncid;
@@ -119,7 +120,8 @@ reclaimNode(NCD4node* node)
 static int
 build(NCD4meta* builder, NCD4node* root)
 {
-    int i,ret = NC_NOERR;
+    size_t i;
+    int ret = NC_NOERR;
     size_t len = nclistlength(builder->allnodes);
 
     /* Tag the root group */
@@ -223,7 +225,8 @@ done:
 static int
 buildGroups(NCD4meta* builder, NCD4node* parent)
 {
-    int i,ret=NC_NOERR;
+    size_t i;
+    int ret = NC_NOERR;
 #ifdef D4DEBUG
     fprintf(stderr,"build group: %s\n",parent->name);
 #endif
@@ -261,7 +264,8 @@ done:
 static int
 buildEnumeration(NCD4meta* builder, NCD4node* en)
 {
-    int i,ret = NC_NOERR;
+    size_t i;
+    int ret = NC_NOERR;
     NCD4node* group = NCD4_groupFor(en);
     NCCHECK((nc_def_enum(group->meta.id,en->basetype->meta.id,en->name,&en->meta.id)));
     for(i=0;i<nclistlength(en->en.econsts);i++) {
@@ -342,7 +346,8 @@ done:
 static int
 buildMaps(NCD4meta* builder, NCD4node* var)
 {
-    int i,ret = NC_NOERR;
+    size_t i;
+    int ret = NC_NOERR;
     size_t count = nclistlength(var->maps);
     char** memory = NULL;
     char** p;
@@ -372,7 +377,8 @@ done:
 static int
 buildAttributes(NCD4meta* builder, NCD4node* varorgroup)
 {
-    int i,ret = NC_NOERR;
+    size_t i;
+    int ret = NC_NOERR;
     NClist* blobs = NULL;
 
     for(i=0;i<nclistlength(varorgroup->attributes);i++) {
@@ -479,7 +485,8 @@ done:
 static int
 buildCompound(NCD4meta* builder, NCD4node* cmpdtype, NCD4node* group, char* name)
 {
-    int i,ret = NC_NOERR;
+    size_t i;
+    int ret = NC_NOERR;
 
     /* Step 1: compute field offsets */
     computeOffsets(builder,cmpdtype);
@@ -613,7 +620,7 @@ savevarbyid(NCD4node* group, NCD4node* var)
 char*
 NCD4_getVarFQN(NCD4node* var, const char* tail)
 {
-    int i;
+    size_t i;
     NCD4node* x = NULL;
     NClist* path = NULL;
     NCbytes* fqn =  NULL;
@@ -646,7 +653,7 @@ NCD4_getVarFQN(NCD4node* var, const char* tail)
 static char*
 getFieldFQN(NCD4node* field, const char* tail)
 {
-    int i;
+    size_t i;
     NCD4node* x = NULL;
     NClist* path = NULL;
     NCbytes* fqn =  NULL;
@@ -676,8 +683,8 @@ getFieldFQN(NCD4node* field, const char* tail)
 static size_t
 getDimrefs(NCD4node* var, int* dimids)
 {
-    int i;
-    int rank = nclistlength(var->dims);
+    size_t i;
+    size_t rank = nclistlength(var->dims);
     for(i=0;i<rank;i++) {
 	NCD4node* dim = (NCD4node*)nclistget(var->dims,i);
 	dimids[i] = dim->meta.id;
@@ -688,8 +695,8 @@ getDimrefs(NCD4node* var, int* dimids)
 static size_t
 getDimsizes(NCD4node* var, int* dimsizes)
 {
-    int i;
-    int rank = nclistlength(var->dims);
+    size_t i;
+    size_t rank = nclistlength(var->dims);
     for(i=0;i<rank;i++) {
 	NCD4node* dim = (NCD4node*)nclistget(var->dims,i);
 	dimsizes[i] = (int)dim->dim.size;
@@ -720,7 +727,8 @@ to nc_put_att().
 static int
 compileAttrValues(NCD4meta* builder, NCD4node* attr, void** memoryp, NClist* blobs)
 {
-    int i,ret = NC_NOERR;
+    size_t i;
+    int ret = NC_NOERR;
     unsigned char* memory = NULL;
     unsigned char* p;
     size_t size;
@@ -730,7 +738,7 @@ compileAttrValues(NCD4meta* builder, NCD4node* attr, void** memoryp, NClist* blo
     NCD4node* container = attr->container;
     NCD4node* basetype = attr->basetype;
     NClist* values = attr->attr.values;
-    int count = nclistlength(values);
+    size_t count = nclistlength(values);
 
     memset((void*)&converter,0,sizeof(converter));
 
@@ -887,7 +895,8 @@ Note: this will work if the econst string is a number or a econst name
 static int
 decodeEconst(NCD4meta* builder, NCD4node* enumtype, const char* nameorval, union ATOMICS* converter)
 {
-    int i,ret=NC_NOERR;
+    size_t i;
+    int ret = NC_NOERR;
     union ATOMICS number;
     NCD4node* match = NULL;
 
@@ -949,7 +958,7 @@ backslashEscape(const char* s)
 static int
 markfixedsize(NCD4meta* meta)
 {
-    int i,j;
+    size_t i,j;
     for(i=0;i<nclistlength(meta->allnodes);i++) {
 	int fixed = 1;
 	NCD4node* n = (NCD4node*)nclistget(meta->allnodes,i);
@@ -979,7 +988,7 @@ markfixedsize(NCD4meta* meta)
 static void
 computeOffsets(NCD4meta* builder, NCD4node* cmpd)
 {
-    int i;
+    size_t i;
     d4size_t offset = 0;
     d4size_t largestalign = 1;
     d4size_t size = 0;
@@ -1103,7 +1112,7 @@ getpadding(d4size_t offset, size_t alignment)
 static int
 markdapsize(NCD4meta* meta)
 {
-    int i,j;
+    size_t i,j;
     for(i=0;i<nclistlength(meta->allnodes);i++) {
 	NCD4node* type = (NCD4node*)nclistget(meta->allnodes,i);
 	size_t totalsize;
@@ -1161,10 +1170,10 @@ NCD4_findvar(NC* ncp, int gid, int varid, NCD4node** varp, NCD4node** grpp)
 	return THROW(NC_EBADID);
     /* Locate var node via (grpid,varid) */
     grp_id = GROUPIDPART(gid);
-    group = nclistget(meta->groupbyid,grp_id);
+    group = nclistget(meta->groupbyid, (size_t)grp_id);
     if(group == NULL)
 	return THROW(NC_EBADID);
-    var = nclistget(group->group.varbyid,varid);
+    var = nclistget(group->group.varbyid, (size_t)varid);
     if(var == NULL)
 	return THROW(NC_EBADID);
     if(varp) *varp = var;

--- a/libdap4/d4parser.c
+++ b/libdap4/d4parser.c
@@ -6,6 +6,7 @@
 #include "d4includes.h"
 #include <stdarg.h>
 #include <assert.h>
+#include <stddef.h>
 #include "ncxml.h"
 
 /**
@@ -878,7 +879,8 @@ Find or create an opaque type
 static NCD4node*
 getOpaque(NCD4parser* parser, ncxml_t varxml, NCD4node* group)
 {
-    int i, ret = NC_NOERR;
+    size_t i;
+    int ret = NC_NOERR;
     long long len;
     NCD4node* opaquetype = NULL;
     char* xattr;
@@ -1024,7 +1026,7 @@ done:
 NCD4node*
 NCD4_findAttr(NCD4node* container, const char* attrname)
 {
-    int i;
+    size_t i;
     /* Look directly under this xml for <Attribute> */
     for(i=0;i<nclistlength(container->attributes);i++) {
 	NCD4node* attr = (NCD4node*)nclistget(container->attributes,i);
@@ -1095,7 +1097,8 @@ static int
 lookupFQNList(NCD4parser* parser, NClist* fqn, NCD4sort sort, NCD4node** result)
 {
     int ret = NC_NOERR;
-    int i,nsteps;
+    size_t i;
+    int nsteps;
     NCD4node* current;
     char* name = NULL;
     NCD4node* node = NULL;
@@ -1139,7 +1142,7 @@ lookupFQNList(NCD4parser* parser, NClist* fqn, NCD4sort sort, NCD4node** result)
     assert (i < (nsteps - 1));
     i++; /* skip variable name */
     for(;;i++) {
-	int j;
+	size_t j;
 	name = (char*)nclistget(fqn,i);
 	assert(ISTYPE(current->sort) && ISCMPD(current->subsort));
 	for(node=NULL,j=0;j<nclistlength(current->vars);j++) {
@@ -1166,7 +1169,7 @@ notfound:
 static NCD4node*
 lookFor(NClist* elems, const char* name, NCD4sort sort)
 {
-    int n,i;
+    size_t n,i;
     if(elems == NULL || nclistlength(elems) == 0) return NULL;
     n = nclistlength(elems);
     for(i=0;i<n;i++) {
@@ -1180,7 +1183,7 @@ lookFor(NClist* elems, const char* name, NCD4sort sort)
 void
 NCD4_printElems(NCD4node* group)
 {
-    int n,i;
+    size_t n,i;
     NClist* elems;
     elems = group->group.elements;
     if(elems == NULL || nclistlength(elems) == 0) return;
@@ -1646,7 +1649,7 @@ static int
 parseForwards(NCD4parser* parser, NCD4node* root)
 {
     int ret = NC_NOERR;
-    int i,j;
+    size_t i,j;
 
     /* process all vars */
     for(i=0;i<nclistlength(parser->vars);i++) {

--- a/libdap4/d4printer.c
+++ b/libdap4/d4printer.c
@@ -4,6 +4,7 @@
  *********************************************************************/
 
 #include "d4includes.h"
+#include <stddef.h>
 
 /**
 This provides a simple dap4  metadata -> xml printer.
@@ -87,7 +88,7 @@ static int
 printNode(D4printer* out, NCD4node* node, int depth)
 {
     int ret = NC_NOERR;
-    int i;
+    size_t i;
     char* fqn = NULL;
 
     switch (node->sort) {
@@ -297,13 +298,12 @@ static int
 printGroupBody(D4printer* out, NCD4node* node, int depth)
 {
     int ret = NC_NOERR;
-    int i,ngroups,nvars,ntypes,ndims,nattrs;
-
-    ngroups = nclistlength(node->groups);
-    nvars = nclistlength(node->vars);
-    ntypes = nclistlength(node->types);
-    ndims = nclistlength(node->dims);
-    nattrs = nclistlength(node->attributes);
+    size_t i;
+    size_t ngroups = nclistlength(node->groups);
+    size_t nvars = nclistlength(node->vars);
+    size_t ntypes = nclistlength(node->types);
+    size_t ndims = nclistlength(node->dims);
+    size_t nattrs = nclistlength(node->attributes);
 
     if(ndims > 0) {
 	INDENT(depth);
@@ -371,7 +371,7 @@ static int
 printMetaData(D4printer* out, NCD4node* node, int depth)
 {
     int ret = NC_NOERR;
-    int i;
+    size_t i;
 
     if(nclistlength(node->dims) > 0) {
 	for(i=0;i<nclistlength(node->dims);i++) {
@@ -456,7 +456,7 @@ static int
 printAttribute(D4printer* out, NCD4node* attr, int depth)
 {
     int ret = NC_NOERR;
-    int i = 0;
+    size_t i = 0;
     char* fqn = NULL;
 
     INDENT(depth); CAT("<Attribute");

--- a/libdap4/d4swap.c
+++ b/libdap4/d4swap.c
@@ -5,6 +5,7 @@
 
 #include "d4includes.h"
 #include <stdarg.h>
+#include <stddef.h>
 #include "d4includes.h"
 
 /*
@@ -151,7 +152,7 @@ static int
 walkStruct(NCD4response* resp, NCD4node* topvar, NCD4node* structtype, NCD4offset* offset, int doswap)
 {
     int ret = NC_NOERR;
-    int i;
+    size_t i;
 
     for(i=0;i<nclistlength(structtype->vars);i++) {
 	NCD4node* field = (NCD4node*)nclistget(structtype->vars,i);

--- a/libdap4/d4util.c
+++ b/libdap4/d4util.c
@@ -4,6 +4,7 @@
  *********************************************************************/
 
 #include "d4includes.h"
+#include <stddef.h>
 #ifdef HAVE_SYS_STAT_H
 #include <sys/stat.h>
 #endif
@@ -92,7 +93,7 @@ NCD4_typesize(nc_type tid)
 d4size_t
 NCD4_dimproduct(NCD4node* node)
 {
-    int i;
+    size_t i;
     d4size_t product = 1;
     for(i=0;i<nclistlength(node->dims);i++) {
         NCD4node* dim = (NCD4node*)nclistget(node->dims,i);
@@ -156,7 +157,7 @@ create the last part of the fqn
 char*
 NCD4_makeName(NCD4node* elem, const char* sep)
 {
-    int i;
+    size_t i;
     size_t estimate = 0;
     NCD4node* n;
     NClist* path = nclistnew();

--- a/libdap4/d4varx.c
+++ b/libdap4/d4varx.c
@@ -9,6 +9,7 @@
 #include "nc4internal.h"
 #include "d4includes.h"
 #include "d4odom.h"
+#include <stddef.h>
 
 /* Forward */
 static int getvarx(int gid, int varid, NCD4INFO**, NCD4node** varp, nc_type* xtypep, size_t*, nc_type* nc4typep, size_t*);
@@ -31,7 +32,8 @@ NCD4_get_vars(int gid, int varid,
 	    const size_t *start, const size_t *edges, const ptrdiff_t* stride,
             void *memoryin, nc_type xtype)
 {
-    int i,ret;
+    size_t i;
+    int ret;
     NCD4INFO* info;
     NCD4meta* meta;
     NCD4node* ncvar;
@@ -41,7 +43,7 @@ NCD4_get_vars(int gid, int varid,
     size_t nc4size, xsize, dapsize;
     void* instance = NULL; /* Staging area in case we have to convert */
     NClist* blobs = NULL;
-    int rank;
+    size_t rank;
     size_t dimsizes[NC_MAX_VAR_DIMS];
     d4size_t dimproduct;
     size_t dstpos;
@@ -246,7 +248,8 @@ findbyname(const char* name, NClist* nodes)
 static int
 matchvar(NCD4meta* dmrmeta, NCD4node* dapvar, NCD4node** dmrvarp)
 {
-    int i,ret = NC_NOERR;
+    size_t i;
+    int ret = NC_NOERR;
     NCD4node* x = NULL;
     NClist* dappath = nclistnew();
     NClist* dmrpath = nclistnew(); /* compute path for this dmr var */
@@ -259,7 +262,7 @@ matchvar(NCD4meta* dmrmeta, NCD4node* dapvar, NCD4node** dmrvarp)
     for(i=0;i<nclistlength(dmrmeta->allnodes);i++) {
 	NCD4node* node = (NCD4node*)nclistget(dmrmeta->allnodes,i);
 	if(ISVAR(node->sort) && strcmp(node->name,dapvar->name)==0) { /* possible candidate */
-	    int j;
+	    size_t j;
     	    found = 0;
 	    nclistclear(dmrpath);
 	    for(x=node;x != NULL;x=x->container) nclistinsert(dmrpath,0,x);
@@ -292,7 +295,8 @@ toplevel dmr var and transfer necessary info;
 static int
 mapvars(NCD4meta* dapmeta, NCD4meta* dmrmeta, int inferredchecksumming)
 {
-    int i, ret = NC_NOERR;
+    size_t i;
+    int ret = NC_NOERR;
     NCD4node* daproot = dapmeta->root;
     NClist* daptop = NULL; /* top variables in dap tree */
 

--- a/libdap4/ncd4dispatch.c
+++ b/libdap4/ncd4dispatch.c
@@ -3,6 +3,7 @@
  *   See netcdf/COPYRIGHT file for copying and redistribution conditions.
  *********************************************************************/
 
+#include <stddef.h>
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -841,7 +842,7 @@ NCD4_inq_dim(int ncid, int dimid, char* name, size_t* lenp)
     NC* ncp;
     NCD4INFO* info;
     NCD4meta* meta;
-    int i;
+    size_t i;
     NCD4node* dim = NULL;
 
     if((ret = NC_check_id(ncid, (NC**)&ncp)) != NC_NOERR)

--- a/libdispatch/dhttp.c
+++ b/libdispatch/dhttp.c
@@ -8,6 +8,7 @@
 */
 
 #include "config.h"
+#include <stddef.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -715,7 +716,7 @@ headersoff(NC_HTTP_STATE* state)
 static int
 lookupheader(NC_HTTP_STATE* state, const char* key, const char** valuep)
 {
-    int i;
+    size_t i;
     const char* value = NULL;
     /* Get the content length header */
     for(i=0;i<nclistlength(state->curl.response.headers);i+=2) {

--- a/libdispatch/dinfermodel.c
+++ b/libdispatch/dinfermodel.c
@@ -9,6 +9,7 @@
 */
 
 #include "config.h"
+#include <stddef.h>
 #include <stdlib.h>
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
@@ -399,7 +400,7 @@ done:
 static char*
 envvlist2string(NClist* envv, const char* delim)
 {
-    int i;
+    size_t i;
     NCbytes* buf = NULL;
     char* result = NULL;
 
@@ -441,7 +442,8 @@ processmodearg(const char* arg, NCmodel* model)
 static int
 processmacros(NClist* fraglenv, NClist* expanded)
 {
-    int i, stat = NC_NOERR;
+    size_t i;
+    int stat = NC_NOERR;
     const struct MACRODEF* macros = NULL;
 
     for(i=0;i<nclistlength(fraglenv);i+=2) {
@@ -478,7 +480,7 @@ processinferences(NClist* fraglenv)
     NClist* newmodes = nclistnew();
     NClist* currentmodes = NULL;
     NClist* nextmodes = nclistnew();
-    int i;
+    size_t i;
     char* newmodeval = NULL;
 
     /* Get "mode" entry */
@@ -574,7 +576,7 @@ negateone(const char* mode, NClist* newmodes)
 static void
 infernext(NClist* current, NClist* next)
 {
-    int i;
+    size_t i;
     for(i=0;i<nclistlength(current);i++) {
         const struct MODEINFER* tests = NULL;
 	const char* cur = nclistget(current,i);
@@ -594,7 +596,7 @@ Given a list of strings, remove nulls and duplicates
 static int
 mergelist(NClist** valuesp)
 {
-    int i,j;
+    size_t i,j;
     int stat = NC_NOERR;
     NClist* values = *valuesp;
     NClist* allvalues = nclistnew();
@@ -634,7 +636,7 @@ done:
 static int
 lcontains(NClist* l, const char* key0)
 {
-    int i;
+    size_t i;
     for(i=0;i<nclistlength(l);i++) {
         const char* key1 = nclistget(l,i);
 	if(strcasecmp(key0,key1)==0) return 1;
@@ -646,7 +648,7 @@ lcontains(NClist* l, const char* key0)
 static void
 collectvaluesbykey(NClist* fraglenv, const char* key, NClist* values)
 {
-    int i;
+    size_t i;
     /* collect all the values with the same key (including this one) */
     for(i=0;i<nclistlength(fraglenv);i+=2) {
         const char* key2 = nclistget(fraglenv,i);
@@ -661,7 +663,7 @@ collectvaluesbykey(NClist* fraglenv, const char* key, NClist* values)
 static void
 collectallkeys(NClist* fraglenv, NClist* allkeys)
 {
-    int i;
+    size_t i;
     /* collect all the distinct keys */
     for(i=0;i<nclistlength(fraglenv);i+=2) {
 	char* key = nclistget(fraglenv,i);
@@ -675,7 +677,8 @@ collectallkeys(NClist* fraglenv, NClist* allkeys)
 static int
 cleanfragments(NClist* fraglenv, NClist* newlist)
 {
-    int i,stat = NC_NOERR;
+    size_t i;
+    int stat = NC_NOERR;
     NClist* tmp = NULL;
     NClist* allkeys = NULL;
     NCbytes* buf = NULL;
@@ -836,7 +839,8 @@ set_default_mode(int* modep)
 int
 NC_infermodel(const char* path, int* omodep, int iscreate, int useparallel, void* params, NCmodel* model, char** newpathp)
 {
-    int i,stat = NC_NOERR;
+    size_t i;
+    int stat = NC_NOERR;
     NCURI* uri = NULL;
     int omode = *omodep;
     NClist* fraglenv = nclistnew();
@@ -1100,7 +1104,7 @@ done:
 static const char*
 getmodekey(const NClist* envv)
 {
-    int i;
+    size_t i;
     /* Get "mode" entry */
     for(i=0;i<nclistlength(envv);i+=2) {
 	char* key = NULL;
@@ -1114,7 +1118,7 @@ getmodekey(const NClist* envv)
 static int
 replacemode(NClist* envv, const char* newval)
 {
-    int i;
+    size_t i;
     /* Get "mode" entry */
     for(i=0;i<nclistlength(envv);i+=2) {
 	char* key = NULL;
@@ -1143,7 +1147,7 @@ parsemode(const char* modeval)
 static char*
 list2string(NClist* list)
 {
-    int i;
+    size_t i;
     NCbytes* buf = NULL;
     char* result = NULL;
 

--- a/libdispatch/drc.c
+++ b/libdispatch/drc.c
@@ -4,6 +4,7 @@ See COPYRIGHT for license information.
 */
 
 #include "config.h"
+#include <stddef.h>
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
@@ -204,7 +205,7 @@ rcfreeentry(NCRCentry* t)
 static void
 rcfreeentries(NClist* rc)
 {
-    int i;
+    size_t i;
     for(i=0;i<nclistlength(rc);i++) {
 	NCRCentry* t = (NCRCentry*)nclistget(rc,i);
 	rcfreeentry(t);
@@ -216,7 +217,8 @@ rcfreeentries(NClist* rc)
 static int
 NC_rcload(void)
 {
-    int i,ret = NC_NOERR;
+    size_t i;
+    int ret = NC_NOERR;
     char* path = NULL;
     NCglobalstate* globalstate = NULL;
     NClist* rcfileorder = nclistnew();
@@ -397,8 +399,8 @@ rctrim(char* text)
 static void
 rcorder(NClist* rc)
 {
-    int i;
-    int len = nclistlength(rc);
+    size_t i;
+    size_t len = nclistlength(rc);
     NClist* tmprc = NULL;
     if(rc == NULL || len == 0) return;
     tmprc = nclistnew();
@@ -596,7 +598,7 @@ rcequal(NCRCentry* e1, NCRCentry* e2)
 static int
 rclocatepos(const char* key, const char* hostport, const char* urlpath)
 {
-    int i;
+    size_t i;
     NCglobalstate* globalstate = NC_getglobalstate();
     struct NCRCinfo* info = globalstate->rcinfo;
     NCRCentry* entry = NULL;
@@ -612,7 +614,7 @@ rclocatepos(const char* key, const char* hostport, const char* urlpath)
 
     for(i=0;i<nclistlength(rc);i++) {
       entry = (NCRCentry*)nclistget(rc,i);
-      if(rcequal(entry,&candidate)) return i;
+      if(rcequal(entry,&candidate)) return (int)i;
     }
     return -1;
 }
@@ -972,7 +974,8 @@ done:
 static int
 awsparse(const char* text, NClist* profiles)
 {
-    int i,stat = NC_NOERR;
+    size_t i;
+    int stat = NC_NOERR;
     size_t len;
     AWSparser* parser = NULL;
     struct AWSprofile* profile = NULL;
@@ -1095,7 +1098,7 @@ static void
 freeprofile(struct AWSprofile* profile)
 {
     if(profile) {
-	int i;
+	size_t i;
 #ifdef AWSDEBUG
 fprintf(stderr,">>> freeprofile: %s\n",profile->name);
 #endif
@@ -1113,7 +1116,7 @@ static void
 freeprofilelist(NClist* profiles)
 {
     if(profiles) {
-	int i;
+	size_t i;
 	for(i=0;i<nclistlength(profiles);i++) {
 	    struct AWSprofile* p = (struct AWSprofile*)nclistget(profiles,i);
 	    freeprofile(p);
@@ -1208,7 +1211,7 @@ int
 NC_authgets3profile(const char* profilename, struct AWSprofile** profilep)
 {
     int stat = NC_NOERR;
-    int i = -1;
+    size_t i;
     NCglobalstate* gstate = NC_getglobalstate();
 
     for(i=0;i<nclistlength(gstate->rcinfo->s3profiles);i++) {
@@ -1231,7 +1234,8 @@ done:
 int
 NC_s3profilelookup(const char* profile, const char* key, const char** valuep)
 {
-    int i,stat = NC_NOERR;
+    size_t i;
+    int stat = NC_NOERR;
     struct AWSprofile* awsprof = NULL;
     const char* value = NULL;
 

--- a/libdispatch/ds3util.c
+++ b/libdispatch/ds3util.c
@@ -52,7 +52,8 @@ if provided, otherwise us-east-1.
 int
 NC_s3urlrebuild(NCURI* url, NCS3INFO* s3, NCURI** newurlp)
 {
-    int i,stat = NC_NOERR;
+    size_t i;
+    int stat = NC_NOERR;
     NClist* hostsegments = NULL;
     NClist* pathsegments = NULL;
     NCbytes* buf = ncbytesnew();

--- a/libdispatch/dutil.c
+++ b/libdispatch/dutil.c
@@ -4,6 +4,7 @@
  *********************************************************************/
 
 #include "config.h"
+#include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
@@ -378,7 +379,7 @@ NC_testmode(NCURI* uri, const char* tag)
 {
     int stat = NC_NOERR;
     int found = 0;
-    int i;
+    size_t i;
     const char* modestr = NULL;
     NClist* modelist = NULL;
 
@@ -467,7 +468,7 @@ int
 NC_join(NClist* segments, char** pathp)
 {
     int stat = NC_NOERR;
-    int i;
+    size_t i;
     NCbytes* buf = NULL;
 
     if(segments == NULL)

--- a/libdispatch/nclist.c
+++ b/libdispatch/nclist.c
@@ -1,5 +1,6 @@
 /* Copyright 2018, UCAR/Unidata and OPeNDAP, Inc.
    See the COPYRIGHT file for more information. */
+#include <stddef.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -270,7 +271,7 @@ nclistclone(const NClist* l, int deep)
         nclistsetlength(clone,l->length);
         memcpy((void*)clone->content,(void*)l->content,sizeof(void*)*l->length);
     } else { /*deep*/
-	int i;
+	size_t i;
 	for(i=0;i<nclistlength(l);i++) {
 	    char* dups = strdup(nclistget(l,i));
 	    if(dups == NULL) {nclistfreeall(clone); clone = NULL; goto done;}

--- a/libdispatch/ncuri.c
+++ b/libdispatch/ncuri.c
@@ -4,6 +4,7 @@
  *   $Header$
  *********************************************************************/
 #include "config.h"
+#include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
@@ -431,7 +432,7 @@ static void
 freestringlist(NClist* list)
 {
     if(list != NULL) {
-	int i;
+	size_t i;
 	for(i=0;i<nclistlength(list);i++) {
 	    void* p = nclistget(list,i);
 	    nullfree(p);
@@ -553,8 +554,8 @@ ncurisetfragmentkey(NCURI* duri,const char* key, const char* value)
 	nclistpush(duri->fraglist,key);
 	nclistpush(duri->fraglist,value);
     } else {
-        nullfree(nclistget(duri->fraglist,pos+1));
-        nclistset(duri->fraglist,pos+1,strdup(value));
+        nullfree(nclistget(duri->fraglist,(size_t)pos+1));
+        nclistset(duri->fraglist,(size_t)pos+1,strdup(value));
     }
     /* Rebuild the fragment */
     nullfree(duri->fragment); duri->fragment = NULL;
@@ -576,8 +577,8 @@ ncuriappendfragmentkey(NCURI* duri,const char* key, const char* value)
 	nclistpush((NClist*)duri->fraglist,strdup(key));
 	nclistpush((NClist*)duri->fraglist,nulldup(value));
     } else {
-        nullfree(nclistget(duri->fraglist,pos+1));
-	nclistset(duri->fraglist,pos+1,nulldup(value));
+        nullfree(nclistget(duri->fraglist,(size_t)pos+1));
+	nclistset(duri->fraglist,(size_t)pos+1,nulldup(value));
     }
     /* Rebuild the fragment */
     nullfree(duri->fraglist); duri->fraglist = NULL;
@@ -600,8 +601,8 @@ ncurisetquerykey(NCURI* duri,const char* key, const char* value)
 	nclistpush(duri->querylist,key);
 	nclistpush(duri->querylist,value);
     } else {
-        nullfree(nclistget(duri->querylist,pos+1));
-        nclistset(duri->querylist,pos+1,strdup(value));
+        nullfree(nclistget(duri->querylist,(size_t)pos+1));
+        nclistset(duri->querylist,(size_t)pos+1,strdup(value));
     }
     /* Rebuild the query */
     nullfree(duri->query); duri->query = NULL;
@@ -623,8 +624,8 @@ ncuriappendquerykey(NCURI* duri,const char* key, const char* value)
 	nclistpush((NClist*)duri->querylist,strdup(key));
 	nclistpush((NClist*)duri->querylist,nulldup(value));
     } else {
-        nullfree(nclistget(duri->querylist,pos+1));
-	nclistset(duri->querylist,pos+1,nulldup(value));
+        nullfree(nclistget(duri->querylist,(size_t)pos+1));
+	nclistset(duri->querylist,(size_t)pos+1,nulldup(value));
     }
     /* Rebuild the query */
     nullfree(duri->querylist); duri->querylist = NULL;
@@ -768,7 +769,7 @@ ncurifragmentlookup(NCURI* uri, const char* key)
   if(ensurefraglist(uri)) return NULL;
   i = ncfind(uri->fraglist,key);
   if(i < 0) return NULL;
-  value = nclistget(uri->fraglist,i+1);
+  value = nclistget(uri->fraglist,(size_t)i+1);
   return value;
 }
 
@@ -781,7 +782,7 @@ ncuriquerylookup(NCURI* uri, const char* key)
   if(ensurequerylist(uri)) return NULL;
   i = ncfind(uri->querylist,key);
   if(i < 0) return NULL;
-  value = nclistget(uri->querylist,i+1);
+  value = nclistget(uri->querylist,(size_t)i+1);
   return value;
 }
 
@@ -832,7 +833,7 @@ ncfind(NClist* params, const char* key)
     if(key == NULL) return -1;
     if(params == NULL) return -1;
     for(i=0;i<nclistlength(params);i+=2) {
-        char* p=nclistget(params,i);
+        char* p=nclistget(params,(size_t)i);
 	if(strcasecmp(key,p)==0) return i;
     }
     return -1;
@@ -1274,7 +1275,7 @@ done:
 static void
 removedups(NClist* list)
 {
-    int i,j;
+    size_t i,j;
 
     if(nclistlength(list) <= 2) return; /* need at least 2 pairs */
     for(i=0;i<nclistlength(list);i+=2) {

--- a/libhdf5/hdf5filter.c
+++ b/libhdf5/hdf5filter.c
@@ -13,6 +13,7 @@
  */
 
 #include "config.h"
+#include <stddef.h>
 #include <stdlib.h>
 #include "hdf5internal.h"
 #include "hdf5debug.h"
@@ -335,7 +336,7 @@ fprintf(stderr,"\tid=%s\n",id);
 int
 NC4_hdf5_filter_lookup(NC_VAR_INFO_T* var, unsigned int id, struct NC_HDF5_Filter** specp)
 {
-    int i;
+    size_t i;
     NClist* flist = (NClist*)var->filters;
     
     if(flist == NULL) {
@@ -520,7 +521,7 @@ NC4_hdf5_inq_var_filter_ids(int ncid, int varid, size_t* nfiltersp, unsigned int
 
     nfilters = nclistlength(flist);
     if(nfilters > 0 && ids != NULL) {
-	int k;
+	size_t k;
 	for(k=0;k<nfilters;k++) {
 	    struct NC_HDF5_Filter* f = (struct NC_HDF5_Filter*)nclistget(flist,k);
 	    ids[k] = f->filterid;
@@ -569,7 +570,8 @@ done:
 int
 NC4_hdf5_find_missing_filter(NC_VAR_INFO_T* var, unsigned int* idp)
 {
-    int i,stat = NC_NOERR;
+    size_t i;
+    int stat = NC_NOERR;
     NClist* flist = (NClist*)var->filters;
     int id = 0;
     

--- a/libhdf5/hdf5internal.c
+++ b/libhdf5/hdf5internal.c
@@ -17,6 +17,7 @@
 #include "config.h"
 #include "hdf5internal.h"
 #include "hdf5err.h" /* For BAIL2 */
+#include <stddef.h>
 #ifdef _WIN32
 #include <windows.h>
 #endif
@@ -205,7 +206,7 @@ nc4_rec_find_hdf_type(NC_FILE_INFO_T *h5, hid_t target_hdf_typeid)
 {
     NC_TYPE_INFO_T *type;
     htri_t equal;
-    int i;
+    size_t i;
 
     assert(h5);
 

--- a/libhdf5/hdf5open.c
+++ b/libhdf5/hdf5open.c
@@ -18,6 +18,7 @@
 #include "ncauth.h"
 #include "ncmodel.h"
 #include "ncpathmgr.h"
+#include <stddef.h>
 
 #ifdef ENABLE_BYTERANGE
 #include "H5FDhttp.h"
@@ -2088,7 +2089,7 @@ read_type(NC_GRP_INFO_T *grp, hid_t hdf_typeid, char *type_name)
             return NC_EHDFERR;
         LOG((5, "compound type has %d members", nmembers));
         type->u.c.field = nclistnew();
-        nclistsetalloc(type->u.c.field,nmembers);
+        nclistsetalloc(type->u.c.field, (size_t)nmembers);
 
         for (m = 0; m < nmembers; m++)
         {
@@ -2253,7 +2254,7 @@ read_type(NC_GRP_INFO_T *grp, hid_t hdf_typeid, char *type_name)
         if ((nmembers = H5Tget_nmembers(hdf_typeid)) < 0)
             return NC_EHDFERR;
         type->u.e.enum_member = nclistnew();
-        nclistsetalloc(type->u.e.enum_member,nmembers);
+        nclistsetalloc(type->u.e.enum_member, (size_t)nmembers);
 
         /* Allocate space for one value. */
         if (!(value = calloc(1, type_size)))
@@ -2816,7 +2817,8 @@ rec_read_metadata(NC_GRP_INFO_T *grp)
     hid_t pid = -1;
     unsigned crt_order_flags = 0;
     H5_index_t iter_index;
-    int i, retval = NC_NOERR;
+    size_t i;
+    int retval = NC_NOERR;
 
     assert(grp && grp->hdr.name && grp->format_grp_info);
     LOG((3, "%s: grp->hdr.name %s", __func__, grp->hdr.name));

--- a/libhdf5/hdf5type.c
+++ b/libhdf5/hdf5type.c
@@ -14,6 +14,7 @@
 
 #include "config.h"
 #include "hdf5internal.h"
+#include <stddef.h>
 
 /**
  * @internal Determine if two types are equal.
@@ -69,11 +70,11 @@ NC4_inq_type_equal(int ncid1, nc_type typeid1, int ncid2,
     /* Not atomic types - so find type1 and type2 information. */
     if ((retval = nc4_find_nc4_grp(ncid1, &grpone)))
         return retval;
-    if (!(type1 = nclistget(grpone->nc4_info->alltypes, typeid1)))
+    if (!(type1 = nclistget(grpone->nc4_info->alltypes, (size_t)typeid1)))
         return NC_EBADTYPE;
     if ((retval = nc4_find_nc4_grp(ncid2, &grptwo)))
         return retval;
-    if (!(type2 = nclistget(grptwo->nc4_info->alltypes, typeid2)))
+    if (!(type2 = nclistget(grptwo->nc4_info->alltypes, (size_t)typeid2)))
         return NC_EBADTYPE;
 
     /* Are the two types equal? */

--- a/libhdf5/nc4hdf.c
+++ b/libhdf5/nc4hdf.c
@@ -22,6 +22,7 @@
 #include "hdf5err.h" /* For BAIL2 */
 #include "hdf5debug.h"
 #include <math.h>
+#include <stddef.h>
 
 #ifdef HAVE_INTTYPES_H
 #define __STDC_FORMAT_MACROS
@@ -886,7 +887,7 @@ var_create_dataset(NC_GRP_INFO_T *grp, NC_VAR_INFO_T *var, nc_bool_t write_dimid
      * nc_def_var_filter(). If the user
      * has specified a filter, it will be applied here. */
     if(var->filters != NULL) {
-	int j;
+	size_t j;
 	NClist* filters = (NClist*)var->filters;
 	for(j=0;j<nclistlength(filters);j++) {
 	    struct NC_HDF5_Filter* fi = (struct NC_HDF5_Filter*)nclistget(filters,j);
@@ -1191,7 +1192,7 @@ commit_type(NC_GRP_INFO_T *grp, NC_TYPE_INFO_T *type)
     {
         NC_FIELD_INFO_T *field;
         hid_t hdf_base_typeid, hdf_typeid;
-        int i;
+        size_t i;
 
         if ((hdf5_type->hdf_typeid = H5Tcreate(H5T_COMPOUND, type->size)) < 0)
             return NC_EHDFERR;
@@ -1255,7 +1256,7 @@ commit_type(NC_GRP_INFO_T *grp, NC_TYPE_INFO_T *type)
     else if (type->nc_type_class == NC_ENUM)
     {
         NC_ENUM_MEMBER_INFO_T *enum_m;
-        int i;
+        size_t i;
 
         if (nclistlength(type->u.e.enum_member) == 0)
             return NC_EINVAL;

--- a/libnczarr/zarr.c
+++ b/libnczarr/zarr.c
@@ -4,6 +4,7 @@
  *********************************************************************/
 
 #include "zincludes.h"
+#include <stddef.h>
 
 /**************************************************/
 /* Forwards */
@@ -296,7 +297,7 @@ done:
 static const char*
 controllookup(NClist* controls, const char* key)
 {
-    int i;
+    size_t i;
     for(i=0;i<nclistlength(controls);i+=2) {
         const char* p = (char*)nclistget(controls,i);
 	if(strcasecmp(key,p)==0) {
@@ -310,7 +311,8 @@ controllookup(NClist* controls, const char* key)
 static int
 applycontrols(NCZ_FILE_INFO_T* zinfo)
 {
-    int i,stat = NC_NOERR;
+    size_t i;
+    int stat = NC_NOERR;
     const char* value = NULL;
     NClist* modelist = nclistnew();
     int noflags = 0; /* track non-default negative flags */

--- a/libnczarr/zfile.c
+++ b/libnczarr/zfile.c
@@ -14,6 +14,7 @@
 
 #include "zincludes.h"
 #include "zfilter.h"
+#include <stddef.h>
 
 /* Forward */
 static int NCZ_enddef(NC_FILE_INFO_T* h5);
@@ -103,7 +104,7 @@ static int
 NCZ_enddef(NC_FILE_INFO_T* h5)
 {
     NC_VAR_INFO_T *var;
-    int i,j;
+    size_t i,j;
     int stat = NC_NOERR;
 
     ZTRACE(1,"h5=%s",h5->hdr.name);

--- a/libnczarr/zfilter.c
+++ b/libnczarr/zfilter.c
@@ -30,6 +30,7 @@
  */
 
 #include "config.h"
+#include <stddef.h>
 #include <stdlib.h>
 
 #ifdef HAVE_SYS_STAT_H
@@ -287,7 +288,8 @@ static int pluginnamecheck(const char* name);
 int
 NCZ_filter_freelists(NC_VAR_INFO_T* var)
 {
-    int i, stat=NC_NOERR;
+    size_t i;
+    int stat=NC_NOERR;
     NClist* filters = NULL;
     NCZ_VAR_INFO_T* zvar = (NCZ_VAR_INFO_T*)var->format_var_info;
 
@@ -444,7 +446,7 @@ done:
 static int
 NCZ_filter_lookup(NC_VAR_INFO_T* var, unsigned int id, struct NCZ_Filter** specp)
 {
-    int i;
+    size_t i;
     NClist* flist = (NClist*)var->filters;
     
     ZTRACE(6,"var=%s id=%u",var->hdr.name,id);
@@ -652,7 +654,7 @@ NCZ_inq_var_filter_ids(int ncid, int varid, size_t* nfiltersp, unsigned int* ids
 
     nfilters = nclistlength(flist); /* including incomplets */
     if(nfilters > 0 && ids != NULL) {
-	int k;
+	size_t k;
 	for(k=0;k<nfilters;k++) {
 	    struct NCZ_Filter* f = (struct NCZ_Filter*)nclistget(flist,k);
             ids[k] = f->hdf5.id;
@@ -842,7 +844,8 @@ done:
 int
 NCZ_applyfilterchain(const NC_FILE_INFO_T* file, NC_VAR_INFO_T* var, NClist* chain, size_t inlen, void* indata, size_t* outlenp, void** outdatap, int encode)
 {
-    int i, stat = NC_NOERR;
+    size_t i;
+    int stat = NC_NOERR;
     void* lastbuffer = NULL; /* if not null, then last allocated buffer */
     
     ZTRACE(6,"|chain|=%u inlen=%u indata=%p encode=%d", (unsigned)nclistlength(chain), (unsigned)inlen, indata, encode);
@@ -893,8 +896,9 @@ fprintf(stderr,">>> next: alloc=%u used=%u buf=%p\n",(unsigned)next_alloc,(unsig
 	    }
 	} else {
 	    /* Apply in reverse order */
-            for(i=nclistlength(chain)-1;i>=0;i--) {
-	        f = (struct NCZ_Filter*)nclistget(chain,i);	
+            int k;
+            for(k=(int)nclistlength(chain)-1;k>=0;k--) {
+              f = (struct NCZ_Filter*)nclistget(chain,(size_t)k);	
 		if(f->flags & FLAG_SUPPRESS) continue; /* this filter should not be applied */
 	        ff = f->plugin->hdf5.filter;
 	        /* code can be simplified */
@@ -1151,7 +1155,8 @@ done:
 static int
 NCZ_load_all_plugins(void)
 {
-    int i,j,ret = NC_NOERR;
+    size_t i,j;
+    int ret = NC_NOERR;
     char* pluginroots = NULL;
     struct stat buf;
     NClist* dirs = nclistnew();
@@ -1330,7 +1335,8 @@ done:
 static int
 NCZ_load_plugin_dir(const char* path)
 {
-    int i,stat = NC_NOERR;
+    size_t i;
+    int stat = NC_NOERR;
     size_t pathlen;
     NClist* contents = nclistnew();
     char* file = NULL;
@@ -1605,7 +1611,8 @@ pluginnamecheck(const char* name)
 int
 NCZ_codec_attr(const NC_VAR_INFO_T* var, size_t* lenp, void* data)
 {
-    int i,stat = NC_NOERR;
+    size_t i;
+    int stat = NC_NOERR;
     size_t len;
     char* contents = NULL;
     NCbytes* buf = NULL;
@@ -1761,7 +1768,8 @@ done:
 int
 NCZ_filter_setup(NC_VAR_INFO_T* var)
 {
-    int i,stat = NC_NOERR;
+    size_t i;
+    int stat = NC_NOERR;
     NClist* filters = NULL;
 
     ZTRACE(6,"var=%s",var->hdr.name);

--- a/libnczarr/zmap.c
+++ b/libnczarr/zmap.c
@@ -5,6 +5,7 @@
 
 #include "zincludes.h"
 #include <stdarg.h>
+#include <stddef.h>
 #include "ncpathmgr.h"
 
 /**************************************************/
@@ -217,7 +218,7 @@ int
 nczm_join(NClist* segments, char** pathp)
 {
     int stat = NC_NOERR;
-    int i;
+    size_t i;
     NCbytes* buf = NULL;
 
     if(segments == NULL)

--- a/libnczarr/zmap.c
+++ b/libnczarr/zmap.c
@@ -518,7 +518,7 @@ nczm_compare(const void* arg1, const void* arg2)
 
 /* quick sort a list of strings */
 void
-nczm_sortenvv(int n, char** envv)
+nczm_sortenvv(size_t n, char** envv)
 {
     if(n <= 1) return;
     qsort(envv, n, sizeof(char*), nczm_compare);

--- a/libnczarr/zmap.h
+++ b/libnczarr/zmap.h
@@ -136,6 +136,7 @@ of the implementation.
 #define ZMAP_H
 
 #include "ncexternl.h"
+#include <stddef.h>
 
 #define NCZM_SEP "/"
 
@@ -369,7 +370,7 @@ EXTERNL int nczm_lastsegment(const char* path, char** lastp);
 
 /* bubble sorts (note arguments) */
 EXTERNL void nczm_sortlist(struct NClist* l);
-EXTERNL void nczm_sortenvv(int n, char** envv);
+EXTERNL void nczm_sortenvv(size_t n, char** envv);
 EXTERNL void NCZ_freeenvv(int n, char** envv);
 
 #ifdef __cplusplus

--- a/libnczarr/zmap_file.c
+++ b/libnczarr/zmap_file.c
@@ -3,6 +3,7 @@
  *      See netcdf/COPYRIGHT file for copying and redistribution conditions.
  */
 
+#include <stddef.h>
 #undef DEBUG
 
 /* Not sure this has any effect */
@@ -529,7 +530,8 @@ static int
 zfcreategroup(ZFMAP* zfmap, const char* key, int nskip)
 {
     int stat = NC_NOERR;
-    int i, len;
+    size_t i;
+    int len;
     char* fullpath = NULL;
     NCbytes* path = ncbytesnew();
     NClist* segments = nclistnew();
@@ -948,7 +950,7 @@ static int
 platformdeleter(NCbytes* canonpath, int depth)
 {
     int ret = NC_NOERR;
-    int i;
+    size_t i;
     NClist* subfiles = nclistnew();
     size_t tpathlen = ncbyteslength(canonpath);
     char* local = NULL;

--- a/libnczarr/zsync.c
+++ b/libnczarr/zsync.c
@@ -5,6 +5,7 @@
 
 #include "zincludes.h"
 #include "zfilter.h"
+#include <stddef.h>
 
 #ifndef nulldup
  #define nulldup(x) ((x)?strdup(x):(x))
@@ -277,7 +278,8 @@ done:
 static int
 ncz_sync_var_meta(NC_FILE_INFO_T* file, NC_VAR_INFO_T* var, int isclose)
 {
-    int i,stat = NC_NOERR;
+    size_t i;
+    int stat = NC_NOERR;
     NCZ_FILE_INFO_T* zinfo = NULL;
     char number[1024];
     NCZMAP* map = NULL;
@@ -435,7 +437,7 @@ ncz_sync_var_meta(NC_FILE_INFO_T* file, NC_VAR_INFO_T* var, int isclose)
     if((stat = NCJaddstring(jvar,NCJ_STRING,"filters"))) goto done;
 #ifdef ENABLE_NCZARR_FILTERS
     if(nclistlength(filterchain) > 1) {
-	int k;
+	size_t k;
 	/* jtmp holds the array of filters */
 	if((stat = NCJnew(NCJ_ARRAY,&jtmp))) goto done;
 	for(k=0;k<nclistlength(filterchain)-1;k++) {
@@ -1029,7 +1031,7 @@ computeattrinfo(const char* name, NClist* atypes, nc_type typehint, int purezarr
 		nc_type* typeidp, size_t* typelenp, size_t* lenp, void** datap)
 {
     int stat = NC_NOERR;
-    int i;
+    size_t i;
     size_t len, typelen;
     void* data = NULL;
     nc_type typeid;
@@ -1401,7 +1403,8 @@ done:
 static int
 define_dims(NC_FILE_INFO_T* file, NC_GRP_INFO_T* grp, NClist* diminfo)
 {
-    int i,stat = NC_NOERR;
+    size_t i;
+    int stat = NC_NOERR;
 
     ZTRACE(3,"file=%s grp=%s |diminfo|=%u",file->controller->path,grp->hdr.name,nclistlength(diminfo));
 
@@ -1447,7 +1450,7 @@ static int
 define_vars(NC_FILE_INFO_T* file, NC_GRP_INFO_T* grp, NClist* varnames)
 {
     int stat = NC_NOERR;
-    int i,j;
+    size_t i,j;
     NCZ_FILE_INFO_T* zinfo = NULL;
     NCZMAP* map = NULL;
     int purezarr = 0;
@@ -1823,7 +1826,8 @@ done:
 static int
 define_subgrps(NC_FILE_INFO_T* file, NC_GRP_INFO_T* grp, NClist* subgrpnames)
 {
-    int i,stat = NC_NOERR;
+    size_t i;
+    int stat = NC_NOERR;
 
     ZTRACE(3,"file=%s grp=%s |subgrpnames|=%u",file->controller->path,grp->hdr.name,nclistlength(subgrpnames));
 
@@ -2059,7 +2063,8 @@ done:
 static int
 searchvars(NCZ_FILE_INFO_T* zfile, NC_GRP_INFO_T* grp, NClist* varnames)
 {
-    int i,stat = NC_NOERR;
+    size_t i;
+    int stat = NC_NOERR;
     char* grpkey = NULL;
     char* varkey = NULL;
     char* zarray = NULL;
@@ -2093,7 +2098,8 @@ done:
 static int
 searchsubgrps(NCZ_FILE_INFO_T* zfile, NC_GRP_INFO_T* grp, NClist* subgrpnames)
 {
-    int i,stat = NC_NOERR;
+    size_t i;
+    int stat = NC_NOERR;
     char* grpkey = NULL;
     char* subkey = NULL;
     char* zgroup = NULL;
@@ -2177,7 +2183,8 @@ Given a list of segments, find corresponding group.
 static int
 locategroup(NC_FILE_INFO_T* file, size_t nsegs, NClist* segments, NC_GRP_INFO_T** grpp)
 {
-    int i, j, found, stat = NC_NOERR;
+    size_t i, j;
+    int found, stat = NC_NOERR;
     NC_GRP_INFO_T* grp = NULL;
 
     grp = file->root_grp;
@@ -2206,13 +2213,14 @@ done:
 static int
 parsedimrefs(NC_FILE_INFO_T* file, NClist* dimnames, size64_t* shape, NC_DIM_INFO_T** dims, int create)
 {
-    int i, stat = NC_NOERR;
+    size_t i;
+    int stat = NC_NOERR;
     NClist* segments = NULL;
 
     for(i=0;i<nclistlength(dimnames);i++) {
 	NC_GRP_INFO_T* g = NULL;
 	NC_DIM_INFO_T* d = NULL;
-	int j;
+	size_t j;
 	const char* dimpath = nclistget(dimnames,i);
 	const char* dimname = NULL;
 
@@ -2369,7 +2377,7 @@ static int
 computedimrefs(NC_FILE_INFO_T* file, NC_VAR_INFO_T* var, int purezarr, int xarray, int ndims, NClist* dimnames, size64_t* shapes, NC_DIM_INFO_T** dims)
 {
     int stat = NC_NOERR;
-    int i;
+    size_t i;
     int createdims = 0; /* 1 => we need to create the dims in root if they do not already exist */
     NCZ_FILE_INFO_T* zfile = (NCZ_FILE_INFO_T*)file->format_file_info;
     NCZ_VAR_INFO_T* zvar = (NCZ_VAR_INFO_T*)(var->format_var_info);

--- a/libnczarr/ztype.c
+++ b/libnczarr/ztype.c
@@ -14,6 +14,7 @@
  */
 
 #include "zincludes.h"
+#include <stddef.h>
 
 /**
  * @internal Determine if two types are equal.
@@ -69,11 +70,11 @@ NCZ_inq_type_equal(int ncid1, nc_type typeid1, int ncid2,
     /* Not atomic types - so find type1 and type2 information. */
     if ((retval = nc4_find_nc4_grp(ncid1, &grpone)))
         return retval;
-    if (!(type1 = nclistget(grpone->nc4_info->alltypes, typeid1)))
+    if (!(type1 = nclistget(grpone->nc4_info->alltypes, (size_t)typeid1)))
         return NC_EBADTYPE;
     if ((retval = nc4_find_nc4_grp(ncid2, &grptwo)))
         return retval;
-    if (!(type2 = nclistget(grptwo->nc4_info->alltypes, typeid2)))
+    if (!(type2 = nclistget(grptwo->nc4_info->alltypes, (size_t)typeid2)))
         return NC_EBADTYPE;
 
 #ifdef LOOK

--- a/libnczarr/zutil.c
+++ b/libnczarr/zutil.c
@@ -11,6 +11,7 @@
  */
 
 #include "zincludes.h"
+#include <stddef.h>
 
 #undef DEBUG
 
@@ -125,7 +126,7 @@ NCZ_grpkey(const NC_GRP_INFO_T* grp, char** pathp)
     NClist* segments = nclistnew();
     NCbytes* path = NULL;
     NC_GRP_INFO_T* parent = NULL;
-    int i;
+    size_t i;
 
     nclistinsert(segments,0,(void*)grp);
     parent = grp->parent;
@@ -475,7 +476,8 @@ Note: need to test with "/", "", and with and without trailing "/".
 int
 NCZ_subobjects(NCZMAP* map, const char* prefix, const char* tag, char dimsep, NClist* objlist)
 {
-    int i,stat=NC_NOERR;
+    size_t i;
+    int stat = NC_NOERR;
     NClist* matches = nclistnew();
     NCbytes* path = ncbytesnew();
 

--- a/libnczarr/zxcache.c
+++ b/libnczarr/zxcache.c
@@ -14,6 +14,7 @@
 #include "zcache.h"
 #include "ncxcache.h"
 #include "zfilter.h"
+#include <stddef.h>
 
 #undef DEBUG
 
@@ -423,7 +424,7 @@ constraincache(NCZChunkCache* cache, size64_t needed)
 
     /* Flush from LRU end if we are at capacity */
     while(nclistlength(cache->mru) > cache->params.nelems || cache->used > final_size) {
-	int i;
+	size_t i;
 	void* ptr;
 	NCZCacheEntry* e = ncxcachelast(cache->xcache); /* last entry is the least recently used */
 	if(e == NULL) break;
@@ -773,7 +774,7 @@ get_chunk(NCZChunkCache* cache, NCZCacheEntry* entry)
         case NC_EEMPTY: empty = 1; stat = NC_NOERR;break;
 	default: goto done;
 	}
-        entry->isfiltered = FILTERED(cache); /* Is the data being read filtered? */
+        entry->isfiltered = (int)FILTERED(cache); /* Is the data being read filtered? */
 	if(tid == NC_STRING)
 	    entry->isfixedstring = 1; /* fill cache is in char[maxstrlen] format */
     }
@@ -890,7 +891,7 @@ NCZ_printxcache(NCZChunkCache* cache)
     static char xs[20000];
     NCbytes* buf = ncbytesnew();
     char s[8192];
-    int i;
+    size_t i;
 
     ncbytescat(buf,"NCZChunkCache:\n");
     snprintf(s,sizeof(s),"\tvar=%s\n\tndims=%u\n\tchunksize=%u\n\tchunkcount=%u\n\tfillchunk=%p\n",
@@ -916,7 +917,7 @@ NCZ_printxcache(NCZChunkCache* cache)
         ncbytescat(buf,"\t\t<empty>\n");
     for(i=0;i<nclistlength(cache->mru);i++) {
 	NCZCacheEntry* e = (NCZCacheEntry*)nclistget(cache->mru,i);
-	snprintf(s,sizeof(s),"\t\t[%d] ",i);
+	snprintf(s,sizeof(s),"\t\t[%zu] ", i);
 	ncbytescat(buf,s);
 	if(e == NULL)
 	    ncbytescat(buf,"<null>");

--- a/libsrc4/nc4internal.c
+++ b/libsrc4/nc4internal.c
@@ -24,6 +24,7 @@
 #include "ncdispatch.h" /* from libdispatch */
 #include "ncutf8.h"
 #include <stdarg.h>
+#include <stddef.h>
 #include "ncrc.h"
 
 /** @internal Number of reserved attributes. These attributes are
@@ -507,7 +508,7 @@ nc4_find_dim(NC_GRP_INFO_T *grp, int dimid, NC_DIM_INFO_T **dim,
     LOG((4, "%s: dimid %d", __func__, dimid));
 
     /* Find the dim info. */
-    if (!((*dim) = nclistget(grp->nc4_info->alldims, dimid)))
+    if (!((*dim) = nclistget(grp->nc4_info->alldims, (size_t)dimid)))
         return NC_EBADDIM;
 
     /* Give the caller the group the dimension is in. */
@@ -597,7 +598,7 @@ nc4_find_type(const NC_FILE_INFO_T *h5, nc_type typeid, NC_TYPE_INFO_T **type)
         return NC_NOERR;
 
     /* Find the type. */
-    if (!(*type = nclistget(h5->alltypes,typeid)))
+    if (!(*type = nclistget(h5->alltypes, (size_t)typeid)))
         return NC_EBADTYPID;
 
     return NC_NOERR;
@@ -1252,7 +1253,7 @@ field_free(NC_FIELD_INFO_T *field)
 int
 nc4_type_free(NC_TYPE_INFO_T *type)
 {
-    int i;
+    size_t i;
 
     assert(type && type->rc && type->hdr.name);
 

--- a/libsrc4/nc4type.c
+++ b/libsrc4/nc4type.c
@@ -13,6 +13,7 @@
  */
 #include "nc4internal.h"
 #include "nc4dispatch.h"
+#include <stddef.h>
 
 #if 0
 #ifdef ENABLE_DAP4
@@ -187,7 +188,7 @@ NC4_inq_type(int ncid, nc_type typeid1, char *name, size_t *size)
         return retval;
 
     /* Find this type. */
-    if (!(type = nclistget(grp->nc4_info->alltypes, typeid1)))
+    if (!(type = nclistget(grp->nc4_info->alltypes, (size_t)typeid1)))
         return NC_EBADTYPE;
 
     if (name)
@@ -237,7 +238,7 @@ NC4_inq_user_type(int ncid, nc_type typeid1, char *name, size_t *size,
         return retval;
 
     /* Find this type. */
-    if (!(type = nclistget(grp->nc4_info->alltypes, typeid1)))
+    if (!(type = nclistget(grp->nc4_info->alltypes, (size_t)typeid1)))
         return NC_EBADTYPE;
 
     /* Count the number of fields. */
@@ -316,11 +317,11 @@ NC4_inq_compound_field(int ncid, nc_type typeid1, int fieldid, char *name,
         return retval;
 
     /* Find this type. */
-    if (!(type = nclistget(grp->nc4_info->alltypes, typeid1)))
+    if (!(type = nclistget(grp->nc4_info->alltypes, (size_t)typeid1)))
         return NC_EBADTYPE;
 
     /* Find the field. */
-    if (!(field = nclistget(type->u.c.field,fieldid)))
+    if (!(field = nclistget(type->u.c.field, (size_t)fieldid)))
         return NC_EBADFIELD;
 
     if (name)
@@ -360,7 +361,7 @@ NC4_inq_compound_fieldindex(int ncid, nc_type typeid1, const char *name, int *fi
     NC_FIELD_INFO_T *field;
     char norm_name[NC_MAX_NAME + 1];
     int retval;
-    int i;
+    size_t i;
 
     LOG((2, "nc_inq_compound_fieldindex: ncid 0x%x typeid %d name %s",
          ncid, typeid1, name));
@@ -422,7 +423,7 @@ NC4_inq_enum_ident(int ncid, nc_type xtype, long long value, char *identifier)
     NC_TYPE_INFO_T *type;
     NC_ENUM_MEMBER_INFO_T *enum_member;
     long long ll_val;
-    int i;
+    size_t i;
     int retval;
     int found;
 
@@ -433,7 +434,7 @@ NC4_inq_enum_ident(int ncid, nc_type xtype, long long value, char *identifier)
         return retval;
 
     /* Find this type. */
-    if (!(type = nclistget(grp->nc4_info->alltypes, xtype)))
+    if (!(type = nclistget(grp->nc4_info->alltypes, (size_t)xtype)))
         return NC_EBADTYPE;
 
     /* Complain if they are confused about the type. */
@@ -525,7 +526,7 @@ NC4_inq_enum_member(int ncid, nc_type typeid1, int idx, char *identifier,
         return retval;
 
     /* Find this type. */
-    if (!(type = nclistget(grp->nc4_info->alltypes, typeid1)))
+    if (!(type = nclistget(grp->nc4_info->alltypes, (size_t)typeid1)))
         return NC_EBADTYPE;
 
     /* Complain if they are confused about the type. */
@@ -533,7 +534,7 @@ NC4_inq_enum_member(int ncid, nc_type typeid1, int idx, char *identifier,
         return NC_EBADTYPE;
 
     /* Move to the desired enum member in the list. */
-    if (!(enum_member = nclistget(type->u.e.enum_member, idx)))
+    if (!(enum_member = nclistget(type->u.e.enum_member, (size_t)idx)))
         return NC_EINVAL;
 
     /* Give the people what they want. */

--- a/libsrc4/ncindex.c
+++ b/libsrc4/ncindex.c
@@ -14,6 +14,7 @@
 */
 
 /* Define this for debug so that table sizes are small */
+#include <stddef.h>
 #undef SMALLTABLE
 #undef NCNOHASH
 
@@ -369,7 +370,7 @@ sortname(NC_SORT sort)
 void
 printindexlist(NClist* lm)
 {
-    int i;
+    size_t i;
     if(lm == NULL) {
         fprintf(stderr,"<empty>\n");
         return;
@@ -377,10 +378,10 @@ printindexlist(NClist* lm)
     for(i=0;i<nclistlength(lm);i++) {
         NC_OBJ* o = (NC_OBJ*)nclistget(lm,i);
         if(o == NULL)
-            fprintf(stderr,"[%ld] <null>\n",(unsigned long)i);
+            fprintf(stderr,"[%zu] <null>\n",i);
         else
-            fprintf(stderr,"[%ld] sort=%s name=|%s| id=%lu\n",
-                    (unsigned long)i,sortname(o->sort),o->name,(unsigned long)o->id);
+            fprintf(stderr,"[%zu] sort=%s name=|%s| id=%lu\n",
+                    i,sortname(o->sort),o->name,(unsigned long)o->id);
     }
 }
 

--- a/ncdump/nc4printer.c
+++ b/ncdump/nc4printer.c
@@ -10,6 +10,7 @@
 */
 
 #include "config.h"
+#include <stddef.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -146,7 +147,7 @@ NC4print(NCbytes* buf, int ncid)
 static void
 freeNC4Printer(NC4printer* out)
 {
-    int i;
+    size_t i;
 
     if(out == NULL) return;
 
@@ -612,17 +613,17 @@ getNumericValue(union NUMVALUE numvalue, nc_type base)
 static NCID*
 findType(NC4printer* out, nc_type t)
 {
-    int len = nclistlength(out->types);
+    size_t len = nclistlength(out->types);
     if(t >= len)
         abort();
-    return (NCID*)nclistget(out->types,t);
+    return (NCID*)nclistget(out->types, (size_t)t);
 }
 
 static NCID*
 findDim(NC4printer* out, int dimid)
 {
     if(nclistlength(out->dims) <= dimid) abort();
-    return (NCID*)nclistget(out->dims,dimid);
+    return (NCID*)nclistget(out->dims, (size_t)dimid);
 }
 
 static void

--- a/nczarr_test/ut_map.c
+++ b/nczarr_test/ut_map.c
@@ -322,7 +322,8 @@ done:
 static int
 searchR(NCZMAP* map, int depth, const char* prefix0, NClist* objects)
 {
-    int i,stat = NC_NOERR;
+    size_t i;
+    int stat = NC_NOERR;
     NClist* matches = nclistnew();
     char prefix[4096]; /* only ok because we know testdata */
     size_t prefixlen;
@@ -360,7 +361,8 @@ done:
 static int
 search(void)
 {
-    int i,stat = NC_NOERR;
+    size_t i;
+    int stat = NC_NOERR;
     NCZMAP* map = NULL;
     NClist* objects = nclistnew();
 
@@ -375,7 +377,7 @@ search(void)
     /* Print out the list */
     for(i=0;i<nclistlength(objects);i++) {
 	const char* key = nclistget(objects,i);
-	printf("[%d] %s\n",i,key);
+	printf("[%zu] %s\n",i,key);
     }
 
 done:

--- a/nczarr_test/ut_mapapi.c
+++ b/nczarr_test/ut_mapapi.c
@@ -4,6 +4,7 @@
  */
 
 #include "ut_includes.h"
+#include <stddef.h>
 
 #undef DEBUG
 
@@ -342,7 +343,8 @@ done:
 static int
 searchR(NCZMAP* map, int depth, const char* prefix0, NClist* objects)
 {
-    int i,stat = NC_NOERR;
+    size_t i;
+    int stat = NC_NOERR;
     NClist* matches = nclistnew();
     char prefix[4096]; /* only ok because we know testdata */
     size_t prefixlen;
@@ -382,7 +384,8 @@ done:
 static int
 search(void)
 {
-    int i,stat = NC_NOERR;
+    size_t i;
+    int stat = NC_NOERR;
     NCZMAP* map = NULL;
     NClist* objects = nclistnew();
 
@@ -398,7 +401,7 @@ search(void)
     /* Print out the list */
     for(i=0;i<nclistlength(objects);i++) {
 	const char* key = nclistget(objects,i);
-	printf("[%d] %s\n",i,key);
+	printf("[%zu] %s\n",i,key);
     }
 
 done:

--- a/nczarr_test/zmapio.c
+++ b/nczarr_test/zmapio.c
@@ -3,6 +3,7 @@
  *      See netcdf/COPYRIGHT file for copying and redistribution conditions.
  */
 
+#include <stddef.h>
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -249,7 +250,7 @@ implfor(const char* path)
     NCURI* uri = NULL;
     const char* mode = NULL;
     NClist* segments = nclistnew();
-    int i;
+    size_t i;
     NCZM_IMPL impl = NCZM_UNDEF;
 
     ncuriparse(path,&uri);
@@ -318,7 +319,7 @@ objdump(void)
     NClist* stack = nclistnew();
     char* obj = NULL;
     char* content = NULL;
-    int depth;
+    size_t depth;
 
     if((stat=nczmap_open(dumpoptions.impl, dumpoptions.infile, NC_NOCLOBBER, 0, NULL, &map)))
         goto done;
@@ -327,10 +328,10 @@ objdump(void)
     if((stat = breadthfirst(map,"/",stack))) goto done;
 
     if(dumpoptions.debug) {
-	int i;
+	size_t i;
         fprintf(stderr,"stack:\n");
         for(i=0;i<nclistlength(stack);i++)
-            fprintf(stderr,"[%d] %s\n",i,(char*)nclistget(stack,i));
+            fprintf(stderr,"[%zu] %s\n",i,(char*)nclistget(stack,i));
     }    
     for(depth=0;depth < nclistlength(stack);depth++) {
         size64_t len = 0;
@@ -359,7 +360,7 @@ objdump(void)
 		if(kind == OK_CHUNK) {
 		    len = ceildiv(len,dumpoptions.nctype->typesize);
 		}
-                printf("[%d] %s : (%llu)",depth,obj,len);
+                printf("[%zu] %s : (%llu)",depth,obj,len);
 		if(kind == OK_CHUNK &&  dumpoptions.nctype->nctype != NC_STRING)
                     printf(" (%s)",dumpoptions.nctype->typename);
                 printf(" |");
@@ -378,10 +379,10 @@ objdump(void)
 		}
 	        printf("|\n");
 	    } else {
-	        printf("[%d] %s : (%llu) ||\n",depth,obj,len);
+	        printf("[%zu] %s : (%llu) ||\n",depth,obj,len);
 	    }
 	} else {
-	    printf("[%d] %s\n",depth,obj);
+	    printf("[%zu] %s\n",depth,obj);
 	}
     }
 done:

--- a/oc2/dapparse.c
+++ b/oc2/dapparse.c
@@ -236,8 +236,8 @@ isnumber(const char* text)
 static void
 dimension(OCnode* node, NClist* dimensions)
 {
-    unsigned int i;
-    unsigned int rank = nclistlength(dimensions);
+    size_t i;
+    size_t rank = nclistlength(dimensions);
     node->array.dimensions = (NClist*)dimensions;
     node->array.rank = rank;
     for(i=0;i<rank;i++) {

--- a/oc2/dapparse.c
+++ b/oc2/dapparse.c
@@ -5,6 +5,7 @@
 #include "config.h"
 #include "dapparselex.h"
 #include "dapy.h"
+#include <stddef.h>
 
 /* Forward */
 
@@ -403,7 +404,7 @@ static NClist*
 scopeduplicates(NClist* list)
 {
     unsigned int i,j;
-    unsigned int len = nclistlength(list);
+    size_t len = nclistlength(list);
     NClist* dups = NULL;
     for(i=0;i<len;i++) {
 	OCnode* io = (OCnode*)nclistget(list,i);

--- a/oc2/ocnode.c
+++ b/oc2/ocnode.c
@@ -80,23 +80,23 @@ computefullname(OCnode* node)
 static char*
 pathtostring(NClist* path, char* separator)
 {
-    int slen,i,len;
+    size_t slen,i,len;
     char* pathname;
     if(path == NULL) return NULL;
     len = nclistlength(path);
     if(len == 0) return NULL;
     for(i=0,slen=0;i<len;i++) {
-	OCnode* node = (OCnode*)nclistget(path,(size_t)i);
+	OCnode* node = (OCnode*)nclistget(path, i);
 	if(node->container == NULL || node->name == NULL) continue;
 	slen += strlen(node->name);
     }
     slen += ((len-1)*strlen(separator));
     slen += 1;   /* for null terminator*/
-    pathname = (char*)ocmalloc((size_t)slen);
+    pathname = (char*)ocmalloc(slen);
     MEMCHECK(pathname,NULL);
     pathname[0] = '\0';
     for(i=0;i<len;i++) {
-	OCnode* node = (OCnode*)nclistget(path,(size_t)i);
+	OCnode* node = (OCnode*)nclistget(path, i);
 	if(node->container == NULL || node->name == NULL) continue;
 	if(strlen(pathname) > 0) strcat(pathname,separator);
         strcat(pathname,node->name);

--- a/oc2/ocnode.c
+++ b/oc2/ocnode.c
@@ -5,6 +5,7 @@
 #include "ocinternal.h"
 #include "occompile.h"
 #include "ocdebug.h"
+#include <stddef.h>
 
 static OCerror mergedas1(OCnode* dds, OCnode* das);
 static OCerror mergedods1(OCnode* dds, OCnode* das);
@@ -417,7 +418,7 @@ static OCerror
 mergeother(OCnode* ddsroot, NClist* dasnodes)
 {
     OCerror stat = OC_NOERR;
-    int i;
+    size_t i;
     for(i=0;i<nclistlength(dasnodes);i++) {
 	OCnode* das = (OCnode*)nclistget(dasnodes,i);
 	if(das == NULL) continue;
@@ -445,7 +446,7 @@ mergeother1(OCnode* root, OCnode* das)
         att = makeattribute(das->fullname,das->etype,das->att.values);	
         nclistpush(root->attributes,(void*)att);
     } else if(das->octype == OC_Attributeset) {
-	int i;
+	size_t i;
 	/* Recurse */
         for(i=0;i<nclistlength(das->subnodes);i++) {
 	    OCnode* sub = (OCnode*)nclistget(das->subnodes,i);


### PR DESCRIPTION
Fixes warnings about sign conversion from uses of `nclistget/nclistlength` and other `NClist` functions.

In a lot of the places that these functions are used, the index is an `int` instead of `size_t`, mostly in loops. In this PR, I've fixed these local variables to be `size_t` -- an alternative would be to change the API for `NClist` to use `int`, but unlike #2781 this still leaves >100 warnings, so there would still be lots of places that need fixing.

I've opted for changing the local variables to `size_t` rather than just casting the argument to `nclistget`, as this tended to fix multiple warnings in one go. There are a few places where casting is the better option, mostly where there's some interaction with a netCDF `int` ID.

There was one place (`libdap2/getvara.c`) where I also changed the function signature, but this was a local `static` function and I could verify all places where it is used.

I've left alone any place where there's some potentially unsafe arithmetic done with the list index, e.g. `index - 1` or `index--`, mostly in loops iterating backwards over the list. I just wanted to go for the easy, low hanging fruit here.

This silences >400 warnings.