### PR TITLE
CI: Fix version of HDF5 used in one-off test

### DIFF
--- a/.github/workflows/run_tests_ubuntu.yml
+++ b/.github/workflows/run_tests_ubuntu.yml
@@ -223,7 +223,7 @@ jobs:
 
     strategy:
       matrix:
-        hdf5: [ 1.14.0 ]
+        hdf5: [ 1.14.3 ]
     steps:
 
       - uses: actions/checkout@v3


### PR DESCRIPTION
I think this change got lost in a merge