### PR TITLE
Silence most warnings in `libsrc`

### DIFF
--- a/include/onstack.h
+++ b/include/onstack.h
@@ -45,7 +45,7 @@
 #endif /* __GNUC__ */
 
 # if !defined(ALLOCA_ARG_T)
-# define ALLOCA_ARG_T int /* the usual type of the alloca argument */
+# define ALLOCA_ARG_T size_t /* the usual type of the alloca argument */
 # endif
 
 # define ALLOC_ONSTACK(name, type, nelems) \

--- a/libsrc/dim.c
+++ b/libsrc/dim.c
@@ -480,7 +480,7 @@ NC3_rename_dim( int ncid, int dimid, const char *unewname)
 	        NC_hashmapremove(ncp->dims.hashmap, old->cp, strlen(old->cp), NULL);
 		dimp->name = newStr;
 
-		intdata = dimid;
+		intdata = (uintptr_t)dimid;
 		NC_hashmapadd(ncp->dims.hashmap, intdata, newStr->cp, strlen(newStr->cp));
 		free_NC_string(old);
 		goto done;

--- a/libsrc/httpio.c
+++ b/libsrc/httpio.c
@@ -58,7 +58,7 @@ static int httpio_filesize(ncio* nciop, off_t* filesizep);
 static int httpio_pad_length(ncio* nciop, off_t length);
 static int httpio_close(ncio* nciop, int);
 
-static long pagesize = 0;
+static size_t pagesize = 0;
 
 /* Create a new ncio struct to hold info about the file. */
 static int
@@ -261,7 +261,7 @@ httpio_get(ncio* const nciop, off_t offset, size_t extent, int rflags, void** co
     assert(http->interval == NULL);
     http->interval = ncbytesnew();
     ncbytessetalloc(http->interval,(unsigned long)extent);
-    if((status = nc_http_read(http->state,offset,extent,http->interval)))
+    if((status = nc_http_read(http->state,(size64_t)offset,extent,http->interval)))
 	goto done;
     assert(ncbyteslength(http->interval) == extent);
     if(vpp) *vpp = ncbytescontents(http->interval);

--- a/libsrc/mmapio.c
+++ b/libsrc/mmapio.c
@@ -313,7 +313,7 @@ mmapio_open(const char* path,
     void* parameters,
     ncio* *nciopp, void** const mempp)
 {
-    ncio* nciop;
+    ncio* nciop = NULL;
     int fd;
     int status;
     int oflags;

--- a/libsrc/mmapio.c
+++ b/libsrc/mmapio.c
@@ -93,7 +93,7 @@ typedef struct NCMMAPIO {
     int locked; /* => we cannot realloc */
     int persist; /* => save to a file; triggered by NC_PERSIST */
     char* memory;
-    off_t alloc;
+    size_t alloc;
     off_t size;
     off_t pos;
     int mapfd;
@@ -111,11 +111,11 @@ static int mmapio_close(ncio* nciop, int);
 /* Mnemonic */
 #define DOOPEN 1
 
-static long pagesize = 0;
+static size_t pagesize = 0;
 
 /* Create a new ncio struct to hold info about the file. */
 static int
-mmapio_new(const char* path, int ioflags, off_t initialsize, ncio** nciopp, NCMMAPIO** mmapp)
+mmapio_new(const char* path, int ioflags, size_t initialsize, ncio** nciopp, NCMMAPIO** mmapp)
 {
     int status = NC_NOERR;
     ncio* nciop = NULL;
@@ -124,9 +124,9 @@ mmapio_new(const char* path, int ioflags, off_t initialsize, ncio** nciopp, NCMM
 
     if(pagesize == 0) {
 #if defined HAVE_SYSCONF
-        pagesize = sysconf(_SC_PAGE_SIZE);
+        pagesize = (size_t)sysconf(_SC_PAGE_SIZE);
 #elif defined HAVE_GETPAGESIZE
-        pagesize = getpagesize();
+        pagesize = (size_t)getpagesize();
 #else
         pagesize = 4096; /* good guess */
 #endif
@@ -247,11 +247,11 @@ mmapio_create(const char* path, int ioflags,
         if(fd < 0) {status = errno; goto unwind_open;}
 	mmapio->mapfd = fd;
 
-	{ /* Cause the output file to have enough allocated space */
-	lseek(fd,mmapio->alloc-1,SEEK_SET); /* cause file to appear */
-        write(fd,"",1);
-	lseek(fd,0,SEEK_SET); /* rewind */
-	}
+        { /* Cause the output file to have enough allocated space */
+            lseek(fd,(off_t)mmapio->alloc-1,SEEK_SET); /* cause file to appear */
+            write(fd,"",1);
+            lseek(fd,0,SEEK_SET); /* rewind */
+        }
         mmapio->memory = (char*)mmap(NULL,mmapio->alloc,
                                     PROT_READ|PROT_WRITE,
 				    MAP_SHARED,
@@ -345,7 +345,7 @@ mmapio_open(const char* path,
     if(filesize < (off_t)sizehint)
         filesize = (off_t)sizehint;
 
-    status = mmapio_new(path, ioflags, filesize, &nciop, &mmapio);
+    status = mmapio_new(path, ioflags, (size_t)filesize, &nciop, &mmapio);
     if(status != NC_NOERR)
 	return status;
     mmapio->size = filesize;
@@ -360,7 +360,7 @@ fprintf(stderr,"mmapio_open: initial memory: %lu/%lu\n",(unsigned long)mmapio->m
 #endif
 
     /* Use half the filesize as the blocksize */
-    sizehint = filesize/2;
+    sizehint = (size_t)filesize/2;
 
     /* sizehint must be multiple of 8 */
     sizehint = (sizehint / 8) * 8;
@@ -425,7 +425,7 @@ mmapio_pad_length(ncio* nciop, off_t length)
 
     if(length > mmapio->alloc) {
         /* Realloc the allocated memory to a multiple of the pagesize*/
-	off_t newsize = length;
+	size_t newsize = (size_t)length;
 	void* newmem = NULL;
 	/* Round to a multiple of pagesize */
 	if((newsize % pagesize) != 0)
@@ -435,7 +435,7 @@ mmapio_pad_length(ncio* nciop, off_t length)
 	{ /* Cause the output file to have enough allocated space */
 	off_t pos = lseek(mmapio->mapfd,0,SEEK_CUR); /* save current position*/
 	/* cause file to be extended in size */
-	lseek(mmapio->mapfd,newsize-1,SEEK_SET);
+	lseek(mmapio->mapfd,(off_t)newsize-1,SEEK_SET);
         write(mmapio->mapfd,"",mmapio->alloc);
 	lseek(mmapio->mapfd,pos,SEEK_SET); /* reset position */
 	}
@@ -524,7 +524,7 @@ mmapio_get(ncio* const nciop, off_t offset, size_t extent, int rflags, void** co
     NCMMAPIO* mmapio;
     if(nciop == NULL || nciop->pvt == NULL) return NC_EINVAL;
     mmapio = (NCMMAPIO*)nciop->pvt;
-    status = guarantee(nciop, offset+extent);
+    status = guarantee(nciop, offset+(off_t)extent);
     mmapio->locked++;
     if(status != NC_NOERR) return status;
     if(vpp) *vpp = mmapio->memory+offset;
@@ -544,11 +544,11 @@ mmapio_move(ncio* const nciop, off_t to, off_t from, size_t nbytes, int ignored)
     mmapio = (NCMMAPIO*)nciop->pvt;
     if(from < to) {
        /* extend if "to" is not currently allocated */
-       status = guarantee(nciop,to+nbytes);
+       status = guarantee(nciop, to + (off_t)nbytes);
        if(status != NC_NOERR) return status;
     }
     /* check for overlap */
-    if((to + nbytes) > from || (from + nbytes) > to) {
+    if((to + (off_t)nbytes) > from || (from + (off_t)nbytes) > to) {
 	/* Ranges overlap */
 #ifdef HAVE_MEMMOVE
         memmove((void*)(mmapio->memory+to),(void*)(mmapio->memory+from),nbytes);

--- a/libsrc/nc3internal.c
+++ b/libsrc/nc3internal.c
@@ -10,6 +10,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <assert.h>
+#include <sys/types.h>
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
@@ -153,7 +154,7 @@ NC_begins(NC3_INFO* ncp,
 	size_t v_minfree, size_t r_align)
 {
 	size_t ii, j;
-	int sizeof_off_t;
+	size_t sizeof_off_t;
 	off_t index = 0;
 	off_t old_ncp_begin_var;
 	NC_var **vpp;
@@ -186,7 +187,7 @@ NC_begins(NC3_INFO* ncp,
 	{
 	  index = (off_t) ncp->xsz;
 	  ncp->begin_var = D_RNDUP(index, v_align);
-	  if(ncp->begin_var < index + h_minfree)
+	  if(ncp->begin_var < index + (off_t)h_minfree)
 	  {
 	    ncp->begin_var = D_RNDUP(index + (off_t)h_minfree, v_align);
 	  }
@@ -253,11 +254,11 @@ fprintf(stderr, "    VAR %d %s: %ld\n", ii, (*vpp)->name->cp, (long)index);
 	/* only (re)calculate begin_rec if there is not sufficient
 	   space at end of non-record variables or if start of record
 	   variables is not aligned as requested by r_align */
-	if (ncp->begin_rec < index + v_minfree ||
+	if (ncp->begin_rec < index + (off_t)v_minfree ||
 	    ncp->begin_rec != D_RNDUP(ncp->begin_rec, r_align) )
 	{
 	  ncp->begin_rec = D_RNDUP(index, r_align);
-	  if(ncp->begin_rec < index + v_minfree)
+	  if(ncp->begin_rec < index + (off_t)v_minfree)
 	  {
 	    ncp->begin_rec = D_RNDUP(index + (off_t)v_minfree, r_align);
 	  }
@@ -524,8 +525,8 @@ fill_added_recs(NC3_INFO *gnu, NC3_INFO *old)
 {
 	NC_var ** const gnu_varpp = (NC_var **)gnu->vars.value;
 
-	const int old_nrecs = (int) NC_get_numrecs(old);
-	int recno = 0;
+	const size_t old_nrecs = NC_get_numrecs(old);
+	size_t recno = 0;
 	NC_var **vpp = gnu_varpp;
 	NC_var *const *const end = &vpp[gnu->vars.nelems];
 	int numrecvars = 0;
@@ -554,7 +555,7 @@ fill_added_recs(NC3_INFO *gnu, NC3_INFO *old)
 			    }
 			/* else */
 			{
-			    size_t varsize = numrecvars == 1 ? gnu->recsize :  gnu_varp->len;
+			    long long varsize = numrecvars == 1 ? gnu->recsize :  gnu_varp->len;
 			    const int status = fill_NC_var(gnu, gnu_varp, varsize, recno);
 			    if(status != NC_NOERR)
 				return status;
@@ -629,8 +630,8 @@ move_recs_r(NC3_INFO *gnu, NC3_INFO *old)
 
 		/* else, a pre-existing variable */
 		old_varp = *(old_varpp + varid);
-		gnu_off = gnu_varp->begin + (off_t)(gnu->recsize * recno);
-		old_off = old_varp->begin + (off_t)(old->recsize * recno);
+		gnu_off = gnu_varp->begin + (off_t)(gnu->recsize * (size_t)recno);
+		old_off = old_varp->begin + (off_t)(old->recsize * (size_t)recno);
 
 		if(gnu_off == old_off)
 			continue; 	/* nothing to do */
@@ -955,7 +956,7 @@ NC_calcsize(const NC3_INFO *ncp, off_t *calcsizep)
 
 	if(ncp->vars.nelems == 0) { /* no non-record variables and
 				       no record variables */
-	    *calcsizep = ncp->xsz; /* size of header */
+	    *calcsizep = (off_t)ncp->xsz; /* size of header */
 	    return NC_NOERR;
 	}
 
@@ -976,16 +977,15 @@ NC_calcsize(const NC3_INFO *ncp, off_t *calcsizep)
 	    assert(last_fix != NULL);
 	    varsize = last_fix->len;
 	    if(last_fix->len == X_UINT_MAX) { /* huge last fixed var */
-		int i;
 		varsize = 1;
-  	        for(i = 0; i < last_fix->ndims; i++ ) {
-                varsize *= (last_fix->shape ? last_fix->shape[i] : 1);
-		    }
+		for(size_t i = 0; i < last_fix->ndims; i++ ) {
+		    varsize *= (last_fix->shape ? last_fix->shape[i] : 1);
+		}
 	    }
 	    *calcsizep = last_fix->begin + varsize;
 	    /*last_var = last_fix;*/
 	} else {       /* we have at least one record variable */
-	    *calcsizep = ncp->begin_rec + ncp->numrecs * ncp->recsize;
+	    *calcsizep = ncp->begin_rec + (off_t)(ncp->numrecs * ncp->recsize);
 	}
 
 	return NC_NOERR;
@@ -1021,7 +1021,7 @@ NC3_create(const char *path, int ioflags, size_t initialsz, int basepe,
 {
 	int status = NC_NOERR;
 	void *xp = NULL;
-	int sizeof_off_t = 0;
+	size_t sizeof_off_t = 0;
         NC *nc;
 	NC3_INFO* nc3 = NULL;
 

--- a/libsrc/posixio.c
+++ b/libsrc/posixio.c
@@ -215,7 +215,7 @@ fgrow(const int fd, const off_t len)
 	    const off_t pos = lseek(fd, 0, SEEK_CUR);
 	    if(pos < 0)
 		return errno;
-	    if (lseek(fd, len-sizeof(dumb), SEEK_SET) < 0)
+	    if (lseek(fd, len-(off_t)sizeof(dumb), SEEK_SET) < 0)
 		return errno;
 	    if(write(fd, &dumb, sizeof(dumb)) < 0)
 		return errno;
@@ -313,11 +313,11 @@ px_pgout(ncio *const nciop,
 	    if(partial == nextent)
 		break;
 	    nvp += partial;
-	    nextent -= partial;
+	    nextent -= (size_t)partial;
 	}
 	if(partial == -1)
 	    return errno;
-	*posp += extent;
+	*posp += (off_t)extent;
 
 	return NC_NOERR;
 }
@@ -390,13 +390,13 @@ px_pgin(ncio *const nciop,
       if( nread == -1 || (status != EINTR && status != NC_NOERR))
         return status;
       /* else it's okay we read less than asked for */
-      (void) memset((char *)vp + nread, 0, (ssize_t)extent - nread);
+      (void) memset((char *)vp + nread, 0, (size_t)((ssize_t)extent - nread));
     }
 
-    *nreadp = nread;
-	*posp += nread;
+    *nreadp = (size_t)nread;
+    *posp += nread;
 
-	return NC_NOERR;
+    return NC_NOERR;
 }
 
 /* This struct is for POSIX systems, with NC_SHARE not in effect. If
@@ -533,8 +533,8 @@ px_get(ncio *const nciop, ncio_px *const pxp,
 	int status = NC_NOERR;
 
 	const off_t blkoffset = _RNDDOWN(offset, (off_t)pxp->blksz);
-	off_t diff = (size_t)(offset - blkoffset);
-	off_t blkextent = _RNDUP(diff + extent, pxp->blksz);
+	off_t diff = offset - blkoffset;
+	size_t blkextent = _RNDUP((size_t)diff + extent, pxp->blksz);
 
 	if(!(extent != 0 && extent < X_INT_MAX && offset >= 0)) /* sanity check */
 	    return NC_ENOTNC;
@@ -588,7 +588,7 @@ px_get(ncio *const nciop, ncio_px *const pxp,
 		if(blkextent == pxp->blksz)
 		{
 			/* all in upper half, no fault needed */
-			diff += pxp->blksz;
+			diff += (off_t)pxp->blksz;
 			goto done;
 		}
 		/* else */
@@ -730,11 +730,11 @@ pgin:
 		 &pxp->pos);
 	if(status != NC_NOERR)
 		return status;
-	 pxp->bf_offset = blkoffset;
-	 pxp->bf_extent = blkextent;
+        pxp->bf_offset = blkoffset;
+        pxp->bf_extent = blkextent;
 
 done:
-	extent += diff;
+	extent += (size_t)diff;
 	if(pxp->bf_cnt < extent)
 		pxp->bf_cnt = extent;
 	assert(pxp->bf_cnt <= pxp->bf_extent);
@@ -913,13 +913,13 @@ fprintf(stderr, "ncio_px_move %ld %ld %ld %ld %ld\n",
 
 if(to > from)
 {
-		off_t frm = from + nbytes;
-		off_t toh = to + nbytes;
+		off_t frm = from + (off_t)nbytes;
+		off_t toh = to + (off_t)nbytes;
 		for(;;)
 		{
 			size_t loopextent = MIN(remaining, pxp->blksz);
-			frm -= loopextent;
-			toh -= loopextent;
+			frm -= (off_t)loopextent;
+                        toh -= (off_t)loopextent;
 
 			status = px_double_buffer(nciop, toh, frm,
 				 	loopextent, rflags) ;
@@ -945,8 +945,8 @@ else
 
 			if(remaining == 0)
 				break; /* normal loop exit */
-			to += loopextent;
-			from += loopextent;
+			to += (off_t)loopextent;
+                        from += (off_t)loopextent;
 		}
 }
 		return NC_NOERR;

--- a/libsrc/putget.m4
+++ b/libsrc/putget.m4
@@ -245,7 +245,7 @@ fill_NC_var(NC3_INFO* ncp, const NC_var *varp, long long varsize, size_t recno)
 	offset = varp->begin;
 	if(IS_RECVAR(varp))
 	{
-		offset += (off_t)ncp->recsize * recno;
+		offset += (off_t)(ncp->recsize * recno);
 	}
 
 	assert(remaining > 0);
@@ -613,10 +613,10 @@ NC_varoffset(const NC3_INFO* ncp, const NC_var *varp, const size_t *coord)
 		for(; up < end; up++, ip++)
 			lcoord += (off_t)(*up) * (off_t)(*ip);
 
-		lcoord *= varp->xsz;
+		lcoord *= (off_t)varp->xsz;
 
 		if(IS_RECVAR(varp))
-			lcoord += (off_t)(*coord) * ncp->recsize;
+			lcoord += (off_t)(*coord * ncp->recsize);
 
 		lcoord += varp->begin;
 		return lcoord;
@@ -1846,7 +1846,7 @@ NC3_get_vara(int ncid, int varid,
         return status;
 
     /* Get the size of the memtype */
-    memtypelen = nctypelen(memtype);
+    memtypelen = (size_t)nctypelen(memtype);
 
     if(varp->ndims == 0) /* scalar variable */
     {
@@ -1880,7 +1880,7 @@ NC3_get_vara(int ncid, int varid,
     { /* inline */
     ALLOC_ONSTACK(coord, size_t, varp->ndims);
     ALLOC_ONSTACK(upper, size_t, varp->ndims);
-    const size_t index = ii;
+    const size_t index = (size_t)ii;
 
     /* copy in starting indices */
     (void) memcpy(coord, start, varp->ndims * sizeof(size_t));
@@ -1956,7 +1956,7 @@ NC3_put_vara(int ncid, int varid,
         return NC_ECHAR;
 
     /* Get the size of the memtype */
-    memtypelen = nctypelen(memtype);
+    memtypelen = (size_t)nctypelen(memtype);
 
     /* If edges is NULL, then this was called from nc_get_var() */
     if(edges == NULL && varp->ndims > 0) {
@@ -2013,7 +2013,7 @@ NC3_put_vara(int ncid, int varid,
     { /* inline */
     ALLOC_ONSTACK(coord, size_t, varp->ndims);
     ALLOC_ONSTACK(upper, size_t, varp->ndims);
-    const size_t index = ii;
+    const size_t index = (size_t)ii;
 
     /* copy in starting indices */
     (void) memcpy(coord, start, varp->ndims * sizeof(size_t));

--- a/libsrc/v1hpg.c
+++ b/libsrc/v1hpg.c
@@ -561,8 +561,8 @@ v1h_get_NC_dimarray(v1hs *gsp, NC_dimarray *ncap)
 				return status;
 			}
 			{
-			  int dimid = (size_t)(dpp - ncap->value);
-			  NC_hashmapadd(ncap->hashmap, (uintptr_t)dimid, (*dpp)->name->cp,strlen((*dpp)->name->cp));
+			  uintptr_t dimid = (uintptr_t)(dpp - ncap->value);
+			  NC_hashmapadd(ncap->hashmap, dimid, (*dpp)->name->cp, strlen((*dpp)->name->cp));
 			}
 		}
 	}
@@ -601,7 +601,7 @@ ncx_len_NC_attr(const NC_attr *attrp, int version)
 
 /*----< ncmpix_len_nctype() >------------------------------------------------*/
 /* return the length of external data type */
-static int
+static size_t
 ncmpix_len_nctype(nc_type type) {
     switch(type) {
         case NC_BYTE:
@@ -1212,8 +1212,8 @@ v1h_get_NC_vararray(v1hs *gsp, NC_vararray *ncap)
 				return status;
 			}
 			{
-			  int varid = (size_t)(vpp - ncap->value);
-			  NC_hashmapadd(ncap->hashmap, (uintptr_t)varid, (*vpp)->name->cp,strlen((*vpp)->name->cp));
+			  uintptr_t varid = (uintptr_t)(vpp - ncap->value);
+			  NC_hashmapadd(ncap->hashmap, varid, (*vpp)->name->cp, strlen((*vpp)->name->cp));
 			}
 		}
 	}


### PR DESCRIPTION
The few remaining warnings are either not obvious what the correct type should be, or would require changing multiple function prototypes to fix, so I've left them in.