### PR TITLE
Remove now unused cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1541,15 +1541,6 @@ foreach(_LIB ${ALL_TLL_LIBS})
   list(APPEND LINKFLAGS "-L${_LIB_DIR}")
 endforeach()
 
-#set(NC_LIBS "-lnetcdf ${NC_LIBS}")
-if(NC_LIBS)
-  string(REPLACE ";" " " NC_LIBS "${NC_LIBS}")
-  string(REPLACE "-lhdf5::hdf5-shared" "-lhdf5" NC_LIBS ${NC_LIBS})
-  string(REPLACE "-lhdf5::hdf5_hl-shared" "-lhdf5_hl" NC_LIBS ${NC_LIBS})
-  string(REPLACE "-lhdf5::hdf5-static" "-lhdf5" NC_LIBS ${NC_LIBS})
-  string(REPLACE "-lhdf5::hdf5_hl-static" "-lhdf5_hl" NC_LIBS ${NC_LIBS})
-endif()
-
 string(REPLACE ";" " " LINKFLAGS "${LINKFLAGS}")
 
 list(REMOVE_DUPLICATES NC_LIBS)


### PR DESCRIPTION
With #2847 and the work done by @ZedThree, I believe we can now

- close #1444
- close 2869

When I make and install netcdf on a mac and linux, I don't see the `hdf5::hdf5-shared` libraries included in `<install-prefix>/lib/pkgconfig/netcdf.pc` and `<install-prefix>/lib/cmake/netCDF/netCDFConfig.cmake` only includes a call to `find_dependency(HDF5)` (as configured). 

My bet is that #2847 with its updates to finding and using hdf5, and updated hdf5 and cmake versions fixed this.

Related is a [spack PR](https://github.com/spack/spack/pull/42878) that should now be redundant, along with the filter code that I removed