### PR TITLE
Link against internally defined libraries

### DIFF
--- a/liblib/CMakeLists.txt
+++ b/liblib/CMakeLists.txt
@@ -47,10 +47,11 @@ IF(ENABLE_PLUGINS)
 ENDIF()
 
 FOREACH(LIBS ${liblib_LIBS})
-  SET(LARGS ${LARGS} $<TARGET_OBJECTS:${LIBS}>)
+  SET(LARGS ${LARGS} $<TARGET_NAME_IF_EXISTS:${LIBS}>)
 ENDFOREACH()
 
-ADD_LIBRARY(netcdf nc_initialize.c ${LARGS} )
+ADD_LIBRARY(netcdf nc_initialize.c )
+target_link_libraries( netcdf ${LARGS} )
 
 IF(STATUS_PARALLEL)
   # TODO: Make PUBLIC when other dependencies have PUBLIC/PRIVATE specified


### PR DESCRIPTION
Neither #2595 nor #2758 fully addressed the underlying issue that final `netcdf` target linking was failing due to missing dependencies previously defined in other internal targets. While a valid solution to manually specify linking dependencies again, part of the effort is to make use of the target structure in cmake to further inform future linking.

The usage of the generator expression `$<TARGET_OBJECTS:...>` negates any target-specific linking that ought to be inherited to the `netcdf` target. To avoid this issue internal targets such as `dispatch` should be directly linked. Since target `netcdf` does not have `PUBLIC/PRIVATE` definitions for its  linking, a compromise for now is to use the `$<TARGET_NAME_IF_EXISTS:...>` generator expression which will fully fix linking even prior to #2595 / #2758 and a valid config able to be found/imported by other cmake projects.