### PR TITLE
Fix warnings in NCZarr tests

### DIFF
--- a/nczarr_test/ncdumpchunks.c
+++ b/nczarr_test/ncdumpchunks.c
@@ -1,3 +1,4 @@
+#include <stddef.h>
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -59,7 +60,7 @@ typedef struct Format {
 } Format;
 
 typedef struct Odometer {
-  size_t rank; /*rank */
+  int rank; /*rank */
   size_t start[NC_MAX_VAR_DIMS];
   size_t stop[NC_MAX_VAR_DIMS];
   size_t max[NC_MAX_VAR_DIMS]; /* max size of ith index */
@@ -74,7 +75,7 @@ static int ncap = 0;
 
 extern int nc__testurl(const char*,char**);
 
-Odometer* odom_new(size_t rank, const size_t* stop, const size_t* max);
+Odometer* odom_new(int rank, const size_t* stop, const size_t* max);
 void odom_free(Odometer* odom);
 int odom_more(Odometer* odom);
 int odom_next(Odometer* odom);
@@ -119,7 +120,7 @@ cleanup(void)
 }
 
 Odometer*
-odom_new(size_t rank, const size_t* stop, const size_t* max)
+odom_new(int rank, const size_t* stop, const size_t* max)
 {
      int i;
      Odometer* odom = NULL;
@@ -150,7 +151,7 @@ odom_more(Odometer* odom)
 int
 odom_next(Odometer* odom)
 {
-     size_t i;
+     int i;
      for(i=odom->rank-1;i>=0;i--) {
 	 odom->index[i]++;
 	 if(odom->index[i] < odom->stop[i]) break;
@@ -265,7 +266,7 @@ printchunk(Format* format, int* chunkdata, size_t indent)
 {
     size_t k[3];
     int rank = format->rank;
-    unsigned cols[3], pos;
+    size_t cols[3], pos;
     size_t* chl = format->chunklens;
 
     memset(cols,0,sizeof(cols));

--- a/nczarr_test/test_unlim_io.c
+++ b/nczarr_test/test_unlim_io.c
@@ -1,3 +1,4 @@
+#include <stddef.h>
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -22,15 +23,15 @@
 #define NDATA MAX_DATA
 static int data[NDATA];
 
-static unsigned chunkprod;
-static unsigned dimprod;
+static size_t chunkprod;
+static size_t dimprod;
 static size_t datasize = 0;
 
 static int
 writedata(void)
 {
     int ret = NC_NOERR;
-    size_t i;
+    int i;
 
     for(i=0;i<NDATA;i++) data[i] = (options->data == 0x7fffffff ? i: options->data);
  

--- a/nczarr_test/test_utils.c
+++ b/nczarr_test/test_utils.c
@@ -165,7 +165,7 @@ getoptions(int* argcp, char*** argvp)
     }
 
     /* Figure out the FORMATX for this file */
-    if(options->file) {
+    if(options->file[0]) {
 	NCURI* uri = NULL;
 	ncuriparse(options->file,&uri);
 	if(uri == NULL) { /* not a url */

--- a/nczarr_test/test_utils.c
+++ b/nczarr_test/test_utils.c
@@ -193,7 +193,7 @@ getoptions(int* argcp, char*** argvp)
 #ifndef _WIN32
     if(options->wdebug) {
 	char s[64];
-	snprintf(s,sizeof(s),"%u",options->wdebug);
+	snprintf(s,sizeof(s),"%d",options->wdebug);
         setenv("NCZ_WDEBUG",s,1);
     }
     if(options->optimize) {
@@ -404,7 +404,7 @@ parsedata(const char* s0, int* data)
         p = strchr(q,',');
         if(p == NULL) {p = q+strlen(q); done=1;}
         *p++ = '\0';
-        data[i++] = (size_t)atoi(q);
+        data[i++] = atoi(q);
     }
     if(s) free(s);
     return i;
@@ -440,7 +440,7 @@ printvector64(int rank, const size64_t* vec)
 }
 
 Odometer*
-odom_new(size_t rank, const size_t* start, const size_t* stop, const size_t* stride, const size_t* max)
+odom_new(int rank, const size_t* start, const size_t* stop, const size_t* stride, const size_t* max)
 {
      size_t i;
      Odometer* odom = NULL;
@@ -473,7 +473,7 @@ odom_more(Odometer* odom)
 int
 odom_next(Odometer* odom)
 {
-     size_t i;
+     int i;
      for(i=odom->rank-1;i>=0;i--) {
 	 odom->index[i] += odom->stride[i];
 	 if(odom->index[i] < odom->stop[i]) break;

--- a/nczarr_test/test_utils.h
+++ b/nczarr_test/test_utils.h
@@ -21,7 +21,7 @@ typedef enum Op {None=0, Create=1, Read=2, Write=3, Wholechunk=4, Odom=5, Extend
 
 typedef struct Options {
     unsigned debug;
-    unsigned wdebug;
+    int wdebug;
     int optimize;
     int wholechunk;
     Op create;
@@ -49,7 +49,7 @@ typedef struct Metadata {
 } Metadata;
 
 typedef struct Odometer {
-  size_t rank; /*rank */
+  int rank; /*rank */
   size_t start[NC_MAX_VAR_DIMS];
   size_t edges[NC_MAX_VAR_DIMS];
   size_t stride[NC_MAX_VAR_DIMS];
@@ -60,7 +60,7 @@ typedef struct Odometer {
 
 extern void usage(int);
 
-EXTERNL Odometer* odom_new(size_t rank, const size_t* start, const size_t* stop, const size_t* stride, const size_t* max);
+EXTERNL Odometer* odom_new(int rank, const size_t* start, const size_t* stop, const size_t* stride, const size_t* max);
 EXTERNL void odom_free(Odometer* odom);
 EXTERNL int odom_more(Odometer* odom);
 EXTERNL int odom_next(Odometer* odom);

--- a/nczarr_test/test_zchunks.c
+++ b/nczarr_test/test_zchunks.c
@@ -9,6 +9,7 @@
 
 #include "ut_includes.h"
 #include "test_nczarr_utils.h"
+#include <stddef.h>
 
 #define DEBUGNOFILL
 #undef PRINT_DEFAULT_CHUNKSIZE_TABLE
@@ -94,8 +95,7 @@ main(int argc, char **argv)
 #define NUM_DIM 4
 #define NUM_TYPE 2
       int ncid;
-      int dim_len[NUM_DIM] = {1, 100, 1000, 2000};
-//      int dim_len[NUM_DIM] = {1, 50, 100, 200};
+      size_t dim_len[NUM_DIM] = {1, 100, 1000, 2000};
       size_t chunksize_in[NUM_DIM];
       int type_id[NUM_TYPE] = {NC_BYTE, NC_INT};
       int dimid[NUM_DIM], varid[NUM_TYPE];
@@ -110,7 +110,7 @@ main(int argc, char **argv)
 
       for (d = 0; d < NUM_DIM; d++)
       {
-	 sprintf(dim_name, "dim_%d", dim_len[d]);
+	 sprintf(dim_name, "dim_%zu", dim_len[d]);
 #ifdef PRINT_DEFAULT_CHUNKSIZE_TABLE
 	 printf("creating dim[%d] %s = %d\n", d,  dim_name, dim_len[d]);
 #endif

--- a/nczarr_test/test_zchunks2.c
+++ b/nczarr_test/test_zchunks2.c
@@ -9,6 +9,7 @@
 
 #include "ut_includes.h"
 #include "test_nczarr_utils.h"
+#include <stddef.h>
 
 #define FILE_NAME "tst_chunks2"
 #define MAX_WASTE 25.0
@@ -37,13 +38,13 @@ calculate_waste(int ndims, size_t *dimlen, size_t *chunksize, float *waste)
       for (num_chunks[d] = 0; (num_chunks[d] * chunksize[d]) < (dimlen[d] ? dimlen[d] : 1);
 	   num_chunks[d]++)
 	 ;
-      chunked *= (num_chunks[d] * chunksize[d]);
+      chunked *= (float)(num_chunks[d] * chunksize[d]);
    }
 
    /* Calculate the minimum space required for this data
     * (i.e. unchunked) or one record of it. */
    for (d = 0; d < ndims; d++)
-      unchunked *= (dimlen[d] ? dimlen[d] : 1);
+      unchunked *= (dimlen[d] ? (float)dimlen[d] : 1);
 
 #ifdef PRINT_CHUNK_WASTE_REPORT
    printf("size for unchunked %g elements; size for chunked %g elements\n",
@@ -51,7 +52,7 @@ calculate_waste(int ndims, size_t *dimlen, size_t *chunksize, float *waste)
 #endif
 
    /* Percent of the chunked file that is wasted space. */
-   *waste = ((float)(chunked - unchunked) / (float)chunked) * 100.0f;
+   *waste = ((chunked - unchunked) / chunked) * 100.0f;
 
 #ifdef PRINT_CHUNK_WASTE_REPORT
    printf("\ndimlen\tchunksize\tnum_chunks\n");
@@ -359,7 +360,7 @@ main(int argc, char **argv)
 	 /* Create a few dimensions. */
 	 for (d = 0; d < NDIMS3; d++)
 	 {
-	    dim_len[d] = rand();
+	    dim_len[d] = (size_t)rand();
 	    sprintf(dim_name, "dim_%d", d);
 	    if (nc_def_dim(ncid, dim_name, dim_len[d], &dimids[d])) ERR;
 	 }
@@ -393,9 +394,9 @@ main(int argc, char **argv)
       {
 	 if (nc_create(itoptions.path, NC_NETCDF4 | NC_CLOBBER, &ncid)) ERR;
 
-	 dim_len[0] = rand();
-	 dim_len[1] = rand();
-	 dim_len[2] = rand() % 1000;
+	 dim_len[0] = (size_t)rand();
+	 dim_len[1] = (size_t)rand();
+	 dim_len[2] = (size_t)rand() % 1000;
 	 /* Create a few dimensions. */
 	 for (d = 0; d < NDIMS3; d++)
 	 {
@@ -432,9 +433,9 @@ main(int argc, char **argv)
       {
 	 if (nc_create(itoptions.path, NC_NETCDF4 | NC_CLOBBER, &ncid)) ERR;
 
-	 dim_len[0] = rand();
-	 dim_len[1] = rand() % 1000;
-	 dim_len[2] = rand() % 1000;
+	 dim_len[0] = (size_t)rand();
+	 dim_len[1] = (size_t)rand() % 1000;
+	 dim_len[2] = (size_t)rand() % 1000;
 	 /* Create a few dimensions. */
 	 for (d = 0; d < NDIMS3; d++)
 	 {

--- a/nczarr_test/test_zchunks2.c
+++ b/nczarr_test/test_zchunks2.c
@@ -23,7 +23,6 @@ calculate_waste(int ndims, size_t *dimlen, size_t *chunksize, float *waste)
    int d;
    float chunked = 1, unchunked = 1;
    size_t *num_chunks;
-   size_t chunk_size = 1;
 
    assert(waste && dimlen && chunksize && ndims);
    if (!(num_chunks = calloc(ndims, sizeof(size_t)))) ERR;
@@ -56,16 +55,13 @@ calculate_waste(int ndims, size_t *dimlen, size_t *chunksize, float *waste)
 
 #ifdef PRINT_CHUNK_WASTE_REPORT
    printf("\ndimlen\tchunksize\tnum_chunks\n");
-#endif
+   size_t chunk_size = 1;
    for (d = 0; d < ndims; d++)
    {
-#ifdef PRINT_CHUNK_WASTE_REPORT
       printf("%ld\t%ld\t\t%ld\n", (long int)dimlen[d], (long int)chunksize[d],
 	     (long int)num_chunks[d]);
-#endif
       chunk_size *= chunksize[d];
    }
-#ifdef PRINT_CHUNK_WASTE_REPORT
    printf("size of chunk: %ld elements; wasted space: %2.2f percent\n",
 	  (long int)chunk_size, *waste);
 #endif

--- a/nczarr_test/test_zchunks3.c
+++ b/nczarr_test/test_zchunks3.c
@@ -66,7 +66,7 @@ main(int argc, char** argv)
 
     /* fvar is unchanged */
     for(i=0; i < NVALS; i++) {
-        fvar_data[i] = NVALS - i;
+        fvar_data[i] = (float)(NVALS - i);
     }
     if ((ret=nc_put_var(ncid, fvarid, fvar_data))) LERR;
 

--- a/nczarr_test/testfilter.c
+++ b/nczarr_test/testfilter.c
@@ -65,7 +65,7 @@ data:
 
 static size_t dimsize = DIMSIZE;
 static size_t chunksize = CHUNKSIZE;
-static size_t actualdims = NDIMS;
+static int actualdims = NDIMS;
 
 static size_t actualproduct = 1; /* x-product over dim sizes */
 static size_t chunkproduct = 1; /* x-product over chunksizes */

--- a/nczarr_test/testfilter_misc.c
+++ b/nczarr_test/testfilter_misc.c
@@ -51,7 +51,7 @@ static size_t dimsize[NDIMS] = {4,4,4,4};
 static size_t chunksize[NDIMS] = {4,4,4,4};
 #endif
 
-static size_t ndims = NDIMS;
+static int ndims = NDIMS;
 
 static size_t totalproduct = 1; /* x-product over max dims */
 static size_t actualproduct = 1; /* x-product over actualdims */
@@ -513,8 +513,8 @@ odom_offset(void)
     int i;
     int offset = 0;
     for(i=0;i<ndims;i++) {
-        offset *= dimsize[i];
-        offset += odom[i];
+        offset *= (int)dimsize[i];
+        offset += (int)odom[i];
     }
     return offset;
 }
@@ -526,8 +526,8 @@ expectedvalue(void)
     float offset = 0;
 
     for(i=0;i<ndims;i++) {
-        offset *= dimsize[i];
-        offset += odom[i];
+        offset *= (float)dimsize[i];
+        offset += (float)odom[i];
     }
     return offset;
 }

--- a/nczarr_test/testfilter_multi.c
+++ b/nczarr_test/testfilter_multi.c
@@ -43,7 +43,7 @@ static const char* testfile = NULL;
 
 static size_t dimsize = DIMSIZE;
 static size_t chunksize = CHUNKSIZE;
-static size_t actualdims = NDIMS;
+static int actualdims = NDIMS;
 
 static size_t actualproduct = 1; /* x-product over dim sizes */
 static size_t chunkproduct = 1; /* x-product over chunksizes */

--- a/nczarr_test/testfilter_order.c
+++ b/nczarr_test/testfilter_order.c
@@ -34,7 +34,7 @@
 static size_t dimsize[NDIMS] = {4,4,4,4};
 static size_t chunksize[NDIMS] = {4,4,4,4};
 
-static size_t ndims = NDIMS;
+static int ndims = NDIMS;
 
 static int creating = 1; /* Default is to do filter test 1 */
 static size_t totalproduct = 1; /* x-product over max dims */
@@ -363,8 +363,8 @@ odom_offset(void)
     int i;
     int offset = 0;
     for(i=0;i<ndims;i++) {
-        offset *= dimsize[i];
-        offset += odom[i];
+        offset *= (int)dimsize[i];
+        offset += (int)odom[i];
     }
     return offset;
 }
@@ -376,8 +376,8 @@ expectedvalue(void)
     float offset = 0;
 
     for(i=0;i<ndims;i++) {
-        offset *= dimsize[i];
-        offset += odom[i];
+        offset *= (float)dimsize[i];
+        offset += (float)odom[i];
     }
     return offset;
 }

--- a/nczarr_test/testfilter_repeat.c
+++ b/nczarr_test/testfilter_repeat.c
@@ -34,7 +34,7 @@
 static size_t dimsize[NDIMS] = {4,4,4,4};
 static size_t chunksize[NDIMS] = {4,4,4,4};
 
-static size_t ndims = NDIMS;
+static int ndims = NDIMS;
 
 static size_t totalproduct = 1; /* x-product over max dims */
 static size_t actualproduct = 1; /* x-product over actualdims */
@@ -318,8 +318,8 @@ odom_offset(void)
     int i;
     int offset = 0;
     for(i=0;i<ndims;i++) {
-        offset *= dimsize[i];
-        offset += odom[i];
+        offset *= (int)dimsize[i];
+        offset += (int)odom[i];
     }
     return offset;
 }
@@ -331,8 +331,8 @@ expectedvalue(void)
     float offset = 0;
 
     for(i=0;i<ndims;i++) {
-        offset *= dimsize[i];
-        offset += odom[i];
+        offset *= (float)dimsize[i];
+        offset += (float)odom[i];
     }
     return offset;
 }

--- a/nczarr_test/ut_map.c
+++ b/nczarr_test/ut_map.c
@@ -3,6 +3,7 @@
  *      See netcdf/COPYRIGHT file for copying and redistribution conditions.
  */
 
+#include "ncconfigure.h"
 #include "ut_includes.h"
 
 #undef DEBUG
@@ -271,7 +272,7 @@ readdata(void)
     NCZMAP* map = NULL;
     char* path = NULL;
     int data1[DATA1LEN];
-    int i;
+    size64_t i;
     size64_t chunklen, totallen;
     char* data1p = NULL; /* byte level pointer into data1 */
 
@@ -306,7 +307,7 @@ readdata(void)
     /* Validate */
     for(i=0;i<DATA1LEN;i++) {
 	if(data1[i] != i) {
-	    fprintf(stderr,"data mismatch: is: %d should be: %d\n",data1[i],i);
+	    fprintf(stderr,"data mismatch: is: %d should be: %llu\n",data1[i],i);
 	    stat = NC_EINVAL;
 	    goto done;
 	}

--- a/nczarr_test/ut_test.c
+++ b/nczarr_test/ut_test.c
@@ -94,9 +94,6 @@ ut_init(int argc, char** argv, struct UTOptions * options)
             case 's': /*slices*/
 		if((stat=parseslices(optarg,&options->nslices,options->slices))) usage(THROW(stat));
                 break;
-            case 'W': /*walk data*/
-		options->idatalen = parseintvector(optarg,4,(void**)&options->idata);
-                break;
             case '?':
                fprintf(stderr,"unknown option: '%c'\n",c);
                stat = NC_EINVAL;

--- a/nczarr_test/ut_test.h
+++ b/nczarr_test/ut_test.h
@@ -53,7 +53,6 @@ struct UTOptions {
     NCZSlice slices[NC_MAX_VAR_DIMS];
     NClist* dimdefs; /*List<struct Dimdef*> */
     NClist* vardefs; /*List<struct Vardef*> */
-    size_t idatalen;
     int* idata;
 };
 

--- a/nczarr_test/ut_util.c
+++ b/nczarr_test/ut_util.c
@@ -199,44 +199,6 @@ parsestringvector(const char* s0, int stopchar, char*** namesp)
     return nelems;
 }
 
-int
-parseintvector(const char* s0, int typelen, void** vectorp)
-{
-    int count,nchars,nelems,index;
-    const char* s = NULL;
-    void* vector = NULL;
-
-    /* First, compute number of elements */
-    for(s=s0,nelems=1;*s;s++) {
-        if(*s == ',') nelems++;
-    }
-
-    vector = calloc(nelems,typelen);
-
-    /* Extract the elements of the vector */
-    /* Skip any leading bracketchar */
-    s=s0;
-    if(strchr(OPEN,*s0) != NULL) s++;
-    for(index=0;*s;index++) {
-        long long elem;
-        nchars = -1;
-        count = sscanf(s,"%lld%n",&elem,&nchars);
-        if(nchars == -1 || count != 1) return THROW(NC_EINVAL);
-        s += nchars;
-        if(*s == ',') s++;
-        switch (typelen) {
-        case 1: ((char*)vector)[index] = (char)elem; break;
-        case 2: ((short*)vector)[index] = (short)elem; break;
-        case 4: ((int*)vector)[index] = (int)elem; break;
-        case 8: ((long long*)vector)[index] = (long long)elem; break;
-        default: abort();
-        }
-    }
-    assert(nelems == index);
-    if(vectorp) *vectorp = vector;
-    return nelems;
-}
-
 void
 freedimdefs(NClist* defs)
 {

--- a/nczarr_test/ut_util.c
+++ b/nczarr_test/ut_util.c
@@ -314,7 +314,7 @@ printvec(int len, size64_t* vec)
 #endif /*0*/
 
 /**************************************************/
-int
+size_t
 ut_typesize(nc_type t)
 {
     switch (t) {

--- a/nczarr_test/ut_util.h
+++ b/nczarr_test/ut_util.h
@@ -6,6 +6,7 @@
 #ifndef UT_UTIL_H
 #define UT_UTIL_H
 
+#include <stddef.h>
 extern int parseslices(const char* s0, int* nslicesp, NCZSlice* slices);
 extern int parsedimdef(const char* s0, Dimdef** defp);
 extern int parsevardef(const char* s0, NClist* dimdefs, Vardef** varp);
@@ -17,7 +18,7 @@ extern void freeranges(NCZChunkRange* ranges);
 extern void freeslices(NCZSlice* slices);
 extern void freestringvec(char** vec);
 extern void freeprojvector(int rank, NCZProjection** vec);
-extern int ut_typesize(nc_type t);
+extern size_t ut_typesize(nc_type t);
 extern nc_type ut_typeforname(const char* tname);
 extern NCZM_IMPL kind2impl(const char* kind);
 extern const char* impl2kind(NCZM_IMPL impl);

--- a/nczarr_test/ut_util.h
+++ b/nczarr_test/ut_util.h
@@ -11,7 +11,6 @@ extern int parseslices(const char* s0, int* nslicesp, NCZSlice* slices);
 extern int parsedimdef(const char* s0, Dimdef** defp);
 extern int parsevardef(const char* s0, NClist* dimdefs, Vardef** varp);
 extern int parsestringvector(const char* s0, int stopchar, char*** namesp);
-extern int parseintvector(const char* s0, int typelen, void** vectorp);
 extern void freedimdefs(NClist* defs);
 extern void freevardefs(NClist* defs);
 extern void freeranges(NCZChunkRange* ranges);

--- a/nczarr_test/zhex.c
+++ b/nczarr_test/zhex.c
@@ -14,13 +14,10 @@
 
 #undef DEBUG
 
-static char hex[16] = "0123456789abcdef";
-
 int
 main(int argc, char** argv)
 {
     unsigned char c;
-    unsigned int c0,c1;
     FILE* f = NULL;
 
     if(argc > 1) {
@@ -33,12 +30,7 @@ main(int argc, char** argv)
     for(;;) {
 	int ret = fread(&c, 1, 1, f);
 	if(ret != 1) break;
-        c1 = c;
-        c0 = c1 & 0xf;
-	c1 = (c1 >> 4);
-        c0 = hex[c0];
-        c1 = hex[c1];
-        printf("%c%c",(char)c1,(char)c0);
+        printf("%.2hhx", c);
     }
     if(f != stdin) fclose(f);
     return 0;

--- a/nczarr_test/zhex.c
+++ b/nczarr_test/zhex.c
@@ -7,6 +7,7 @@
 
 #include "stdlib.h"
 #include "stdio.h"
+#include <stddef.h>
 
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
@@ -28,7 +29,7 @@ main(int argc, char** argv)
         f = stdin;
 
     for(;;) {
-	int ret = fread(&c, 1, 1, f);
+	size_t ret = fread(&c, 1, 1, f);
 	if(ret != 1) break;
         printf("%.2hhx", c);
     }

--- a/nczarr_test/zisjson.c
+++ b/nczarr_test/zisjson.c
@@ -8,6 +8,7 @@
 */
 
 
+#include <stddef.h>
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
@@ -93,7 +94,7 @@ main(int argc, char** argv)
     int stat = NC_NOERR;
     char text[MAXREAD+1];
     NCjson* json = NULL;
-    int i, red, c;
+    int i, c;
     FILE* f = NULL;
 
     nc_initialize();
@@ -127,7 +128,7 @@ main(int argc, char** argv)
     /* Read json from stdin */
     for(i=0;;i++) {
 	unsigned char c;
-	red = fread(&c, 1, 1, f);
+	size_t red = fread(&c, 1, 1, f);
 	if(red != 1) break;
 	if(i < MAXREAD) text[i] = (char)c;
     }

--- a/nczarr_test/zmapio.c
+++ b/nczarr_test/zmapio.c
@@ -3,6 +3,8 @@
  *      See netcdf/COPYRIGHT file for copying and redistribution conditions.
  */
 
+#include "ncconfigure.h"
+#include <stddef.h>
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -54,7 +56,7 @@ static struct Mops {
 static struct Type {
     const char* typename;
     nc_type nctype;
-    int typesize;
+    size_t typesize;
     const char format[16];
 } types[] = {
 {"ubyte",NC_UBYTE,1,"%u"},
@@ -448,12 +450,11 @@ printcontent(size64_t len, const char* content, OBJKIND kind)
     size64_t i, count;
 
     const char* format = NULL;
-    int strlen = 1;
+    size64_t strlen = (size64_t)dumpoptions.strlen;
 
     format = dumpoptions.nctype->format;
     if(dumpoptions.format[0] != '\0')
         format = dumpoptions.format;
-    strlen = dumpoptions.strlen;
     count = len;
 
 #ifdef DEBUG

--- a/nczarr_test/zmapio.c
+++ b/nczarr_test/zmapio.c
@@ -441,13 +441,11 @@ breadthfirst(NCZMAP* map, const char* key, NClist* stack)
     return stat;
 }
 
-static char hex[16] = "0123456789abcdef";
 
 static void
 printcontent(size64_t len, const char* content, OBJKIND kind)
 {
     size64_t i, count;
-    unsigned int c0,c1;
 
     const char* format = NULL;
     int strlen = 1;
@@ -487,12 +485,7 @@ printcontent(size64_t len, const char* content, OBJKIND kind)
 	    printf("%c",content[i]);
 	    break;
 	default:
-	    c1 = (unsigned char)(content[i]);
-            c0 = c1 & 0xf;
-	    c1 = (c1 >> 4);
-            c0 = hex[c0];
-            c1 = hex[c1];
-	    printf("%c%c",(char)c1,(char)c0);
+	    printf("%.2hhx", content[i]);
         }
     }
 }


### PR DESCRIPTION
Fixes the remaining 80 warnings in the NCZarr tests that aren't fixed by my other PRs.

I noticed that there's a `Odometer` struct along with some related free functions that are duplicated with some minor variations between various tests here and in `nc4_tests` -- potential for consolidating those into a single test helper library and reducing duplication?