### PR TITLE
Fix for H5Literate() callback versioning

### DIFF
--- a/h5_test/tst_h_files4.c
+++ b/h5_test/tst_h_files4.c
@@ -54,8 +54,9 @@ op_func (hid_t g_id, const char *name,
    strcpy((char *)op_data, name);
 #if H5_VERSION_LE(1, 10, 11) || defined(H5_USE_110_API_DEFAULT) || defined(H5_USE_18_API_DEFAULT) || defined(H5_USE_16_API_DEFAULT)
    /* This library is either 1.10.11 (the last 1.10 release) or earlier
-    * OR this a later version of the library built with a 1.10 or
-    * earlier API.
+    * OR this is a later version of the library built with a 1.10 or
+    * earlier API (earlier versions did not define their own USE
+    * API symbol).
     */
    if ((id = H5Oopen_by_addr(g_id, info->u.address)) < 0) ERR;
 #else

--- a/h5_test/tst_h_files4.c
+++ b/h5_test/tst_h_files4.c
@@ -45,21 +45,18 @@ with the H5Lvisit function call
 */
 herr_t
 op_func (hid_t g_id, const char *name, 
-#if H5_VERSION_GE(1,12,0)
-         const H5L_info2_t *info,
-#else
-         const H5L_info_t *info,
-#endif
+     const H5L_info_t *info,
 	 void *op_data)  
 {
    hid_t id;
    H5I_type_t obj_type;
 
    strcpy((char *)op_data, name);
-#if H5_VERSION_GE(1,12,0)
-   if ((id = H5Oopen_by_token(g_id, info->u.token)) < 0) ERR;
-#else
+#if defined(H5_USE_110_API_DEFAULT) || defined(H5_USE_18_API_DEFAULT) || defined(H5_USE_16_API_DEFAULT)
    if ((id = H5Oopen_by_addr(g_id, info->u.address)) < 0) ERR;
+#else
+   /* HDF5 1.12 switched from addresses to tokens to better support the VOL */
+   if ((id = H5Oopen_by_token(g_id, info->u.token)) < 0) ERR;
 #endif
 
 /* Using H5Ovisit is really slow. Use H5Iget_type for a fast

--- a/h5_test/tst_h_files4.c
+++ b/h5_test/tst_h_files4.c
@@ -52,7 +52,11 @@ op_func (hid_t g_id, const char *name,
    H5I_type_t obj_type;
 
    strcpy((char *)op_data, name);
-#if defined(H5_USE_110_API_DEFAULT) || defined(H5_USE_18_API_DEFAULT) || defined(H5_USE_16_API_DEFAULT)
+#if H5_VERSION_LE(1, 10, 11) || defined(H5_USE_110_API_DEFAULT) || defined(H5_USE_18_API_DEFAULT) || defined(H5_USE_16_API_DEFAULT)
+   /* This library is either 1.10.11 (the last 1.10 release) or earlier
+    * OR this a later version of the library built with a 1.10 or
+    * earlier API.
+    */
    if ((id = H5Oopen_by_addr(g_id, info->u.address)) < 0) ERR;
 #else
    /* HDF5 1.12 switched from addresses to tokens to better support the VOL */


### PR DESCRIPTION
The netCDF library supports many versions of HDF5, which handles API compatibility via a set of API-call-specific macros. netCDF uses H5Literate(), which was versioned in the 1.12.x maintenance line in order to better support the virtual object layer (VOL).

h5_test/tst_h_files4.c failed to compile with certain compilers when the HDF5 library was built using pre-VOL versions of the library- e.g., 1.10, which can be configured with --with-default-api-version=110. This was due to the API compatibility macros being used to select the 1.10 version of H5Literate(), but not its callback function, which was set using a `H5_VERSION_GE()` macro that does not take the compatibility macros into consideration.

Fixing the problem involved removing the `H5_VERSION_GE()` macro and letting the compatibility macros handle the versioning, and using the `H5_USE_XXX_API_DEFAULT` symbols to protect the H5Oopen_by_addr() call used in the callback (a new call that wasn't versioned, hence the different protection mechanism).

Tested w/ HDF5's develop branch w/ both 1.14 and 1.10 API bindings

Fixes #2886 (4118 in HDF5's issue tracker)