### PR TITLE
Bump HDF5 version in appveyor build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,8 @@ skip_branch_with_pr: true
 
 init:
   - cmd: set PATH=C:\Python310;C:\Python310\Scripts;%PATH%
-
+  - cmd: set CONDA_INSTALL_LOCN=C:\Miniconda38-x64
+  
 install:
   - cmd: set SRC_DIR=%cd%
   - cmd: set INSTALL_LOC=%SRC_DIR%\install

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ install:
   - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
   - cmd: conda config --set always_yes yes --set changeps1 no --set show_channel_urls true
   - cmd: conda update conda
-  - cmd: conda install hdf5=1.10.11 curl hdf4
+  - cmd: conda install hdf5=1.10.6 curl hdf4
 
 configuration: Release
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,8 +11,8 @@ environment:
 platform:
     - x64
 
-branches:
-  except:
+#branches:
+#  except:
 #    - /.*[.]dmh/
 #    - /.*[.]wif/
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ platform:
 branches:
   except:
 #    - /.*[.]dmh/
-    - /.*[.]wif/
+#    - /.*[.]wif/
 
 # Do not build feature branch with open Pull Requests
 skip_branch_with_pr: true
@@ -26,7 +26,7 @@ install:
   - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
   - cmd: conda config --set always_yes yes --set changeps1 no --set show_channel_urls true
   - cmd: conda update conda
-  - cmd: conda install hdf5=1.8.18 curl hdf4
+  - cmd: conda install hdf5=1.10.11 curl hdf4
 
 configuration: Release
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,9 +22,8 @@ platform:
 skip_branch_with_pr: true
 
 init:
-  - cmd: set PATH=C:\Python310;C:\Python310\Scripts;%PATH%
   - cmd: set CONDA_INSTALL_LOCN=C:\Miniconda38-x64
-  
+
 install:
   - cmd: set SRC_DIR=%cd%
   - cmd: set INSTALL_LOC=%SRC_DIR%\install

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,8 @@ environment:
 platform:
     - x64
 
+
+
 #branches:
 #  except:
 #    - /.*[.]dmh/
@@ -18,6 +20,9 @@ platform:
 
 # Do not build feature branch with open Pull Requests
 skip_branch_with_pr: true
+
+init:
+  - cmd: set PATH=C:\Python310;C:\Python310\Scripts;%PATH%
 
 install:
   - cmd: set SRC_DIR=%cd%


### PR DESCRIPTION
Needed in response to #2888.  Will make the same changes directly to that branch, assuming it works here. 