### PR TITLE
Silence most warnings in libhdf5

### DIFF
--- a/include/nc4internal.h
+++ b/include/nc4internal.h
@@ -162,7 +162,7 @@ typedef struct NC_ATT_INFO
 {
     NC_OBJ hdr;             /**< The hdr contains the name and ID. */
     struct NC_OBJ *container;    /**< Pointer to containing group|var. */
-    int len;                /**< Length of attribute data. */
+    size_t len;             /**< Length of attribute data. */
     nc_bool_t dirty;        /**< True if attribute modified. */
     nc_bool_t created;      /**< True if attribute already created. */
     nc_type nc_typeid;      /**< NetCDF type of attribute's data. */

--- a/libhdf5/hdf5attr.c
+++ b/libhdf5/hdf5attr.c
@@ -47,7 +47,7 @@ getattlist(NC_GRP_INFO_T *grp, int varid, NC_VAR_INFO_T **varp,
     {
         NC_VAR_INFO_T *var;
 
-        if (!(var = (NC_VAR_INFO_T *)ncindexith(grp->vars, varid)))
+        if (!(var = (NC_VAR_INFO_T *)ncindexith(grp->vars, (size_t)varid)))
             return NC_ENOTVAR;
         assert(var->hdr.id == varid);
 
@@ -92,14 +92,13 @@ nc4_get_att_special(NC_FILE_INFO_T* h5, const char* name,
         return NC_EATTMETA;
 
     if(strcmp(name,NCPROPS)==0) {
-        int len;
         if(h5->provenance.ncproperties == NULL)
             return NC_ENOTATT;
         if(mem_type == NC_NAT) mem_type = NC_CHAR;
         if(mem_type != NC_CHAR)
             return NC_ECHAR;
         if(filetypep) *filetypep = NC_CHAR;
-	len = strlen(h5->provenance.ncproperties);
+        size_t len = strlen(h5->provenance.ncproperties);
         if(lenp) *lenp = len;
         if(data) strncpy((char*)data,h5->provenance.ncproperties,len+1);
     } else if(strcmp(name,ISNETCDF4ATT)==0
@@ -110,7 +109,7 @@ nc4_get_att_special(NC_FILE_INFO_T* h5, const char* name,
         if(strcmp(name,SUPERBLOCKATT)==0)
             iv = (unsigned long long)h5->provenance.superblockversion;
         else /* strcmp(name,ISNETCDF4ATT)==0 */
-            iv = NC4_isnetcdf4(h5);
+            iv = (unsigned long long)NC4_isnetcdf4(h5);
         if(mem_type == NC_NAT) mem_type = NC_INT;
         if(data)
             switch (mem_type) {
@@ -271,8 +270,6 @@ NC4_HDF5_del_att(int ncid, int varid, const char *name)
     NC_ATT_INFO_T *att;
     NCindex* attlist = NULL;
     hid_t locid = 0;
-    int i;
-    size_t deletedid;
     int retval;
 
     /* Name must be provided. */
@@ -328,7 +325,7 @@ NC4_HDF5_del_att(int ncid, int varid, const char *name)
             return NC_EATTMETA;
     }
 
-    deletedid = att->hdr.id;
+    int deletedid = att->hdr.id;
 
     /* reclaim associated HDF5 info */
     if((retval=nc4_HDF5_close_att(att))) return retval;
@@ -338,7 +335,7 @@ NC4_HDF5_del_att(int ncid, int varid, const char *name)
         return retval;
 
     /* Renumber all attributes with higher indices. */
-    for (i = 0; i < ncindexsize(attlist); i++)
+    for (size_t i = 0; i < ncindexsize(attlist); i++)
     {
         NC_ATT_INFO_T *a;
         if (!(a = (NC_ATT_INFO_T *)ncindexith(attlist, i)))

--- a/libhdf5/hdf5create.c
+++ b/libhdf5/hdf5create.c
@@ -164,7 +164,7 @@ nc4_create_file(const char *path, int cmode, size_t initialsz,
     {
 	NCglobalstate* gs = NC_getglobalstate();
         if(gs->alignment.defined) {
-	    if (H5Pset_alignment(fapl_id, gs->alignment.threshold, gs->alignment.alignment) < 0) {
+	    if (H5Pset_alignment(fapl_id, (hsize_t)gs->alignment.threshold, (hsize_t)gs->alignment.alignment) < 0) {
 	        BAIL(NC_EHDFERR);
 	    }
 	}
@@ -222,12 +222,12 @@ nc4_create_file(const char *path, int cmode, size_t initialsz,
         if(nc4_info->mem.diskless) {
             size_t alloc_incr;     /* Buffer allocation increment */
             size_t min_incr = 65536; /* Minimum buffer increment */
-            double buf_prcnt = 0.1f;  /* Percentage of buffer size to set as increment */
+            double buf_prcnt = 0.1;  /* Percentage of buffer size to set as increment */
             /* set allocation increment to a percentage of the supplied buffer size, or
              * a pre-defined minimum increment value, whichever is larger
              */
-            if ((buf_prcnt * initialsz) > min_incr)
-                alloc_incr = (size_t)(buf_prcnt * initialsz);
+            if ((size_t)(buf_prcnt * (double)initialsz) > min_incr)
+                alloc_incr = (size_t)(buf_prcnt * (double)initialsz);
             else
                 alloc_incr = min_incr;
             /* Configure FAPL to use the core file driver */

--- a/libhdf5/hdf5dim.c
+++ b/libhdf5/hdf5dim.c
@@ -46,7 +46,6 @@ HDF5_def_dim(int ncid, const char *name, size_t len, int *idp)
     NC_DIM_INFO_T *dim;
     char norm_name[NC_MAX_NAME + 1];
     int retval = NC_NOERR;
-    int i;
 
     LOG((2, "%s: ncid 0x%x name %s len %d", __func__, ncid, name,
          (int)len));
@@ -65,7 +64,7 @@ HDF5_def_dim(int ncid, const char *name, size_t len, int *idp)
     {
         /* Only one limited dimenson for strict nc3. */
         if (len == NC_UNLIMITED) {
-            for(i=0;i<ncindexsize(grp->dim);i++) {
+            for(size_t i=0;i<ncindexsize(grp->dim);i++) {
                 dim = (NC_DIM_INFO_T*)ncindexith(grp->dim,i);
                 if(dim == NULL) continue;
                 if (dim->unlimited)

--- a/libhdf5/hdf5file.c
+++ b/libhdf5/hdf5file.c
@@ -15,6 +15,7 @@
 #include "hdf5internal.h"
 #include "ncrc.h"
 #include "ncauth.h"
+#include <sys/types.h>
 
 extern int NC4_extract_file_image(NC_FILE_INFO_T* h5, int abort); /* In nc4memcb.c */
 
@@ -51,10 +52,9 @@ detect_preserve_dimids(NC_GRP_INFO_T *grp, nc_bool_t *bad_coord_orderp)
     NC_GRP_INFO_T *child_grp;
     int last_dimid = -1;
     int retval;
-    int i;
 
     /* Iterate over variables in this group */
-    for (i=0; i < ncindexsize(grp->vars); i++)
+    for (size_t i=0; i < ncindexsize(grp->vars); i++)
     {
         NC_HDF5_VAR_INFO_T *hdf5_var;
         var = (NC_VAR_INFO_T*)ncindexith(grp->vars,i);
@@ -98,7 +98,7 @@ detect_preserve_dimids(NC_GRP_INFO_T *grp, nc_bool_t *bad_coord_orderp)
     }
 
     /* If there are any child groups, check them also for this condition. */
-    for (i = 0; i < ncindexsize(grp->children); i++)
+    for (size_t i = 0; i < ncindexsize(grp->children); i++)
     {
         if (!(child_grp = (NC_GRP_INFO_T *)ncindexith(grp->children, i)))
             continue;
@@ -326,7 +326,6 @@ static void
 dumpopenobjects(NC_FILE_INFO_T* h5)
 {
     NC_HDF5_FILE_INFO_T *hdf5_info;
-    int nobjs;
 
     assert(h5 && h5->format_file_info);
     hdf5_info = (NC_HDF5_FILE_INFO_T *)h5->format_file_info;
@@ -334,7 +333,7 @@ dumpopenobjects(NC_FILE_INFO_T* h5)
     if(hdf5_info->hdfid <= 0)
         return; /* File was never opened */
 
-    nobjs = H5Fget_obj_count(hdf5_info->hdfid, H5F_OBJ_ALL);
+    ssize_t nobjs = H5Fget_obj_count(hdf5_info->hdfid, H5F_OBJ_ALL);
 
     /* Apparently we can get an error even when nobjs == 0 */
     if(nobjs < 0) {
@@ -346,7 +345,7 @@ dumpopenobjects(NC_FILE_INFO_T* h5)
          * objects open, which means there's a bug in the library. So
          * print out some info on to help the poor programmer figure it
          * out. */
-        snprintf(msg,sizeof(msg),"There are %d HDF5 objects open!", nobjs);
+        snprintf(msg,sizeof(msg),"There are %zd HDF5 objects open!", nobjs);
 #ifdef LOGGING
 #ifdef LOGOPEN
         LOG((0, msg));
@@ -485,7 +484,6 @@ NC4_enddef(int ncid)
     NC_FILE_INFO_T *nc4_info;
     NC_GRP_INFO_T *grp;
     int retval;
-    int i;
     NC_VAR_INFO_T* var = NULL;
 
     LOG((1, "%s: ncid 0x%x", __func__, ncid));
@@ -497,7 +495,7 @@ NC4_enddef(int ncid)
     /* Why is this here? Especially since it is not recursive so it
        only applies to the this grp */
     /* When exiting define mode, mark all variable written. */
-    for (i = 0; i < ncindexsize(grp->vars); i++)
+    for (size_t i = 0; i < ncindexsize(grp->vars); i++)
     {
         var = (NC_VAR_INFO_T *)ncindexith(grp->vars, i);
         assert(var);
@@ -658,7 +656,6 @@ NC4_inq(int ncid, int *ndimsp, int *nvarsp, int *nattsp, int *unlimdimidp)
     NC_FILE_INFO_T *h5;
     NC_GRP_INFO_T *grp;
     int retval;
-    int i;
 
     LOG((2, "%s: ncid 0x%x", __func__, ncid));
 
@@ -697,7 +694,7 @@ NC4_inq(int ncid, int *ndimsp, int *nvarsp, int *nattsp, int *unlimdimidp)
            with netcdf-3, then only the last unlimited one will be reported
            back in xtendimp. */
         /* Note that this code is inconsistent with nc_inq_unlimid() */
-        for(i=0;i<ncindexsize(grp->dim);i++) {
+        for(size_t i=0;i<ncindexsize(grp->dim);i++) {
             NC_DIM_INFO_T* d = (NC_DIM_INFO_T*)ncindexith(grp->dim,i);
             if(d == NULL) continue;
             if(d->unlimited) {

--- a/libhdf5/hdf5internal.c
+++ b/libhdf5/hdf5internal.c
@@ -121,7 +121,7 @@ find_var_dim_max_length(NC_GRP_INFO_T *grp, int varid, int dimid,
     LOG((3, "find_var_dim_max_length varid %d dimid %d", varid, dimid));    
 
     /* Find this var. */
-    var = (NC_VAR_INFO_T*)ncindexith(grp->vars,varid);
+    var = (NC_VAR_INFO_T*)ncindexith(grp->vars, (size_t)varid);
     if (!var) return NC_ENOTVAR;
     assert(var->hdr.id == varid);
 
@@ -252,21 +252,20 @@ nc4_find_dim_len(NC_GRP_INFO_T *grp, int dimid, size_t **len)
 {
     NC_VAR_INFO_T *var;
     int retval;
-    int i;
 
     assert(grp && len);
     LOG((3, "%s: grp->name %s dimid %d", __func__, grp->hdr.name, dimid));
 
     /* If there are any groups, call this function recursively on
      * them. */
-    for (i = 0; i < ncindexsize(grp->children); i++)
+    for (size_t i = 0; i < ncindexsize(grp->children); i++)
         if ((retval = nc4_find_dim_len((NC_GRP_INFO_T*)ncindexith(grp->children, i),
                                        dimid, len)))
             return retval;
 
     /* For all variables in this group, find the ones that use this
      * dimension, and remember the max length. */
-    for (i = 0; i < ncindexsize(grp->vars); i++)
+    for (size_t i = 0; i < ncindexsize(grp->vars); i++)
     {
         size_t mylen;
         var = (NC_VAR_INFO_T *)ncindexith(grp->vars, i);
@@ -431,23 +430,21 @@ nc4_reform_coord_var(NC_GRP_INFO_T *grp, NC_VAR_INFO_T *var, NC_DIM_INFO_T *dim)
     {
         int dims_detached = 0;
         int finished = 0;
-        int d;
 
         /* Loop over all dimensions for variable. */
-        for (d = 0; d < var->ndims && !finished; d++)
+        for (unsigned int d = 0; d < var->ndims && !finished; d++)
         {
             /* Is there a dimscale attached to this axis? */
             if (hdf5_var->dimscale_attached[d])
             {
                 NC_GRP_INFO_T *g;
-                int k;
 
                 for (g = grp; g && !finished; g = g->parent)
                 {
                     NC_DIM_INFO_T *dim1;
                     NC_HDF5_DIM_INFO_T *hdf5_dim1;
 
-                    for (k = 0; k < ncindexsize(g->dim); k++)
+                    for (size_t k = 0; k < ncindexsize(g->dim); k++)
                     {
                         dim1 = (NC_DIM_INFO_T *)ncindexith(g->dim, k);
                         assert(dim1 && dim1->format_dim_info);
@@ -542,9 +539,8 @@ static int
 close_gatts(NC_GRP_INFO_T *grp)
 {
     NC_ATT_INFO_T *att;
-    int a;
 
-    for (a = 0; a < ncindexsize(grp->att); a++)
+    for (size_t a = 0; a < ncindexsize(grp->att); a++)
     {
         att = (NC_ATT_INFO_T *)ncindexith(grp->att, a);
         assert(att && att->format_att_info);
@@ -595,9 +591,8 @@ close_vars(NC_GRP_INFO_T *grp)
     NC_VAR_INFO_T *var;
     NC_HDF5_VAR_INFO_T *hdf5_var;
     NC_ATT_INFO_T *att;
-    int a, i;
 
-    for (i = 0; i < ncindexsize(grp->vars); i++)
+    for (size_t i = 0; i < ncindexsize(grp->vars); i++)
     {
         var = (NC_VAR_INFO_T *)ncindexith(grp->vars, i);
         assert(var && var->format_var_info);
@@ -631,7 +626,7 @@ close_vars(NC_GRP_INFO_T *grp)
 		nc4_HDF5_close_type(var->type_info);
         }
 
-        for (a = 0; a < ncindexsize(var->att); a++)
+        for (size_t a = 0; a < ncindexsize(var->att); a++)
         {
             att = (NC_ATT_INFO_T *)ncindexith(var->att, a);
             assert(att && att->format_att_info);
@@ -669,9 +664,8 @@ static int
 close_dims(NC_GRP_INFO_T *grp)
 {
     NC_DIM_INFO_T *dim;
-    int i;
 
-    for (i = 0; i < ncindexsize(grp->dim); i++)
+    for (size_t i = 0; i < ncindexsize(grp->dim); i++)
     {
         NC_HDF5_DIM_INFO_T *hdf5_dim;
 
@@ -704,9 +698,7 @@ close_dims(NC_GRP_INFO_T *grp)
 static int
 close_types(NC_GRP_INFO_T *grp)
 {
-    int i;
-
-    for (i = 0; i < ncindexsize(grp->type); i++)
+    for (size_t i = 0; i < ncindexsize(grp->type); i++)
     {
         NC_TYPE_INFO_T *type;
 
@@ -764,7 +756,6 @@ int
 nc4_rec_grp_HDF5_del(NC_GRP_INFO_T *grp)
 {
     NC_HDF5_GRP_INFO_T *hdf5_grp;
-    int i;
     int retval;
 
     assert(grp && grp->format_grp_info);
@@ -774,7 +765,7 @@ nc4_rec_grp_HDF5_del(NC_GRP_INFO_T *grp)
 
     /* Recursively call this function for each child, if any, stopping
      * if there is an error. */
-    for (i = 0; i < ncindexsize(grp->children); i++)
+    for (size_t i = 0; i < ncindexsize(grp->children); i++)
         if ((retval = nc4_rec_grp_HDF5_del((NC_GRP_INFO_T *)ncindexith(grp->children,
                                                                        i))))
             return retval;
@@ -905,7 +896,7 @@ nc4_hdf5_find_grp_var_att(int ncid, int varid, const char *name, int attnum,
     }
     else
     {
-        if (!(my_var = (NC_VAR_INFO_T *)ncindexith(my_grp->vars, varid)))
+        if (!(my_var = (NC_VAR_INFO_T *)ncindexith(my_grp->vars, (size_t)varid)))
             return NC_ENOTVAR;
 
         /* Do we need to read the var attributes? */
@@ -935,7 +926,7 @@ nc4_hdf5_find_grp_var_att(int ncid, int varid, const char *name, int attnum,
     if (att)
     {
         my_att = use_name ? (NC_ATT_INFO_T *)ncindexlookup(attlist, my_norm_name) :
-            (NC_ATT_INFO_T *)ncindexith(attlist, attnum);
+            (NC_ATT_INFO_T *)ncindexith(attlist, (size_t)attnum);
         if (!my_att)
             return NC_ENOTATT;
     }

--- a/libhdf5/hdf5open.c
+++ b/libhdf5/hdf5open.c
@@ -53,7 +53,7 @@ static const nc_type nc_type_constant_g[NUM_TYPES] = {NC_CHAR, NC_BYTE, NC_SHORT
                                                       NC_UINT64, NC_STRING};
 
 /** @internal NetCDF atomic type sizes. */
-static const int nc_type_size_g[NUM_TYPES] = {sizeof(char), sizeof(char), sizeof(short),
+static const size_t nc_type_size_g[NUM_TYPES] = {sizeof(char), sizeof(char), sizeof(short),
                                               sizeof(int), sizeof(float), sizeof(double), sizeof(unsigned char),
                                               sizeof(unsigned short), sizeof(unsigned int), sizeof(long long),
                                               sizeof(unsigned long long), sizeof(char *)};
@@ -451,11 +451,10 @@ create_phony_dims(NC_GRP_INFO_T *grp, hid_t hdf_datasetid, NC_VAR_INFO_T *var)
      * unless there already is one the correct size. */
     for (d = 0; d < var->ndims; d++)
     {
-        int k;
         int match = 0;
 
         /* Is there already a phony dimension of the correct size? */
-        for (k = 0; k < ncindexsize(grp->dim); k++)
+        for (size_t k = 0; k < ncindexsize(grp->dim); k++)
         {
             dim = (NC_DIM_INFO_T *)ncindexith(grp->dim, k);
             assert(dim);
@@ -535,19 +534,18 @@ rec_match_dimscales(NC_GRP_INFO_T *grp)
     NC_VAR_INFO_T *var;
     NC_DIM_INFO_T *dim;
     int retval = NC_NOERR;
-    int i;
 
     assert(grp && grp->hdr.name);
     LOG((4, "%s: grp->hdr.name %s", __func__, grp->hdr.name));
 
     /* Perform var dimscale match for child groups. */
-    for (i = 0; i < ncindexsize(grp->children); i++)
+    for (size_t i = 0; i < ncindexsize(grp->children); i++)
         if ((retval = rec_match_dimscales((NC_GRP_INFO_T *)ncindexith(grp->children, i))))
             return retval;
 
     /* Check all the vars in this group. If they have dimscale info,
      * try and find a dimension for them. */
-    for (i = 0; i < ncindexsize(grp->vars); i++)
+    for (size_t i = 0; i < ncindexsize(grp->vars); i++)
     {
         NC_HDF5_VAR_INFO_T *hdf5_var;
         int d;
@@ -578,7 +576,6 @@ rec_match_dimscales(NC_GRP_INFO_T *grp)
         if (!hdf5_var->dimscale)
         {
             int d;
-            int j;
 
             /* Are there dimscales for this variable? */
             if (hdf5_var->dimscale_hdf5_objids)
@@ -600,7 +597,7 @@ rec_match_dimscales(NC_GRP_INFO_T *grp)
                     for (g = grp; g && !finished; g = g->parent)
                     {
                         /* Check all dims in this group. */
-                        for (j = 0; j < ncindexsize(g->dim); j++)
+                        for (size_t j = 0; j < ncindexsize(g->dim); j++)
                         {
                             /* Get the HDF5 specific dim info. */
                             NC_HDF5_DIM_INFO_T *hdf5_dim;
@@ -836,7 +833,7 @@ nc4_open_file(const char *path, int mode, void* parameters, int ncid)
     {
 	NCglobalstate* gs = NC_getglobalstate();
         if(gs->alignment.defined) {
-	    if (H5Pset_alignment(fapl_id, gs->alignment.threshold, gs->alignment.alignment) < 0) {
+	    if (H5Pset_alignment(fapl_id, (hsize_t)gs->alignment.threshold, (hsize_t)gs->alignment.alignment) < 0) {
 	        BAIL(NC_EHDFERR);
 	    }
 	}
@@ -1077,7 +1074,6 @@ static int get_filter_info(hid_t propid, NC_VAR_INFO_T *var)
     int num_filters;
     unsigned int* cd_values = NULL;
     size_t cd_nelems;
-    int f;
     int stat = NC_NOERR;
     NC_HDF5_VAR_INFO_T *hdf5_var;
     int varsized = 0;
@@ -1094,7 +1090,7 @@ static int get_filter_info(hid_t propid, NC_VAR_INFO_T *var)
        it has filters defined, suppress the variable. */
     varsized = NC4_var_varsized(var);
 
-    for (f = 0; f < num_filters; f++)
+    for (unsigned int f = 0; f < num_filters; f++)
     {
 	htri_t avail = -1;
         unsigned flags = 0;
@@ -1342,10 +1338,9 @@ get_chunking_info(hid_t propid, NC_VAR_INFO_T *var)
  * @author Ed Hartnett, Dennis Heimbigner
  */
 static int
-get_attached_info(NC_VAR_INFO_T *var, NC_HDF5_VAR_INFO_T *hdf5_var, int ndims,
+get_attached_info(NC_VAR_INFO_T *var, NC_HDF5_VAR_INFO_T *hdf5_var, size_t ndims,
                   hid_t datasetid)
 {
-    int d;
     int num_scales = 0;
 
     LOG((4, "%s ndims %d datasetid %ld", __func__, ndims, datasetid));
@@ -1374,7 +1369,7 @@ get_attached_info(NC_VAR_INFO_T *var, NC_HDF5_VAR_INFO_T *hdf5_var, int ndims,
 
         /* Store id information allowing us to match hdf5 dimscales to
          * netcdf dimensions. */
-        for (d = 0; d < var->ndims; d++)
+        for (unsigned int d = 0; d < var->ndims; d++)
         {
             LOG((4, "about to iterate scales for dim %d", d));
             if (H5DSiterate_scales(hdf5_var->hdf_datasetid, d, NULL, dimscale_visitor,
@@ -1409,7 +1404,7 @@ get_attached_info(NC_VAR_INFO_T *var, NC_HDF5_VAR_INFO_T *hdf5_var, int ndims,
  */
 static int
 get_scale_info(NC_GRP_INFO_T *grp, NC_DIM_INFO_T *dim, NC_VAR_INFO_T *var,
-               NC_HDF5_VAR_INFO_T *hdf5_var, int ndims, hid_t datasetid)
+               NC_HDF5_VAR_INFO_T *hdf5_var, size_t ndims, hid_t datasetid)
 {
     int retval;
 
@@ -1575,7 +1570,7 @@ read_var(NC_GRP_INFO_T *grp, hid_t datasetid, const char *obj_name,
         finalname = strdup(obj_name);
 
     /* Add a variable to the end of the group's var list. */
-    if ((retval = nc4_var_list_add(grp, finalname, ndims, &var)))
+    if ((retval = nc4_var_list_add(grp, finalname, (int)ndims, &var)))
         BAIL(retval);
 
     /* Add storage for HDF5-specific var info. */
@@ -1831,7 +1826,7 @@ read_hdf5_att(NC_GRP_INFO_T *grp, hid_t attid, NC_ATT_INFO_T *att)
     if (att_ndims == 0 && att_npoints == 0)
         dims[0] = 0;
     else if (att->nc_typeid == NC_STRING)
-        dims[0] = att_npoints;
+        dims[0] = (hsize_t)att_npoints;
     else if (att->nc_typeid == NC_CHAR)
     {
         /* NC_CHAR attributes are written as a scalar in HDF5, of type
@@ -1845,7 +1840,7 @@ read_hdf5_att(NC_GRP_INFO_T *grp, hid_t attid, NC_ATT_INFO_T *att)
         {
             /* This is really a string type! */
             att->nc_typeid = NC_STRING;
-            dims[0] = att_npoints;
+            dims[0] = (hsize_t)att_npoints;
         }
     }
     else
@@ -2139,7 +2134,7 @@ read_type(NC_GRP_INFO_T *grp, hid_t hdf_typeid, char *type_name)
                     return NC_EHDFERR;
 
                 for (d = 0; d < ndims; d++)
-                    dim_size[d] = dims[d];
+                    dim_size[d] = (int)dims[d];
 
                 /* What is the netCDF typeid of this member? */
                 if ((retval = get_netcdf_type(grp->nc4_info, H5Tget_super(member_hdf_typeid),
@@ -2224,7 +2219,6 @@ read_type(NC_GRP_INFO_T *grp, hid_t hdf_typeid, char *type_name)
         hid_t base_hdf_typeid;
         nc_type base_nc_type = NC_NAT;
         void *value;
-        int i;
         char *member_name = NULL;
 #ifdef JNA
         char jna[1001];
@@ -2261,7 +2255,7 @@ read_type(NC_GRP_INFO_T *grp, hid_t hdf_typeid, char *type_name)
             return NC_ENOMEM;
 
         /* Read each name and value defined in the enum. */
-        for (i = 0; i < nmembers; i++)
+        for (unsigned int i = 0; i < nmembers; i++)
         {
             /* Get the name and value from HDF5. */
             if (!(member_name = H5Tget_member_name(hdf_typeid, i)))
@@ -2466,7 +2460,7 @@ read_scale(NC_GRP_INFO_T *grp, hid_t datasetid, const char *obj_name,
     htri_t attr_exists = -1; /* Flag indicating hidden attribute exists */
     hid_t attid = -1; /* ID of hidden attribute (to store dim ID) */
     int dimscale_created = 0; /* Remember if a dimension was created (for error recovery) */
-    short initial_next_dimid = grp->nc4_info->next_dimid;/* Retain for error recovery */
+    int initial_next_dimid = grp->nc4_info->next_dimid;/* Retain for error recovery */
     size_t len = 0;
     int too_long = NC_FALSE;
     int assigned_id = -1;
@@ -2638,7 +2632,7 @@ read_dataset(NC_GRP_INFO_T *grp, hid_t datasetid, const char *obj_name,
      * unless this is one of those funny dimscales that are a
      * dimension in netCDF but not a variable. (Spooky!) */
     if (!dim || (dim && !hdf5_dim->hdf_dimscaleid))
-        if ((retval = read_var(grp, datasetid, obj_name, ndims, dim)))
+        if ((retval = read_var(grp, datasetid, obj_name, (size_t)ndims, dim)))
             BAIL(retval);
 
 exit:

--- a/libhdf5/hdf5type.c
+++ b/libhdf5/hdf5type.c
@@ -481,7 +481,7 @@ NC4_get_vlen_element(int ncid, int typeid1, const void *vlen_element,
                      size_t *len, void *data)
 {
     const nc_vlen_t *tmp = (nc_vlen_t*)vlen_element;
-    int type_size = 4;
+    const size_t type_size = 4;
 
     *len = tmp->len;
     memcpy(data, tmp->p, tmp->len * type_size);

--- a/libhdf5/hdf5var.c
+++ b/libhdf5/hdf5var.c
@@ -508,7 +508,7 @@ nc_def_var_extra(int ncid, int varid, int *shuffle, int *unused1,
         return NC_EPERM;
 
     /* Find the var. */
-    if (!(var = (NC_VAR_INFO_T *)ncindexith(grp->vars, varid)))
+    if (!(var = (NC_VAR_INFO_T *)ncindexith(grp->vars, (size_t)varid)))
         return NC_ENOTVAR;
     assert(var && var->hdr.id == varid);
 
@@ -1077,7 +1077,7 @@ nc_def_var_chunking_ints(int ncid, int varid, int storage, int *chunksizesp)
 
     /* Copy to size_t array. */
     for (i = 0; i < var->ndims; i++)
-        cs[i] = chunksizesp[i];
+        cs[i] = (size_t)chunksizesp[i];
 
     retval = nc_def_var_extra(ncid, varid, NULL, NULL, NULL, NULL,
                               &storage, cs, NULL, NULL, NULL, NULL, NULL);
@@ -1217,7 +1217,7 @@ NC4_rename_var(int ncid, int varid, const char *name)
         return retval;
 
     /* Get the variable wrt varid */
-    if (!(var = (NC_VAR_INFO_T *)ncindexith(grp->vars, varid)))
+    if (!(var = (NC_VAR_INFO_T *)ncindexith(grp->vars, (size_t)varid)))
         return NC_ENOTVAR;
 
     /* Check if new name is in use; note that renaming to same name is
@@ -1257,7 +1257,6 @@ NC4_rename_var(int ncid, int varid, const char *name)
        there. */
     if (var->created)
     {
-        int v;
         char *hdf5_name; /* Dataset will be renamed to this. */
         hdf5_name = use_secret_name ? var->alt_name: (char *)name;
 
@@ -1291,7 +1290,7 @@ NC4_rename_var(int ncid, int varid, const char *name)
          * and we have just changed that for this var. We must do the
          * same for all vars with a > varid, so that the creation order
          * will continue to be correct. */
-        for (v = var->hdr.id + 1; v < ncindexsize(grp->vars); v++)
+        for (size_t v = (size_t)var->hdr.id + 1; v < ncindexsize(grp->vars); v++)
         {
             NC_VAR_INFO_T *my_var;
             my_var = (NC_VAR_INFO_T *)ncindexith(grp->vars, v);
@@ -1597,7 +1596,7 @@ NC4_put_vars(int ncid, int varid, const size_t *startp, const size_t *countp,
 
         start[i] = startp[i];
         count[i] = countp ? countp[i] : var->dim[i]->len;
-        stride[i] = stridep ? stridep[i] : 1;
+        stride[i] = stridep ? (hsize_t)stridep[i] : 1;
         ones[i] = 1;
 	LOG((4, "start[%d] %ld count[%d] %ld stride[%d] %ld", i, start[i], i, count[i], i, stride[i]));
 
@@ -1660,7 +1659,7 @@ NC4_put_vars(int ncid, int varid, const size_t *startp, const size_t *countp,
 
         /* Create a space for the memory, just big enough to hold the slab
            we want. */
-        if ((mem_spaceid = H5Screate_simple(var->ndims, count, NULL)) < 0)
+        if ((mem_spaceid = H5Screate_simple((int)var->ndims, count, NULL)) < 0)
             BAIL(NC_EHDFERR);
     }
 
@@ -1936,7 +1935,7 @@ NC4_get_vars(int ncid, int varid, const size_t *startp, const size_t *countp,
 
         start[i] = startp[i];
         count[i] = countp[i];
-        stride[i] = stridep ? stridep[i] : 1;
+        stride[i] = stridep ? (hsize_t)stridep[i] : 1;
         ones[i] = 1;
 
         /* if any of the count values are zero don't actually read. */
@@ -2079,7 +2078,7 @@ NC4_get_vars(int ncid, int varid, const size_t *startp, const size_t *countp,
 
             /* Create a space for the memory, just big enough to hold the slab
                we want. */
-            if ((mem_spaceid = H5Screate_simple(var->ndims, count, NULL)) < 0)
+            if ((mem_spaceid = H5Screate_simple((int)var->ndims, count, NULL)) < 0)
                 BAIL(NC_EHDFERR);
         }
 
@@ -2366,7 +2365,7 @@ NC4_HDF5_set_var_chunk_cache(int ncid, int varid, size_t size, size_t nelems,
     assert(grp && h5);
 
     /* Find the var. */
-    if (!(var = (NC_VAR_INFO_T *)ncindexith(grp->vars, varid)))
+    if (!(var = (NC_VAR_INFO_T *)ncindexith(grp->vars, (size_t)varid)))
         return NC_ENOTVAR;
     assert(var && var->hdr.id == varid);
 
@@ -2410,7 +2409,7 @@ nc_set_var_chunk_cache_ints(int ncid, int varid, int size, int nelems,
         real_size = ((size_t) size) * MEGABYTE;
 
     if (nelems >= 0)
-        real_nelems = nelems;
+        real_nelems = (size_t)nelems;
 
     if (preemption >= 0)
         real_preemption = (float)(preemption / 100.);

--- a/libhdf5/nc4hdf.c
+++ b/libhdf5/nc4hdf.c
@@ -43,13 +43,12 @@ static int
 flag_atts_dirty(NCindex *attlist) {
 
     NC_ATT_INFO_T *att = NULL;
-    int i;
 
     if(attlist == NULL) {
         return NC_NOERR;
     }
 
-    for(i=0;i<ncindexsize(attlist);i++) {
+    for(size_t i=0;i<ncindexsize(attlist);i++) {
         att = (NC_ATT_INFO_T*)ncindexith(attlist,i);
         if(att == NULL) continue;
         att->dirty = NC_TRUE;
@@ -79,7 +78,7 @@ rec_reattach_scales(NC_GRP_INFO_T *grp, int dimid, hid_t dimscaleid)
 {
     NC_VAR_INFO_T *var;
     NC_GRP_INFO_T *child_grp;
-    int d, i;
+    size_t i;
     int retval;
 
     assert(grp && grp->hdr.name && dimid >= 0 && dimscaleid >= 0);
@@ -104,7 +103,7 @@ rec_reattach_scales(NC_GRP_INFO_T *grp, int dimid, hid_t dimscaleid)
 
 	hdf5_var = (NC_HDF5_VAR_INFO_T*)var->format_var_info;	
 	assert(hdf5_var != NULL);
-        for (d = 0; d < var->ndims; d++)
+        for (unsigned int d = 0; d < var->ndims; d++)
         {
             if (var->dimids[d] == dimid && !hdf5_var->dimscale)
             {
@@ -144,7 +143,7 @@ rec_detach_scales(NC_GRP_INFO_T *grp, int dimid, hid_t dimscaleid)
 {
     NC_VAR_INFO_T *var;
     NC_GRP_INFO_T *child_grp;
-    int d, i;
+    size_t i;
     int retval;
 
     assert(grp && grp->hdr.name && dimid >= 0 && dimscaleid >= 0);
@@ -166,7 +165,7 @@ rec_detach_scales(NC_GRP_INFO_T *grp, int dimid, hid_t dimscaleid)
         assert(var && var->format_var_info);
         hdf5_var = (NC_HDF5_VAR_INFO_T *)var->format_var_info;
 
-        for (d = 0; d < var->ndims; d++)
+        for (unsigned int d = 0; d < var->ndims; d++)
         {
             if (var->dimids[d] == dimid && !hdf5_var->dimscale)
             {
@@ -208,7 +207,7 @@ nc4_open_var_grp2(NC_GRP_INFO_T *grp, int varid, hid_t *dataset)
     assert(grp && grp->format_grp_info && dataset);
 
     /* Find the requested varid. */
-    if (!(var = (NC_VAR_INFO_T *)ncindexith(grp->vars, varid)))
+    if (!(var = (NC_VAR_INFO_T *)ncindexith(grp->vars, (size_t)varid)))
         return NC_ENOTVAR;
     assert(var && var->hdr.id == varid && var->format_var_info);
     hdf5_var = (NC_HDF5_VAR_INFO_T *)var->format_var_info;
@@ -461,7 +460,7 @@ put_att_grpa(NC_GRP_INFO_T *grp, int varid, NC_ATT_INFO_T *att)
 
     /* Get the length ready, and find the HDF type we'll be
      * writing. */
-    dims[0] = att->len;
+    dims[0] = (hsize_t)att->len;
     if ((retval = nc4_get_hdf_typeid(grp->nc4_info, att->nc_typeid,
                                      &file_typeid, 0)))
         BAIL(retval);
@@ -609,9 +608,8 @@ write_attlist(NCindex *attlist, int varid, NC_GRP_INFO_T *grp)
 {
     NC_ATT_INFO_T *att;
     int retval;
-    int i;
 
-    for(i = 0; i < ncindexsize(attlist); i++)
+    for(size_t i = 0; i < ncindexsize(attlist); i++)
     {
         att = (NC_ATT_INFO_T *)ncindexith(attlist, i);
         assert(att);
@@ -898,19 +896,16 @@ var_create_dataset(NC_GRP_INFO_T *grp, NC_VAR_INFO_T *var, nc_bool_t write_dimid
 	        if(H5Pset_shuffle(plistid) < 0)
                     BAIL(NC_EHDFERR);
             } else if(fi->filterid == H5Z_FILTER_DEFLATE) {/* Handle zip case here */
-                unsigned level;
                 if(fi->nparams != 1)
                     BAIL(NC_EFILTER);
-                level = (int)fi->params[0];
+                unsigned int level = fi->params[0];
                 if(H5Pset_deflate(plistid, level) < 0)
                     BAIL(NC_EFILTER);
             } else if(fi->filterid == H5Z_FILTER_SZIP) {/* Handle szip case here */
-                int options_mask;
-                int bits_per_pixel;
                 if(fi->nparams != 2)
                     BAIL(NC_EFILTER);
-                options_mask = (int)fi->params[0];
-                bits_per_pixel = (int)fi->params[1];
+                unsigned int options_mask = fi->params[0];
+                unsigned int bits_per_pixel = fi->params[1];
                 if(H5Pset_szip(plistid, options_mask, bits_per_pixel) < 0)
                     BAIL(NC_EFILTER);
             } else {
@@ -970,8 +965,8 @@ var_create_dataset(NC_GRP_INFO_T *grp, NC_VAR_INFO_T *var, nc_bool_t write_dimid
                     if (dim->unlimited)
                         chunksize[d] = 1;
                     else
-                        chunksize[d] = pow((double)DEFAULT_CHUNK_SIZE/type_size,
-                                           1/(double)(var->ndims - unlimdim));
+                        chunksize[d] = (hsize_t)pow(DEFAULT_CHUNK_SIZE/(double)type_size,
+                                                    1/(double)((int)var->ndims - unlimdim));
 
                     /* If the chunksize is greater than the dim
                      * length, make it the dim length. */
@@ -985,7 +980,7 @@ var_create_dataset(NC_GRP_INFO_T *grp, NC_VAR_INFO_T *var, nc_bool_t write_dimid
         }
 
         /* Create the dataspace. */
-        if ((spaceid = H5Screate_simple(var->ndims, dimsize, maxdimsize)) < 0)
+        if ((spaceid = H5Screate_simple((int)var->ndims, dimsize, maxdimsize)) < 0)
             BAIL(NC_EHDFERR);
     }
     else
@@ -1009,7 +1004,7 @@ var_create_dataset(NC_GRP_INFO_T *grp, NC_VAR_INFO_T *var, nc_bool_t write_dimid
     }
     else if (var->ndims)
     {
-        if (H5Pset_chunk(plistid, var->ndims, chunksize) < 0)
+        if (H5Pset_chunk(plistid, (int)var->ndims, chunksize) < 0)
             BAIL(NC_EHDFERR);
     }
 
@@ -1420,10 +1415,9 @@ attach_dimscales(NC_GRP_INFO_T *grp)
 {
     NC_VAR_INFO_T *var;
     NC_HDF5_VAR_INFO_T *hdf5_var;
-    int d, v;
 
     /* Attach dimension scales. */
-    for (v = 0; v < ncindexsize(grp->vars); v++)
+    for (size_t v = 0; v < ncindexsize(grp->vars); v++)
     {
         /* Get pointer to var and HDF5-specific var info. */
         var = (NC_VAR_INFO_T *)ncindexith(grp->vars, v);
@@ -1436,7 +1430,7 @@ attach_dimscales(NC_GRP_INFO_T *grp)
             continue;
 
         /* Find the scale for each dimension, if any, and attach it. */
-        for (d = 0; d < var->ndims; d++)
+        for (unsigned int d = 0; d < var->ndims; d++)
         {
             /* Is there a dimscale for this dimension? */
             if (hdf5_var->dimscale_attached)
@@ -1660,8 +1654,6 @@ write_var(NC_VAR_INFO_T *var, NC_GRP_INFO_T *grp, nc_bool_t write_dimid)
      * and delete dimscale attributes from the var. */
     if (var->was_coord_var && hdf5_var->dimscale_attached)
     {
-        int d;
-
         /* If the variable already exists in the file, Remove any dimension scale
          * attributes from it, if they exist. */
         if (var->created)
@@ -1669,7 +1661,7 @@ write_var(NC_VAR_INFO_T *var, NC_GRP_INFO_T *grp, nc_bool_t write_dimid)
                 return retval;
 
         /* If this is a regular var, detach all its dim scales. */
-        for (d = 0; d < var->ndims; d++)
+        for (unsigned int d = 0; d < var->ndims; d++)
         {
             if (hdf5_var->dimscale_attached[d])
             {
@@ -1941,10 +1933,9 @@ nc4_rec_write_metadata(NC_GRP_INFO_T *grp, nc_bool_t bad_coord_order)
     NC_VAR_INFO_T *var = NULL;
     NC_GRP_INFO_T *child_grp = NULL;
     int coord_varid = -1;
-    int var_index = 0;
-    int dim_index = 0;
+    size_t var_index = 0;
+    size_t dim_index = 0;
     int retval;
-    int i;
 
     assert(grp && grp->hdr.name &&
            ((NC_HDF5_GRP_INFO_T *)(grp->format_grp_info))->hdf_grpid);
@@ -2003,7 +1994,7 @@ nc4_rec_write_metadata(NC_GRP_INFO_T *grp, nc_bool_t bad_coord_order)
     }
 
     /* If there are any child groups, write their metadata. */
-    for (i = 0; i < ncindexsize(grp->children); i++)
+    for (size_t i = 0; i < ncindexsize(grp->children); i++)
     {
         child_grp = (NC_GRP_INFO_T *)ncindexith(grp->children, i);
         assert(child_grp);
@@ -2029,7 +2020,7 @@ nc4_rec_write_groups_types(NC_GRP_INFO_T *grp)
     NC_HDF5_GRP_INFO_T *hdf5_grp;
     NC_TYPE_INFO_T *type;
     int retval;
-    int i;
+    size_t i;
 
     assert(grp && grp->hdr.name && grp->format_grp_info);
     LOG((3, "%s: grp->hdr.name %s", __func__, grp->hdr.name));
@@ -2085,7 +2076,7 @@ nc4_rec_match_dimscales(NC_GRP_INFO_T *grp)
     NC_VAR_INFO_T *var;
     NC_DIM_INFO_T *dim;
     int retval = NC_NOERR;
-    int i;
+    size_t i;
 
     assert(grp && grp->hdr.name);
     LOG((4, "%s: grp->hdr.name %s", __func__, grp->hdr.name));
@@ -2104,7 +2095,6 @@ nc4_rec_match_dimscales(NC_GRP_INFO_T *grp)
     for (i = 0; i < ncindexsize(grp->vars); i++)
     {
         NC_HDF5_VAR_INFO_T *hdf5_var;
-        int ndims;
         int d;
 
         /* Get pointer to var and to the HDF5-specific var info. */
@@ -2127,8 +2117,8 @@ nc4_rec_match_dimscales(NC_GRP_INFO_T *grp)
            The solution I choose is to modify nc4_var_list_add to initialize dimids to
            illegal values (-1). This is another example of the problems with dimscales.
         */
-        ndims = var->ndims;
-        for (d = 0; d < ndims; d++)
+        const size_t ndims = var->ndims;
+        for (size_t d = 0; d < ndims; d++)
         {
             if (var->dim[d] == NULL) {
                 nc4_find_dim(grp, var->dimids[d], &var->dim[d], NULL);
@@ -2139,13 +2129,10 @@ nc4_rec_match_dimscales(NC_GRP_INFO_T *grp)
         /* Skip dimension scale variables */
         if (!hdf5_var->dimscale)
         {
-            int d;
-            int j;
-
             /* Are there dimscales for this variable? */
             if (hdf5_var->dimscale_hdf5_objids)
             {
-                for (d = 0; d < var->ndims; d++)
+                for (size_t d = 0; d < var->ndims; d++)
                 {
                     nc_bool_t finished = NC_FALSE;
                     LOG((5, "%s: var %s has dimscale info...", __func__, var->hdr.name));
@@ -2154,7 +2141,7 @@ nc4_rec_match_dimscales(NC_GRP_INFO_T *grp)
                     for (g = grp; g && !finished; g = g->parent)
                     {
                         /* Check all dims in this group. */
-                        for (j = 0; j < ncindexsize(g->dim); j++)
+                        for (size_t j = 0; j < ncindexsize(g->dim); j++)
                         {
                             /* Get the HDF5 specific dim info. */
                             NC_HDF5_DIM_INFO_T *hdf5_dim;
@@ -2243,19 +2230,18 @@ nc4_rec_match_dimscales(NC_GRP_INFO_T *grp)
                  * size. */
                 for (d = 0; d < var->ndims; d++)
                 {
-                    int k;
-                    int match;
+                    nc_bool_t match = NC_FALSE;
                     /* Is there already a phony dimension of the correct size? */
-                    for(match=-1,k=0;k<ncindexsize(grp->dim);k++) {
+                    for(size_t k=0;k<ncindexsize(grp->dim);k++) {
                         if((dim = (NC_DIM_INFO_T*)ncindexith(grp->dim,k)) == NULL) continue;
                         if ((dim->len == h5dimlen[d]) &&
                             ((h5dimlenmax[d] == H5S_UNLIMITED && dim->unlimited) ||
                              (h5dimlenmax[d] != H5S_UNLIMITED && !dim->unlimited)))
-                        {match = k; break;}
+                        {match = NC_TRUE; break;}
                     }
 
                     /* Didn't find a phony dim? Then create one. */
-                    if (match < 0)
+                    if (match == NC_FALSE)
                     {
                         char phony_dim_name[NC_MAX_NAME + 1];
                         snprintf(phony_dim_name, sizeof(phony_dim_name), "phony_dim_%d", grp->nc4_info->next_dimid);
@@ -2607,8 +2593,7 @@ NC4_walk(hid_t gid, int* countp)
                 if(aid >= 0) {
                     const NC_reservedatt* ra;
                     ssize_t len = H5Aget_name(aid, NC_HDF5_MAX_NAME, name);
-                    if(len < 0) return len;
-                    /* Is this a netcdf-4 marker attribute */
+                    if(len < 0) return (int)len;
                     /* Is this a netcdf-4 marker attribute */
                     ra = NC_findreserved(name);
                     if(ra != NULL)

--- a/libhdf5/nc4hdf.c
+++ b/libhdf5/nc4hdf.c
@@ -1214,7 +1214,7 @@ commit_type(NC_GRP_INFO_T *grp, NC_TYPE_INFO_T *type)
                 hsize_t dims[NC_MAX_VAR_DIMS];
 
                 for (d = 0; d < field->ndims; d++)
-                    dims[d] = field->dim_size[d];
+                    dims[d] = (hsize_t)field->dim_size[d];
                 if ((hdf_typeid = H5Tarray_create1(hdf_base_typeid, field->ndims,
 						   dims, NULL)) < 0)
                 {
@@ -2350,7 +2350,6 @@ reportopenobjectsT(int uselog, hid_t fid, int ntypes, unsigned int* otypes)
 {
     int t,i;
     ssize_t ocount;
-    size_t maxobjs = -1;
     hid_t* idlist = NULL;
 
     /* Always report somehow */
@@ -2360,7 +2359,7 @@ reportopenobjectsT(int uselog, hid_t fid, int ntypes, unsigned int* otypes)
     else
 #endif
         fprintf(stdout,"\nReport: open objects on %lld\n",(long long)fid);
-    maxobjs = H5Fget_obj_count(fid,H5F_OBJ_ALL);
+    size_t maxobjs = (size_t)H5Fget_obj_count(fid,H5F_OBJ_ALL);
     if(idlist != NULL) free(idlist);
     idlist = (hid_t*)malloc(sizeof(hid_t)*maxobjs);
     for(t=0;t<ntypes;t++) {
@@ -2573,7 +2572,7 @@ static int
 NC4_walk(hid_t gid, int* countp)
 {
     int ncstat = NC_NOERR;
-    int i,j,na;
+    int j,na;
     ssize_t len;
     hsize_t nobj;
     herr_t err;
@@ -2585,12 +2584,12 @@ NC4_walk(hid_t gid, int* countp)
     err = H5Gget_num_objs(gid, &nobj);
     if(err < 0) return err;
 
-    for(i = 0; i < nobj; i++) {
+    for(hsize_t i = 0; i < nobj; i++) {
         /* Get name & kind of object in the group */
-        len = H5Gget_objname_by_idx(gid,(hsize_t)i,name,(size_t)NC_HDF5_MAX_NAME);
-        if(len < 0) return len;
+        len = H5Gget_objname_by_idx(gid,i,name,(size_t)NC_HDF5_MAX_NAME);
+        if(len < 0) return (int)len;
 
-        otype =  H5Gget_objtype_by_idx(gid,(size_t)i);
+        otype =  H5Gget_objtype_by_idx(gid, i);
         switch(otype) {
         case H5G_GROUP:
 	    grpid = H5Gopen1(gid,name);

--- a/libhdf5/nc4memcb.c
+++ b/libhdf5/nc4memcb.c
@@ -723,7 +723,7 @@ NC4_image_init(NC_FILE_INFO_T* h5)
     char                file_name[64];	/* Filename buffer */
     size_t              alloc_incr;     /* Buffer allocation increment */
     size_t              min_incr = 65536; /* Minimum buffer increment */
-    double              buf_prcnt = 0.1f;  /* Percentage of buffer size to set
+    double              buf_prcnt = 0.1;  /* Percentage of buffer size to set
                                              as increment */
     unsigned imageflags;
     int create = 0;
@@ -753,8 +753,8 @@ NC4_image_init(NC_FILE_INFO_T* h5)
     /* set allocation increment to a percentage of the supplied buffer size, or
      * a pre-defined minimum increment value, whichever is larger
      */
-    if ((buf_prcnt * h5->mem.memio.size) > min_incr)
-        alloc_incr = (size_t)(buf_prcnt * h5->mem.memio.size);
+    if ((size_t)(buf_prcnt * (double)h5->mem.memio.size) > min_incr)
+        alloc_incr = (size_t)(buf_prcnt * (double)h5->mem.memio.size);
     else
         alloc_incr = min_incr;
 


### PR DESCRIPTION
The remaining warnings basically fall into two categories: 

- those from `NC_ATT_INFO.len` being `int` -- changing this to `size_t` would silence a lot of warnings in one go
- those from HDF5 filters -- the filter type in HDF5 itself is `H5Zfilter_t == int`, whereas netcdf mostly uses `unsigned int`; and then the flags/parameters are exactly the other way round.

The filter types can't be completely fixed because they're in the netcdf public API, but we could fix the internals and just convert on the boundary. This is would change a bunch of internal API though, so I haven't done that here.