### PR TITLE
CMake: Add support for UNITY_BUILD

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,7 +8,7 @@ This file contains a high-level description of this package's evolution. Release
 ## 4.9.3 - TBD
 
 
-* Added infrastructure to allow for `CMAKE_UNITY_BUILD`, @jschueller.  See [Github #2839](https://github.com/Unidata/netcdf-c/pull/2839) for more information.
+* Added infrastructure to allow for `CMAKE_UNITY_BUILD`, (thanks \@jschueller).  See [Github #2839](https://github.com/Unidata/netcdf-c/pull/2839) for more information.
 * [cmake] Move dependency management out of the root-level `CMakeLists.txt` into two different files in the `cmake/` folder, `dependencies.cmake` and `netcdf_functions_macros.cmake`. See [Github #2838](https://github.com/Unidata/netcdf-c/pull/2838/) for more information.
 * Obviate a number of irrelevant warnings. See [Github #2781](https://github.com/Unidata/netcdf-c/pull/2781).
 * Improve the speed and data quantity for DAP4 queries. See [Github #2765](https://github.com/Unidata/netcdf-c/pull/2765).

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,7 @@ This file contains a high-level description of this package's evolution. Release
 
 ## 4.9.3 - TBD
 
+* Added infrastructure to allow for `CMAKE_UNITY_BUILD`, @jschueller.  See [Github #2839](https://github.com/Unidata/netcdf-c/pull/2839) for more information.
 * Obviate a number of irrelevant warnings. See [Github #2781](https://github.com/Unidata/netcdf-c/pull/2781).
 * Improve the speed and data quantity for DAP4 queries. See [Github #2765](https://github.com/Unidata/netcdf-c/pull/2765).
 * Remove the use of execinfo to programmatically dump the stack; it never worked. See [Github #2789](https://github.com/Unidata/netcdf-c/pull/2789).

--- a/libdap2/CMakeLists.txt
+++ b/libdap2/CMakeLists.txt
@@ -6,6 +6,10 @@
 # See netcdf-c/COPYRIGHT file for more info.
 SET(dap2_SOURCES constraints.c dapcvt.c dapodom.c daputil.c ncdaperr.c cdf.c cache.c dapdump.c dapdebug.c dapattr.c ncd2dispatch.c getvara.c dceconstraints.c dcetab.c dceparse.c dcelex.c)
 
+set_property(SOURCE ncd2dispatch.c
+  PROPERTY
+    SKIP_UNITY_BUILD_INCLUSION ON)
+
 add_library(dap2 OBJECT ${dap2_SOURCES})
 
 IF(STATUS_PARALLEL)

--- a/libdap2/CMakeLists.txt
+++ b/libdap2/CMakeLists.txt
@@ -6,6 +6,20 @@
 # See netcdf-c/COPYRIGHT file for more info.
 SET(dap2_SOURCES constraints.c dapcvt.c dapodom.c daputil.c ncdaperr.c cdf.c cache.c dapdump.c dapdebug.c dapattr.c ncd2dispatch.c getvara.c dceconstraints.c dcetab.c dceparse.c dcelex.c)
 
+## 
+# Turn off inclusion of particular files when using the cmake-native
+# option to turn on Unity Builds.  
+#
+# For more information, see:
+#  * https://github.com/Unidata/netcdf-c/pull/2839/
+#  * https://cmake.org/cmake/help/latest/prop_tgt/UNITY_BUILD.html
+#  * https://cmake.org/cmake/help/latest/prop_tgt/UNITY_BUILD_MODE.html#prop_tgt:UNITY_BUILD_MODE
+##
+set_property(SOURCE ncd2dispatch.c
+  PROPERTY
+    SKIP_UNITY_BUILD_INCLUSION ON)
+
+
 set_property(SOURCE ncd2dispatch.c
   PROPERTY
     SKIP_UNITY_BUILD_INCLUSION ON)

--- a/libdap4/CMakeLists.txt
+++ b/libdap4/CMakeLists.txt
@@ -6,6 +6,10 @@
 # See netcdf-c/COPYRIGHT file for more info.
 SET(dap4_SOURCES d4curlfunctions.c d4fix.c d4data.c d4file.c d4parser.c d4meta.c d4varx.c d4dump.c d4swap.c d4chunk.c d4printer.c d4read.c d4http.c d4util.c d4odom.c d4cvt.c d4debug.c ncd4dispatch.c)
 
+set_property(SOURCE d4meta.c
+  PROPERTY
+    SKIP_UNITY_BUILD_INCLUSION ON)
+
 add_library(dap4 OBJECT ${dap4_SOURCES})
 
 IF(STATUS_PARALLEL)

--- a/libdap4/CMakeLists.txt
+++ b/libdap4/CMakeLists.txt
@@ -6,6 +6,15 @@
 # See netcdf-c/COPYRIGHT file for more info.
 SET(dap4_SOURCES d4curlfunctions.c d4fix.c d4data.c d4file.c d4parser.c d4meta.c d4varx.c d4dump.c d4swap.c d4chunk.c d4printer.c d4read.c d4http.c d4util.c d4odom.c d4cvt.c d4debug.c ncd4dispatch.c)
 
+## 
+# Turn off inclusion of particular files when using the cmake-native
+# option to turn on Unity Builds.  
+#
+# For more information, see:
+#  * https://github.com/Unidata/netcdf-c/pull/2839/
+#  * https://cmake.org/cmake/help/latest/prop_tgt/UNITY_BUILD.html
+#  * https://cmake.org/cmake/help/latest/prop_tgt/UNITY_BUILD_MODE.html#prop_tgt:UNITY_BUILD_MODE
+##
 set_property(SOURCE d4meta.c
   PROPERTY
     SKIP_UNITY_BUILD_INCLUSION ON)

--- a/libdispatch/CMakeLists.txt
+++ b/libdispatch/CMakeLists.txt
@@ -8,6 +8,15 @@ SET(libdispatch_SOURCES dcopy.c dfile.c ddim.c datt.c dattinq.c dattput.c dattge
 daux.c dinstance.c dinstance_intern.c
 dcrc32.c dcrc32.h dcrc64.c ncexhash.c ncxcache.c ncjson.c ds3util.c dparallel.c dmissing.c)
 
+## 
+# Turn off inclusion of particular files when using the cmake-native
+# option to turn on Unity Builds.  
+#
+# For more information, see:
+#  * https://github.com/Unidata/netcdf-c/pull/2839/
+#  * https://cmake.org/cmake/help/latest/prop_tgt/UNITY_BUILD.html
+#  * https://cmake.org/cmake/help/latest/prop_tgt/UNITY_BUILD_MODE.html#prop_tgt:UNITY_BUILD_MODE
+##
 set_property(SOURCE dinstance_intern.c dinstance.c dvarput.c
   PROPERTY
     SKIP_UNITY_BUILD_INCLUSION ON)

--- a/libdispatch/CMakeLists.txt
+++ b/libdispatch/CMakeLists.txt
@@ -8,6 +8,10 @@ SET(libdispatch_SOURCES dcopy.c dfile.c ddim.c datt.c dattinq.c dattput.c dattge
 daux.c dinstance.c dinstance_intern.c
 dcrc32.c dcrc32.h dcrc64.c ncexhash.c ncxcache.c ncjson.c ds3util.c dparallel.c dmissing.c)
 
+set_property(SOURCE dinstance_intern.c dinstance.c dvarput.c
+  PROPERTY
+    SKIP_UNITY_BUILD_INCLUSION ON)
+
 # Netcdf-4 only functions. Must be defined even if not used
 SET(libdispatch_SOURCES ${libdispatch_SOURCES} dgroup.c dvlen.c dcompound.c dtype.c denum.c dopaque.c dfilter.c)
 

--- a/libsrc/CMakeLists.txt
+++ b/libsrc/CMakeLists.txt
@@ -4,6 +4,15 @@
 SET(libsrc_SOURCES v1hpg.c putget.c attr.c nc3dispatch.c
   nc3internal.c var.c dim.c ncx.c lookup3.c ncio.c)
 
+## 
+# Turn off inclusion of particular files when using the cmake-native
+# option to turn on Unity Builds.  
+#
+# For more information, see:
+#  * https://github.com/Unidata/netcdf-c/pull/2839/
+#  * https://cmake.org/cmake/help/latest/prop_tgt/UNITY_BUILD.html
+#  * https://cmake.org/cmake/help/latest/prop_tgt/UNITY_BUILD_MODE.html#prop_tgt:UNITY_BUILD_MODE
+##
 set_property(SOURCE httpio.c posixio.c mmapio.c
   PROPERTY
     SKIP_UNITY_BUILD_INCLUSION ON)

--- a/libsrc/CMakeLists.txt
+++ b/libsrc/CMakeLists.txt
@@ -4,6 +4,10 @@
 SET(libsrc_SOURCES v1hpg.c putget.c attr.c nc3dispatch.c
   nc3internal.c var.c dim.c ncx.c lookup3.c ncio.c)
 
+set_property(SOURCE httpio.c posixio.c mmapio.c
+  PROPERTY
+    SKIP_UNITY_BUILD_INCLUSION ON)
+
 # Process these files with m4.
 SET(m4_SOURCES attr ncx putget)
 foreach (f ${m4_SOURCES})

--- a/nc_test/CMakeLists.txt
+++ b/nc_test/CMakeLists.txt
@@ -34,6 +34,16 @@ TARGET_LINK_LIBRARIES(nc_test
   netcdf
   ${HAVE_LIBM}
   )
+
+## 
+# Turn off inclusion of particular files when using the cmake-native
+# option to turn on Unity Builds.  
+#
+# For more information, see:
+#  * https://github.com/Unidata/netcdf-c/pull/2839/
+#  * https://cmake.org/cmake/help/latest/prop_tgt/UNITY_BUILD.html
+#  * https://cmake.org/cmake/help/latest/prop_tgt/UNITY_BUILD_MODE.html#prop_tgt:UNITY_BUILD_MODE
+##
 set_property(TARGET nc_test PROPERTY UNITY_BUILD OFF)
 
 # Some extra stand-alone tests

--- a/nc_test/CMakeLists.txt
+++ b/nc_test/CMakeLists.txt
@@ -34,6 +34,7 @@ TARGET_LINK_LIBRARIES(nc_test
   netcdf
   ${HAVE_LIBM}
   )
+set_property(TARGET nc_test PROPERTY UNITY_BUILD OFF)
 
 # Some extra stand-alone tests
 SET(TESTS t_nc tst_small tst_misc tst_norm tst_names tst_nofill tst_nofill2 tst_nofill3 tst_meta tst_inq_type tst_utf8_phrases tst_global_fillval tst_max_var_dims tst_formats tst_def_var_fill tst_err_enddef tst_default_format)

--- a/ncdump/CMakeLists.txt
+++ b/ncdump/CMakeLists.txt
@@ -24,6 +24,15 @@ SET(ncpathcvt_FILES ncpathcvt.c ${XGETOPTSRC})
 SET(ncfilteravail_FILES ncfilteravail.c ${XGETOPTSRC})
 SET(nchdf5version_FILES nchdf5version.c)
  
+## 
+# Turn off inclusion of particular files when using the cmake-native
+# option to turn on Unity Builds.  
+#
+# For more information, see:
+#  * https://github.com/Unidata/netcdf-c/pull/2839/
+#  * https://cmake.org/cmake/help/latest/prop_tgt/UNITY_BUILD.html
+#  * https://cmake.org/cmake/help/latest/prop_tgt/UNITY_BUILD_MODE.html#prop_tgt:UNITY_BUILD_MODE
+##
 set_property(SOURCE dumplib.c
   PROPERTY
     SKIP_UNITY_BUILD_INCLUSION ON)

--- a/ncdump/CMakeLists.txt
+++ b/ncdump/CMakeLists.txt
@@ -24,6 +24,10 @@ SET(ncpathcvt_FILES ncpathcvt.c ${XGETOPTSRC})
 SET(ncfilteravail_FILES ncfilteravail.c ${XGETOPTSRC})
 SET(nchdf5version_FILES nchdf5version.c)
  
+set_property(SOURCE dumplib.c
+  PROPERTY
+    SKIP_UNITY_BUILD_INCLUSION ON)
+
 ADD_EXECUTABLE(ncdump ${ncdump_FILES})
 ADD_EXECUTABLE(nccopy ${nccopy_FILES})
 ADD_EXECUTABLE(ncvalidator ${ncvalidator_FILES})

--- a/ncgen/CMakeLists.txt
+++ b/ncgen/CMakeLists.txt
@@ -22,6 +22,15 @@ util.c bytebuffer.h data.h debug.h dump.h
 generate.h generr.h genlib.h includes.h list.h
 ncgen.h ncgeny.h util.h ${XGETOPTSRC})
 
+## 
+# Turn off inclusion of particular files when using the cmake-native
+# option to turn on Unity Builds.  
+#
+# For more information, see:
+#  * https://github.com/Unidata/netcdf-c/pull/2839/
+#  * https://cmake.org/cmake/help/latest/prop_tgt/UNITY_BUILD.html
+#  * https://cmake.org/cmake/help/latest/prop_tgt/UNITY_BUILD_MODE.html#prop_tgt:UNITY_BUILD_MODE
+##
 set_property(SOURCE data.c
   PROPERTY
     SKIP_UNITY_BUILD_INCLUSION ON)

--- a/ncgen/CMakeLists.txt
+++ b/ncgen/CMakeLists.txt
@@ -22,6 +22,10 @@ util.c bytebuffer.h data.h debug.h dump.h
 generate.h generr.h genlib.h includes.h list.h
 ncgen.h ncgeny.h util.h ${XGETOPTSRC})
 
+set_property(SOURCE data.c
+  PROPERTY
+    SKIP_UNITY_BUILD_INCLUSION ON)
+
 # Obsolete
 SET(OBSOLETE odom.c odom.h jdatastd.c jdatajni.c genjni.c cdfdata.c cmldata.c)
 

--- a/nctest/CMakeLists.txt
+++ b/nctest/CMakeLists.txt
@@ -16,6 +16,7 @@ FILE(COPY ${COPY_FILES} DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/)
 ADD_EXECUTABLE(nctest ${nctest_SRC})
 TARGET_LINK_LIBRARIES(nctest netcdf)
 ADD_TEST(nctest ${EXECUTABLE_OUTPUT_PATH}/nctest)
+set_property(TARGET nctest PROPERTY UNITY_BUILD OFF)
 
 add_bin_test_no_prefix(tst_rename)
 IF(BUILD_UTILITIES)

--- a/nctest/CMakeLists.txt
+++ b/nctest/CMakeLists.txt
@@ -16,6 +16,16 @@ FILE(COPY ${COPY_FILES} DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/)
 ADD_EXECUTABLE(nctest ${nctest_SRC})
 TARGET_LINK_LIBRARIES(nctest netcdf)
 ADD_TEST(nctest ${EXECUTABLE_OUTPUT_PATH}/nctest)
+
+## 
+# Turn off inclusion of particular files when using the cmake-native
+# option to turn on Unity Builds.  
+#
+# For more information, see:
+#  * https://github.com/Unidata/netcdf-c/pull/2839/
+#  * https://cmake.org/cmake/help/latest/prop_tgt/UNITY_BUILD.html
+#  * https://cmake.org/cmake/help/latest/prop_tgt/UNITY_BUILD_MODE.html#prop_tgt:UNITY_BUILD_MODE
+##
 set_property(TARGET nctest PROPERTY UNITY_BUILD OFF)
 
 add_bin_test_no_prefix(tst_rename)


### PR DESCRIPTION
Allows to speed-up compilation, or at least avoid erros in vtk where netcdf is used as a third-party