### PR TITLE
Add static build to one-off GitHub Actions testing.

### DIFF
--- a/.github/workflows/run_tests_osx.yml
+++ b/.github/workflows/run_tests_osx.yml
@@ -49,10 +49,9 @@ jobs:
           make install -j
           popd
 
-
   nc-autotools-osx:
 
-    needs: [ nc-cmake-tests-oneoff-osx, nc-ac-tests-oneoff-osx ]
+    needs: [ nc-cmake-tests-oneoff-osx-shared, nc-cmake-tests-oneoff-osx-static, nc-ac-tests-oneoff-osx ]
     runs-on: macos-11
 
     strategy:
@@ -65,9 +64,9 @@ jobs:
 
       - uses: actions/checkout@v3
 
-###
-# Set Environmental Variables
-###
+      ###
+      # Set Environmental Variables
+      ###
 
       - run: echo "CFLAGS=-I${HOME}/environments/${{ matrix.hdf5 }}/include" >> $GITHUB_ENV
       - run: echo "LDFLAGS=-L${HOME}/environments/${{ matrix.hdf5 }}/lib" >> $GITHUB_ENV
@@ -89,9 +88,9 @@ jobs:
       - run: echo "ENABLE_NCZARR=--enable-nczarr" >> $GITHUB_ENV
         if: matrix.use_nczarr == 'nczarr_on'
 
-###
-# Fetch Cache
-###
+      ###
+      # Fetch Cache
+      ###
 
       - name: Fetch HDF Cache
         id: cache-hdf-osx
@@ -104,9 +103,9 @@ jobs:
         shell: bash -l {0}
         run: ls ${HOME}/environments && ls ${HOME}/environments/${{ matrix.hdf5 }} && ls ${HOME}/environments/${{ matrix.hdf5}}/lib
 
-###
-# Configure and build
-###
+      ###
+      # Configure and build
+      ###
       - name: Install autoconf
         shell: bash -l {0}
         run: brew install automake
@@ -144,10 +143,10 @@ jobs:
         run: CFLAGS=${CFLAGS} LDFLAGS=${LDFLAGS} LD_LIBRARY_PATH=${LD_LIBRARY_PATH} make check -j
         if: ${{ success() }}
 
-     # - name: Make Distcheck
-     #   shell: bash -l {0}
-     #   run: CFLAGS=${CFLAGS} LDFLAGS=${LDFLAGS} LD_LIBRARY_PATH=${LD_LIBRARY_PATH} DISTCHECK_CONFIGURE_FLAGS="${ENABLE_HDF4} ${ENABLE_HDF5} ${ENABLE_DAP} ${ENABLE_NCZARR}" make distcheck
-     #   if: ${{ success() }}
+      # - name: Make Distcheck
+      #   shell: bash -l {0}
+      #   run: CFLAGS=${CFLAGS} LDFLAGS=${LDFLAGS} LD_LIBRARY_PATH=${LD_LIBRARY_PATH} DISTCHECK_CONFIGURE_FLAGS="${ENABLE_HDF4} ${ENABLE_HDF5} ${ENABLE_DAP} ${ENABLE_NCZARR}" make distcheck
+      #  if: ${{ success() }}
 
       #- name: Start SSH Debug
       #  uses: luchihoratiu/debug-via-ssh@main
@@ -158,7 +157,7 @@ jobs:
 
   nc-cmake-osx:
 
-    needs: [ nc-cmake-tests-oneoff-osx, nc-ac-tests-oneoff-osx ]
+    needs: [ nc-cmake-tests-oneoff-osx-shared, nc-cmake-tests-oneoff-osx-static, nc-ac-tests-oneoff-osx ]
     runs-on: macos-11
 
     strategy:
@@ -171,9 +170,9 @@ jobs:
 
       - uses: actions/checkout@v3
 
-###
-# Set Environmental Variables
-###
+    ###
+    # Set Environmental Variables
+    ###
 
       - run: echo "CMAKE_PREFIX_PATH=${HOME}/environments/${{ matrix.hdf5 }}/" >> $GITHUB_ENV
       - run: echo "LD_LIBRARY_PATH=${HOME}/environments/${{ matrix.hdf5 }}/lib" >> $GITHUB_ENV
@@ -195,9 +194,9 @@ jobs:
         if: matrix.use_nczarr == 'nczarr_on'
       - run: echo "CTEST_OUTPUT_ON_FAILURE=1" >> $GITHUB_ENV
 
-###
-# Fetch Cache
-###
+    ###
+    # Fetch Cache
+    ###
 
       - name: Fetch HDF Cache
         id: cache-hdf5-osx
@@ -210,9 +209,9 @@ jobs:
         shell: bash -l {0}
         run: ls ${HOME}/environments && ls ${HOME}/environments/${{ matrix.hdf5 }} && ls ${HOME}/environments/${{ matrix.hdf5}}/lib
 
-###
-# Configure and build
-###
+    ###
+    # Configure and build
+    ###
 
       - name: Perform out-of-directory build
         shell: bash -l {0}
@@ -248,10 +247,9 @@ jobs:
           LD_LIBRARY_PATH=${LD_LIBRARY_PATH} ctest -j 12 --rerun-failed --output-on-failure -VV
         if: ${{ failure() }}
 
-
-#####
-# One-Off Autotools-based tests.
-#####
+  #####
+  # One-Off Autotools-based tests.
+  #####
   nc-ac-tests-oneoff-osx:
 
     needs: build-deps-osx
@@ -264,18 +262,18 @@ jobs:
 
       - uses: actions/checkout@v3
 
-###
-# Set Environmental Variables
-###
+      ###
+      # Set Environmental Variables
+      ###
 
       - run: echo "CFLAGS=-I${HOME}/environments/${{ matrix.hdf5 }}/include" >> $GITHUB_ENV
       - run: echo "LDFLAGS=-L${HOME}/environments/${{ matrix.hdf5 }}/lib" >> $GITHUB_ENV
       - run: echo "LD_LIBRARY_PATH=${HOME}/environments/${{ matrix.hdf5 }}/lib" >> $GITHUB_ENV
 
 
-###
-# Fetch Cache
-###
+      ###
+      # Fetch Cache
+      ###
 
       - name: Fetch HDF Cache
         id: cache-hdf-osx
@@ -288,9 +286,9 @@ jobs:
         shell: bash -l {0}
         run: ls ${HOME}/environments && ls ${HOME}/environments/${{ matrix.hdf5 }} && ls ${HOME}/environments/${{ matrix.hdf5}}/lib
 
-###
-# Configure and build
-###
+      ###
+      # Configure and build
+      ###
 
       - name: Install autoconf
         shell: bash -l {0}
@@ -329,11 +327,11 @@ jobs:
         run: CFLAGS=${CFLAGS} LDFLAGS=${LDFLAGS} LD_LIBRARY_PATH=${LD_LIBRARY_PATH} make check -j
         if: ${{ success() }}
 
-#####
-# One-Off CMake-based tests.
-#####
+  #####
+  # One-Off CMake-based tests.
+  #####
 
-  nc-cmake-tests-oneoff-osx:
+  nc-cmake-tests-oneoff-osx-shared:
 
     needs: build-deps-osx
     runs-on: macos-11
@@ -346,16 +344,16 @@ jobs:
 
       - uses: actions/checkout@v3
 
-###
-# Set Environmental Variables
-###
+    ###
+    # Set Environmental Variables
+    ###
 
       - run: echo "CMAKE_PREFIX_PATH=${HOME}/environments/${{ matrix.hdf5 }}/" >> $GITHUB_ENV
       - run: echo "LD_LIBRARY_PATH=${HOME}/environments/${{ matrix.hdf5 }}/lib" >> $GITHUB_ENV
 
-###
-# Fetch Cache
-###
+    ###
+    # Fetch Cache
+    ###
 
       - name: Fetch HDF Cache
         id: cache-hdf5-osx
@@ -368,9 +366,9 @@ jobs:
         shell: bash -l {0}
         run: ls ${HOME}/environments && ls ${HOME}/environments/${{ matrix.hdf5 }} && ls ${HOME}/environments/${{ matrix.hdf5}}/lib
 
-###
-# Configure and build
-###
+    ###
+    # Configure and build
+    ###
 
       - name: Perform out-of-directory build
         shell: bash -l {0}
@@ -378,6 +376,81 @@ jobs:
           mkdir build
           cd build
           LD_LIBRARY_PATH=${LD_LIBRARY_PATH} cmake .. -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH} -DENABLE_DAP=TRUE -DENABLE_HDF5=TRUE -DENABLE_NCZARR=TRUE -D ENABLE_DAP_LONG_TESTS=TRUE -DENABLE_XML2=FALSE
+
+      - name: Print Summary
+        shell: bash -l {0}
+        run: |
+          cd build
+          cat libnetcdf.settings
+
+      - name: Build All
+        shell: bash -l {0}
+        run: |
+          cd build
+          LD_LIBRARY_PATH=${LD_LIBRARY_PATH} make -j 12
+        if: ${{ success() }}
+
+      - name: Run Tests
+        shell: bash -l {0}
+        run: |
+          cd build
+          LD_LIBRARY_PATH=${LD_LIBRARY_PATH} ctest --output-on-failure -j 12 .
+        if: ${{ success() }}
+
+      - name: Verbose Output if CTest Failure
+        shell: bash -l {0}
+        run: |
+          cd build
+          LD_LIBRARY_PATH=${LD_LIBRARY_PATH} ctest -j 12 --rerun-failed --output-on-failure -VV
+        if: ${{ failure() }}
+
+
+  nc-cmake-tests-oneoff-osx-static:
+
+    needs: build-deps-osx
+    runs-on: macos-11
+
+    strategy:
+      matrix:
+        hdf5: [ 1.12.2, 1.14.0 ]
+
+    steps:
+
+      - uses: actions/checkout@v3
+
+    ###
+    # Set Environmental Variables
+    ###
+
+      - run: echo "CMAKE_PREFIX_PATH=${HOME}/environments/${{ matrix.hdf5 }}/" >> $GITHUB_ENV
+      - run: echo "LD_LIBRARY_PATH=${HOME}/environments/${{ matrix.hdf5 }}/lib" >> $GITHUB_ENV
+      - run: echo "CMAKE_C_FLAGS=-fPIC" >> $GITHUB_ENV
+
+    ###
+    # Fetch Cache
+    ###
+
+      - name: Fetch HDF Cache
+        id: cache-hdf5-osx
+        uses: actions/cache@v3
+        with:
+          path: ~/environments/${{ matrix.hdf5 }}
+          key: hdf5-${{ runner.os }}-${{ matrix.hdf5 }}
+
+      - name: Check Cache
+        shell: bash -l {0}
+        run: ls ${HOME}/environments && ls ${HOME}/environments/${{ matrix.hdf5 }} && ls ${HOME}/environments/${{ matrix.hdf5}}/lib
+
+    ###
+    # Configure and build
+    ###
+
+      - name: Perform out-of-directory build
+        shell: bash -l {0}
+        run: |
+          mkdir build
+          cd build
+          LD_LIBRARY_PATH=${LD_LIBRARY_PATH} cmake .. -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH} -DENABLE_DAP=TRUE -DENABLE_HDF5=TRUE -DENABLE_NCZARR=TRUE -D ENABLE_DAP_LONG_TESTS=TRUE -DENABLE_XML2=FALSE -DBUILD_SHARED_LIBS=OFF -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
 
       - name: Print Summary
         shell: bash -l {0}

--- a/.github/workflows/run_tests_ubuntu.yml
+++ b/.github/workflows/run_tests_ubuntu.yml
@@ -309,7 +309,6 @@ jobs:
             *.tgz
 
 
-
   ##
   # Parallel
   ##
@@ -496,6 +495,7 @@ jobs:
 
       - run: echo "CMAKE_PREFIX_PATH=${HOME}/environments/${{ matrix.hdf5 }}/" >> $GITHUB_ENV
       - run: echo "LD_LIBRARY_PATH=${HOME}/environments/${{ matrix.hdf5 }}/lib" >> $GITHUB_ENV
+      - run: echo "CMAKE_C_FLAGS=-fPIC" >> $GITHUB_ENV
 
       ###
       # Fetch Cache
@@ -521,7 +521,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          LD_LIBRARY_PATH=${LD_LIBRARY_PATH} cmake .. -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH} -DENABLE_DAP=TRUE -DENABLE_HDF5=TRUE -DENABLE_NCZARR=TRUE -DENABLE_DAP_LONG_TESTS=TRUE -DENABLE_XML2=FALSE -DBUILD_SHARED_LIBS=FALSE
+          LD_LIBRARY_PATH=${LD_LIBRARY_PATH} cmake .. -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH} -DENABLE_DAP=TRUE -DENABLE_HDF5=TRUE -DENABLE_NCZARR=TRUE -DENABLE_DAP_LONG_TESTS=TRUE -DENABLE_XML2=FALSE -DBUILD_SHARED_LIBS=FALSE -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
 
       - name: Print Summary
         shell: bash -l {0}

--- a/.github/workflows/run_tests_ubuntu.yml
+++ b/.github/workflows/run_tests_ubuntu.yml
@@ -119,9 +119,9 @@ jobs:
   # One-Off Autotools-based tests.
   #####
   ##
-  # Serial
+  # Serial, Shared
   ##
-  nc-ac-tests-oneoff-serial:
+  nc-ac-tests-oneoff-serial-shared:
 
     needs: build-deps-serial
     runs-on: ubuntu-latest
@@ -212,6 +212,103 @@ jobs:
             *.tar*
             *.zip
             *.tgz
+
+  ##
+  #
+  ## Serial, Static
+  nc-ac-tests-oneoff-serial-static:
+
+    needs: build-deps-serial
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        hdf5: [ 1.14.0 ]
+    steps:
+
+      - uses: actions/checkout@v3
+
+      - name: Install System dependencies
+        shell: bash -l {0}
+        run: sudo apt update && sudo apt install -y libaec-dev zlib1g-dev automake autoconf libcurl4-openssl-dev libjpeg-dev wget curl bzip2 m4 flex bison cmake libzip-dev doxygen valgrind
+
+        ###
+        # Set Environmental Variables
+        ###
+
+      - run: echo "CFLAGS=-I${HOME}/environments/${{ matrix.hdf5 }}/include" >> $GITHUB_ENV
+      - run: echo "LDFLAGS=-L${HOME}/environments/${{ matrix.hdf5 }}/lib" >> $GITHUB_ENV
+      - run: echo "LD_LIBRARY_PATH=${HOME}/environments/${{ matrix.hdf5 }}/lib" >> $GITHUB_ENV
+
+
+        ###
+        # Fetch Cache
+        ###
+
+      - name: Fetch HDF Cache
+        id: cache-hdf
+        uses: actions/cache@v3
+        with:
+          path: ~/environments/${{ matrix.hdf5 }}
+          key: hdf5-${{ runner.os }}-${{ matrix.hdf5 }}
+
+      - name: Check Cache
+        shell: bash -l {0}
+        run: ls ${HOME}/environments && ls ${HOME}/environments/${{ matrix.hdf5 }} && ls ${HOME}/environments/${{ matrix.hdf5}}/lib
+
+        ###
+        # Configure and build
+        ###
+
+      - name: Run autoconf
+        shell: bash -l {0}
+        run: autoreconf -if
+
+      - name: Configure
+        shell: bash -l {0}
+        run: CFLAGS=${CFLAGS} LDFLAGS=${LDFLAGS} LD_LIBRARY_PATH=${LD_LIBRARY_PATH} ./configure --enable-hdf5 --enable-dap --disable-dap-remote-tests  --enable-doxygen  --enable-external-server-tests --disable-xml2 --disable-shared --enable-static
+        if: ${{ success() }}
+
+      - name: Look at config.log if error
+        shell: bash -l {0}
+        run: cat config.log
+        if: ${{ failure() }}
+
+      - name: Print Summary
+        shell: bash -l {0}
+        run: cat libnetcdf.settings
+
+      - name: Build Library and Utilities
+        shell: bash -l {0}
+        run: CFLAGS=${CFLAGS} LDFLAGS=${LDFLAGS} LD_LIBRARY_PATH=${LD_LIBRARY_PATH} make -j
+        if: ${{ success() }}
+
+      - name: Build Tests
+        shell: bash -l {0}
+        run: CFLAGS=${CFLAGS} LDFLAGS=${LDFLAGS} LD_LIBRARY_PATH=${LD_LIBRARY_PATH} make check TESTS="" -j
+        if: ${{ success() }}
+
+      - name: Run Tests
+        shell: bash -l {0}
+        run: |
+          LD_LIBRARY_PATH="/home/runner/work/netcdf-c/netcdf-c/liblib/.libs:${LD_LIBRARY_PATH}"
+          CFLAGS=${CFLAGS} LDFLAGS=${LDFLAGS} LD_LIBRARY_PATH=${LD_LIBRARY_PATH} make check -j
+        if: ${{ success() }}
+
+      - name: Create source distribution
+        shell: bash -l {0}
+        if: ${{ success() }}
+        run: make dist -j
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: netcdf-c-autotools-source-distribution
+          path: |
+            *.tar*
+            *.zip
+            *.tgz
+
+
 
   ##
   # Parallel
@@ -455,7 +552,7 @@ jobs:
 
   nc-autotools:
 
-    needs: [ nc-cmake-tests-oneoff-serial, nc-ac-tests-oneoff-serial, nc-cmake-tests-oneoff-parallel, nc-ac-tests-oneoff-parallel ]
+    needs: [ nc-cmake-tests-oneoff-serial, nc-ac-tests-oneoff-serial-shared, nc-ac-tests-oneoff-serial-static, nc-cmake-tests-oneoff-parallel, nc-ac-tests-oneoff-parallel ]
     runs-on: ubuntu-latest
 
     strategy:
@@ -619,7 +716,7 @@ jobs:
 
   nc-cmake:
 
-    needs: [ nc-cmake-tests-oneoff-serial, nc-ac-tests-oneoff-serial, nc-cmake-tests-oneoff-parallel, nc-ac-tests-oneoff-parallel ]
+    needs: [ nc-cmake-tests-oneoff-serial, nc-ac-tests-oneoff-serial-shared, nc-ac-tests-oneoff-serial-static, nc-cmake-tests-oneoff-parallel, nc-ac-tests-oneoff-parallel ]
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/run_tests_ubuntu.yml
+++ b/.github/workflows/run_tests_ubuntu.yml
@@ -391,9 +391,9 @@ jobs:
   # One-Off CMake-based tests.
   #####
   ##
-  # Serial
+  # Serial, Shared
   ##
-  nc-cmake-tests-oneoff-serial:
+  nc-cmake-tests-oneoff-serial-shared:
 
     needs: build-deps-serial
     runs-on: ubuntu-latest
@@ -469,6 +469,87 @@ jobs:
           cd build
           LD_LIBRARY_PATH=${LD_LIBRARY_PATH} ctest -j 12 --rerun-failed --output-on-failure -VV
         if: ${{ failure() }}
+
+ ##
+  # Serial, Shared
+  ##
+  nc-cmake-tests-oneoff-serial-static:
+
+    needs: build-deps-serial
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        hdf5: [ 1.14.0 ]
+
+    steps:
+
+      - uses: actions/checkout@v3
+
+      - name: Install System dependencies
+        shell: bash -l {0}
+        run: sudo apt update && sudo apt install -y libaec-dev zlib1g-dev automake autoconf libcurl4-openssl-dev libjpeg-dev wget curl bzip2 m4 flex bison cmake libzip-dev doxygen
+
+      ###
+      # Set Environmental Variables
+      ###
+
+      - run: echo "CMAKE_PREFIX_PATH=${HOME}/environments/${{ matrix.hdf5 }}/" >> $GITHUB_ENV
+      - run: echo "LD_LIBRARY_PATH=${HOME}/environments/${{ matrix.hdf5 }}/lib" >> $GITHUB_ENV
+
+      ###
+      # Fetch Cache
+      ###
+
+      - name: Fetch HDF Cache
+        id: cache-hdf5
+        uses: actions/cache@v3
+        with:
+          path: ~/environments/${{ matrix.hdf5 }}
+          key: hdf5-${{ runner.os }}-${{ matrix.hdf5 }}
+
+      - name: Check Cache
+        shell: bash -l {0}
+        run: ls ${HOME}/environments && ls ${HOME}/environments/${{ matrix.hdf5 }} && ls ${HOME}/environments/${{ matrix.hdf5}}/lib
+
+      ###
+      # Configure and build
+      ###
+
+      - name: Perform out-of-directory build
+        shell: bash -l {0}
+        run: |
+          mkdir build
+          cd build
+          LD_LIBRARY_PATH=${LD_LIBRARY_PATH} cmake .. -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH} -DENABLE_DAP=TRUE -DENABLE_HDF5=TRUE -DENABLE_NCZARR=TRUE -DENABLE_DAP_LONG_TESTS=TRUE -DENABLE_XML2=FALSE -DBUILD_SHARED_LIBS=FALSE
+
+      - name: Print Summary
+        shell: bash -l {0}
+        run: |
+          cd build
+          cat libnetcdf.settings
+
+      - name: Build All
+        shell: bash -l {0}
+        run: |
+          cd build
+          LD_LIBRARY_PATH=${LD_LIBRARY_PATH} make -j 12
+        if: ${{ success() }}
+
+      - name: Run Tests
+        shell: bash -l {0}
+        run: |
+          cd build
+          LD_LIBRARY_PATH=${LD_LIBRARY_PATH} ctest --output-on-failure -j 12 .
+        if: ${{ success() }}
+
+      - name: Verbose Output if CTest Failure
+        shell: bash -l {0}
+        run: |
+          cd build
+          LD_LIBRARY_PATH=${LD_LIBRARY_PATH} ctest -j 12 --rerun-failed --output-on-failure -VV
+        if: ${{ failure() }}
+
 
   ##
   # Parallel
@@ -552,7 +633,7 @@ jobs:
 
   nc-autotools:
 
-    needs: [ nc-cmake-tests-oneoff-serial, nc-ac-tests-oneoff-serial-shared, nc-ac-tests-oneoff-serial-static, nc-cmake-tests-oneoff-parallel, nc-ac-tests-oneoff-parallel ]
+    needs: [ nc-cmake-tests-oneoff-serial-shared, nc-cmake-tests-oneoff-serial-static, nc-ac-tests-oneoff-serial-shared, nc-ac-tests-oneoff-serial-static, nc-cmake-tests-oneoff-parallel, nc-ac-tests-oneoff-parallel ]
     runs-on: ubuntu-latest
 
     strategy:
@@ -716,7 +797,7 @@ jobs:
 
   nc-cmake:
 
-    needs: [ nc-cmake-tests-oneoff-serial, nc-ac-tests-oneoff-serial-shared, nc-ac-tests-oneoff-serial-static, nc-cmake-tests-oneoff-parallel, nc-ac-tests-oneoff-parallel ]
+    needs: [ nc-cmake-tests-oneoff-serial-shared, nc-cmake-tests-oneoff-serial-static, nc-ac-tests-oneoff-serial-shared, nc-ac-tests-oneoff-serial-static, nc-cmake-tests-oneoff-parallel, nc-ac-tests-oneoff-parallel ]
     runs-on: ubuntu-latest
 
     strategy:


### PR DESCRIPTION
As discovered in #2847, we are not properly testing static builds, which has allowed an issue to creep in. 