### PR TITLE
Fixes finding HDF5 header

### DIFF
--- a/cmake/check_hdf5.cmake
+++ b/cmake/check_hdf5.cmake
@@ -18,9 +18,9 @@ function(check_hdf5_feature_header)
 
   message(STATUS "Checking for HDF5 config header")
   foreach(_h5_header "H5public.h" "H5pubconf.h" "H5pubconf-64.h" "H5pubconf-32.h")
-    check_include_file(${_h5_header} _can_include_h5_header)
+    check_include_file(${_h5_header} _can_include_h5_header${_h5_header})
 
-    if (_can_include_h5_header)
+    if (_can_include_h5_header${_h5_header})
       message(STATUS "Using ${_h5_header} to check for feature macros")
       set(_H5_FEATURE_HEADER ${_h5_header} CACHE INTERNAL "")
       return()


### PR DESCRIPTION
Without this PR, only the first file within the loop is checked for. Therefore, it fails if the first file is not found.

Without PR:
```
-- Checking for HDF5 config header
-- Looking for H5public.h
-- Looking for H5public.h - not found
CMake Error at cmake/check_hdf5.cmake:30 (message):
  Could not include any HDF5 config headers
Call Stack (most recent call first):

```
With PR:
```
-- Looking for H5public.h
-- Looking for H5public.h - not found
-- Looking for H5pubconf.h
-- Looking for H5pubconf.h - found
-- Using H5pubconf.h to check for feature macros
```