### PR TITLE
Fix some important bugs in various files

### DIFF
--- a/include/ncpathmgr.h
+++ b/include/ncpathmgr.h
@@ -14,6 +14,9 @@
 #ifdef HAVE_DIRENT_H
 #include <dirent.h>
 #endif
+#ifdef HAVE_SYS_TYPES_H
+#include <sys/types.h>
+#endif
 #ifdef HAVE_SYS_STAT_H
 #include <sys/stat.h>
 #endif

--- a/include/ncs3sdk.h
+++ b/include/ncs3sdk.h
@@ -6,6 +6,9 @@
 #ifndef NCS3SDK_H
 #define NCS3SDK_H 1
 
+#define AWSHOST ".amazonaws.com"
+#define GOOGLEHOST "storage.googleapis.com"
+
 /* Track the server type, if known */
 typedef enum NCS3SVC {NCS3UNK=0, /* unknown */
                  NCS3=1,    /* s3.amazon.aws */

--- a/libdispatch/dcopy.c
+++ b/libdispatch/dcopy.c
@@ -694,7 +694,7 @@ searchgrouptree(int ncid1, int tid1, int grp, int* tid2)
     int gid;
     uintptr_t id;
 
-    id = grp;
+    id = (uintptr_t)grp;
     nclistpush(queue,(void*)id); /* prime the queue */
     while(nclistlength(queue) > 0) {
         id = (uintptr_t)nclistremove(queue,0);
@@ -712,7 +712,7 @@ searchgrouptree(int ncid1, int tid1, int grp, int* tid2)
             goto done;
 	/* push onto the end of the queue */
         for(i=0;i<nids;i++) {
-	    id = ids[i];
+	    id = (uintptr_t)ids[i];
 	    nclistpush(queue,(void*)id);
 	}
 	free(ids); ids = NULL;

--- a/libdispatch/derror.c
+++ b/libdispatch/derror.c
@@ -267,9 +267,9 @@ const char *nc_strerror(int ncerr1)
       case NC_EMPI: return "NetCDF: MPI operation failed.";
       case NC_ERCFILE:
 	return "NetCDF: RC File Failure.";
-     case NC_ENULLPAD:
+      case NC_ENULLPAD:
        return "NetCDF: File fails strict Null-Byte Header check.";
-     case NC_EINMEMORY:
+      case NC_EINMEMORY:
        return "NetCDF: In-memory File operation failed.";
       case NC_ENCZARR:
 	 return "NetCDF: NCZarr error";

--- a/libdispatch/nch5s3comms.c
+++ b/libdispatch/nch5s3comms.c
@@ -1152,7 +1152,7 @@ NCH5_s3comms_s3r_open(const char* root, NCS3SVC svc, const char *region, const c
         /* Compute the signing key */
         if (SUCCEED != NCH5_s3comms_signing_key(&signing_key, access_key, region, iso8601now))
             HGOTO_ERROR(H5E_ARGS, NC_EINVAL, NULL, "problem in NCH5_s3comms_s3comms_signing_key.");
-        if (nulllen(signing_key)==0)
+        if (signing_key == NULL)
             HGOTO_ERROR(H5E_ARGS, NC_EAUTH, NULL, "signing key cannot be null.");
 	handle->signing_key = signing_key;
 	signing_key = NULL;
@@ -2033,7 +2033,7 @@ NCH5_s3comms_signing_key(unsigned char **mdp, const char *secret, const char *re
     if ((size_t)ret != (AWS4_secret_len - 1))
         HGOTO_ERRORVA(H5E_ARGS, NC_EINVAL, FAIL, "problem writing AWS4+secret `%s`", secret);
 
-    if((md = (unsigned char*)malloc(SHA256_DIGEST_LENGTH))==NULL)
+    if((md = (unsigned char*)calloc(1,SHA256_DIGEST_LENGTH))==NULL)
        HGOTO_ERROR(H5E_ARGS, NC_ENOMEM, NULL, "could not malloc space for signing key .");
 
     /* hash_func, key, len(key), msg, len(msg), digest_dest, digest_len_dest

--- a/libdispatch/nclist.c
+++ b/libdispatch/nclist.c
@@ -31,7 +31,7 @@ NClist* nclistnew(void)
     ncinitialized = 1;
   }
 */
-  l = (NClist*)malloc(sizeof(NClist));
+  l = (NClist*)calloc(1,sizeof(NClist));
   if(l) {
     l->alloc=0;
     l->length=0;
@@ -286,10 +286,13 @@ done:
 void*
 nclistextract(NClist* l)
 {
-    void* result = l->content;
+    void* result = NULL;
+    if(l) {
+    result = l->content;
     l->alloc = 0;
     l->length = 0;
     l->content = NULL;
+    }
     return result;
 }
 

--- a/libncpoco/cp_unix.c
+++ b/libncpoco/cp_unix.c
@@ -46,7 +46,7 @@ static void
 ncperr(const char* fcn, NCPSharedLib* lib)
 {
     const char* msg = dlerror();
-    lib->err.msg[0] = '\0';
+    memset(lib->err.msg,0,sizeof(lib->err.msg));
     if(msg != NULL) {
 	strlcat(lib->err.msg,fcn,sizeof(lib->err.msg));
 	strlcat(lib->err.msg,": ",sizeof(lib->err.msg));

--- a/libncpoco/cp_win32.c
+++ b/libncpoco/cp_win32.c
@@ -105,10 +105,9 @@ load(NCPSharedLib* lib , const char* path0, int flags)
 	char* msg = NULL;
         FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
                           NULL, errcode, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), &msg, 0, NULL);
-	if(msg) {
+	memset(lib->err.msg,0,sizeof(lib->err.msg));
+	if(msg)
 	    strncpy(lib->err.msg,msg,sizeof(lib->err.msg));
-	} else
-	    lib->err.msg[0] = '\0';
 	ret = NC_ENOTFOUND;
 	goto ldone;
     }

--- a/libncpoco/ncpoco.c
+++ b/libncpoco/ncpoco.c
@@ -68,6 +68,7 @@ EXTERNL int
 ncpload(NCPSharedLib* lib, const char* path, int flags)
 {
     if(lib == NULL || path == NULL) return NC_EINVAL;
+    ncpclearerrmsg(lib);
     return lib->api.load(lib,path,flags);
 }
 
@@ -75,6 +76,7 @@ EXTERNL int
 ncpunload(NCPSharedLib* lib) /* Unloads a shared library. */
 {
     if(lib == NULL) return NC_EINVAL;
+    ncpclearerrmsg(lib);
     return lib->api.unload(lib);
 }
 
@@ -93,6 +95,7 @@ EXTERNL void*
 ncpgetsymbol(NCPSharedLib* lib,const char* name)
 {
     if(lib == NULL) return NULL;
+    ncpclearerrmsg(lib);
     return lib->api.getsymbol(lib,name);
 }
 
@@ -112,4 +115,12 @@ ncpgeterrmsg(NCPSharedLib* lib)
 {
     if(lib == NULL) return NULL;
     return (lib->err.msg[0] == '\0' ? NULL : lib->err.msg);
+}
+
+/* Clear the last err msg. */
+EXTERNL void
+ncpclearerrmsg(NCPSharedLib* lib)
+{
+    if(lib == NULL) return;
+    memset(lib->err.msg,0,sizeof(lib->err.msg));
 }

--- a/libncpoco/ncpoco.h
+++ b/libncpoco/ncpoco.h
@@ -71,6 +71,9 @@ EXTERNL const char* ncpgetpath(NCPSharedLib*);
 /* Return last err msg */
 EXTERNL const char* ncpgeterrmsg(NCPSharedLib* lib);
 
+/* Clear the last err msg. */
+EXTERNL void ncpclearerrmsg(NCPSharedLib* lib);
+
 EXTERNL const char* intstr(int err1);
 
 #endif /*NCPOCO_H*/

--- a/libsrc/v1hpg.c
+++ b/libsrc/v1hpg.c
@@ -1254,7 +1254,7 @@ NC_computeshapes(NC3_INFO* ncp)
 		for( /*NADA*/; vpp < end; vpp++)
 		{
 			status = NC_var_shape(*vpp, &ncp->dims);
-	        if(status != NC_NOERR)
+		        if(status != NC_NOERR)
 				return(status);
 
 		  	if(IS_RECVAR(*vpp))
@@ -1265,13 +1265,13 @@ NC_computeshapes(NC3_INFO* ncp)
 			}
 			else
 			{
-		        if(first_var == NULL)
+		            if(first_var == NULL)
 			        first_var = *vpp;
-				/*
-				 * Overwritten each time thru.
-				 * Usually overwritten in first_rec != NULL clause below.
-				 */
-				ncp->begin_rec = (*vpp)->begin + (off_t)(*vpp)->len;
+			    /*
+			     * Overwritten each time thru.
+			     * Usually overwritten in first_rec != NULL clause below.
+			     */
+			    ncp->begin_rec = (*vpp)->begin + (off_t)(*vpp)->len;
 			}
 		}
 	}

--- a/s3gc.in
+++ b/s3gc.in
@@ -61,7 +61,9 @@ if ! aws s3api list-objects-v2 --bucket ${S3TESTBUCKET} --prefix "${S3TESTSUBTRE
 fi
 aws s3api list-objects-v2 --bucket ${S3TESTBUCKET} --prefix "${S3TESTSUBTREE}" | grep -F '"Key":' >s3gc.keys
 while read -r line; do
-  KEY=`echo "$line" | sed -e 's|[^"]*"Key":[^"]*"\([^"]*\)".*|\1|'`
+  KEY0=`echo "$line" | sed -e 's|[^"]*"Key":[^"]*"\([^"]*\)".*|\1|'`
+  # Strip off any leading '/'
+  KEY=`echo "$KEY0" | sed -e 's|^[/]*\(.*\)|\1|'`
   # Ignore keys that do not start with ${S3TESTSUBTREE}
   PREFIX=`echo "$KEY" | sed -e 's|\([^/]*\)/.*|\1|'`
   if test "x$PREFIX" = "x$S3TESTSUBTREE" ; then


### PR DESCRIPTION
The most critical bug is in nch5s3comms.c.
I for some reason assumed that signing keys
did not contain any zero bytes. But obviously
it can, so some conditional code was removed.

Other fixes:
1. Guarantee allocated memory is initialized to all zeros.
2. Cleanup errmsg handling in libncpoco.
3. Fix processing of aws list-objects-v2 because I misread the syntax.