### PR TITLE
Fix most warnings in `dumplib.c`

### DIFF
--- a/ncdump/dumplib.c
+++ b/ncdump/dumplib.c
@@ -657,8 +657,8 @@ ncvlen_val_equals(const nctype_t *this,
 bool_t
 nccomp_val_equals(const nctype_t *this,
 		  const void *v1p, const void *v2p) {
-    int nfields = this->nfields;
-    int fidx;			/* field id */
+    size_t nfields = this->nfields;
+    size_t fidx;			/* field id */
 
     for (fidx = 0; fidx < nfields; fidx++) {
 	size_t offset = this->offsets[fidx];
@@ -969,7 +969,7 @@ ncopaque_val_as_hex(size_t size, char *sout, const void *valp) {
     char *sp = sout;
     int i;
     char *prefix = "0X";
-    int prelen = strlen(prefix);
+    size_t prelen = strlen(prefix);
 
     snprintf(sp, prelen + 1, "%s", prefix);
     sp += prelen;
@@ -980,7 +980,7 @@ ncopaque_val_as_hex(size_t size, char *sout, const void *valp) {
 	sp += 2;
     }
     *sp = '\0';
-    return 2*size + prelen;
+    return (int)(2*size + prelen);
 }
 
 /* Convert an opaque value to a string, represented as hexadecimal
@@ -1080,8 +1080,8 @@ chars_tostring(
    each member field */
 int
 nccomp_typ_tostring(const nctype_t *tinfo, safebuf_t *sfbf, const void *valp) {
-    int nfields = tinfo->nfields;
-    int fidx;			/* field id */
+    size_t nfields = tinfo->nfields;
+    size_t fidx;			/* field id */
     safebuf_t* sout2 = sbuf_new();
 
     sbuf_cpy(sfbf, "{");
@@ -1104,11 +1104,9 @@ nccomp_typ_tostring(const nctype_t *tinfo, safebuf_t *sfbf, const void *valp) {
 	    sbuf_cpy(sout2, "{");
 	    if(finfo->tid == NC_CHAR) { /* aggregate char rows into strings */
 		int rank = tinfo->ranks[fidx];
-		size_t nstrings;
-		size_t slen;
 		int j;
-		slen = tinfo->sides[fidx][rank-1];
-		nstrings = 1;	/* product of all but last array dimension */
+		size_t slen = (size_t)tinfo->sides[fidx][rank-1];
+		int nstrings = 1;	/* product of all but last array dimension */
 		for(j=0; j < rank-1; j++) {
 		    nstrings *= tinfo->sides[fidx][j];
 		}
@@ -1135,7 +1133,7 @@ nccomp_typ_tostring(const nctype_t *tinfo, safebuf_t *sfbf, const void *valp) {
 	    sbuf_free(sout3);
 	}
 	sbuf_catb(sfbf, sout2);
-	if(fidx < nfields - 1) {
+	if((fidx + 1) < nfields) {
 	    sbuf_cat(sfbf, ", ");
 	}
     }
@@ -1265,7 +1263,7 @@ nctime_val_tostring(const ncvar_t *varp, safebuf_t *sfbf, const void *valp) {
     if(isfinite(vv)) {
 	int oldopts = 0;
 	int newopts = 0;
-	int res;
+	size_t res;
 	sout[0]='"';
 	/* Make nctime dump error messages */
 	oldopts = cdSetErrOpts(0);

--- a/ncdump/dumplib.c
+++ b/ncdump/dumplib.c
@@ -1244,10 +1244,10 @@ double to_double(const ncvar_t *varp, const void *valp) {
 	dd = *(unsigned int *)valp;
 	break;
     case NC_INT64:
-	dd = *(long long *)valp;
+	dd = (double)*(long long *)valp;
 	break;
     case NC_UINT64:
-	dd = *(unsigned long long *)valp;
+	dd = (double)*(unsigned long long *)valp;
 	break;
     default:
 	error("to_double: type not numeric primitive");

--- a/ncdump/dumplib.c
+++ b/ncdump/dumplib.c
@@ -11,6 +11,7 @@
 
 #include "config.h"
 #include <stdarg.h>
+#include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -203,7 +204,7 @@ sbuf_catb(safebuf_t *s1, const safebuf_t *s2) {
     size_t res;
     assert(SAFEBUF_CHECK(s1));
     assert(SAFEBUF_CHECK(s2));
-    s2len = sbuf_len(s2);
+    s2len = (size_t)sbuf_len(s2);
     sbuf_grow(s1, 1 + s1->cl + s2len);
     res = strlcat(s1->buf + s1->cl, s2->buf, s1->len - s1->cl);
     assert( res < s1->len );
@@ -212,10 +213,10 @@ sbuf_catb(safebuf_t *s1, const safebuf_t *s2) {
 }
 
 /* Return length of string in sbuf */
-size_t
+int
 sbuf_len(const safebuf_t *sb) {
     assert(SAFEBUF_CHECK(sb));
-    return sb->cl;
+    return (int)sb->cl;
 }
 
 /* Return C string in an sbuf */

--- a/ncdump/dumplib.h
+++ b/ncdump/dumplib.h
@@ -99,7 +99,7 @@ void sbuf_cat(safebuf_t *sbuf, const char *s2);
 void sbuf_catb(safebuf_t *s1, const safebuf_t *s2);
 
 /* Return length of the string in sbuf */
-size_t sbuf_len(const safebuf_t *sbuf);
+int sbuf_len(const safebuf_t *sbuf);
 
 /* Return the C string inside an sbuf */
 char *sbuf_str(const safebuf_t *sbuf);


### PR DESCRIPTION
The easy win here was changing the return type of `sbuf_len` which is used in a lot of places in this file. Two alternatives that I think would be cleaner but require touching more places:

1. Change the `typ_tostring_func` function pointer typedef to return `size_t`. This is more correct as it matches the current return type of `sbuf_len`, which is returned from the implementations of this prototype.
2. Change the `typ_tostring_func` return type to `void` -- as far as I can tell, the return value of these functions isn't used anywhere that they're called, I think it's an entirely internal module. Doing this would also mean that the call to `sbuf_len` in these functions could also be removed entirely

This PR fixes about 55 warnings