### PR TITLE
Fix warnings from backwards-loops

### DIFF
--- a/libdap2/cache.c
+++ b/libdap2/cache.c
@@ -25,7 +25,7 @@ static int iscacheableconstraint(DCEconstraint* con);
 int
 iscached(NCDAPCOMMON* nccomm, CDFnode* target, NCcachenode** cachenodep)
 {
-    int i, found;
+    int found;
     size_t j;
     size_t index;
     NCcache* cache;
@@ -39,7 +39,8 @@ iscached(NCDAPCOMMON* nccomm, CDFnode* target, NCcachenode** cachenodep)
     cache = nccomm->cdf.cache;
     cachenode = cache->prefetch;
     if(cachenode!= NULL) {
-        for(found=0,i=0;i<nclistlength(cachenode->vars);i++) {
+        found = 0;
+        for(size_t i=0;i<nclistlength(cachenode->vars);i++) {
             CDFnode* var = (CDFnode*)nclistget(cachenode->vars,i);
 	    if(var == target) {
                 if(cachenodep) *cachenodep = cachenode;
@@ -51,7 +52,7 @@ iscached(NCDAPCOMMON* nccomm, CDFnode* target, NCcachenode** cachenodep)
 
     /*search other cache nodes starting at latest first */
     index = 0;
-    for(i=nclistlength(cache->nodes)-1;i>=0;i--) {
+    for(size_t i = nclistlength(cache->nodes); i-->0;) {
         cachenode = (NCcachenode*)nclistget(cache->nodes,i);
 	/* We currently do not try to match constraints;
            If the cachenode is constrained by more than

--- a/libdap2/constraints.c
+++ b/libdap2/constraints.c
@@ -623,11 +623,10 @@ next:   continue;
     } /*for(;;)*/
 
     /* remove all NULL elements */
-    int n;
-    for(n=nclistlength(list)-1;n>=0;n--) {
+    for(size_t n = nclistlength(list); n-->0;) {
         DCEprojection* target = (DCEprojection*)nclistget(list,n);
-	if(target == NULL)
-	    nclistremove(list,n);
+        if(target == NULL)
+            nclistremove(list,n);
     }
 done:
 #ifdef DEBUG

--- a/libdap2/dapodom.c
+++ b/libdap2/dapodom.c
@@ -114,9 +114,8 @@ dapodom_count(Dapodometer* odom)
 int
 dapodom_next(Dapodometer* odom)
 {
-    int i; /* do not make unsigned */
     if(odom->rank == 0) return 0; 
-    for(i=odom->rank-1;i>=0;i--) {
+    for(size_t i = odom->rank; i-->0;) {
         odom->index[i] += odom->stride[i];
         if(odom->index[i] < odom->stop[i]) break;
 	if(i == 0) return 0; /* leave the 0th entry if it overflows*/

--- a/libdap2/daputil.c
+++ b/libdap2/daputil.c
@@ -268,11 +268,8 @@ nclistminus(NClist* l1, NClist* l2)
 int
 nclistdeleteall(NClist* l, void* elem)
 {
-    int i; /* do not make unsigned */
-    unsigned int len,found;
-    found = 0;
-    len = nclistlength(l);
-    for(i=len-1;i>=0;i--) {
+    int found = 0;
+    for(size_t i = nclistlength(l); i-->0;) {
 	void* test = nclistget(l,i);
 	if(test==elem) {
 	    nclistremove(l,i);

--- a/libdap2/ncd2dispatch.c
+++ b/libdap2/ncd2dispatch.c
@@ -2146,14 +2146,14 @@ fail:
 static NCerror
 suppressunusablevars(NCDAPCOMMON* dapcomm)
 {
-    int i,j;
+    size_t i,j;
     int found = 1;
     NClist* path = nclistnew();
 
     while(found) {
 	found = 0;
 	/* Walk backwards to aid removal semantics */
-	for(i=nclistlength(dapcomm->cdf.ddsroot->tree->varnodes)-1;i>=0;i--) {
+	for(i = nclistlength(dapcomm->cdf.ddsroot->tree->varnodes); i-->0;) {
 	    CDFnode* var = (CDFnode*)nclistget(dapcomm->cdf.ddsroot->tree->varnodes,i);
 	    /* See if this var is under an unusable sequence */
 	    nclistclear(path);

--- a/libdispatch/dinfermodel.c
+++ b/libdispatch/dinfermodel.c
@@ -557,10 +557,9 @@ negateone(const char* mode, NClist* newmodes)
     const struct MODEINFER* tests = modenegations;
     int changed = 0;
     for(;tests->key;tests++) {
-	int i;
 	if(strcasecmp(tests->key,mode)==0) {
 	    /* Find and remove all instances of the inference value */
-	    for(i=nclistlength(newmodes)-1;i>=0;i--) {
+	    for(size_t i = nclistlength(newmodes); i-- > 0;) {
 		char* candidate = nclistget(newmodes,i);
 		if(strcasecmp(candidate,tests->inference)==0) {
 		    nclistremove(newmodes,i);
@@ -1188,25 +1187,25 @@ cleancommalist(const char* commalist, int caseinsensitive)
 static void
 cleanstringlist(NClist* strs, int caseinsensitive)
 {
-    int i,j;
+    int j;
     if(nclistlength(strs) == 0) return;
     /* Remove nulls */
-    for(i=nclistlength(strs)-1;i>=0;i--) {
+    for(size_t i = nclistlength(strs); i-->0;) {
         if(nclistget(strs,i)==NULL) nclistremove(strs,i);
     }
     /* Remove duplicates*/
-    for(i=0;i<nclistlength(strs);i++) {
+    for(size_t i=0;i<nclistlength(strs);i++) {
         const char* value = nclistget(strs,i);
 	/* look ahead for duplicates */
         for(j=nclistlength(strs)-1;j>i;j--) {
 	    int match;
             const char* candidate = nclistget(strs,j);
             if(caseinsensitive)
-	        match = (strcasecmp(value,candidate) == 0);
-	    else
-		match = (strcmp(value,candidate) == 0);
-	    if(match) {char* dup = nclistremove(strs,j); nullfree(dup);}
-	}
+                match = (strcasecmp(value,candidate) == 0);
+            else
+                match = (strcmp(value,candidate) == 0);
+            if(match) {char* dup = nclistremove(strs,j); nullfree(dup);}
+        }
     }
 }
 

--- a/libdispatch/dinfermodel.c
+++ b/libdispatch/dinfermodel.c
@@ -1187,18 +1187,18 @@ cleancommalist(const char* commalist, int caseinsensitive)
 static void
 cleanstringlist(NClist* strs, int caseinsensitive)
 {
-    int j;
     if(nclistlength(strs) == 0) return;
     /* Remove nulls */
     for(size_t i = nclistlength(strs); i-->0;) {
         if(nclistget(strs,i)==NULL) nclistremove(strs,i);
     }
+    if(nclistlength(strs) <= 1) return;
     /* Remove duplicates*/
     for(size_t i=0;i<nclistlength(strs);i++) {
         const char* value = nclistget(strs,i);
-	/* look ahead for duplicates */
-        for(j=nclistlength(strs)-1;j>i;j--) {
-	    int match;
+        /* look ahead for duplicates */
+        for(size_t j=nclistlength(strs)-1;j>i;j--) {
+            int match;
             const char* candidate = nclistget(strs,j);
             if(caseinsensitive)
                 match = (strcasecmp(value,candidate) == 0);

--- a/libdispatch/drc.c
+++ b/libdispatch/drc.c
@@ -362,7 +362,6 @@ rctrim(char* text)
     char* p;
     char* q;
     size_t len = 0;
-    int i;
 
     if(text == NULL || *text == '\0') return;
 
@@ -375,7 +374,7 @@ rctrim(char* text)
     len = strlen(p);
     /* locate last non-trimchar */
     if(len > 0) {
-        for(i=(len-1);i>=0;i--) {
+        for(size_t i = len; i-->0;) {
 	    p = &text[i];
 	    if(*p != ' ' && *p != '\t' && *p != '\r') {break;}
 	    *p = '\0'; /* elide trailing trimchars */

--- a/libhdf5/hdf5filter.c
+++ b/libhdf5/hdf5filter.c
@@ -224,13 +224,13 @@ printfilterlist(NC_VAR_INFO_T* var, const char* tag, int line)
 int
 NC4_hdf5_filter_freelist(NC_VAR_INFO_T* var)
 {
-    int i, stat=NC_NOERR;
+    int stat=NC_NOERR;
     NClist* filters = (NClist*)var->filters;
 
     if(filters == NULL) goto done;
 PRINTFILTERLIST(var,"free: before");
     /* Free the filter list backward */
-    for(i=nclistlength(filters)-1;i>=0;i--) {
+    for(size_t i = nclistlength(filters);i-->0;) {
 	struct NC_HDF5_Filter* spec = (struct NC_HDF5_Filter*)nclistremove(filters,i);
 	if(spec->nparams > 0) nullfree(spec->params);
 	nullfree(spec);
@@ -312,11 +312,10 @@ done:
 int
 NC4_hdf5_filter_remove(NC_VAR_INFO_T* var, unsigned int id)
 {
-    int k;
     NClist* flist = (NClist*)var->filters;
 
     /* Walk backwards */
-    for(k=nclistlength(flist)-1;k>=0;k--) {
+    for(size_t k = nclistlength(flist); k-->0;) {
 	struct NC_HDF5_Filter* f = (struct NC_HDF5_Filter*)nclistget(flist,k);
         if(f->filterid == id) {
 	    /* Remove from variable */

--- a/libnczarr/zchunking.c
+++ b/libnczarr/zchunking.c
@@ -96,8 +96,7 @@ NCZ_compute_projections(struct Common* common,  int r, size64_t chunkindex, cons
     projection = &projections[n];
     if(n > 0) {
 	/* Find last non-skipped projection */
-	int i;
-	for(i=n-1;i>=0;i--) { /* walk backward */
+	for(size_t i=n;i-->0;) { /* walk backward */
             if(!projections[i].skip) {
 	        prev = &projections[i];
 		break;

--- a/libnczarr/zfilter.c
+++ b/libnczarr/zfilter.c
@@ -423,12 +423,12 @@ done:
 int
 NCZ_filter_remove(NC_VAR_INFO_T* var, unsigned int id)
 {
-    int k, stat = NC_NOERR;
+    int stat = NC_NOERR;
     NClist* flist = (NClist*)var->filters;
 
     ZTRACE(6,"var=%s id=%u",var->hdr.name,id);
     /* Walk backwards */
-    for(k=nclistlength(flist)-1;k>=0;k--) {
+    for(size_t k = nclistlength(flist); k-->0;) {
 	struct NCZ_Filter* f = (struct NCZ_Filter*)nclistget(flist,k);
         if(f->hdf5.id == id) {
 	    /* Remove from variable */
@@ -896,9 +896,8 @@ fprintf(stderr,">>> next: alloc=%u used=%u buf=%p\n",(unsigned)next_alloc,(unsig
 	    }
 	} else {
 	    /* Apply in reverse order */
-            int k;
-            for(k=(int)nclistlength(chain)-1;k>=0;k--) {
-              f = (struct NCZ_Filter*)nclistget(chain,(size_t)k);	
+            for(size_t k=nclistlength(chain); k-->0;) {
+              f = (struct NCZ_Filter*)nclistget(chain, k);
 		if(f->flags & FLAG_SUPPRESS) continue; /* this filter should not be applied */
 	        ff = f->plugin->hdf5.filter;
 	        /* code can be simplified */

--- a/ncdump/ocprint.c
+++ b/ncdump/ocprint.c
@@ -1104,11 +1104,10 @@ odom_init(size_t rank, size_t* indices, size_t* dimsizes)
 static void
 odom_next(size_t rank, size_t* indices, size_t* dimsizes)
 {
-    int i;
-    for(i=rank-1;i>=0;i--) {
-	indices[i]++;
-	if(indices[i] < dimsizes[i]) break;
-	if(i > 0) indices[i] = 0;
+    for(size_t i = rank; i-->0;) {
+        indices[i]++;
+        if(indices[i] < dimsizes[i]) break;
+        if(i > 0) indices[i] = 0;
     }
 }
 

--- a/oc2/ocutil.c
+++ b/oc2/ocutil.c
@@ -490,10 +490,9 @@ ocarrayoffset(size_t rank, size_t* sizes, const size_t* indices)
 void
 ocarrayindices(size_t index, size_t rank, size_t* sizes, size_t* indices)
 {
-    int i;
-    for(i=rank-1;i>=0;i--) {
-	indices[i] = index % sizes[i];
-	index = (index - indices[i]) / sizes[i];
+    for(size_t i = rank; i-->0;) {
+        indices[i] = index % sizes[i];
+        index = (index - indices[i]) / sizes[i];
     }
 }
 


### PR DESCRIPTION
Changes backward-loops over lists\* from this pattern:

```c
int i;
size_t length_of_list = /* ... */;
for(i=length_of_list-1;i>=0;i--) {
...
```

to this:

```c
size_t length_of_list = /* ... */;
for(size_t i = length_of_list; i-->0;) {
...
```

This form enables using an unsigned type for the loop index, which usually fixes a couple of sign conversion warnings.

---
\* or at least those that currently trigger sign-conversion warnings in the `for` statement or in the loop body

