### PR TITLE
Define USE_SZIP variable for nc-config.cmake.in

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1158,6 +1158,7 @@ ENDIF()
 set(STD_FILTERS "deflate") # Always have deflate*/
 set_std_filter(Szip)
 SET(HAVE_SZ ${Szip_FOUND})
+SET(USE_SZIP ${HAVE_SZ})
 set_std_filter(Blosc)
 IF(Zstd_FOUND)
   set_std_filter(Zstd)


### PR DESCRIPTION
The cmake build of nc-config relies on config file variable `USE_SZIP` which does not exist. In keeping consistent with the naming, this value is derived from `HAVE_SZ`