### PR TITLE
Fix warnings in `ncgen3`

### DIFF
--- a/ncgen3/CMakeLists.txt
+++ b/ncgen3/CMakeLists.txt
@@ -14,23 +14,32 @@ SET(ncgen3_FILES main.c load.c escapes.c getfill.c init.c genlib.c ncgeny.c ${XG
 FILE(GLOB COPY_FILES ${CMAKE_CURRENT_SOURCE_DIR}/*.nc ${CMAKE_CURRENT_SOURCE_DIR}/*.sh ${CMAKE_CURRENT_SOURCE_DIR}/*.cdl)
 FILE(COPY ${COPY_FILES} DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/ FILE_PERMISSIONS OWNER_WRITE OWNER_READ OWNER_EXECUTE)
 
-IF(NOT EXISTS ${netCDF_SOURCE_DIR}/ncgen3/ncgeny.c AND NOT EXISTS
-    ${netCDF_SOURCE_DIR}/ncgen3/ncgeny.h)
-  ADD_CUSTOM_COMMAND(
-  OUTPUT ncgentab.h
-  COMMAND flex -Pncg -8 ncgen.l
-  COMMAND rm -f ncgenl.c
-  COMMAND mv lex.ncg.c ncgenl.c
-  COMMAND bison -pncg -t -d ncgen.y
-  COMMAND rm -f ncgeny.c ncgeny.h
-  COMMAND mv ncgen.tab.c ncgeny.c
-  COMMAND mv ncgen.tab.h ncgeny.h
-  COMMAND mv ncgeny.h ${CMAKE_CURRENT_SOURCE_DIR}
-  COMMAND mv ncgeny.c ${CMAKE_CURRENT_SOURCE_DIR}
-  COMMAND mv ncgenl.c ${CMAKE_CURRENT_SOURCE_DIR}
-  VERBATIM
+# With this option enabled, automatically generate the parser source
+# files from the yacc input files when they're changed. They don't
+# change very often, so this option is off by default.
+if (NETCDF_GENERATE_NCGEN)
+  find_program(FLEX flex REQUIRED)
+  find_program(BISON bison REQUIRED)
+
+  add_custom_command(
+    OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/ncgeny.h ${CMAKE_CURRENT_SOURCE_DIR}/ncgeny.c ${CMAKE_CURRENT_SOURCE_DIR}/ncgenl.c
+    DEPENDS ncgen.y ncgen.l
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+
+    COMMAND ${FLEX} -Pncg -8 ncgen/ncgen.l
+    COMMAND mv lex.ncg.c "${CMAKE_CURRENT_SOURCE_DIR}/ncgenl.c"
+
+    COMMAND ${BISON} -pncg -t -d ncgen/ncgen.y
+    COMMAND mv ncgen.tab.c "${CMAKE_CURRENT_SOURCE_DIR}/ncgeny.c"
+    COMMAND mv ncgen.tab.h "${CMAKE_CURRENT_SOURCE_DIR}/ncgeny.h"
+
+    # Fix the `#line` preprocessor directives with the correct source paths
+    COMMAND sed -i s/ncgen.tab/ncgeny/ "${CMAKE_CURRENT_SOURCE_DIR}/ncgeny.c"
+    COMMAND sed -i s/lex.ncg/ncgenl/ "${CMAKE_CURRENT_SOURCE_DIR}/ncgenl.c"
+    COMMAND sed -i s/ncgen.tab/ncgeny/ "${CMAKE_CURRENT_SOURCE_DIR}/ncgeny.h"
+    VERBATIM
     )
-ENDIF()
+endif()
 
 ADD_EXECUTABLE(ncgen3 ${ncgen3_FILES})
 TARGET_LINK_LIBRARIES(ncgen3 netcdf ${ALL_TLL_LIBS})

--- a/ncgen3/genlib.c
+++ b/ncgen3/genlib.c
@@ -193,7 +193,7 @@ cstring(
 	return cp;
 
       case NC_DOUBLE:
-    cp_size = 20;
+	cp_size = 24;
 	cp = (char *) emalloc (cp_size);
 	doublep = (double *)valp;
 	(void) snprintf(cp,cp_size,"%.16g",* (doublep + num));

--- a/ncgen3/genlib.c
+++ b/ncgen3/genlib.c
@@ -1866,13 +1866,13 @@ extern char*
 decodify (
     const char *name)
 {
-    int count;		/* number chars in newname */
+    size_t count;		/* number chars in newname */
     char *newname;
     const char *cp;
     char *sp;
     static int init = 0;
     static char* repls[256];	/* replacement string for each char */
-    static int lens[256];	/* lengths of replacement strings */
+    static size_t lens[256];	/* lengths of replacement strings */
     static struct {
 	char c;
 	char *s;
@@ -1911,7 +1911,7 @@ decodify (
  	{'/', "_SLASH_"} 		/* should not occur in names */
 /* 	{'_', "_UNDERSCORE_"} */
     };
-    static int idtlen;
+    static size_t idtlen;
     static size_t hexlen;
     int nctable = (sizeof(ctable))/(sizeof(ctable[0]));
     size_t newlen;
@@ -1924,12 +1924,12 @@ decodify (
 
 	for(i = 0; i < 128; i++) {
 	    rp = emalloc(2);
-	    rp[0] = i;
+	    rp[0] = (char)i;
 	    rp[1] = '\0';
 	    repls[i] = rp;
 	}
 	for(i=0; i < nctable; i++) {
-	    size_t j = ctable[i].c;
+	    size_t j = (size_t)ctable[i].c;
 	    free(repls[j]);
 	    repls[j] = ctable[i].s;
 	}
@@ -1950,9 +1950,9 @@ decodify (
     while(*cp != '\0') {	/* get number of extra bytes for newname */
 	size_t j;
         if(*cp < 0) {		/* handle signed or unsigned chars */
-	    j = *cp + 256;
+	    j = (size_t)*cp + 256;
 	} else {
-	    j = *cp;
+	    j = (size_t)*cp;
 	}
  	count += lens[j] - 1;
 	cp++;
@@ -1976,9 +1976,9 @@ decodify (
 	size_t j, len;
 	/* cp is current position in name, sp is current position in newname */
         if(*cp < 0) {	      /* j is table index for character *cp */
-	    j = *cp + 256;
+	    j = (size_t)*cp + 256;
 	} else {
-	    j = *cp;
+	    j = (size_t)*cp;
 	}
 	len = strlcat(sp, repls[j], newlen);
 	assert(len < newlen);

--- a/ncgen3/ncgen.l
+++ b/ncgen3/ncgen.l
@@ -142,8 +142,8 @@ data:|DATA:		{return (DATA);}
                         yyerror("netCDF name required");
                         return (DATA); /* generate syntax error */
                 }
-		netcdfname = (char *) emalloc(t-s+1);
-		(void) strncpy(netcdfname, s, t-s);
+		netcdfname = (char *) emalloc((size_t)(t-s+1));
+		(void) strncpy(netcdfname, s, (size_t)(t-s));
 		netcdfname[t-s] = '\0';
 		deescapify(netcdfname);  /* so "\5foo" becomes "5foo", for example */
 		return (NETCDF);
@@ -184,7 +184,7 @@ FloatInf|-?Inff	{ /* missing value (pre-2.4 backward compatibility) */
 		    snprintf(errstr, sizeof(errstr),"bad byte constant: %s",(char*)yytext);
 		    yyerror(errstr);
 		}
-                byte_val = ii;
+                byte_val = (signed char)ii;
 		if (ii != (int)byte_val) {
 		    snprintf(errstr, sizeof(errstr),"byte constant out of range (-128,127): %s",(char*)yytext);
 		    yyerror(errstr);

--- a/ncgen3/ncgen.y
+++ b/ncgen3/ncgen.y
@@ -142,7 +142,7 @@ dimdecline:     dimdecl
 dimdecl:        dimd '=' INT_CONST
 		   { if (int_val <= 0)
 			 derror("dimension length must be positive");
-		     dims[ndims].size = int_val;
+		     dims[ndims].size = (size_t)int_val;
 		     ndims++;
 		   }
                 | dimd '=' DOUBLE_CONST
@@ -629,10 +629,10 @@ const:         CHAR_CONST
 		       atype_code = NC_SHORT;
 		       switch (valtype) {
 			 case NC_CHAR:
-			   *char_valp++ = short_val;
+			   *char_valp++ = (char)short_val;
 			   break;
 			 case NC_BYTE:
-			   *byte_valp++ = short_val;
+			   *byte_valp++ = (signed char)short_val;
 			   break;
 			 case NC_SHORT:
 			   *short_valp++ = short_val;
@@ -655,19 +655,19 @@ const:         CHAR_CONST
 		       atype_code = NC_INT;
 		       switch (valtype) {
 			 case NC_CHAR:
-			   *char_valp++ = int_val;
+			   *char_valp++ = (char)int_val;
 			   break;
 			 case NC_BYTE:
-			   *byte_valp++ = int_val;
+			   *byte_valp++ = (signed char)int_val;
 			   break;
 			 case NC_SHORT:
-			   *short_valp++ = int_val;
+			   *short_valp++ = (short)int_val;
 			   break;
 			 case NC_INT:
 			   *int_valp++ = int_val;
 			   break;
 			 case NC_FLOAT:
-			   *float_valp++ = int_val;
+			   *float_valp++ = (float)int_val;
 			   break;
 			 case NC_DOUBLE:
 			   *double_valp++ = int_val;
@@ -681,16 +681,16 @@ const:         CHAR_CONST
 		       atype_code = NC_FLOAT;
 		       switch (valtype) {
 			 case NC_CHAR:
-			   *char_valp++ = float_val;
+			   *char_valp++ = (char)float_val;
 			   break;
 			 case NC_BYTE:
-			   *byte_valp++ = float_val;
+			   *byte_valp++ = (signed char)float_val;
 			   break;
 			 case NC_SHORT:
-			   *short_valp++ = float_val;
+			   *short_valp++ = (short)float_val;
 			   break;
 			 case NC_INT:
-			   *int_valp++ = float_val;
+			   *int_valp++ = (int)float_val;
 			   break;
 			 case NC_FLOAT:
 			   *float_valp++ = float_val;
@@ -707,22 +707,22 @@ const:         CHAR_CONST
 		       atype_code = NC_DOUBLE;
 		       switch (valtype) {
 			 case NC_CHAR:
-			   *char_valp++ = double_val;
+			   *char_valp++ = (char)double_val;
 			   break;
 			 case NC_BYTE:
-			   *byte_valp++ = double_val;
+			   *byte_valp++ = (signed char)double_val;
 			   break;
 			 case NC_SHORT:
-			   *short_valp++ = double_val;
+			   *short_valp++ = (short)double_val;
 			   break;
 			 case NC_INT:
-			   *int_valp++ = double_val;
+			   *int_valp++ = (int)double_val;
 			   break;
 			 case NC_FLOAT:
 			   if (double_val == NC_FILL_DOUBLE)
 			     *float_valp++ = NC_FILL_FLOAT;
 			   else
-			     *float_valp++ = double_val;
+			     *float_valp++ = (float)double_val;
 			   break;
 			 case NC_DOUBLE:
 			   *double_valp++ = double_val;

--- a/ncgen3/ncgenl.c
+++ b/ncgen3/ncgenl.c
@@ -1,5 +1,5 @@
 
-#line 3 "ncgenl.c"
+#line 2 "ncgenl.c"
 
 #define  YY_INT_ALIGNED short int
 
@@ -7,14 +7,20 @@
 
 #define yy_create_buffer ncg_create_buffer
 #define yy_delete_buffer ncg_delete_buffer
-#define yy_flex_debug ncg_flex_debug
+#define yy_scan_buffer ncg_scan_buffer
+#define yy_scan_string ncg_scan_string
+#define yy_scan_bytes ncg_scan_bytes
 #define yy_init_buffer ncg_init_buffer
 #define yy_flush_buffer ncg_flush_buffer
 #define yy_load_buffer_state ncg_load_buffer_state
 #define yy_switch_to_buffer ncg_switch_to_buffer
+#define yypush_buffer_state ncgpush_buffer_state
+#define yypop_buffer_state ncgpop_buffer_state
+#define yyensure_buffer_stack ncgensure_buffer_stack
+#define yy_flex_debug ncg_flex_debug
 #define yyin ncgin
 #define yyleng ncgleng
-#define yylex ncglex
+#define yyncgenllex
 #define yylineno ncglineno
 #define yyout ncgout
 #define yyrestart ncgrestart
@@ -27,9 +33,243 @@
 #define FLEX_SCANNER
 #define YY_FLEX_MAJOR_VERSION 2
 #define YY_FLEX_MINOR_VERSION 6
-#define YY_FLEX_SUBMINOR_VERSION 0
+#define YY_FLEX_SUBMINOR_VERSION 4
 #if YY_FLEX_SUBMINOR_VERSION > 0
 #define FLEX_BETA
+#endif
+
+#ifdef yy_create_buffer
+#define ncg_create_buffer_ALREADY_DEFINED
+#else
+#define yy_create_buffer ncg_create_buffer
+#endif
+
+#ifdef yy_delete_buffer
+#define ncg_delete_buffer_ALREADY_DEFINED
+#else
+#define yy_delete_buffer ncg_delete_buffer
+#endif
+
+#ifdef yy_scan_buffer
+#define ncg_scan_buffer_ALREADY_DEFINED
+#else
+#define yy_scan_buffer ncg_scan_buffer
+#endif
+
+#ifdef yy_scan_string
+#define ncg_scan_string_ALREADY_DEFINED
+#else
+#define yy_scan_string ncg_scan_string
+#endif
+
+#ifdef yy_scan_bytes
+#define ncg_scan_bytes_ALREADY_DEFINED
+#else
+#define yy_scan_bytes ncg_scan_bytes
+#endif
+
+#ifdef yy_init_buffer
+#define ncg_init_buffer_ALREADY_DEFINED
+#else
+#define yy_init_buffer ncg_init_buffer
+#endif
+
+#ifdef yy_flush_buffer
+#define ncg_flush_buffer_ALREADY_DEFINED
+#else
+#define yy_flush_buffer ncg_flush_buffer
+#endif
+
+#ifdef yy_load_buffer_state
+#define ncg_load_buffer_state_ALREADY_DEFINED
+#else
+#define yy_load_buffer_state ncg_load_buffer_state
+#endif
+
+#ifdef yy_switch_to_buffer
+#define ncg_switch_to_buffer_ALREADY_DEFINED
+#else
+#define yy_switch_to_buffer ncg_switch_to_buffer
+#endif
+
+#ifdef yypush_buffer_state
+#define ncgpush_buffer_state_ALREADY_DEFINED
+#else
+#define yypush_buffer_state ncgpush_buffer_state
+#endif
+
+#ifdef yypop_buffer_state
+#define ncgpop_buffer_state_ALREADY_DEFINED
+#else
+#define yypop_buffer_state ncgpop_buffer_state
+#endif
+
+#ifdef yyensure_buffer_stack
+#define ncgensure_buffer_stack_ALREADY_DEFINED
+#else
+#define yyensure_buffer_stack ncgensure_buffer_stack
+#endif
+
+#ifdef yylex
+#define ncglex_ALREADY_DEFINED
+#else
+#define yyncgenllex
+#endif
+
+#ifdef yyrestart
+#define ncgrestart_ALREADY_DEFINED
+#else
+#define yyrestart ncgrestart
+#endif
+
+#ifdef yylex_init
+#define ncglex_init_ALREADY_DEFINED
+#else
+#define yylex_init ncglex_init
+#endif
+
+#ifdef yylex_init_extra
+#define ncglex_init_extra_ALREADY_DEFINED
+#else
+#define yylex_init_extra ncglex_init_extra
+#endif
+
+#ifdef yylex_destroy
+#define ncglex_destroy_ALREADY_DEFINED
+#else
+#define yylex_destroy ncglex_destroy
+#endif
+
+#ifdef yyget_debug
+#define ncgget_debug_ALREADY_DEFINED
+#else
+#define yyget_debug ncgget_debug
+#endif
+
+#ifdef yyset_debug
+#define ncgset_debug_ALREADY_DEFINED
+#else
+#define yyset_debug ncgset_debug
+#endif
+
+#ifdef yyget_extra
+#define ncgget_extra_ALREADY_DEFINED
+#else
+#define yyget_extra ncgget_extra
+#endif
+
+#ifdef yyset_extra
+#define ncgset_extra_ALREADY_DEFINED
+#else
+#define yyset_extra ncgset_extra
+#endif
+
+#ifdef yyget_in
+#define ncgget_in_ALREADY_DEFINED
+#else
+#define yyget_in ncgget_in
+#endif
+
+#ifdef yyset_in
+#define ncgset_in_ALREADY_DEFINED
+#else
+#define yyset_in ncgset_in
+#endif
+
+#ifdef yyget_out
+#define ncgget_out_ALREADY_DEFINED
+#else
+#define yyget_out ncgget_out
+#endif
+
+#ifdef yyset_out
+#define ncgset_out_ALREADY_DEFINED
+#else
+#define yyset_out ncgset_out
+#endif
+
+#ifdef yyget_leng
+#define ncgget_leng_ALREADY_DEFINED
+#else
+#define yyget_leng ncgget_leng
+#endif
+
+#ifdef yyget_text
+#define ncgget_text_ALREADY_DEFINED
+#else
+#define yyget_text ncgget_text
+#endif
+
+#ifdef yyget_lineno
+#define ncgget_lineno_ALREADY_DEFINED
+#else
+#define yyget_lineno ncgget_lineno
+#endif
+
+#ifdef yyset_lineno
+#define ncgset_lineno_ALREADY_DEFINED
+#else
+#define yyset_lineno ncgset_lineno
+#endif
+
+#ifdef yywrap
+#define ncgwrap_ALREADY_DEFINED
+#else
+#define yywrap ncgwrap
+#endif
+
+#ifdef yyalloc
+#define ncgalloc_ALREADY_DEFINED
+#else
+#define yyalloc ncgalloc
+#endif
+
+#ifdef yyrealloc
+#define ncgrealloc_ALREADY_DEFINED
+#else
+#define yyrealloc ncgrealloc
+#endif
+
+#ifdef yyfree
+#define ncgfree_ALREADY_DEFINED
+#else
+#define yyfree ncgfree
+#endif
+
+#ifdef yytext
+#define ncgtext_ALREADY_DEFINED
+#else
+#define yytext ncgtext
+#endif
+
+#ifdef yyleng
+#define ncgleng_ALREADY_DEFINED
+#else
+#define yyleng ncgleng
+#endif
+
+#ifdef yyin
+#define ncgin_ALREADY_DEFINED
+#else
+#define yyin ncgin
+#endif
+
+#ifdef yyout
+#define ncgout_ALREADY_DEFINED
+#else
+#define yyout ncgout
+#endif
+
+#ifdef yy_flex_debug
+#define ncg_flex_debug_ALREADY_DEFINED
+#else
+#define yy_flex_debug ncg_flex_debug
+#endif
+
+#ifdef yylineno
+#define ncglineno_ALREADY_DEFINED
+#else
+#define yylineno ncglineno
 #endif
 
 /* First, we deal with  platform-specific or compiler-specific issues. */
@@ -102,60 +342,48 @@ typedef unsigned int flex_uint32_t;
 #define UINT32_MAX             (4294967295U)
 #endif
 
+#ifndef SIZE_MAX
+#define SIZE_MAX               (~(size_t)0)
+#endif
+
 #endif /* ! C99 */
 
 #endif /* ! FLEXINT_H */
 
-#ifdef __cplusplus
+/* begin standard C++ headers. */
 
-/* The "const" storage-class-modifier is valid. */
-#define YY_USE_CONST
-
-#else	/* ! __cplusplus */
-
-/* C99 requires __STDC__ to be defined as 1. */
-#if defined (__STDC__)
-
-#define YY_USE_CONST
-
-#endif	/* defined (__STDC__) */
-#endif	/* ! __cplusplus */
-
-#ifdef YY_USE_CONST
+/* TODO: this is always defined, so inline it */
 #define yyconst const
+
+#if defined(__GNUC__) && __GNUC__ >= 3
+#define yynoreturn __attribute__((__noreturn__))
 #else
-#define yyconst
+#define yynoreturn
 #endif
 
 /* Returned upon end-of-file. */
 #define YY_NULL 0
 
-/* Promotes a possibly negative, possibly signed char to an unsigned
- * integer for use as an array index.  If the signed char is negative,
- * we want to instead treat it as an 8-bit unsigned char, hence the
- * double cast.
+/* Promotes a possibly negative, possibly signed char to an
+ *   integer in range [0..255] for use as an array index.
  */
-#define YY_SC_TO_UI(c) ((unsigned int) (unsigned char) c)
+#define YY_SC_TO_UI(c) ((YY_CHAR) (c))
 
 /* Enter a start condition.  This macro really ought to take a parameter,
  * but we do it the disgusting crufty way forced on us by the ()-less
  * definition of BEGIN.
  */
 #define BEGIN (yy_start) = 1 + 2 *
-
 /* Translate the current start state into a value that can be later handed
  * to BEGIN to return to the state.  The YYSTATE alias is for lex
  * compatibility.
  */
 #define YY_START (((yy_start) - 1) / 2)
 #define YYSTATE YY_START
-
 /* Action number for EOF rule of a given start state. */
 #define YY_STATE_EOF(state) (YY_END_OF_BUFFER + state + 1)
-
 /* Special action meaning "start processing a new file". */
-#define YY_NEW_FILE ncgrestart(ncgin  )
-
+#define YY_NEW_FILE yyrestart( yyin  )
 #define YY_END_OF_BUFFER_CHAR 0
 
 /* Size of default input buffer. */
@@ -185,14 +413,14 @@ typedef struct yy_buffer_state *YY_BUFFER_STATE;
 typedef size_t yy_size_t;
 #endif
 
-extern yy_size_t ncgleng;
+extern int yyleng;
 
-extern FILE *ncgin, *ncgout;
+extern FILE *yyin, *yyout;
 
 #define EOB_ACT_CONTINUE_SCAN 0
 #define EOB_ACT_END_OF_FILE 1
 #define EOB_ACT_LAST_MATCH 2
-
+    
     #define YY_LESS_LINENO(n)
     #define YY_LINENO_REWIND_TO(ptr)
     
@@ -200,16 +428,15 @@ extern FILE *ncgin, *ncgout;
 #define yyless(n) \
 	do \
 		{ \
-		/* Undo effects of setting up ncgtext. */ \
+		/* Undo effects of setting up yytext. */ \
         int yyless_macro_arg = (n); \
         YY_LESS_LINENO(yyless_macro_arg);\
 		*yy_cp = (yy_hold_char); \
 		YY_RESTORE_YY_MORE_OFFSET \
 		(yy_c_buf_p) = yy_cp = yy_bp + yyless_macro_arg - YY_MORE_ADJ; \
-		YY_DO_BEFORE_ACTION; /* set up ncgtext again */ \
+		YY_DO_BEFORE_ACTION; /* set up yytext again */ \
 		} \
 	while ( 0 )
-
 #define unput(c) yyunput( c, (yytext_ptr)  )
 
 #ifndef YY_STRUCT_YY_BUFFER_STATE
@@ -224,7 +451,7 @@ struct yy_buffer_state
 	/* Size of input buffer in bytes, not including room for EOB
 	 * characters.
 	 */
-	yy_size_t yy_buf_size;
+	int yy_buf_size;
 
 	/* Number of characters read into yy_ch_buf, not including EOB
 	 * characters.
@@ -252,7 +479,7 @@ struct yy_buffer_state
 
     int yy_bs_lineno; /**< The line count. */
     int yy_bs_column; /**< The column count. */
-    
+
 	/* Whether to try to fill the input buffer when we reach the
 	 * end of it.
 	 */
@@ -269,8 +496,8 @@ struct yy_buffer_state
 	 * possible backing-up.
 	 *
 	 * When we actually see the EOF, we change the status to "new"
-	 * (via ncgrestart()), so that the user can continue scanning by
-	 * just pointing ncgin at a new input file.
+	 * (via yyrestart()), so that the user can continue scanning by
+	 * just pointing yyin at a new input file.
 	 */
 #define YY_BUFFER_EOF_PENDING 2
 
@@ -280,7 +507,7 @@ struct yy_buffer_state
 /* Stack of input buffers. */
 static size_t yy_buffer_stack_top = 0; /**< index of top of stack. */
 static size_t yy_buffer_stack_max = 0; /**< capacity of stack. */
-static YY_BUFFER_STATE * yy_buffer_stack = 0; /**< Stack as an array. */
+static YY_BUFFER_STATE * yy_buffer_stack = NULL; /**< Stack as an array. */
 
 /* We provide macros for accessing buffer states in case in the
  * future we want to put the buffer states in a more general
@@ -291,109 +518,98 @@ static YY_BUFFER_STATE * yy_buffer_stack = 0; /**< Stack as an array. */
 #define YY_CURRENT_BUFFER ( (yy_buffer_stack) \
                           ? (yy_buffer_stack)[(yy_buffer_stack_top)] \
                           : NULL)
-
 /* Same as previous macro, but useful when we know that the buffer stack is not
  * NULL or when we need an lvalue. For internal use only.
  */
 #define YY_CURRENT_BUFFER_LVALUE (yy_buffer_stack)[(yy_buffer_stack_top)]
 
-/* yy_hold_char holds the character lost when ncgtext is formed. */
+/* yy_hold_char holds the character lost when yytext is formed. */
 static char yy_hold_char;
 static int yy_n_chars;		/* number of characters read into yy_ch_buf */
-yy_size_t ncgleng;
+int yyleng;
 
 /* Points to current character in buffer. */
-static char *yy_c_buf_p = (char *) 0;
+static char *yy_c_buf_p = NULL;
 static int yy_init = 0;		/* whether we need to initialize */
 static int yy_start = 0;	/* start state number */
 
-/* Flag which is used to allow ncgwrap()'s to do buffer switches
- * instead of setting up a fresh ncgin.  A bit of a hack ...
+/* Flag which is used to allow yywrap()'s to do buffer switches
+ * instead of setting up a fresh yyin.  A bit of a hack ...
  */
 static int yy_did_buffer_switch_on_eof;
 
-void ncgrestart (FILE *input_file  );
-void ncg_switch_to_buffer (YY_BUFFER_STATE new_buffer  );
-YY_BUFFER_STATE ncg_create_buffer (FILE *file,int size  );
-void ncg_delete_buffer (YY_BUFFER_STATE b  );
-void ncg_flush_buffer (YY_BUFFER_STATE b  );
-void ncgpush_buffer_state (YY_BUFFER_STATE new_buffer  );
-void ncgpop_buffer_state (void );
+void yyrestart ( FILE *input_file  );
+void yy_switch_to_buffer ( YY_BUFFER_STATE new_buffer  );
+YY_BUFFER_STATE yy_create_buffer ( FILE *file, int size  );
+void yy_delete_buffer ( YY_BUFFER_STATE b  );
+void yy_flush_buffer ( YY_BUFFER_STATE b  );
+void yypush_buffer_state ( YY_BUFFER_STATE new_buffer  );
+void yypop_buffer_state ( void );
 
-static void ncgensure_buffer_stack (void );
-static void ncg_load_buffer_state (void );
-static void ncg_init_buffer (YY_BUFFER_STATE b,FILE *file  );
+static void yyensure_buffer_stack ( void );
+static void yy_load_buffer_state ( void );
+static void yy_init_buffer ( YY_BUFFER_STATE b, FILE *file  );
+#define YY_FLUSH_BUFFER yy_flush_buffer( YY_CURRENT_BUFFER )
 
-#define YY_FLUSH_BUFFER ncg_flush_buffer(YY_CURRENT_BUFFER )
+YY_BUFFER_STATE yy_scan_buffer ( char *base, yy_size_t size  );
+YY_BUFFER_STATE yy_scan_string ( const char *yy_str  );
+YY_BUFFER_STATE yy_scan_bytes ( const char *bytes, int len  );
 
-YY_BUFFER_STATE ncg_scan_buffer (char *base,yy_size_t size  );
-YY_BUFFER_STATE ncg_scan_string (yyconst char *yy_str  );
-YY_BUFFER_STATE ncg_scan_bytes (yyconst char *bytes,yy_size_t len  );
+void *yyalloc ( yy_size_t  );
+void *yyrealloc ( void *, yy_size_t  );
+void yyfree ( void *  );
 
-void *ncgalloc (yy_size_t  );
-void *ncgrealloc (void *,yy_size_t  );
-void ncgfree (void *  );
-
-#define yy_new_buffer ncg_create_buffer
-
+#define yy_new_buffer yy_create_buffer
 #define yy_set_interactive(is_interactive) \
 	{ \
 	if ( ! YY_CURRENT_BUFFER ){ \
-        ncgensure_buffer_stack (); \
+        yyensure_buffer_stack (); \
 		YY_CURRENT_BUFFER_LVALUE =    \
-            ncg_create_buffer(ncgin,YY_BUF_SIZE ); \
+            yy_create_buffer( yyin, YY_BUF_SIZE ); \
 	} \
 	YY_CURRENT_BUFFER_LVALUE->yy_is_interactive = is_interactive; \
 	}
-
 #define yy_set_bol(at_bol) \
 	{ \
 	if ( ! YY_CURRENT_BUFFER ){\
-        ncgensure_buffer_stack (); \
+        yyensure_buffer_stack (); \
 		YY_CURRENT_BUFFER_LVALUE =    \
-            ncg_create_buffer(ncgin,YY_BUF_SIZE ); \
+            yy_create_buffer( yyin, YY_BUF_SIZE ); \
 	} \
 	YY_CURRENT_BUFFER_LVALUE->yy_at_bol = at_bol; \
 	}
-
 #define YY_AT_BOL() (YY_CURRENT_BUFFER_LVALUE->yy_at_bol)
 
 /* Begin user sect3 */
+typedef flex_uint8_t YY_CHAR;
 
-typedef unsigned char YY_CHAR;
-
-FILE *ncgin = (FILE *) 0, *ncgout = (FILE *) 0;
+FILE *yyin = NULL, *yyout = NULL;
 
 typedef int yy_state_type;
 
-extern int ncglineno;
+extern int yylineno;
+int yylineno = 1;
 
-int ncglineno = 1;
-
-extern char *ncgtext;
+extern char *yytext;
 #ifdef yytext_ptr
 #undef yytext_ptr
 #endif
-#define yytext_ptr ncgtext
+#define yytext_ptr yytext
 
-static yy_state_type yy_get_previous_state (void );
-static yy_state_type yy_try_NUL_trans (yy_state_type current_state  );
-static int yy_get_next_buffer (void );
-#if defined(__GNUC__) && __GNUC__ >= 3
-__attribute__((__noreturn__))
-#endif
-static void yy_fatal_error (yyconst char msg[]  );
+static yy_state_type yy_get_previous_state ( void );
+static yy_state_type yy_try_NUL_trans ( yy_state_type current_state  );
+static int yy_get_next_buffer ( void );
+static void yynoreturn yy_fatal_error ( const char* msg  );
 
 /* Done after the current pattern has been matched and before the
- * corresponding action - sets up ncgtext.
+ * corresponding action - sets up yytext.
  */
 #define YY_DO_BEFORE_ACTION \
 	(yytext_ptr) = yy_bp; \
-	ncgleng = (size_t) (yy_cp - yy_bp); \
+	yyleng = (int) (yy_cp - yy_bp); \
 	(yy_hold_char) = *yy_cp; \
 	*yy_cp = '\0'; \
 	(yy_c_buf_p) = yy_cp;
-
 #define YY_NUM_RULES 30
 #define YY_END_OF_BUFFER 31
 /* This struct is not used in this scanner,
@@ -403,7 +619,7 @@ struct yy_trans_info
 	flex_int32_t yy_verify;
 	flex_int32_t yy_nxt;
 	};
-static yyconst flex_int16_t yy_accept[236] =
+static const flex_int16_t yy_accept[236] =
     {   0,
         0,    0,   31,   29,   28,   17,   29,   29,   29,   29,
        19,   29,   22,   22,   16,   16,   16,   16,   16,   16,
@@ -433,7 +649,7 @@ static yyconst flex_int16_t yy_accept[236] =
        16,   11,   16,   10,    0
     } ;
 
-static yyconst YY_CHAR yy_ec[256] =
+static const YY_CHAR yy_ec[256] =
     {   0,
         1,    1,    1,    1,    1,    1,    1,    1,    2,    3,
         1,    4,    4,    1,    1,    1,    1,    1,    1,    1,
@@ -465,7 +681,7 @@ static yyconst YY_CHAR yy_ec[256] =
         1,    1,    1,    1,    1
     } ;
 
-static yyconst YY_CHAR yy_meta[61] =
+static const YY_CHAR yy_meta[61] =
     {   0,
         1,    1,    2,    1,    1,    1,    1,    3,    4,    4,
         4,    1,    5,    5,    5,    1,    4,    5,    5,    5,
@@ -475,7 +691,7 @@ static yyconst YY_CHAR yy_meta[61] =
         4,    4,    4,    4,    4,    7,    1,    4,    4,    4
     } ;
 
-static yyconst flex_uint16_t yy_base[246] =
+static const flex_int16_t yy_base[246] =
     {   0,
         0,    0,  327, 1206,   59, 1206,   55,  277,   54,   59,
        88,  295,  124,  165,   30,   57,  159,   61,  141,  149,
@@ -506,7 +722,7 @@ static yyconst flex_uint16_t yy_base[246] =
      1187,   66, 1191, 1194, 1199
     } ;
 
-static yyconst flex_int16_t yy_def[246] =
+static const flex_int16_t yy_def[246] =
     {   0,
       235,    1,  235,  235,  235,  235,  236,  237,  235,  235,
       235,  235,  235,  235,  238,  238,  238,  238,  238,  238,
@@ -537,7 +753,7 @@ static yyconst flex_int16_t yy_def[246] =
       235,  235,  235,  235,  235
     } ;
 
-static yyconst flex_uint16_t yy_nxt[1267] =
+static const flex_int16_t yy_nxt[1267] =
     {   0,
         4,    5,    6,    5,    5,    4,    7,    8,    9,   10,
        11,   12,   13,   14,   14,    4,    4,   15,   15,   15,
@@ -680,7 +896,7 @@ static yyconst flex_uint16_t yy_nxt[1267] =
       235,  235,  235,  235,  235,  235
     } ;
 
-static yyconst flex_int16_t yy_chk[1267] =
+static const flex_int16_t yy_chk[1267] =
     {   0,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
@@ -826,8 +1042,8 @@ static yyconst flex_int16_t yy_chk[1267] =
 static yy_state_type yy_last_accepting_state;
 static char *yy_last_accepting_cpos;
 
-extern int ncg_flex_debug;
-int ncg_flex_debug = 0;
+extern int yy_flex_debug;
+int yy_flex_debug = 0;
 
 /* The intent behind this definition is that it'll catch
  * any uses of REJECT which flex missed.
@@ -836,9 +1052,9 @@ int ncg_flex_debug = 0;
 #define yymore() yymore_used_but_not_detected
 #define YY_MORE_ADJ 0
 #define YY_RESTORE_YY_MORE_OFFSET
-char *ncgtext;
-#line 1 "ncgen.l"
-#line 2 "ncgen.l"
+char *yytext;
+#line 1 "ncgen3/ncgen.l"
+#line 2 "ncgen3/ncgen.l"
 /*********************************************************************
  *   Copyright 2018, UCAR/Unidata
  *   See netcdf/COPYRIGHT file for copying and redistribution conditions.
@@ -886,6 +1102,7 @@ char errstr[100];		/* for short error messages */
                                    but make sure every action ends with
                                    "return" or "break"! */
 
+#line 1105 "ncgenl.c"
 /* The most correct (validating) version of UTF8 character set
    (Taken from: http://www.w3.org/2005/03/23-lex-U)
 
@@ -925,7 +1142,7 @@ ID ([A-Za-z_]|{UTF8})([A-Z.@#\[\]a-z_0-9+-]|{UTF8})*
 /* Note: this definition of string will work for utf8 as well,
    although it is a very relaxed definition
 */
-#line 929 "ncgenl.c"
+#line 1145 "ncgenl.c"
 
 #define INITIAL 0
 
@@ -941,36 +1158,36 @@ ID ([A-Za-z_]|{UTF8})([A-Z.@#\[\]a-z_0-9+-]|{UTF8})*
 #define YY_EXTRA_TYPE void *
 #endif
 
-static int yy_init_globals (void );
+static int yy_init_globals ( void );
 
 /* Accessor methods to globals.
    These are made visible to non-reentrant scanners for convenience. */
 
-int ncglex_destroy (void );
+int yylex_destroy ( void );
 
-int ncgget_debug (void );
+int yyget_debug ( void );
 
-void ncgset_debug (int debug_flag  );
+void yyset_debug ( int debug_flag  );
 
-YY_EXTRA_TYPE ncgget_extra (void );
+YY_EXTRA_TYPE yyget_extra ( void );
 
-void ncgset_extra (YY_EXTRA_TYPE user_defined  );
+void yyset_extra ( YY_EXTRA_TYPE user_defined  );
 
-FILE *ncgget_in (void );
+FILE *yyget_in ( void );
 
-void ncgset_in  (FILE * _in_str  );
+void yyset_in  ( FILE * _in_str  );
 
-FILE *ncgget_out (void );
+FILE *yyget_out ( void );
 
-void ncgset_out  (FILE * _out_str  );
+void yyset_out  ( FILE * _out_str  );
 
-yy_size_t ncgget_leng (void );
+			int yyget_leng ( void );
 
-char *ncgget_text (void );
+char *yyget_text ( void );
 
-int ncgget_lineno (void );
+int yyget_lineno ( void );
 
-void ncgset_lineno (int _line_number  );
+void yyset_lineno ( int _line_number  );
 
 /* Macros after this point can all be overridden by user definitions in
  * section 1.
@@ -978,32 +1195,31 @@ void ncgset_lineno (int _line_number  );
 
 #ifndef YY_SKIP_YYWRAP
 #ifdef __cplusplus
-extern "C" int ncgwrap (void );
+extern "C" int yywrap ( void );
 #else
-extern int ncgwrap (void );
+extern int yywrap ( void );
 #endif
 #endif
 
 #ifndef YY_NO_UNPUT
     
-    static void yyunput (int c,char *buf_ptr  );
+    static void yyunput ( int c, char *buf_ptr  );
     
 #endif
 
 #ifndef yytext_ptr
-static void yy_flex_strncpy (char *,yyconst char *,int );
+static void yy_flex_strncpy ( char *, const char *, int );
 #endif
 
 #ifdef YY_NEED_STRLEN
-static int yy_flex_strlen (yyconst char * );
+static int yy_flex_strlen ( const char * );
 #endif
 
 #ifndef YY_NO_INPUT
-
 #ifdef __cplusplus
-static int yyinput (void );
+static int yyinput ( void );
 #else
-static int input (void );
+static int input ( void );
 #endif
 
 #endif
@@ -1023,7 +1239,7 @@ static int input (void );
 /* This used to be an fputs(), but since the string might contain NUL's,
  * we now use fwrite().
  */
-#define ECHO do { if (fwrite( ncgtext, ncgleng, 1, ncgout )) {} } while (0)
+#define ECHO do { if (fwrite( yytext, (size_t) yyleng, 1, yyout )) {} } while (0)
 #endif
 
 /* Gets input and stuffs it into "buf".  number of characters read, or YY_NULL,
@@ -1034,20 +1250,20 @@ static int input (void );
 	if ( YY_CURRENT_BUFFER_LVALUE->yy_is_interactive ) \
 		{ \
 		int c = '*'; \
-		size_t n; \
+		int n; \
 		for ( n = 0; n < max_size && \
-			     (c = getc( ncgin )) != EOF && c != '\n'; ++n ) \
+			     (c = getc( yyin )) != EOF && c != '\n'; ++n ) \
 			buf[n] = (char) c; \
 		if ( c == '\n' ) \
 			buf[n++] = (char) c; \
-		if ( c == EOF && ferror( ncgin ) ) \
+		if ( c == EOF && ferror( yyin ) ) \
 			YY_FATAL_ERROR( "input in flex scanner failed" ); \
 		result = n; \
 		} \
 	else \
 		{ \
 		errno=0; \
-		while ( (result = fread(buf, 1, max_size, ncgin))==0 && ferror(ncgin)) \
+		while ( (result = (int) fread(buf, 1, (yy_size_t) max_size, yyin)) == 0 && ferror(yyin)) \
 			{ \
 			if( errno != EINTR) \
 				{ \
@@ -1055,7 +1271,7 @@ static int input (void );
 				break; \
 				} \
 			errno=0; \
-			clearerr(ncgin); \
+			clearerr(yyin); \
 			} \
 		}\
 \
@@ -1088,12 +1304,12 @@ static int input (void );
 #ifndef YY_DECL
 #define YY_DECL_IS_OURS 1
 
-extern int ncglex (void);
+extern int yylex (void);
 
-#define YY_DECL int ncglex (void)
+#define YY_DECL int yylex (void)
 #endif /* !YY_DECL */
 
-/* Code executed at the beginning of each rule, after ncgtext and ncgleng
+/* Code executed at the beginning of each rule, after yytext and yyleng
  * have been set up.
  */
 #ifndef YY_USER_ACTION
@@ -1127,31 +1343,31 @@ YY_DECL
 		if ( ! (yy_start) )
 			(yy_start) = 1;	/* first start state */
 
-		if ( ! ncgin )
-			ncgin = stdin;
+		if ( ! yyin )
+			yyin = stdin;
 
-		if ( ! ncgout )
-			ncgout = stdout;
+		if ( ! yyout )
+			yyout = stdout;
 
 		if ( ! YY_CURRENT_BUFFER ) {
-			ncgensure_buffer_stack ();
+			yyensure_buffer_stack ();
 			YY_CURRENT_BUFFER_LVALUE =
-				ncg_create_buffer(ncgin,YY_BUF_SIZE );
+				yy_create_buffer( yyin, YY_BUF_SIZE );
 		}
 
-		ncg_load_buffer_state( );
+		yy_load_buffer_state(  );
 		}
 
 	{
-#line 107 "ncgen.l"
+#line 107 "ncgen3/ncgen.l"
 
-#line 1149 "ncgenl.c"
+#line 1364 "ncgenl.c"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
 		yy_cp = (yy_c_buf_p);
 
-		/* Support of ncgtext. */
+		/* Support of yytext. */
 		*yy_cp = (yy_hold_char);
 
 		/* yy_bp points to the position in yy_ch_buf of the start of
@@ -1173,9 +1389,9 @@ yy_match:
 				{
 				yy_current_state = (int) yy_def[yy_current_state];
 				if ( yy_current_state >= 236 )
-					yy_c = yy_meta[(unsigned int) yy_c];
+					yy_c = yy_meta[yy_c];
 				}
-			yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
+			yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 			++yy_cp;
 			}
 		while ( yy_base[yy_current_state] != 1206 );
@@ -1204,7 +1420,7 @@ do_action:	/* This label is used only to access EOF actions. */
 
 case 1:
 YY_RULE_SETUP
-#line 108 "ncgen.l"
+#line 108 "ncgen3/ncgen.l"
 { /* comment */
                           break;
                         }
@@ -1212,74 +1428,74 @@ YY_RULE_SETUP
 case 2:
 /* rule 2 can match eol */
 YY_RULE_SETUP
-#line 112 "ncgen.l"
+#line 112 "ncgen3/ncgen.l"
 {
-			 if(ncgleng > MAXTRST) {
+			 if(yyleng > MAXTRST) {
 				yyerror("string too long, truncated\n");
-			        ncgtext[MAXTRST-1] = '\0';
+			        yytext[MAXTRST-1] = '\0';
 			 }
-			 expand_escapes(termstring,(char *)ncgtext,ncgleng);
+			 expand_escapes(termstring,(char *)yytext,yyleng);
 		 	 return (TERMSTRING);
 		        }
 	YY_BREAK
 case 3:
 YY_RULE_SETUP
-#line 121 "ncgen.l"
+#line 121 "ncgen3/ncgen.l"
 {return (FLOAT_K);}
 	YY_BREAK
 case 4:
 YY_RULE_SETUP
-#line 122 "ncgen.l"
+#line 122 "ncgen3/ncgen.l"
 {return (CHAR_K);}
 	YY_BREAK
 case 5:
 YY_RULE_SETUP
-#line 123 "ncgen.l"
+#line 123 "ncgen3/ncgen.l"
 {return (BYTE_K);}
 	YY_BREAK
 case 6:
 YY_RULE_SETUP
-#line 124 "ncgen.l"
+#line 124 "ncgen3/ncgen.l"
 {return (SHORT_K);}
 	YY_BREAK
 case 7:
 YY_RULE_SETUP
-#line 125 "ncgen.l"
+#line 125 "ncgen3/ncgen.l"
 {return (INT_K);}
 	YY_BREAK
 case 8:
 YY_RULE_SETUP
-#line 126 "ncgen.l"
+#line 126 "ncgen3/ncgen.l"
 {return (DOUBLE_K);}
 	YY_BREAK
 case 9:
 YY_RULE_SETUP
-#line 127 "ncgen.l"
+#line 127 "ncgen3/ncgen.l"
 {int_val = -1;
 			 return (NC_UNLIMITED_K);}
 	YY_BREAK
 case 10:
 YY_RULE_SETUP
-#line 130 "ncgen.l"
+#line 130 "ncgen3/ncgen.l"
 {return (DIMENSIONS);}
 	YY_BREAK
 case 11:
 YY_RULE_SETUP
-#line 131 "ncgen.l"
+#line 131 "ncgen3/ncgen.l"
 {return (VARIABLES);}
 	YY_BREAK
 case 12:
 YY_RULE_SETUP
-#line 132 "ncgen.l"
+#line 132 "ncgen3/ncgen.l"
 {return (DATA);}
 	YY_BREAK
 case 13:
 /* rule 13 can match eol */
 YY_RULE_SETUP
-#line 133 "ncgen.l"
+#line 133 "ncgen3/ncgen.l"
 {
-		char *s = (char*)ncgtext+strlen("netcdf");
-		char *t = (char*)ncgtext+ncgleng-1;
+		char *s = (char*)yytext+strlen("netcdf");
+		char *t = (char*)yytext+yyleng-1;
 		while (isspace(*s))
 			s++;
 		while (isspace(*t))
@@ -1298,9 +1514,9 @@ YY_RULE_SETUP
 	YY_BREAK
 case 14:
 YY_RULE_SETUP
-#line 151 "ncgen.l"
+#line 151 "ncgen3/ncgen.l"
 { /* missing value (pre-2.4 backward compatibility) */
-                if (ncgtext[0] == '-') {
+                if (yytext[0] == '-') {
 		    double_val = -NC_FILL_DOUBLE;
                 } else {
 		    double_val = NC_FILL_DOUBLE;
@@ -1310,9 +1526,9 @@ YY_RULE_SETUP
 	YY_BREAK
 case 15:
 YY_RULE_SETUP
-#line 159 "ncgen.l"
+#line 159 "ncgen3/ncgen.l"
 { /* missing value (pre-2.4 backward compatibility) */
-                if (ncgtext[0] == '-') {
+                if (yytext[0] == '-') {
 		    float_val = -NC_FILL_FLOAT;
                 } else {
 		    float_val = NC_FILL_FLOAT;
@@ -1322,12 +1538,12 @@ YY_RULE_SETUP
 	YY_BREAK
 case 16:
 YY_RULE_SETUP
-#line 167 "ncgen.l"
+#line 167 "ncgen3/ncgen.l"
 {
-                if (STREQ((char *)ncgtext, FILL_STRING))
+                if (STREQ((char *)yytext, FILL_STRING))
 		        return (FILLVALUE);
-		if ((yylval = lookup((char *)ncgtext)) == NULL) {
-			yylval = install((char *)ncgtext);
+		if ((yylval = lookup((char *)yytext)) == NULL) {
+			yylval = install((char *)yytext);
 			}
 		return (IDENT);
 		}
@@ -1335,7 +1551,7 @@ YY_RULE_SETUP
 case 17:
 /* rule 17 can match eol */
 YY_RULE_SETUP
-#line 176 "ncgen.l"
+#line 176 "ncgen3/ncgen.l"
 {
 		lineno++ ;
                 break;
@@ -1343,16 +1559,16 @@ YY_RULE_SETUP
 	YY_BREAK
 case 18:
 YY_RULE_SETUP
-#line 181 "ncgen.l"
+#line 181 "ncgen3/ncgen.l"
 {
                 int ii;
-		if (sscanf((char*)ncgtext, "%d", &ii) != 1) {
-		    snprintf(errstr,sizeof(errstr),"bad byte constant: %s",(char*)ncgtext);
+		if (sscanf((char*)yytext, "%d", &ii) != 1) {
+		    snprintf(errstr, sizeof(errstr),"bad byte constant: %s",(char*)yytext);
 		    yyerror(errstr);
 		}
                 byte_val = ii;
 		if (ii != (int)byte_val) {
-		    snprintf(errstr,sizeof(errstr),"byte constant out of range (-128,127): %s",(char*)ncgtext);
+		    snprintf(errstr, sizeof(errstr),"byte constant out of range (-128,127): %s",(char*)yytext);
 		    yyerror(errstr);
 		}
 		return (BYTE_CONST);
@@ -1360,10 +1576,10 @@ YY_RULE_SETUP
 	YY_BREAK
 case 19:
 YY_RULE_SETUP
-#line 195 "ncgen.l"
+#line 195 "ncgen3/ncgen.l"
 {
-		if (sscanf((char*)ncgtext, "%le", &double_val) != 1) {
-		    snprintf(errstr,sizeof(errstr),"bad long or double constant: %s",(char*)ncgtext);
+		if (sscanf((char*)yytext, "%le", &double_val) != 1) {
+		    snprintf(errstr, sizeof(errstr),"bad long or double constant: %s",(char*)yytext);
 		    yyerror(errstr);
 		}
                 return (DOUBLE_CONST);
@@ -1371,10 +1587,10 @@ YY_RULE_SETUP
 	YY_BREAK
 case 20:
 YY_RULE_SETUP
-#line 202 "ncgen.l"
+#line 202 "ncgen3/ncgen.l"
 {
-		if (sscanf((char*)ncgtext, "%e", &float_val) != 1) {
-		    snprintf(errstr,sizeof(errstr),"bad float constant: %s",(char*)ncgtext);
+		if (sscanf((char*)yytext, "%e", &float_val) != 1) {
+		    snprintf(errstr, sizeof(errstr),"bad float constant: %s",(char*)yytext);
 		    yyerror(errstr);
 		}
                 return (FLOAT_CONST);
@@ -1382,11 +1598,11 @@ YY_RULE_SETUP
 	YY_BREAK
 case 21:
 YY_RULE_SETUP
-#line 209 "ncgen.l"
+#line 209 "ncgen3/ncgen.l"
 {
 		int tmp = 0;
-		if (sscanf((char*)ncgtext, "%d", &tmp) != 1) {
-		    snprintf(errstr,sizeof(errstr),"bad short constant: %s",(char*)ncgtext);
+		if (sscanf((char*)yytext, "%d", &tmp) != 1) {
+		    snprintf(errstr, sizeof(errstr),"bad short constant: %s",(char*)yytext);
 		    yyerror(errstr);
 		}
 		short_val = (short)tmp;
@@ -1395,13 +1611,13 @@ YY_RULE_SETUP
 	YY_BREAK
 case 22:
 YY_RULE_SETUP
-#line 218 "ncgen.l"
+#line 218 "ncgen3/ncgen.l"
 {
     		char *ptr;
                 errno = 0;
-		double_val = strtod((char*)ncgtext, &ptr);
+		double_val = strtod((char*)yytext, &ptr);
 		if (errno != 0 && double_val == 0.0) {
-		    snprintf(errstr,sizeof(errstr),"bad numerical constant: %s",(char*)ncgtext);
+		    snprintf(errstr, sizeof(errstr),"bad numerical constant: %s",(char*)yytext);
 		    yyerror(errstr);
 		}
                 if (double_val < XDR_INT_MIN ||double_val > XDR_INT_MAX) {
@@ -1414,14 +1630,14 @@ YY_RULE_SETUP
 	YY_BREAK
 case 23:
 YY_RULE_SETUP
-#line 233 "ncgen.l"
+#line 233 "ncgen3/ncgen.l"
 {
     		char *ptr;
                 long long_val;
                 errno = 0;
-		long_val = strtol((char*)ncgtext, &ptr, 0);
+		long_val = strtol((char*)yytext, &ptr, 0);
 		if (errno != 0) {
-		    snprintf(errstr,sizeof(errstr),"bad long constant: %s",(char*)ncgtext);
+		    snprintf(errstr, sizeof(errstr),"bad long constant: %s",(char*)yytext);
 		    yyerror(errstr);
 		}
                 if (long_val < XDR_INT_MIN || long_val > XDR_INT_MAX) {
@@ -1436,33 +1652,33 @@ YY_RULE_SETUP
 case 24:
 /* rule 24 can match eol */
 YY_RULE_SETUP
-#line 250 "ncgen.l"
+#line 250 "ncgen3/ncgen.l"
 {
-	        (void) sscanf((char*)&ncgtext[1],"%c",&byte_val);
+	        (void) sscanf((char*)&yytext[1],"%c",&byte_val);
 		return (BYTE_CONST);
                 }
 	YY_BREAK
 case 25:
 YY_RULE_SETUP
-#line 254 "ncgen.l"
+#line 254 "ncgen3/ncgen.l"
 {
-		byte_val = (char) strtol((char*)&ncgtext[2], (char **) 0, 8);
+		byte_val = (char) strtol((char*)&yytext[2], (char **) 0, 8);
 		return (BYTE_CONST);
                 }
 	YY_BREAK
 case 26:
 YY_RULE_SETUP
-#line 258 "ncgen.l"
+#line 258 "ncgen3/ncgen.l"
 {
-		byte_val = (char) strtol((char*)&ncgtext[3], (char **) 0, 16);
+		byte_val = (char) strtol((char*)&yytext[3], (char **) 0, 16);
 		return (BYTE_CONST);
                 }
 	YY_BREAK
 case 27:
 YY_RULE_SETUP
-#line 262 "ncgen.l"
+#line 262 "ncgen3/ncgen.l"
 {
-	       switch ((char)ncgtext[2]) {
+	       switch ((char)yytext[2]) {
 	          case 'a': byte_val = '\007'; break; /* not everyone under-
 						       * stands '\a' yet */
      	          case 'b': byte_val = '\b'; break;
@@ -1474,31 +1690,31 @@ YY_RULE_SETUP
 		  case '\\': byte_val = '\\'; break;
 		  case '?': byte_val = '\177'; break;
 		  case '\'': byte_val = '\''; break;
-		  default: byte_val = (char)ncgtext[2];
+		  default: byte_val = (char)yytext[2];
 	           }
 		return (BYTE_CONST);
                 }
 	YY_BREAK
 case 28:
 YY_RULE_SETUP
-#line 280 "ncgen.l"
+#line 280 "ncgen3/ncgen.l"
 { /* whitespace */
 		  break;
 		}
 	YY_BREAK
 case 29:
 YY_RULE_SETUP
-#line 283 "ncgen.l"
+#line 283 "ncgen3/ncgen.l"
 {/* Note: this next rule will not work for UTF8 characters */
-		return (ncgtext[0]) ;
+		return (yytext[0]) ;
 		}
 	YY_BREAK
 case 30:
 YY_RULE_SETUP
-#line 287 "ncgen.l"
+#line 287 "ncgen3/ncgen.l"
 ECHO;
 	YY_BREAK
-#line 1502 "ncgenl.c"
+#line 1717 "ncgenl.c"
 case YY_STATE_EOF(INITIAL):
 	yyterminate();
 
@@ -1515,15 +1731,15 @@ case YY_STATE_EOF(INITIAL):
 			{
 			/* We're scanning a new file or input source.  It's
 			 * possible that this happened because the user
-			 * just pointed ncgin at a new source and called
-			 * ncglex().  If so, then we have to assure
+			 * just pointed yyin at a new source and called
+			 * yylex().  If so, then we have to assure
 			 * consistency between YY_CURRENT_BUFFER and our
 			 * globals.  Here is the right place to do so, because
 			 * this is the first action (other than possibly a
 			 * back-up) that will match for the new input source.
 			 */
 			(yy_n_chars) = YY_CURRENT_BUFFER_LVALUE->yy_n_chars;
-			YY_CURRENT_BUFFER_LVALUE->yy_input_file = ncgin;
+			YY_CURRENT_BUFFER_LVALUE->yy_input_file = yyin;
 			YY_CURRENT_BUFFER_LVALUE->yy_buffer_status = YY_BUFFER_NORMAL;
 			}
 
@@ -1576,11 +1792,11 @@ case YY_STATE_EOF(INITIAL):
 				{
 				(yy_did_buffer_switch_on_eof) = 0;
 
-				if ( ncgwrap( ) )
+				if ( yywrap(  ) )
 					{
 					/* Note: because we've taken care in
 					 * yy_get_next_buffer() to have set up
-					 * ncgtext, we can now set up
+					 * yytext, we can now set up
 					 * yy_c_buf_p so that if some total
 					 * hoser (like flex itself) wants to
 					 * call the scanner after we return the
@@ -1630,7 +1846,7 @@ case YY_STATE_EOF(INITIAL):
 	} /* end of action switch */
 		} /* end of scanning one token */
 	} /* end of user's declarations */
-} /* end of ncglex */
+} /* end of yylex */
 
 /* yy_get_next_buffer - try to read in a new buffer
  *
@@ -1643,7 +1859,7 @@ static int yy_get_next_buffer (void)
 {
     	char *dest = YY_CURRENT_BUFFER_LVALUE->yy_ch_buf;
 	char *source = (yytext_ptr);
-	yy_size_t number_to_move, i;
+	int number_to_move, i;
 	int ret_val;
 
 	if ( (yy_c_buf_p) > &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[(yy_n_chars) + 1] )
@@ -1672,7 +1888,7 @@ static int yy_get_next_buffer (void)
 	/* Try to read more data. */
 
 	/* First move last chars to start of buffer. */
-	number_to_move = (yy_size_t) ((yy_c_buf_p) - (yytext_ptr)) - 1;
+	number_to_move = (int) ((yy_c_buf_p) - (yytext_ptr) - 1);
 
 	for ( i = 0; i < number_to_move; ++i )
 		*(dest++) = *(source++);
@@ -1685,7 +1901,7 @@ static int yy_get_next_buffer (void)
 
 	else
 		{
-			yy_size_t num_to_read =
+			int num_to_read =
 			YY_CURRENT_BUFFER_LVALUE->yy_buf_size - number_to_move - 1;
 
 		while ( num_to_read <= 0 )
@@ -1699,7 +1915,7 @@ static int yy_get_next_buffer (void)
 
 			if ( b->yy_is_our_buffer )
 				{
-				yy_size_t new_size = b->yy_buf_size * 2;
+				int new_size = b->yy_buf_size * 2;
 
 				if ( new_size <= 0 )
 					b->yy_buf_size += b->yy_buf_size / 8;
@@ -1708,11 +1924,12 @@ static int yy_get_next_buffer (void)
 
 				b->yy_ch_buf = (char *)
 					/* Include room in for 2 EOB chars. */
-					ncgrealloc((void *) b->yy_ch_buf,b->yy_buf_size + 2  );
+					yyrealloc( (void *) b->yy_ch_buf,
+							 (yy_size_t) (b->yy_buf_size + 2)  );
 				}
 			else
 				/* Can't grow it, we don't own it. */
-				b->yy_ch_buf = 0;
+				b->yy_ch_buf = NULL;
 
 			if ( ! b->yy_ch_buf )
 				YY_FATAL_ERROR(
@@ -1740,7 +1957,7 @@ static int yy_get_next_buffer (void)
 		if ( number_to_move == YY_MORE_ADJ )
 			{
 			ret_val = EOB_ACT_END_OF_FILE;
-			ncgrestart(ncgin  );
+			yyrestart( yyin  );
 			}
 
 		else
@@ -1754,12 +1971,15 @@ static int yy_get_next_buffer (void)
 	else
 		ret_val = EOB_ACT_CONTINUE_SCAN;
 
-	if ((int) ((yy_n_chars) + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
+	if (((yy_n_chars) + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
 		/* Extend the array by 50%, plus the number we really need. */
 		int new_size = (yy_n_chars) + number_to_move + ((yy_n_chars) >> 1);
-		YY_CURRENT_BUFFER_LVALUE->yy_ch_buf = (char *) ncgrealloc((void *) YY_CURRENT_BUFFER_LVALUE->yy_ch_buf,new_size  );
+		YY_CURRENT_BUFFER_LVALUE->yy_ch_buf = (char *) yyrealloc(
+			(void *) YY_CURRENT_BUFFER_LVALUE->yy_ch_buf, (yy_size_t) new_size  );
 		if ( ! YY_CURRENT_BUFFER_LVALUE->yy_ch_buf )
 			YY_FATAL_ERROR( "out of dynamic memory in yy_get_next_buffer()" );
+		/* "- 2" to take care of EOB's */
+		YY_CURRENT_BUFFER_LVALUE->yy_buf_size = (int) (new_size - 2);
 	}
 
 	(yy_n_chars) += number_to_move;
@@ -1792,9 +2012,9 @@ static int yy_get_next_buffer (void)
 			{
 			yy_current_state = (int) yy_def[yy_current_state];
 			if ( yy_current_state >= 236 )
-				yy_c = yy_meta[(unsigned int) yy_c];
+				yy_c = yy_meta[yy_c];
 			}
-		yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
+		yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 		}
 
 	return yy_current_state;
@@ -1820,9 +2040,9 @@ static int yy_get_next_buffer (void)
 		{
 		yy_current_state = (int) yy_def[yy_current_state];
 		if ( yy_current_state >= 236 )
-			yy_c = yy_meta[(unsigned int) yy_c];
+			yy_c = yy_meta[yy_c];
 		}
-	yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
+	yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 	yy_is_jam = (yy_current_state == 235);
 
 		return yy_is_jam ? 0 : yy_current_state;
@@ -1836,13 +2056,13 @@ static int yy_get_next_buffer (void)
     
     yy_cp = (yy_c_buf_p);
 
-	/* undo effects of setting up ncgtext */
+	/* undo effects of setting up yytext */
 	*yy_cp = (yy_hold_char);
 
 	if ( yy_cp < YY_CURRENT_BUFFER_LVALUE->yy_ch_buf + 2 )
 		{ /* need to shift things up to make room */
 		/* +2 for EOB chars. */
-		yy_size_t number_to_move = (yy_n_chars) + 2;
+		int number_to_move = (yy_n_chars) + 2;
 		char *dest = &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[
 					YY_CURRENT_BUFFER_LVALUE->yy_buf_size + 2];
 		char *source =
@@ -1854,7 +2074,7 @@ static int yy_get_next_buffer (void)
 		yy_cp += (int) (dest - source);
 		yy_bp += (int) (dest - source);
 		YY_CURRENT_BUFFER_LVALUE->yy_n_chars =
-			(yy_n_chars) = YY_CURRENT_BUFFER_LVALUE->yy_buf_size;
+			(yy_n_chars) = (int) YY_CURRENT_BUFFER_LVALUE->yy_buf_size;
 
 		if ( yy_cp < YY_CURRENT_BUFFER_LVALUE->yy_ch_buf + 2 )
 			YY_FATAL_ERROR( "flex scanner push-back overflow" );
@@ -1893,7 +2113,7 @@ static int yy_get_next_buffer (void)
 
 		else
 			{ /* need more input */
-			yy_size_t offset = (yy_c_buf_p) - (yytext_ptr);
+			int offset = (int) ((yy_c_buf_p) - (yytext_ptr));
 			++(yy_c_buf_p);
 
 			switch ( yy_get_next_buffer(  ) )
@@ -1910,14 +2130,14 @@ static int yy_get_next_buffer (void)
 					 */
 
 					/* Reset buffer status. */
-					ncgrestart(ncgin );
+					yyrestart( yyin );
 
 					/*FALLTHROUGH*/
 
 				case EOB_ACT_END_OF_FILE:
 					{
-					if ( ncgwrap( ) )
-						return EOF;
+					if ( yywrap(  ) )
+						return 0;
 
 					if ( ! (yy_did_buffer_switch_on_eof) )
 						YY_NEW_FILE;
@@ -1936,7 +2156,7 @@ static int yy_get_next_buffer (void)
 		}
 
 	c = *(unsigned char *) (yy_c_buf_p);	/* cast for 8-bit char's */
-	*(yy_c_buf_p) = '\0';	/* preserve ncgtext */
+	*(yy_c_buf_p) = '\0';	/* preserve yytext */
 	(yy_hold_char) = *++(yy_c_buf_p);
 
 	return c;
@@ -1948,32 +2168,32 @@ static int yy_get_next_buffer (void)
  * 
  * @note This function does not reset the start condition to @c INITIAL .
  */
-    void ncgrestart  (FILE * input_file )
+    void yyrestart  (FILE * input_file )
 {
     
 	if ( ! YY_CURRENT_BUFFER ){
-        ncgensure_buffer_stack ();
+        yyensure_buffer_stack ();
 		YY_CURRENT_BUFFER_LVALUE =
-            ncg_create_buffer(ncgin,YY_BUF_SIZE );
+            yy_create_buffer( yyin, YY_BUF_SIZE );
 	}
 
-	ncg_init_buffer(YY_CURRENT_BUFFER,input_file );
-	ncg_load_buffer_state( );
+	yy_init_buffer( YY_CURRENT_BUFFER, input_file );
+	yy_load_buffer_state(  );
 }
 
 /** Switch to a different input buffer.
  * @param new_buffer The new input buffer.
  * 
  */
-    void ncg_switch_to_buffer  (YY_BUFFER_STATE  new_buffer )
+    void yy_switch_to_buffer  (YY_BUFFER_STATE  new_buffer )
 {
     
 	/* TODO. We should be able to replace this entire function body
 	 * with
-	 *		ncgpop_buffer_state();
-	 *		ncgpush_buffer_state(new_buffer);
+	 *		yypop_buffer_state();
+	 *		yypush_buffer_state(new_buffer);
      */
-	ncgensure_buffer_stack ();
+	yyensure_buffer_stack ();
 	if ( YY_CURRENT_BUFFER == new_buffer )
 		return;
 
@@ -1986,21 +2206,21 @@ static int yy_get_next_buffer (void)
 		}
 
 	YY_CURRENT_BUFFER_LVALUE = new_buffer;
-	ncg_load_buffer_state( );
+	yy_load_buffer_state(  );
 
 	/* We don't actually know whether we did this switch during
-	 * EOF (ncgwrap()) processing, but the only time this flag
-	 * is looked at is after ncgwrap() is called, so it's safe
+	 * EOF (yywrap()) processing, but the only time this flag
+	 * is looked at is after yywrap() is called, so it's safe
 	 * to go ahead and always set it.
 	 */
 	(yy_did_buffer_switch_on_eof) = 1;
 }
 
-static void ncg_load_buffer_state  (void)
+static void yy_load_buffer_state  (void)
 {
     	(yy_n_chars) = YY_CURRENT_BUFFER_LVALUE->yy_n_chars;
 	(yytext_ptr) = (yy_c_buf_p) = YY_CURRENT_BUFFER_LVALUE->yy_buf_pos;
-	ncgin = YY_CURRENT_BUFFER_LVALUE->yy_input_file;
+	yyin = YY_CURRENT_BUFFER_LVALUE->yy_input_file;
 	(yy_hold_char) = *(yy_c_buf_p);
 }
 
@@ -2010,35 +2230,35 @@ static void ncg_load_buffer_state  (void)
  * 
  * @return the allocated buffer state.
  */
-    YY_BUFFER_STATE ncg_create_buffer  (FILE * file, int  size )
+    YY_BUFFER_STATE yy_create_buffer  (FILE * file, int  size )
 {
 	YY_BUFFER_STATE b;
     
-	b = (YY_BUFFER_STATE) ncgalloc(sizeof( struct yy_buffer_state )  );
+	b = (YY_BUFFER_STATE) yyalloc( sizeof( struct yy_buffer_state )  );
 	if ( ! b )
-		YY_FATAL_ERROR( "out of dynamic memory in ncg_create_buffer()" );
+		YY_FATAL_ERROR( "out of dynamic memory in yy_create_buffer()" );
 
-	b->yy_buf_size = (yy_size_t)size;
+	b->yy_buf_size = size;
 
 	/* yy_ch_buf has to be 2 characters longer than the size given because
 	 * we need to put in 2 end-of-buffer characters.
 	 */
-	b->yy_ch_buf = (char *) ncgalloc(b->yy_buf_size + 2  );
+	b->yy_ch_buf = (char *) yyalloc( (yy_size_t) (b->yy_buf_size + 2)  );
 	if ( ! b->yy_ch_buf )
-		YY_FATAL_ERROR( "out of dynamic memory in ncg_create_buffer()" );
+		YY_FATAL_ERROR( "out of dynamic memory in yy_create_buffer()" );
 
 	b->yy_is_our_buffer = 1;
 
-	ncg_init_buffer(b,file );
+	yy_init_buffer( b, file );
 
 	return b;
 }
 
 /** Destroy the buffer.
- * @param b a buffer created with ncg_create_buffer()
+ * @param b a buffer created with yy_create_buffer()
  * 
  */
-    void ncg_delete_buffer (YY_BUFFER_STATE  b )
+    void yy_delete_buffer (YY_BUFFER_STATE  b )
 {
     
 	if ( ! b )
@@ -2048,27 +2268,27 @@ static void ncg_load_buffer_state  (void)
 		YY_CURRENT_BUFFER_LVALUE = (YY_BUFFER_STATE) 0;
 
 	if ( b->yy_is_our_buffer )
-		ncgfree((void *) b->yy_ch_buf  );
+		yyfree( (void *) b->yy_ch_buf  );
 
-	ncgfree((void *) b  );
+	yyfree( (void *) b  );
 }
 
 /* Initializes or reinitializes a buffer.
  * This function is sometimes called more than once on the same buffer,
- * such as during a ncgrestart() or at EOF.
+ * such as during a yyrestart() or at EOF.
  */
-    static void ncg_init_buffer  (YY_BUFFER_STATE  b, FILE * file )
+    static void yy_init_buffer  (YY_BUFFER_STATE  b, FILE * file )
 
 {
 	int oerrno = errno;
     
-	ncg_flush_buffer(b );
+	yy_flush_buffer( b );
 
 	b->yy_input_file = file;
 	b->yy_fill_buffer = 1;
 
-    /* If b is the current buffer, then ncg_init_buffer was _probably_
-     * called from ncgrestart() or through yy_get_next_buffer.
+    /* If b is the current buffer, then yy_init_buffer was _probably_
+     * called from yyrestart() or through yy_get_next_buffer.
      * In that case, we don't want to reset the lineno or column.
      */
     if (b != YY_CURRENT_BUFFER){
@@ -2085,7 +2305,7 @@ static void ncg_load_buffer_state  (void)
  * @param b the buffer state to be flushed, usually @c YY_CURRENT_BUFFER.
  * 
  */
-    void ncg_flush_buffer (YY_BUFFER_STATE  b )
+    void yy_flush_buffer (YY_BUFFER_STATE  b )
 {
     	if ( ! b )
 		return;
@@ -2105,7 +2325,7 @@ static void ncg_load_buffer_state  (void)
 	b->yy_buffer_status = YY_BUFFER_NEW;
 
 	if ( b == YY_CURRENT_BUFFER )
-		ncg_load_buffer_state( );
+		yy_load_buffer_state(  );
 }
 
 /** Pushes the new state onto the stack. The new state becomes
@@ -2114,14 +2334,14 @@ static void ncg_load_buffer_state  (void)
  *  @param new_buffer The new state.
  *  
  */
-void ncgpush_buffer_state (YY_BUFFER_STATE new_buffer )
+void yypush_buffer_state (YY_BUFFER_STATE new_buffer )
 {
     	if (new_buffer == NULL)
 		return;
 
-	ncgensure_buffer_stack();
+	yyensure_buffer_stack();
 
-	/* This block is copied from ncg_switch_to_buffer. */
+	/* This block is copied from yy_switch_to_buffer. */
 	if ( YY_CURRENT_BUFFER )
 		{
 		/* Flush out information for old buffer. */
@@ -2135,8 +2355,8 @@ void ncgpush_buffer_state (YY_BUFFER_STATE new_buffer )
 		(yy_buffer_stack_top)++;
 	YY_CURRENT_BUFFER_LVALUE = new_buffer;
 
-	/* copied from ncg_switch_to_buffer. */
-	ncg_load_buffer_state( );
+	/* copied from yy_switch_to_buffer. */
+	yy_load_buffer_state(  );
 	(yy_did_buffer_switch_on_eof) = 1;
 }
 
@@ -2144,18 +2364,18 @@ void ncgpush_buffer_state (YY_BUFFER_STATE new_buffer )
  *  The next element becomes the new top.
  *  
  */
-void ncgpop_buffer_state (void)
+void yypop_buffer_state (void)
 {
     	if (!YY_CURRENT_BUFFER)
 		return;
 
-	ncg_delete_buffer(YY_CURRENT_BUFFER );
+	yy_delete_buffer(YY_CURRENT_BUFFER );
 	YY_CURRENT_BUFFER_LVALUE = NULL;
 	if ((yy_buffer_stack_top) > 0)
 		--(yy_buffer_stack_top);
 
 	if (YY_CURRENT_BUFFER) {
-		ncg_load_buffer_state( );
+		yy_load_buffer_state(  );
 		(yy_did_buffer_switch_on_eof) = 1;
 	}
 }
@@ -2163,7 +2383,7 @@ void ncgpop_buffer_state (void)
 /* Allocates the stack if it does not exist.
  *  Guarantees space for at least one push.
  */
-static void ncgensure_buffer_stack (void)
+static void yyensure_buffer_stack (void)
 {
 	yy_size_t num_to_alloc;
     
@@ -2173,15 +2393,15 @@ static void ncgensure_buffer_stack (void)
 		 * scanner will even need a stack. We use 2 instead of 1 to avoid an
 		 * immediate realloc on the next call.
          */
-		num_to_alloc = 1; /* After all that talk, this was set to 1 anyways... */
-		(yy_buffer_stack) = (struct yy_buffer_state**)ncgalloc
+      num_to_alloc = 1; /* After all that talk, this was set to 1 anyways... */
+		(yy_buffer_stack) = (struct yy_buffer_state**)yyalloc
 								(num_to_alloc * sizeof(struct yy_buffer_state*)
 								);
 		if ( ! (yy_buffer_stack) )
-			YY_FATAL_ERROR( "out of dynamic memory in ncgensure_buffer_stack()" );
-								  
+			YY_FATAL_ERROR( "out of dynamic memory in yyensure_buffer_stack()" );
+
 		memset((yy_buffer_stack), 0, num_to_alloc * sizeof(struct yy_buffer_state*));
-				
+
 		(yy_buffer_stack_max) = num_to_alloc;
 		(yy_buffer_stack_top) = 0;
 		return;
@@ -2193,12 +2413,12 @@ static void ncgensure_buffer_stack (void)
 		yy_size_t grow_size = 8 /* arbitrary grow size */;
 
 		num_to_alloc = (yy_buffer_stack_max) + grow_size;
-		(yy_buffer_stack) = (struct yy_buffer_state**)ncgrealloc
+		(yy_buffer_stack) = (struct yy_buffer_state**)yyrealloc
 								((yy_buffer_stack),
 								num_to_alloc * sizeof(struct yy_buffer_state*)
 								);
 		if ( ! (yy_buffer_stack) )
-			YY_FATAL_ERROR( "out of dynamic memory in ncgensure_buffer_stack()" );
+			YY_FATAL_ERROR( "out of dynamic memory in yyensure_buffer_stack()" );
 
 		/* zero only the new slots.*/
 		memset((yy_buffer_stack) + (yy_buffer_stack_max), 0, grow_size * sizeof(struct yy_buffer_state*));
@@ -2210,9 +2430,9 @@ static void ncgensure_buffer_stack (void)
  * @param base the character buffer
  * @param size the size in bytes of the character buffer
  * 
- * @return the newly allocated buffer state object. 
+ * @return the newly allocated buffer state object.
  */
-YY_BUFFER_STATE ncg_scan_buffer  (char * base, yy_size_t  size )
+YY_BUFFER_STATE yy_scan_buffer  (char * base, yy_size_t  size )
 {
 	YY_BUFFER_STATE b;
     
@@ -2220,69 +2440,69 @@ YY_BUFFER_STATE ncg_scan_buffer  (char * base, yy_size_t  size )
 	     base[size-2] != YY_END_OF_BUFFER_CHAR ||
 	     base[size-1] != YY_END_OF_BUFFER_CHAR )
 		/* They forgot to leave room for the EOB's. */
-		return 0;
+		return NULL;
 
-	b = (YY_BUFFER_STATE) ncgalloc(sizeof( struct yy_buffer_state )  );
+	b = (YY_BUFFER_STATE) yyalloc( sizeof( struct yy_buffer_state )  );
 	if ( ! b )
-		YY_FATAL_ERROR( "out of dynamic memory in ncg_scan_buffer()" );
+		YY_FATAL_ERROR( "out of dynamic memory in yy_scan_buffer()" );
 
-	b->yy_buf_size = size - 2;	/* "- 2" to take care of EOB's */
+	b->yy_buf_size = (int) (size - 2);	/* "- 2" to take care of EOB's */
 	b->yy_buf_pos = b->yy_ch_buf = base;
 	b->yy_is_our_buffer = 0;
-	b->yy_input_file = 0;
+	b->yy_input_file = NULL;
 	b->yy_n_chars = b->yy_buf_size;
 	b->yy_is_interactive = 0;
 	b->yy_at_bol = 1;
 	b->yy_fill_buffer = 0;
 	b->yy_buffer_status = YY_BUFFER_NEW;
 
-	ncg_switch_to_buffer(b  );
+	yy_switch_to_buffer( b  );
 
 	return b;
 }
 
-/** Setup the input buffer state to scan a string. The next call to ncglex() will
+/** Setup the input buffer state to scan a string. The next call to yylex() will
  * scan from a @e copy of @a str.
  * @param yystr a NUL-terminated string to scan
  * 
  * @return the newly allocated buffer state object.
  * @note If you want to scan bytes that may contain NUL values, then use
- *       ncg_scan_bytes() instead.
+ *       yy_scan_bytes() instead.
  */
-YY_BUFFER_STATE ncg_scan_string (yyconst char * yystr )
+YY_BUFFER_STATE yy_scan_string (const char * yystr )
 {
     
-	return ncg_scan_bytes(yystr,strlen(yystr) );
+	return yy_scan_bytes( yystr, (int) strlen(yystr) );
 }
 
-/** Setup the input buffer state to scan the given bytes. The next call to ncglex() will
+/** Setup the input buffer state to scan the given bytes. The next call to yylex() will
  * scan from a @e copy of @a bytes.
  * @param yybytes the byte buffer to scan
  * @param _yybytes_len the number of bytes in the buffer pointed to by @a bytes.
  * 
  * @return the newly allocated buffer state object.
  */
-YY_BUFFER_STATE ncg_scan_bytes  (yyconst char * yybytes, yy_size_t  _yybytes_len )
+YY_BUFFER_STATE yy_scan_bytes  (const char * yybytes, int  _yybytes_len )
 {
 	YY_BUFFER_STATE b;
 	char *buf;
 	yy_size_t n;
-	yy_size_t i;
+	int i;
     
 	/* Get memory for full buffer, including space for trailing EOB's. */
-	n = _yybytes_len + 2;
-	buf = (char *) ncgalloc(n  );
+	n = (yy_size_t) (_yybytes_len + 2);
+	buf = (char *) yyalloc( n  );
 	if ( ! buf )
-		YY_FATAL_ERROR( "out of dynamic memory in ncg_scan_bytes()" );
+		YY_FATAL_ERROR( "out of dynamic memory in yy_scan_bytes()" );
 
 	for ( i = 0; i < _yybytes_len; ++i )
 		buf[i] = yybytes[i];
 
 	buf[_yybytes_len] = buf[_yybytes_len+1] = YY_END_OF_BUFFER_CHAR;
 
-	b = ncg_scan_buffer(buf,n );
+	b = yy_scan_buffer( buf, n );
 	if ( ! b )
-		YY_FATAL_ERROR( "bad buffer in ncg_scan_bytes()" );
+		YY_FATAL_ERROR( "bad buffer in yy_scan_bytes()" );
 
 	/* It's okay to grow etc. this buffer, and we should throw it
 	 * away when we're done.
@@ -2296,9 +2516,9 @@ YY_BUFFER_STATE ncg_scan_bytes  (yyconst char * yybytes, yy_size_t  _yybytes_len
 #define YY_EXIT_FAILURE 2
 #endif
 
-static void yy_fatal_error (yyconst char* msg )
+static void yynoreturn yy_fatal_error (const char* msg )
 {
-			(void) fprintf( stderr, "%s\n", msg );
+			fprintf( stderr, "%s\n", msg );
 	exit( YY_EXIT_FAILURE );
 }
 
@@ -2308,14 +2528,14 @@ static void yy_fatal_error (yyconst char* msg )
 #define yyless(n) \
 	do \
 		{ \
-		/* Undo effects of setting up ncgtext. */ \
+		/* Undo effects of setting up yytext. */ \
         int yyless_macro_arg = (n); \
         YY_LESS_LINENO(yyless_macro_arg);\
-		ncgtext[ncgleng] = (yy_hold_char); \
-		(yy_c_buf_p) = ncgtext + yyless_macro_arg; \
+		yytext[yyleng] = (yy_hold_char); \
+		(yy_c_buf_p) = yytext + yyless_macro_arg; \
 		(yy_hold_char) = *(yy_c_buf_p); \
 		*(yy_c_buf_p) = '\0'; \
-		ncgleng = yyless_macro_arg; \
+		yyleng = yyless_macro_arg; \
 		} \
 	while ( 0 )
 
@@ -2324,126 +2544,126 @@ static void yy_fatal_error (yyconst char* msg )
 /** Get the current line number.
  * 
  */
-int ncgget_lineno  (void)
+int yyget_lineno  (void)
 {
-        
-    return ncglineno;
+    
+    return yylineno;
 }
 
 /** Get the input stream.
  * 
  */
-FILE *ncgget_in  (void)
+FILE *yyget_in  (void)
 {
-        return ncgin;
+        return yyin;
 }
 
 /** Get the output stream.
  * 
  */
-FILE *ncgget_out  (void)
+FILE *yyget_out  (void)
 {
-        return ncgout;
+        return yyout;
 }
 
 /** Get the length of the current token.
  * 
  */
-yy_size_t ncgget_leng  (void)
+int yyget_leng  (void)
 {
-        return ncgleng;
+        return yyleng;
 }
 
 /** Get the current token.
  * 
  */
 
-char *ncgget_text  (void)
+char *yyget_text  (void)
 {
-        return ncgtext;
+        return yytext;
 }
 
 /** Set the current line number.
  * @param _line_number line number
  * 
  */
-void ncgset_lineno (int  _line_number )
+void yyset_lineno (int  _line_number )
 {
     
-    ncglineno = _line_number;
+    yylineno = _line_number;
 }
 
 /** Set the input stream. This does not discard the current
  * input buffer.
  * @param _in_str A readable stream.
  * 
- * @see ncg_switch_to_buffer
+ * @see yy_switch_to_buffer
  */
-void ncgset_in (FILE *  _in_str )
+void yyset_in (FILE *  _in_str )
 {
-        ncgin = _in_str ;
+        yyin = _in_str ;
 }
 
-void ncgset_out (FILE *  _out_str )
+void yyset_out (FILE *  _out_str )
 {
-        ncgout = _out_str ;
+        yyout = _out_str ;
 }
 
-int ncgget_debug  (void)
+int yyget_debug  (void)
 {
-        return ncg_flex_debug;
+        return yy_flex_debug;
 }
 
-void ncgset_debug (int  _bdebug )
+void yyset_debug (int  _bdebug )
 {
-        ncg_flex_debug = _bdebug ;
+        yy_flex_debug = _bdebug ;
 }
 
 static int yy_init_globals (void)
 {
         /* Initialization is the same as for the non-reentrant scanner.
-     * This function is called from ncglex_destroy(), so don't allocate here.
+     * This function is called from yylex_destroy(), so don't allocate here.
      */
 
-    (yy_buffer_stack) = 0;
+    (yy_buffer_stack) = NULL;
     (yy_buffer_stack_top) = 0;
     (yy_buffer_stack_max) = 0;
-    (yy_c_buf_p) = (char *) 0;
+    (yy_c_buf_p) = NULL;
     (yy_init) = 0;
     (yy_start) = 0;
 
 /* Defined in main.c */
 #ifdef YY_STDINIT
-    ncgin = stdin;
-    ncgout = stdout;
+    yyin = stdin;
+    yyout = stdout;
 #else
-    ncgin = (FILE *) 0;
-    ncgout = (FILE *) 0;
+    yyin = NULL;
+    yyout = NULL;
 #endif
 
     /* For future reference: Set errno on error, since we are called by
-     * ncglex_init()
+     * yylex_init()
      */
     return 0;
 }
 
-/* ncglex_destroy is for both reentrant and non-reentrant scanners. */
-int ncglex_destroy  (void)
+/* yylex_destroy is for both reentrant and non-reentrant scanners. */
+int yylex_destroy  (void)
 {
     
     /* Pop the buffer stack, destroying each element. */
 	while(YY_CURRENT_BUFFER){
-		ncg_delete_buffer(YY_CURRENT_BUFFER  );
+		yy_delete_buffer( YY_CURRENT_BUFFER  );
 		YY_CURRENT_BUFFER_LVALUE = NULL;
-		ncgpop_buffer_state();
+		yypop_buffer_state();
 	}
 
 	/* Destroy the stack itself. */
-	ncgfree((yy_buffer_stack) );
+	yyfree((yy_buffer_stack) );
 	(yy_buffer_stack) = NULL;
 
     /* Reset the globals. This is important in a non-reentrant scanner so the next time
-     * ncglex() is called, initialization will occur. */
+     * yylex() is called, initialization will occur. */
     yy_init_globals( );
 
     return 0;
@@ -2454,7 +2674,7 @@ int ncglex_destroy  (void)
  */
 
 #ifndef yytext_ptr
-static void yy_flex_strncpy (char* s1, yyconst char * s2, int n )
+static void yy_flex_strncpy (char* s1, const char * s2, int n )
 {
 		
 	int i;
@@ -2464,7 +2684,7 @@ static void yy_flex_strncpy (char* s1, yyconst char * s2, int n )
 #endif
 
 #ifdef YY_NEED_STRLEN
-static int yy_flex_strlen (yyconst char * s )
+static int yy_flex_strlen (const char * s )
 {
 	int n;
 	for ( n = 0; s[n]; ++n )
@@ -2474,12 +2694,12 @@ static int yy_flex_strlen (yyconst char * s )
 }
 #endif
 
-void *ncgalloc (yy_size_t  size )
+void *yyalloc (yy_size_t  size )
 {
-			return (void *) malloc( size );
+			return malloc(size);
 }
 
-void *ncgrealloc  (void * ptr, yy_size_t  size )
+void *yyrealloc  (void * ptr, yy_size_t  size )
 {
 		
 	/* The cast to (char *) in the following accommodates both
@@ -2489,18 +2709,17 @@ void *ncgrealloc  (void * ptr, yy_size_t  size )
 	 * any pointer type to void*, and deal with argument conversions
 	 * as though doing an assignment.
 	 */
-	return (void *) realloc( (char *) ptr, size );
+	return realloc(ptr, size);
 }
 
-void ncgfree (void * ptr )
+void yyfree (void * ptr )
 {
-			free( (char *) ptr );	/* see ncgrealloc() for (char *) cast */
+			free( (char *) ptr );	/* see yyrealloc() for (char *) cast */
 }
 
 #define YYTABLES_NAME "yytables"
 
-#line 287 "ncgen.l"
-
+#line 287 "ncgen3/ncgen.l"
 
 
 /* Hack to keep compile quiet */

--- a/ncgen3/ncgenl.c
+++ b/ncgen3/ncgenl.c
@@ -1505,8 +1505,8 @@ YY_RULE_SETUP
                         yyerror("netCDF name required");
                         return (DATA); /* generate syntax error */
                 }
-		netcdfname = (char *) emalloc(t-s+1);
-		(void) strncpy(netcdfname, s, t-s);
+		netcdfname = (char *) emalloc((size_t)(t-s+1));
+		(void) strncpy(netcdfname, s, (size_t)(t-s));
 		netcdfname[t-s] = '\0';
 		deescapify(netcdfname);  /* so "\5foo" becomes "5foo", for example */
 		return (NETCDF);
@@ -1566,7 +1566,7 @@ YY_RULE_SETUP
 		    snprintf(errstr, sizeof(errstr),"bad byte constant: %s",(char*)yytext);
 		    yyerror(errstr);
 		}
-                byte_val = ii;
+                byte_val = (signed char)ii;
 		if (ii != (int)byte_val) {
 		    snprintf(errstr, sizeof(errstr),"byte constant out of range (-128,127): %s",(char*)yytext);
 		    yyerror(errstr);

--- a/ncgen3/ncgeny.c
+++ b/ncgen3/ncgeny.c
@@ -1310,7 +1310,7 @@ yyreduce:
 #line 143 "ncgen3/ncgen.y"
                    { if (int_val <= 0)
 			 derror("dimension length must be positive");
-		     dims[ndims].size = int_val;
+		     dims[ndims].size = (size_t)int_val;
 		     ndims++;
 		   }
 #line 1317 "ncgeny.c"
@@ -1881,10 +1881,10 @@ yyreduce:
 		       atype_code = NC_SHORT;
 		       switch (valtype) {
 			 case NC_CHAR:
-			   *char_valp++ = short_val;
+			   *char_valp++ = (char)short_val;
 			   break;
 			 case NC_BYTE:
-			   *byte_valp++ = short_val;
+			   *byte_valp++ = (signed char)short_val;
 			   break;
 			 case NC_SHORT:
 			   *short_valp++ = short_val;
@@ -1911,19 +1911,19 @@ yyreduce:
 		       atype_code = NC_INT;
 		       switch (valtype) {
 			 case NC_CHAR:
-			   *char_valp++ = int_val;
+			   *char_valp++ = (char)int_val;
 			   break;
 			 case NC_BYTE:
-			   *byte_valp++ = int_val;
+			   *byte_valp++ = (signed char)int_val;
 			   break;
 			 case NC_SHORT:
-			   *short_valp++ = int_val;
+			   *short_valp++ = (short)int_val;
 			   break;
 			 case NC_INT:
 			   *int_valp++ = int_val;
 			   break;
 			 case NC_FLOAT:
-			   *float_valp++ = int_val;
+			   *float_valp++ = (float)int_val;
 			   break;
 			 case NC_DOUBLE:
 			   *double_valp++ = int_val;
@@ -1941,16 +1941,16 @@ yyreduce:
 		       atype_code = NC_FLOAT;
 		       switch (valtype) {
 			 case NC_CHAR:
-			   *char_valp++ = float_val;
+			   *char_valp++ = (char)float_val;
 			   break;
 			 case NC_BYTE:
-			   *byte_valp++ = float_val;
+			   *byte_valp++ = (signed char)float_val;
 			   break;
 			 case NC_SHORT:
-			   *short_valp++ = float_val;
+			   *short_valp++ = (short)float_val;
 			   break;
 			 case NC_INT:
-			   *int_valp++ = float_val;
+			   *int_valp++ = (int)float_val;
 			   break;
 			 case NC_FLOAT:
 			   *float_valp++ = float_val;
@@ -1971,22 +1971,22 @@ yyreduce:
 		       atype_code = NC_DOUBLE;
 		       switch (valtype) {
 			 case NC_CHAR:
-			   *char_valp++ = double_val;
+			   *char_valp++ = (char)double_val;
 			   break;
 			 case NC_BYTE:
-			   *byte_valp++ = double_val;
+			   *byte_valp++ = (signed char)double_val;
 			   break;
 			 case NC_SHORT:
-			   *short_valp++ = double_val;
+			   *short_valp++ = (short)double_val;
 			   break;
 			 case NC_INT:
-			   *int_valp++ = double_val;
+			   *int_valp++ = (int)double_val;
 			   break;
 			 case NC_FLOAT:
 			   if (double_val == NC_FILL_DOUBLE)
 			     *float_valp++ = NC_FILL_FLOAT;
 			   else
-			     *float_valp++ = double_val;
+			     *float_valp++ = (float)double_val;
 			   break;
 			 case NC_DOUBLE:
 			   *double_valp++ = double_val;

--- a/ncgen3/ncgeny.c
+++ b/ncgen3/ncgeny.c
@@ -1,8 +1,9 @@
-/* A Bison parser, made by GNU Bison 3.0.4.  */
+/* A Bison parser, made by GNU Bison 3.8.2.  */
 
 /* Bison implementation for Yacc-like parsers in C
 
-   Copyright (C) 1984, 1989-1990, 2000-2015 Free Software Foundation, Inc.
+   Copyright (C) 1984, 1989-1990, 2000-2015, 2018-2021 Free Software Foundation,
+   Inc.
 
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -15,7 +16,7 @@
    GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License
-   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.  */
 
 /* As a special exception, you may create a larger work that contains
    part or all of the Bison parser skeleton and distribute that work
@@ -33,6 +34,10 @@
 /* C LALR(1) parser skeleton written by Richard Stallman, by
    simplifying the original so-called "semantic" parser.  */
 
+/* DO NOT RELY ON FEATURES THAT ARE NOT DOCUMENTED in the manual,
+   especially those whose name start with YY_ or yy_.  They are
+   private implementation details that can be changed or removed.  */
+
 /* All symbols defined below should begin with yy or YY, to avoid
    infringing on user name space.  This should be done even for local
    variables, as they might otherwise be expanded by user macros.
@@ -40,11 +45,11 @@
    define necessary library symbols; they are noted "INFRINGES ON
    USER NAME SPACE" below.  */
 
-/* Identify Bison output.  */
-#define YYBISON 1
+/* Identify Bison output, and Bison version.  */
+#define YYBISON 30802
 
-/* Bison version.  */
-#define YYBISON_VERSION "3.0.4"
+/* Bison version string.  */
+#define YYBISON_VERSION "3.8.2"
 
 /* Skeleton name.  */
 #define YYSKELETON_NAME "yacc.c"
@@ -65,12 +70,11 @@
 #define yyerror         ncgerror
 #define yydebug         ncgdebug
 #define yynerrs         ncgnerrs
-
 #define yylval          ncglval
 #define yychar          ncgchar
 
-/* Copy the first part of user declarations.  */
-#line 9 "ncgen.y" /* yacc.c:339  */
+/* First part of user prologue.  */
+#line 9 "ncgen3/ncgen.y"
 
 #ifdef sccs
 static char SccsId[] = "$Id: ncgen.y,v 1.34 2010/03/31 18:18:41 dmh Exp $";
@@ -146,108 +150,198 @@ void yyerror(char*);
 int yyerror(char*);
 #endif
 
-#line 150 "ncgeny.c" /* yacc.c:339  */
+#line 154 "ncgeny.c"
 
-# ifndef YY_NULLPTR
-#  if defined __cplusplus && 201103L <= __cplusplus
-#   define YY_NULLPTR nullptr
+# ifndef YY_CAST
+#  ifdef __cplusplus
+#   define YY_CAST(Type, Val) static_cast<Type> (Val)
+#   define YY_REINTERPRET_CAST(Type, Val) reinterpret_cast<Type> (Val)
 #  else
-#   define YY_NULLPTR 0
+#   define YY_CAST(Type, Val) ((Type) (Val))
+#   define YY_REINTERPRET_CAST(Type, Val) ((Type) (Val))
+#  endif
+# endif
+# ifndef YY_NULLPTR
+#  if defined __cplusplus
+#   if 201103L <= __cplusplus
+#    define YY_NULLPTR nullptr
+#   else
+#    define YY_NULLPTR 0
+#   endif
+#  else
+#   define YY_NULLPTR ((void*)0)
 #  endif
 # endif
 
-/* Enabling verbose error messages.  */
-#ifdef YYERROR_VERBOSE
-# undef YYERROR_VERBOSE
-# define YYERROR_VERBOSE 1
-#else
-# define YYERROR_VERBOSE 0
-#endif
+#include "ncgeny.h"
+/* Symbol kind.  */
+enum yysymbol_kind_t
+{
+  YYSYMBOL_YYEMPTY = -2,
+  YYSYMBOL_YYEOF = 0,                      /* "end of file"  */
+  YYSYMBOL_YYerror = 1,                    /* error  */
+  YYSYMBOL_YYUNDEF = 2,                    /* "invalid token"  */
+  YYSYMBOL_NC_UNLIMITED_K = 3,             /* NC_UNLIMITED_K  */
+  YYSYMBOL_BYTE_K = 4,                     /* BYTE_K  */
+  YYSYMBOL_CHAR_K = 5,                     /* CHAR_K  */
+  YYSYMBOL_SHORT_K = 6,                    /* SHORT_K  */
+  YYSYMBOL_INT_K = 7,                      /* INT_K  */
+  YYSYMBOL_FLOAT_K = 8,                    /* FLOAT_K  */
+  YYSYMBOL_DOUBLE_K = 9,                   /* DOUBLE_K  */
+  YYSYMBOL_IDENT = 10,                     /* IDENT  */
+  YYSYMBOL_TERMSTRING = 11,                /* TERMSTRING  */
+  YYSYMBOL_BYTE_CONST = 12,                /* BYTE_CONST  */
+  YYSYMBOL_CHAR_CONST = 13,                /* CHAR_CONST  */
+  YYSYMBOL_SHORT_CONST = 14,               /* SHORT_CONST  */
+  YYSYMBOL_INT_CONST = 15,                 /* INT_CONST  */
+  YYSYMBOL_FLOAT_CONST = 16,               /* FLOAT_CONST  */
+  YYSYMBOL_DOUBLE_CONST = 17,              /* DOUBLE_CONST  */
+  YYSYMBOL_DIMENSIONS = 18,                /* DIMENSIONS  */
+  YYSYMBOL_VARIABLES = 19,                 /* VARIABLES  */
+  YYSYMBOL_NETCDF = 20,                    /* NETCDF  */
+  YYSYMBOL_DATA = 21,                      /* DATA  */
+  YYSYMBOL_FILLVALUE = 22,                 /* FILLVALUE  */
+  YYSYMBOL_23_ = 23,                       /* '{'  */
+  YYSYMBOL_24_ = 24,                       /* '}'  */
+  YYSYMBOL_25_ = 25,                       /* ';'  */
+  YYSYMBOL_26_ = 26,                       /* ','  */
+  YYSYMBOL_27_ = 27,                       /* '='  */
+  YYSYMBOL_28_ = 28,                       /* '('  */
+  YYSYMBOL_29_ = 29,                       /* ')'  */
+  YYSYMBOL_30_ = 30,                       /* ':'  */
+  YYSYMBOL_YYACCEPT = 31,                  /* $accept  */
+  YYSYMBOL_ncdesc = 32,                    /* ncdesc  */
+  YYSYMBOL_33_1 = 33,                      /* $@1  */
+  YYSYMBOL_34_2 = 34,                      /* $@2  */
+  YYSYMBOL_dimsection = 35,                /* dimsection  */
+  YYSYMBOL_dimdecls = 36,                  /* dimdecls  */
+  YYSYMBOL_dimdecline = 37,                /* dimdecline  */
+  YYSYMBOL_dimdecl = 38,                   /* dimdecl  */
+  YYSYMBOL_dimd = 39,                      /* dimd  */
+  YYSYMBOL_dim = 40,                       /* dim  */
+  YYSYMBOL_vasection = 41,                 /* vasection  */
+  YYSYMBOL_vadecls = 42,                   /* vadecls  */
+  YYSYMBOL_vadecl = 43,                    /* vadecl  */
+  YYSYMBOL_gattdecls = 44,                 /* gattdecls  */
+  YYSYMBOL_vardecl = 45,                   /* vardecl  */
+  YYSYMBOL_type = 46,                      /* type  */
+  YYSYMBOL_varlist = 47,                   /* varlist  */
+  YYSYMBOL_varspec = 48,                   /* varspec  */
+  YYSYMBOL_49_3 = 49,                      /* $@3  */
+  YYSYMBOL_var = 50,                       /* var  */
+  YYSYMBOL_dimspec = 51,                   /* dimspec  */
+  YYSYMBOL_dimlist = 52,                   /* dimlist  */
+  YYSYMBOL_vdim = 53,                      /* vdim  */
+  YYSYMBOL_attdecl = 54,                   /* attdecl  */
+  YYSYMBOL_55_4 = 55,                      /* $@4  */
+  YYSYMBOL_gattdecl = 56,                  /* gattdecl  */
+  YYSYMBOL_57_5 = 57,                      /* $@5  */
+  YYSYMBOL_att = 58,                       /* att  */
+  YYSYMBOL_gatt = 59,                      /* gatt  */
+  YYSYMBOL_avar = 60,                      /* avar  */
+  YYSYMBOL_attr = 61,                      /* attr  */
+  YYSYMBOL_attvallist = 62,                /* attvallist  */
+  YYSYMBOL_aconst = 63,                    /* aconst  */
+  YYSYMBOL_attconst = 64,                  /* attconst  */
+  YYSYMBOL_datasection = 65,               /* datasection  */
+  YYSYMBOL_datadecls = 66,                 /* datadecls  */
+  YYSYMBOL_datadecl = 67,                  /* datadecl  */
+  YYSYMBOL_68_6 = 68,                      /* $@6  */
+  YYSYMBOL_constlist = 69,                 /* constlist  */
+  YYSYMBOL_dconst = 70,                    /* dconst  */
+  YYSYMBOL_71_7 = 71,                      /* $@7  */
+  YYSYMBOL_const = 72                      /* const  */
+};
+typedef enum yysymbol_kind_t yysymbol_kind_t;
 
-/* In a future release of Bison, this section will be replaced
-   by #include "ncgeny.h".  */
-#ifndef YY_NCG_NCGEN_TAB_H_INCLUDED
-# define YY_NCG_NCGEN_TAB_H_INCLUDED
-/* Debug traces.  */
-#ifndef YYDEBUG
-# define YYDEBUG 1
-#endif
-#if YYDEBUG
-extern int ncgdebug;
-#endif
-
-/* Token type.  */
-#ifndef YYTOKENTYPE
-# define YYTOKENTYPE
-  enum yytokentype
-  {
-    NC_UNLIMITED_K = 258,
-    BYTE_K = 259,
-    CHAR_K = 260,
-    SHORT_K = 261,
-    INT_K = 262,
-    FLOAT_K = 263,
-    DOUBLE_K = 264,
-    IDENT = 265,
-    TERMSTRING = 266,
-    BYTE_CONST = 267,
-    CHAR_CONST = 268,
-    SHORT_CONST = 269,
-    INT_CONST = 270,
-    FLOAT_CONST = 271,
-    DOUBLE_CONST = 272,
-    DIMENSIONS = 273,
-    VARIABLES = 274,
-    NETCDF = 275,
-    DATA = 276,
-    FILLVALUE = 277
-  };
-#endif
-
-/* Value type.  */
-#if ! defined YYSTYPE && ! defined YYSTYPE_IS_DECLARED
-typedef int YYSTYPE;
-# define YYSTYPE_IS_TRIVIAL 1
-# define YYSTYPE_IS_DECLARED 1
-#endif
 
 
-extern YYSTYPE ncglval;
-
-int ncgparse (void);
-
-#endif /* !YY_NCG_NCGEN_TAB_H_INCLUDED  */
-
-/* Copy the second part of user declarations.  */
-
-#line 224 "ncgeny.c" /* yacc.c:358  */
 
 #ifdef short
 # undef short
 #endif
 
-#ifdef YYTYPE_UINT8
-typedef YYTYPE_UINT8 yytype_uint8;
-#else
-typedef unsigned char yytype_uint8;
+/* On compilers that do not define __PTRDIFF_MAX__ etc., make sure
+   <limits.h> and (if available) <stdint.h> are included
+   so that the code can choose integer types of a good width.  */
+
+#ifndef __PTRDIFF_MAX__
+# include <limits.h> /* INFRINGES ON USER NAME SPACE */
+# if defined __STDC_VERSION__ && 199901 <= __STDC_VERSION__
+#  include <stdint.h> /* INFRINGES ON USER NAME SPACE */
+#  define YY_STDINT_H
+# endif
 #endif
 
-#ifdef YYTYPE_INT8
-typedef YYTYPE_INT8 yytype_int8;
+/* Narrow types that promote to a signed type and that can represent a
+   signed or unsigned integer of at least N bits.  In tables they can
+   save space and decrease cache pressure.  Promoting to a signed type
+   helps avoid bugs in integer arithmetic.  */
+
+#ifdef __INT_LEAST8_MAX__
+typedef __INT_LEAST8_TYPE__ yytype_int8;
+#elif defined YY_STDINT_H
+typedef int_least8_t yytype_int8;
 #else
 typedef signed char yytype_int8;
 #endif
 
-#ifdef YYTYPE_UINT16
-typedef YYTYPE_UINT16 yytype_uint16;
+#ifdef __INT_LEAST16_MAX__
+typedef __INT_LEAST16_TYPE__ yytype_int16;
+#elif defined YY_STDINT_H
+typedef int_least16_t yytype_int16;
 #else
-typedef unsigned short int yytype_uint16;
+typedef short yytype_int16;
 #endif
 
-#ifdef YYTYPE_INT16
-typedef YYTYPE_INT16 yytype_int16;
+/* Work around bug in HP-UX 11.23, which defines these macros
+   incorrectly for preprocessor constants.  This workaround can likely
+   be removed in 2023, as HPE has promised support for HP-UX 11.23
+   (aka HP-UX 11i v2) only through the end of 2022; see Table 2 of
+   <https://h20195.www2.hpe.com/V2/getpdf.aspx/4AA4-7673ENW.pdf>.  */
+#ifdef __hpux
+# undef UINT_LEAST8_MAX
+# undef UINT_LEAST16_MAX
+# define UINT_LEAST8_MAX 255
+# define UINT_LEAST16_MAX 65535
+#endif
+
+#if defined __UINT_LEAST8_MAX__ && __UINT_LEAST8_MAX__ <= __INT_MAX__
+typedef __UINT_LEAST8_TYPE__ yytype_uint8;
+#elif (!defined __UINT_LEAST8_MAX__ && defined YY_STDINT_H \
+       && UINT_LEAST8_MAX <= INT_MAX)
+typedef uint_least8_t yytype_uint8;
+#elif !defined __UINT_LEAST8_MAX__ && UCHAR_MAX <= INT_MAX
+typedef unsigned char yytype_uint8;
 #else
-typedef short int yytype_int16;
+typedef short yytype_uint8;
+#endif
+
+#if defined __UINT_LEAST16_MAX__ && __UINT_LEAST16_MAX__ <= __INT_MAX__
+typedef __UINT_LEAST16_TYPE__ yytype_uint16;
+#elif (!defined __UINT_LEAST16_MAX__ && defined YY_STDINT_H \
+       && UINT_LEAST16_MAX <= INT_MAX)
+typedef uint_least16_t yytype_uint16;
+#elif !defined __UINT_LEAST16_MAX__ && USHRT_MAX <= INT_MAX
+typedef unsigned short yytype_uint16;
+#else
+typedef int yytype_uint16;
+#endif
+
+#ifndef YYPTRDIFF_T
+# if defined __PTRDIFF_TYPE__ && defined __PTRDIFF_MAX__
+#  define YYPTRDIFF_T __PTRDIFF_TYPE__
+#  define YYPTRDIFF_MAXIMUM __PTRDIFF_MAX__
+# elif defined PTRDIFF_MAX
+#  ifndef ptrdiff_t
+#   include <stddef.h> /* INFRINGES ON USER NAME SPACE */
+#  endif
+#  define YYPTRDIFF_T ptrdiff_t
+#  define YYPTRDIFF_MAXIMUM PTRDIFF_MAX
+# else
+#  define YYPTRDIFF_T long
+#  define YYPTRDIFF_MAXIMUM LONG_MAX
+# endif
 #endif
 
 #ifndef YYSIZE_T
@@ -255,15 +349,28 @@ typedef short int yytype_int16;
 #  define YYSIZE_T __SIZE_TYPE__
 # elif defined size_t
 #  define YYSIZE_T size_t
-# elif ! defined YYSIZE_T
+# elif defined __STDC_VERSION__ && 199901 <= __STDC_VERSION__
 #  include <stddef.h> /* INFRINGES ON USER NAME SPACE */
 #  define YYSIZE_T size_t
 # else
-#  define YYSIZE_T unsigned int
+#  define YYSIZE_T unsigned
 # endif
 #endif
 
-#define YYSIZE_MAXIMUM ((YYSIZE_T) -1)
+#define YYSIZE_MAXIMUM                                  \
+  YY_CAST (YYPTRDIFF_T,                                 \
+           (YYPTRDIFF_MAXIMUM < YY_CAST (YYSIZE_T, -1)  \
+            ? YYPTRDIFF_MAXIMUM                         \
+            : YY_CAST (YYSIZE_T, -1)))
+
+#define YYSIZEOF(X) YY_CAST (YYPTRDIFF_T, sizeof (X))
+
+
+/* Stored state numbers (used for stacks). */
+typedef yytype_int8 yy_state_t;
+
+/* State numbers in computations.  */
+typedef int yy_state_fast_t;
 
 #ifndef YY_
 # if defined YYENABLE_NLS && YYENABLE_NLS
@@ -277,47 +384,43 @@ typedef short int yytype_int16;
 # endif
 #endif
 
-#ifndef YY_ATTRIBUTE
-# if (defined __GNUC__                                               \
-      && (2 < __GNUC__ || (__GNUC__ == 2 && 96 <= __GNUC_MINOR__)))  \
-     || defined __SUNPRO_C && 0x5110 <= __SUNPRO_C
-#  define YY_ATTRIBUTE(Spec) __attribute__(Spec)
+
+#ifndef YY_ATTRIBUTE_PURE
+# if defined __GNUC__ && 2 < __GNUC__ + (96 <= __GNUC_MINOR__)
+#  define YY_ATTRIBUTE_PURE __attribute__ ((__pure__))
 # else
-#  define YY_ATTRIBUTE(Spec) /* empty */
+#  define YY_ATTRIBUTE_PURE
 # endif
 #endif
 
-#ifndef YY_ATTRIBUTE_PURE
-# define YY_ATTRIBUTE_PURE   YY_ATTRIBUTE ((__pure__))
-#endif
-
 #ifndef YY_ATTRIBUTE_UNUSED
-# define YY_ATTRIBUTE_UNUSED YY_ATTRIBUTE ((__unused__))
-#endif
-
-#if !defined _Noreturn \
-     && (!defined __STDC_VERSION__ || __STDC_VERSION__ < 201112)
-# if defined _MSC_VER && 1200 <= _MSC_VER
-#  define _Noreturn __declspec (noreturn)
+# if defined __GNUC__ && 2 < __GNUC__ + (7 <= __GNUC_MINOR__)
+#  define YY_ATTRIBUTE_UNUSED __attribute__ ((__unused__))
 # else
-#  define _Noreturn YY_ATTRIBUTE ((__noreturn__))
+#  define YY_ATTRIBUTE_UNUSED
 # endif
 #endif
 
 /* Suppress unused-variable warnings by "using" E.  */
 #if ! defined lint || defined __GNUC__
-# define YYUSE(E) ((void) (E))
+# define YY_USE(E) ((void) (E))
 #else
-# define YYUSE(E) /* empty */
+# define YY_USE(E) /* empty */
 #endif
 
-#if defined __GNUC__ && 407 <= __GNUC__ * 100 + __GNUC_MINOR__
 /* Suppress an incorrect diagnostic about yylval being uninitialized.  */
-# define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN \
-    _Pragma ("GCC diagnostic push") \
-    _Pragma ("GCC diagnostic ignored \"-Wuninitialized\"")\
+#if defined __GNUC__ && ! defined __ICC && 406 <= __GNUC__ * 100 + __GNUC_MINOR__
+# if __GNUC__ * 100 + __GNUC_MINOR__ < 407
+#  define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN                           \
+    _Pragma ("GCC diagnostic push")                                     \
+    _Pragma ("GCC diagnostic ignored \"-Wuninitialized\"")
+# else
+#  define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN                           \
+    _Pragma ("GCC diagnostic push")                                     \
+    _Pragma ("GCC diagnostic ignored \"-Wuninitialized\"")              \
     _Pragma ("GCC diagnostic ignored \"-Wmaybe-uninitialized\"")
-# define YY_IGNORE_MAYBE_UNINITIALIZED_END \
+# endif
+# define YY_IGNORE_MAYBE_UNINITIALIZED_END      \
     _Pragma ("GCC diagnostic pop")
 #else
 # define YY_INITIAL_VALUE(Value) Value
@@ -330,8 +433,22 @@ typedef short int yytype_int16;
 # define YY_INITIAL_VALUE(Value) /* Nothing. */
 #endif
 
+#if defined __cplusplus && defined __GNUC__ && ! defined __ICC && 6 <= __GNUC__
+# define YY_IGNORE_USELESS_CAST_BEGIN                          \
+    _Pragma ("GCC diagnostic push")                            \
+    _Pragma ("GCC diagnostic ignored \"-Wuseless-cast\"")
+# define YY_IGNORE_USELESS_CAST_END            \
+    _Pragma ("GCC diagnostic pop")
+#endif
+#ifndef YY_IGNORE_USELESS_CAST_BEGIN
+# define YY_IGNORE_USELESS_CAST_BEGIN
+# define YY_IGNORE_USELESS_CAST_END
+#endif
 
-#if ! defined yyoverflow || YYERROR_VERBOSE
+
+#define YY_ASSERT(E) ((void) (0 && (E)))
+
+#if !defined yyoverflow
 
 /* The parser invokes alloca or malloc; define the necessary symbols.  */
 
@@ -396,8 +513,7 @@ void free (void *); /* INFRINGES ON USER NAME SPACE */
 #   endif
 #  endif
 # endif
-#endif /* ! defined yyoverflow || YYERROR_VERBOSE */
-
+#endif /* !defined yyoverflow */
 
 #if (! defined yyoverflow \
      && (! defined __cplusplus \
@@ -406,17 +522,17 @@ void free (void *); /* INFRINGES ON USER NAME SPACE */
 /* A type that is properly aligned for any stack member.  */
 union yyalloc
 {
-  yytype_int16 yyss_alloc;
+  yy_state_t yyss_alloc;
   YYSTYPE yyvs_alloc;
 };
 
 /* The size of the maximum gap between one aligned stack and the next.  */
-# define YYSTACK_GAP_MAXIMUM (sizeof (union yyalloc) - 1)
+# define YYSTACK_GAP_MAXIMUM (YYSIZEOF (union yyalloc) - 1)
 
 /* The size of an array large to enough to hold all stacks, each with
    N elements.  */
 # define YYSTACK_BYTES(N) \
-     ((N) * (sizeof (yytype_int16) + sizeof (YYSTYPE)) \
+     ((N) * (YYSIZEOF (yy_state_t) + YYSIZEOF (YYSTYPE)) \
       + YYSTACK_GAP_MAXIMUM)
 
 # define YYCOPY_NEEDED 1
@@ -429,11 +545,11 @@ union yyalloc
 # define YYSTACK_RELOCATE(Stack_alloc, Stack)                           \
     do                                                                  \
       {                                                                 \
-        YYSIZE_T yynewbytes;                                            \
+        YYPTRDIFF_T yynewbytes;                                         \
         YYCOPY (&yyptr->Stack_alloc, Stack, yysize);                    \
         Stack = &yyptr->Stack_alloc;                                    \
-        yynewbytes = yystacksize * sizeof (*Stack) + YYSTACK_GAP_MAXIMUM; \
-        yyptr += yynewbytes / sizeof (*yyptr);                          \
+        yynewbytes = yystacksize * YYSIZEOF (*Stack) + YYSTACK_GAP_MAXIMUM; \
+        yyptr += yynewbytes / YYSIZEOF (*yyptr);                        \
       }                                                                 \
     while (0)
 
@@ -445,12 +561,12 @@ union yyalloc
 # ifndef YYCOPY
 #  if defined __GNUC__ && 1 < __GNUC__
 #   define YYCOPY(Dst, Src, Count) \
-      __builtin_memcpy (Dst, Src, (Count) * sizeof (*(Src)))
+      __builtin_memcpy (Dst, Src, YY_CAST (YYSIZE_T, (Count)) * sizeof (*(Src)))
 #  else
 #   define YYCOPY(Dst, Src, Count)              \
       do                                        \
         {                                       \
-          YYSIZE_T yyi;                         \
+          YYPTRDIFF_T yyi;                      \
           for (yyi = 0; yyi < (Count); yyi++)   \
             (Dst)[yyi] = (Src)[yyi];            \
         }                                       \
@@ -473,17 +589,20 @@ union yyalloc
 /* YYNSTATES -- Number of states.  */
 #define YYNSTATES  112
 
-/* YYTRANSLATE[YYX] -- Symbol number corresponding to YYX as returned
-   by yylex, with out-of-bounds checking.  */
-#define YYUNDEFTOK  2
+/* YYMAXUTOK -- Last valid token kind.  */
 #define YYMAXUTOK   277
 
-#define YYTRANSLATE(YYX)                                                \
-  ((unsigned int) (YYX) <= YYMAXUTOK ? yytranslate[YYX] : YYUNDEFTOK)
+
+/* YYTRANSLATE(TOKEN-NUM) -- Symbol number corresponding to TOKEN-NUM
+   as returned by yylex, with out-of-bounds checking.  */
+#define YYTRANSLATE(YYX)                                \
+  (0 <= (YYX) && (YYX) <= YYMAXUTOK                     \
+   ? YY_CAST (yysymbol_kind_t, yytranslate[YYX])        \
+   : YYSYMBOL_YYUNDEF)
 
 /* YYTRANSLATE[TOKEN-NUM] -- Symbol number corresponding to TOKEN-NUM
-   as returned by yylex, without out-of-bounds checking.  */
-static const yytype_uint8 yytranslate[] =
+   as returned by yylex.  */
+static const yytype_int8 yytranslate[] =
 {
        0,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
@@ -516,8 +635,8 @@ static const yytype_uint8 yytranslate[] =
 };
 
 #if YYDEBUG
-  /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
-static const yytype_uint16 yyrline[] =
+/* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
+static const yytype_int16 yyrline[] =
 {
        0,   117,   117,   120,   115,   133,   134,   136,   137,   139,
      140,   142,   148,   159,   167,   184,   186,   187,   188,   190,
@@ -530,49 +649,51 @@ static const yytype_uint16 yyrline[] =
 };
 #endif
 
-#if YYDEBUG || YYERROR_VERBOSE || 0
+/** Accessing symbol of state STATE.  */
+#define YY_ACCESSING_SYMBOL(State) YY_CAST (yysymbol_kind_t, yystos[State])
+
+#if YYDEBUG || 0
+/* The user-facing name of the symbol whose (internal) number is
+   YYSYMBOL.  No bounds checking.  */
+static const char *yysymbol_name (yysymbol_kind_t yysymbol) YY_ATTRIBUTE_UNUSED;
+
 /* YYTNAME[SYMBOL-NUM] -- String name of the symbol SYMBOL-NUM.
    First, the terminals, then, starting at YYNTOKENS, nonterminals.  */
 static const char *const yytname[] =
 {
-  "$end", "error", "$undefined", "NC_UNLIMITED_K", "BYTE_K", "CHAR_K",
-  "SHORT_K", "INT_K", "FLOAT_K", "DOUBLE_K", "IDENT", "TERMSTRING",
-  "BYTE_CONST", "CHAR_CONST", "SHORT_CONST", "INT_CONST", "FLOAT_CONST",
-  "DOUBLE_CONST", "DIMENSIONS", "VARIABLES", "NETCDF", "DATA", "FILLVALUE",
-  "'{'", "'}'", "';'", "','", "'='", "'('", "')'", "':'", "$accept",
-  "ncdesc", "$@1", "$@2", "dimsection", "dimdecls", "dimdecline",
-  "dimdecl", "dimd", "dim", "vasection", "vadecls", "vadecl", "gattdecls",
-  "vardecl", "type", "varlist", "varspec", "$@3", "var", "dimspec",
-  "dimlist", "vdim", "attdecl", "$@4", "gattdecl", "$@5", "att", "gatt",
-  "avar", "attr", "attvallist", "aconst", "attconst", "datasection",
-  "datadecls", "datadecl", "$@6", "constlist", "dconst", "$@7", "const", YY_NULLPTR
+  "\"end of file\"", "error", "\"invalid token\"", "NC_UNLIMITED_K",
+  "BYTE_K", "CHAR_K", "SHORT_K", "INT_K", "FLOAT_K", "DOUBLE_K", "IDENT",
+  "TERMSTRING", "BYTE_CONST", "CHAR_CONST", "SHORT_CONST", "INT_CONST",
+  "FLOAT_CONST", "DOUBLE_CONST", "DIMENSIONS", "VARIABLES", "NETCDF",
+  "DATA", "FILLVALUE", "'{'", "'}'", "';'", "','", "'='", "'('", "')'",
+  "':'", "$accept", "ncdesc", "$@1", "$@2", "dimsection", "dimdecls",
+  "dimdecline", "dimdecl", "dimd", "dim", "vasection", "vadecls", "vadecl",
+  "gattdecls", "vardecl", "type", "varlist", "varspec", "$@3", "var",
+  "dimspec", "dimlist", "vdim", "attdecl", "$@4", "gattdecl", "$@5", "att",
+  "gatt", "avar", "attr", "attvallist", "aconst", "attconst",
+  "datasection", "datadecls", "datadecl", "$@6", "constlist", "dconst",
+  "$@7", "const", YY_NULLPTR
 };
+
+static const char *
+yysymbol_name (yysymbol_kind_t yysymbol)
+{
+  return yytname[yysymbol];
+}
 #endif
 
-# ifdef YYPRINT
-/* YYTOKNUM[NUM] -- (External) token number corresponding to the
-   (internal) symbol number NUM (which must be that of a token).  */
-static const yytype_uint16 yytoknum[] =
-{
-       0,   256,   257,   258,   259,   260,   261,   262,   263,   264,
-     265,   266,   267,   268,   269,   270,   271,   272,   273,   274,
-     275,   276,   277,   123,   125,    59,    44,    61,    40,    41,
-      58
-};
-# endif
+#define YYPACT_NINF (-73)
 
-#define YYPACT_NINF -73
+#define yypact_value_is_default(Yyn) \
+  ((Yyn) == YYPACT_NINF)
 
-#define yypact_value_is_default(Yystate) \
-  (!!((Yystate) == (-73)))
+#define YYTABLE_NINF (-1)
 
-#define YYTABLE_NINF -1
-
-#define yytable_value_is_error(Yytable_value) \
+#define yytable_value_is_error(Yyn) \
   0
 
-  /* YYPACT[STATE-NUM] -- Index in YYTABLE of the portion describing
-     STATE-NUM.  */
+/* YYPACT[STATE-NUM] -- Index in YYTABLE of the portion describing
+   STATE-NUM.  */
 static const yytype_int8 yypact[] =
 {
       10,     3,    31,   -73,   -73,    19,    36,     6,   -73,    36,
@@ -589,10 +710,10 @@ static const yytype_int8 yypact[] =
      -73,   -73
 };
 
-  /* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
-     Performed when YYTABLE does not specify something else to do.  Zero
-     means the default is an error.  */
-static const yytype_uint8 yydefact[] =
+/* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
+   Performed when YYTABLE does not specify something else to do.  Zero
+   means the default is an error.  */
+static const yytype_int8 yydefact[] =
 {
        0,     0,     0,     2,     1,     5,     0,    16,    15,     6,
        0,     9,     0,    14,     0,     0,     3,    18,     0,    45,
@@ -608,7 +729,7 @@ static const yytype_uint8 yydefact[] =
       71,    69
 };
 
-  /* YYPGOTO[NTERM-NUM].  */
+/* YYPGOTO[NTERM-NUM].  */
 static const yytype_int8 yypgoto[] =
 {
      -73,   -73,   -73,   -73,   -73,   -73,    49,    44,   -73,   -72,
@@ -618,20 +739,20 @@ static const yytype_int8 yypgoto[] =
      -73,   -73
 };
 
-  /* YYDEFGOTO[NTERM-NUM].  */
+/* YYDEFGOTO[NTERM-NUM].  */
 static const yytype_int8 yydefgoto[] =
 {
-      -1,     2,     5,    42,     7,     9,    10,    11,    12,    13,
+       0,     2,     5,    42,     7,     9,    10,    11,    12,    13,
       16,    31,    32,    17,    33,    34,    53,    54,    64,    35,
       83,    90,    91,    36,    56,    37,    45,    38,    19,    39,
       41,    78,    79,    80,    59,    68,    69,    85,    97,    98,
       99,   110
 };
 
-  /* YYTABLE[YYPACT[STATE-NUM]] -- What to do in state STATE-NUM.  If
-     positive, shift that token.  If negative, reduce the rule whose
-     number is the opposite.  If YYTABLE_NINF, syntax error.  */
-static const yytype_uint8 yytable[] =
+/* YYTABLE[YYPACT[STATE-NUM]] -- What to do in state STATE-NUM.  If
+   positive, shift that token.  If negative, reduce the rule whose
+   number is the opposite.  If YYTABLE_NINF, syntax error.  */
+static const yytype_int8 yytable[] =
 {
       55,    24,    25,    26,    27,    28,    29,    30,    48,    95,
       89,    18,    96,   102,   103,   104,   105,   106,   107,   108,
@@ -655,9 +776,9 @@ static const yytype_int8 yycheck[] =
       25,    57,    26,    88,   101,    -1,    68,    -1,    31
 };
 
-  /* YYSTOS[STATE-NUM] -- The (internal number of the) accessing
-     symbol of state STATE-NUM.  */
-static const yytype_uint8 yystos[] =
+/* YYSTOS[STATE-NUM] -- The symbol kind of the accessing symbol of
+   state STATE-NUM.  */
+static const yytype_int8 yystos[] =
 {
        0,    20,    32,    23,     0,    33,    18,    35,    10,    36,
       37,    38,    39,    40,    19,    30,    41,    44,    56,    59,
@@ -673,8 +794,8 @@ static const yytype_uint8 yystos[] =
       72,    70
 };
 
-  /* YYR1[YYN] -- Symbol number of symbol that rule YYN derives.  */
-static const yytype_uint8 yyr1[] =
+/* YYR1[RULE-NUM] -- Symbol kind of the left-hand side of rule RULE-NUM.  */
+static const yytype_int8 yyr1[] =
 {
        0,    31,    33,    34,    32,    35,    35,    36,    36,    37,
       37,    38,    38,    38,    39,    40,    41,    41,    41,    42,
@@ -686,8 +807,8 @@ static const yytype_uint8 yyr1[] =
       71,    70,    72,    72,    72,    72,    72,    72,    72,    72
 };
 
-  /* YYR2[YYN] -- Number of symbols on the right hand side of rule YYN.  */
-static const yytype_uint8 yyr2[] =
+/* YYR2[RULE-NUM] -- Number of symbols on the right-hand side of rule RULE-NUM.  */
+static const yytype_int8 yyr2[] =
 {
        0,     2,     0,     0,     8,     0,     2,     2,     3,     1,
        3,     3,     3,     3,     1,     1,     0,     2,     1,     2,
@@ -700,39 +821,39 @@ static const yytype_uint8 yyr2[] =
 };
 
 
+enum { YYENOMEM = -2 };
+
 #define yyerrok         (yyerrstatus = 0)
 #define yyclearin       (yychar = YYEMPTY)
-#define YYEMPTY         (-2)
-#define YYEOF           0
 
 #define YYACCEPT        goto yyacceptlab
 #define YYABORT         goto yyabortlab
 #define YYERROR         goto yyerrorlab
+#define YYNOMEM         goto yyexhaustedlab
 
 
 #define YYRECOVERING()  (!!yyerrstatus)
 
-#define YYBACKUP(Token, Value)                                  \
-do                                                              \
-  if (yychar == YYEMPTY)                                        \
-    {                                                           \
-      yychar = (Token);                                         \
-      yylval = (Value);                                         \
-      YYPOPSTACK (yylen);                                       \
-      yystate = *yyssp;                                         \
-      goto yybackup;                                            \
-    }                                                           \
-  else                                                          \
-    {                                                           \
-      yyerror (YY_("syntax error: cannot back up")); \
-      YYERROR;                                                  \
-    }                                                           \
-while (0)
+#define YYBACKUP(Token, Value)                                    \
+  do                                                              \
+    if (yychar == YYEMPTY)                                        \
+      {                                                           \
+        yychar = (Token);                                         \
+        yylval = (Value);                                         \
+        YYPOPSTACK (yylen);                                       \
+        yystate = *yyssp;                                         \
+        goto yybackup;                                            \
+      }                                                           \
+    else                                                          \
+      {                                                           \
+        yyerror (YY_("syntax error: cannot back up")); \
+        YYERROR;                                                  \
+      }                                                           \
+  while (0)
 
-/* Error token number */
-#define YYTERROR        1
-#define YYERRCODE       256
-
+/* Backward compatibility with an undocumented macro.
+   Use YYerror or YYUNDEF. */
+#define YYERRCODE YYUNDEF
 
 
 /* Enable debugging if requested.  */
@@ -749,55 +870,52 @@ do {                                            \
     YYFPRINTF Args;                             \
 } while (0)
 
-/* This macro is provided for backward compatibility. */
-#ifndef YY_LOCATION_PRINT
-# define YY_LOCATION_PRINT(File, Loc) ((void) 0)
-#endif
 
 
-# define YY_SYMBOL_PRINT(Title, Type, Value, Location)                    \
+
+# define YY_SYMBOL_PRINT(Title, Kind, Value, Location)                    \
 do {                                                                      \
   if (yydebug)                                                            \
     {                                                                     \
       YYFPRINTF (stderr, "%s ", Title);                                   \
       yy_symbol_print (stderr,                                            \
-                  Type, Value); \
+                  Kind, Value); \
       YYFPRINTF (stderr, "\n");                                           \
     }                                                                     \
 } while (0)
 
 
-/*----------------------------------------.
-| Print this symbol's value on YYOUTPUT.  |
-`----------------------------------------*/
+/*-----------------------------------.
+| Print this symbol's value on YYO.  |
+`-----------------------------------*/
 
 static void
-yy_symbol_value_print (FILE *yyoutput, int yytype, YYSTYPE const * const yyvaluep)
+yy_symbol_value_print (FILE *yyo,
+                       yysymbol_kind_t yykind, YYSTYPE const * const yyvaluep)
 {
-  FILE *yyo = yyoutput;
-  YYUSE (yyo);
+  FILE *yyoutput = yyo;
+  YY_USE (yyoutput);
   if (!yyvaluep)
     return;
-# ifdef YYPRINT
-  if (yytype < YYNTOKENS)
-    YYPRINT (yyoutput, yytoknum[yytype], *yyvaluep);
-# endif
-  YYUSE (yytype);
+  YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
+  YY_USE (yykind);
+  YY_IGNORE_MAYBE_UNINITIALIZED_END
 }
 
 
-/*--------------------------------.
-| Print this symbol on YYOUTPUT.  |
-`--------------------------------*/
+/*---------------------------.
+| Print this symbol on YYO.  |
+`---------------------------*/
 
 static void
-yy_symbol_print (FILE *yyoutput, int yytype, YYSTYPE const * const yyvaluep)
+yy_symbol_print (FILE *yyo,
+                 yysymbol_kind_t yykind, YYSTYPE const * const yyvaluep)
 {
-  YYFPRINTF (yyoutput, "%s %s (",
-             yytype < YYNTOKENS ? "token" : "nterm", yytname[yytype]);
+  YYFPRINTF (yyo, "%s %s (",
+             yykind < YYNTOKENS ? "token" : "nterm", yysymbol_name (yykind));
 
-  yy_symbol_value_print (yyoutput, yytype, yyvaluep);
-  YYFPRINTF (yyoutput, ")");
+  yy_symbol_value_print (yyo, yykind, yyvaluep);
+  YYFPRINTF (yyo, ")");
 }
 
 /*------------------------------------------------------------------.
@@ -806,7 +924,7 @@ yy_symbol_print (FILE *yyoutput, int yytype, YYSTYPE const * const yyvaluep)
 `------------------------------------------------------------------*/
 
 static void
-yy_stack_print (yytype_int16 *yybottom, yytype_int16 *yytop)
+yy_stack_print (yy_state_t *yybottom, yy_state_t *yytop)
 {
   YYFPRINTF (stderr, "Stack now");
   for (; yybottom <= yytop; yybottom++)
@@ -829,21 +947,21 @@ do {                                                            \
 `------------------------------------------------*/
 
 static void
-yy_reduce_print (yytype_int16 *yyssp, YYSTYPE *yyvsp, int yyrule)
+yy_reduce_print (yy_state_t *yyssp, YYSTYPE *yyvsp,
+                 int yyrule)
 {
-  unsigned long int yylno = yyrline[yyrule];
+  int yylno = yyrline[yyrule];
   int yynrhs = yyr2[yyrule];
   int yyi;
-  YYFPRINTF (stderr, "Reducing stack by rule %d (line %lu):\n",
+  YYFPRINTF (stderr, "Reducing stack by rule %d (line %d):\n",
              yyrule - 1, yylno);
   /* The symbols being reduced.  */
   for (yyi = 0; yyi < yynrhs; yyi++)
     {
       YYFPRINTF (stderr, "   $%d = ", yyi + 1);
       yy_symbol_print (stderr,
-                       yystos[yyssp[yyi + 1 - yynrhs]],
-                       &(yyvsp[(yyi + 1) - (yynrhs)])
-                                              );
+                       YY_ACCESSING_SYMBOL (+yyssp[yyi + 1 - yynrhs]),
+                       &yyvsp[(yyi + 1) - (yynrhs)]);
       YYFPRINTF (stderr, "\n");
     }
 }
@@ -858,8 +976,8 @@ do {                                    \
    multiple parsers can coexist.  */
 int yydebug;
 #else /* !YYDEBUG */
-# define YYDPRINTF(Args)
-# define YY_SYMBOL_PRINT(Title, Type, Value, Location)
+# define YYDPRINTF(Args) ((void) 0)
+# define YY_SYMBOL_PRINT(Title, Kind, Value, Location)
 # define YY_STACK_PRINT(Bottom, Top)
 # define YY_REDUCE_PRINT(Rule)
 #endif /* !YYDEBUG */
@@ -882,255 +1000,38 @@ int yydebug;
 #endif
 
 
-#if YYERROR_VERBOSE
 
-# ifndef yystrlen
-#  if defined __GLIBC__ && defined _STRING_H
-#   define yystrlen strlen
-#  else
-/* Return the length of YYSTR.  */
-static YYSIZE_T
-yystrlen (const char *yystr)
-{
-  YYSIZE_T yylen;
-  for (yylen = 0; yystr[yylen]; yylen++)
-    continue;
-  return yylen;
-}
-#  endif
-# endif
 
-# ifndef yystpcpy
-#  if defined __GLIBC__ && defined _STRING_H && defined _GNU_SOURCE
-#   define yystpcpy stpcpy
-#  else
-/* Copy YYSRC to YYDEST, returning the address of the terminating '\0' in
-   YYDEST.  */
-static char *
-yystpcpy (char *yydest, const char *yysrc)
-{
-  char *yyd = yydest;
-  const char *yys = yysrc;
 
-  while ((*yyd++ = *yys++) != '\0')
-    continue;
-
-  return yyd - 1;
-}
-#  endif
-# endif
-
-# ifndef yytnamerr
-/* Copy to YYRES the contents of YYSTR after stripping away unnecessary
-   quotes and backslashes, so that it's suitable for yyerror.  The
-   heuristic is that double-quoting is unnecessary unless the string
-   contains an apostrophe, a comma, or backslash (other than
-   backslash-backslash).  YYSTR is taken from yytname.  If YYRES is
-   null, do not copy; instead, return the length of what the result
-   would have been.  */
-static YYSIZE_T
-yytnamerr (char *yyres, const char *yystr)
-{
-  if (*yystr == '"')
-    {
-      YYSIZE_T yyn = 0;
-      char const *yyp = yystr;
-
-      for (;;)
-        switch (*++yyp)
-          {
-          case '\'':
-          case ',':
-            goto do_not_strip_quotes;
-
-          case '\\':
-            if (*++yyp != '\\')
-              goto do_not_strip_quotes;
-            /* Fall through.  */
-          default:
-            if (yyres)
-              yyres[yyn] = *yyp;
-            yyn++;
-            break;
-
-          case '"':
-            if (yyres)
-              yyres[yyn] = '\0';
-            return yyn;
-          }
-    do_not_strip_quotes: ;
-    }
-
-  if (! yyres)
-    return yystrlen (yystr);
-
-  return yystpcpy (yyres, yystr) - yyres;
-}
-# endif
-
-/* Copy into *YYMSG, which is of size *YYMSG_ALLOC, an error message
-   about the unexpected token YYTOKEN for the state stack whose top is
-   YYSSP.
-
-   Return 0 if *YYMSG was successfully written.  Return 1 if *YYMSG is
-   not large enough to hold the message.  In that case, also set
-   *YYMSG_ALLOC to the required number of bytes.  Return 2 if the
-   required number of bytes is too large to store.  */
-static int
-yysyntax_error (YYSIZE_T *yymsg_alloc, char **yymsg,
-                yytype_int16 *yyssp, int yytoken)
-{
-  YYSIZE_T yysize0 = yytnamerr (YY_NULLPTR, yytname[yytoken]);
-  YYSIZE_T yysize = yysize0;
-  enum { YYERROR_VERBOSE_ARGS_MAXIMUM = 5 };
-  /* Internationalized format string. */
-  const char *yyformat = YY_NULLPTR;
-  /* Arguments of yyformat. */
-  char const *yyarg[YYERROR_VERBOSE_ARGS_MAXIMUM];
-  /* Number of reported tokens (one for the "unexpected", one per
-     "expected"). */
-  int yycount = 0;
-
-  /* There are many possibilities here to consider:
-     - If this state is a consistent state with a default action, then
-       the only way this function was invoked is if the default action
-       is an error action.  In that case, don't check for expected
-       tokens because there are none.
-     - The only way there can be no lookahead present (in yychar) is if
-       this state is a consistent state with a default action.  Thus,
-       detecting the absence of a lookahead is sufficient to determine
-       that there is no unexpected or expected token to report.  In that
-       case, just report a simple "syntax error".
-     - Don't assume there isn't a lookahead just because this state is a
-       consistent state with a default action.  There might have been a
-       previous inconsistent state, consistent state with a non-default
-       action, or user semantic action that manipulated yychar.
-     - Of course, the expected token list depends on states to have
-       correct lookahead information, and it depends on the parser not
-       to perform extra reductions after fetching a lookahead from the
-       scanner and before detecting a syntax error.  Thus, state merging
-       (from LALR or IELR) and default reductions corrupt the expected
-       token list.  However, the list is correct for canonical LR with
-       one exception: it will still contain any token that will not be
-       accepted due to an error action in a later state.
-  */
-  if (yytoken != YYEMPTY)
-    {
-      int yyn = yypact[*yyssp];
-      yyarg[yycount++] = yytname[yytoken];
-      if (!yypact_value_is_default (yyn))
-        {
-          /* Start YYX at -YYN if negative to avoid negative indexes in
-             YYCHECK.  In other words, skip the first -YYN actions for
-             this state because they are default actions.  */
-          int yyxbegin = yyn < 0 ? -yyn : 0;
-          /* Stay within bounds of both yycheck and yytname.  */
-          int yychecklim = YYLAST - yyn + 1;
-          int yyxend = yychecklim < YYNTOKENS ? yychecklim : YYNTOKENS;
-          int yyx;
-
-          for (yyx = yyxbegin; yyx < yyxend; ++yyx)
-            if (yycheck[yyx + yyn] == yyx && yyx != YYTERROR
-                && !yytable_value_is_error (yytable[yyx + yyn]))
-              {
-                if (yycount == YYERROR_VERBOSE_ARGS_MAXIMUM)
-                  {
-                    yycount = 1;
-                    yysize = yysize0;
-                    break;
-                  }
-                yyarg[yycount++] = yytname[yyx];
-                {
-                  YYSIZE_T yysize1 = yysize + yytnamerr (YY_NULLPTR, yytname[yyx]);
-                  if (! (yysize <= yysize1
-                         && yysize1 <= YYSTACK_ALLOC_MAXIMUM))
-                    return 2;
-                  yysize = yysize1;
-                }
-              }
-        }
-    }
-
-  switch (yycount)
-    {
-# define YYCASE_(N, S)                      \
-      case N:                               \
-        yyformat = S;                       \
-      break
-      YYCASE_(0, YY_("syntax error"));
-      YYCASE_(1, YY_("syntax error, unexpected %s"));
-      YYCASE_(2, YY_("syntax error, unexpected %s, expecting %s"));
-      YYCASE_(3, YY_("syntax error, unexpected %s, expecting %s or %s"));
-      YYCASE_(4, YY_("syntax error, unexpected %s, expecting %s or %s or %s"));
-      YYCASE_(5, YY_("syntax error, unexpected %s, expecting %s or %s or %s or %s"));
-# undef YYCASE_
-    }
-
-  {
-    YYSIZE_T yysize1 = yysize + yystrlen (yyformat);
-    if (! (yysize <= yysize1 && yysize1 <= YYSTACK_ALLOC_MAXIMUM))
-      return 2;
-    yysize = yysize1;
-  }
-
-  if (*yymsg_alloc < yysize)
-    {
-      *yymsg_alloc = 2 * yysize;
-      if (! (yysize <= *yymsg_alloc
-             && *yymsg_alloc <= YYSTACK_ALLOC_MAXIMUM))
-        *yymsg_alloc = YYSTACK_ALLOC_MAXIMUM;
-      return 1;
-    }
-
-  /* Avoid snprintf, as that infringes on the user's name space.
-     Don't have undefined behavior even if the translation
-     produced a string with the wrong number of "%s"s.  */
-  {
-    char *yyp = *yymsg;
-    int yyi = 0;
-    while ((*yyp = *yyformat) != '\0')
-      if (*yyp == '%' && yyformat[1] == 's' && yyi < yycount)
-        {
-          yyp += yytnamerr (yyp, yyarg[yyi++]);
-          yyformat += 2;
-        }
-      else
-        {
-          yyp++;
-          yyformat++;
-        }
-  }
-  return 0;
-}
-#endif /* YYERROR_VERBOSE */
 
 /*-----------------------------------------------.
 | Release the memory associated to this symbol.  |
 `-----------------------------------------------*/
 
 static void
-yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep)
+yydestruct (const char *yymsg,
+            yysymbol_kind_t yykind, YYSTYPE *yyvaluep)
 {
-  YYUSE (yyvaluep);
+  YY_USE (yyvaluep);
   if (!yymsg)
     yymsg = "Deleting";
-  YY_SYMBOL_PRINT (yymsg, yytype, yyvaluep, yylocationp);
+  YY_SYMBOL_PRINT (yymsg, yykind, yyvaluep, yylocationp);
 
   YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
-  YYUSE (yytype);
+  YY_USE (yykind);
   YY_IGNORE_MAYBE_UNINITIALIZED_END
 }
 
 
-
-
-/* The lookahead symbol.  */
+/* Lookahead token kind.  */
 int yychar;
 
 /* The semantic value of the lookahead symbol.  */
 YYSTYPE yylval;
 /* Number of syntax errors so far.  */
 int yynerrs;
+
+
 
 
 /*----------.
@@ -1140,43 +1041,36 @@ int yynerrs;
 int
 yyparse (void)
 {
-    int yystate;
+    yy_state_fast_t yystate = 0;
     /* Number of tokens to shift before error messages enabled.  */
-    int yyerrstatus;
+    int yyerrstatus = 0;
 
-    /* The stacks and their tools:
-       'yyss': related to states.
-       'yyvs': related to semantic values.
-
-       Refer to the stacks through separate pointers, to allow yyoverflow
+    /* Refer to the stacks through separate pointers, to allow yyoverflow
        to reallocate them elsewhere.  */
 
-    /* The state stack.  */
-    yytype_int16 yyssa[YYINITDEPTH];
-    yytype_int16 *yyss;
-    yytype_int16 *yyssp;
+    /* Their size.  */
+    YYPTRDIFF_T yystacksize = YYINITDEPTH;
 
-    /* The semantic value stack.  */
+    /* The state stack: array, bottom, top.  */
+    yy_state_t yyssa[YYINITDEPTH];
+    yy_state_t *yyss = yyssa;
+    yy_state_t *yyssp = yyss;
+
+    /* The semantic value stack: array, bottom, top.  */
     YYSTYPE yyvsa[YYINITDEPTH];
-    YYSTYPE *yyvs;
-    YYSTYPE *yyvsp;
-
-    YYSIZE_T yystacksize;
+    YYSTYPE *yyvs = yyvsa;
+    YYSTYPE *yyvsp = yyvs;
 
   int yyn;
+  /* The return value of yyparse.  */
   int yyresult;
-  /* Lookahead token as an internal (translated) token number.  */
-  int yytoken = 0;
+  /* Lookahead symbol kind.  */
+  yysymbol_kind_t yytoken = YYSYMBOL_YYEMPTY;
   /* The variables used to return semantic value and location from the
      action routines.  */
   YYSTYPE yyval;
 
-#if YYERROR_VERBOSE
-  /* Buffer for error messages, and its allocated size.  */
-  char yymsgbuf[128];
-  char *yymsg = yymsgbuf;
-  YYSIZE_T yymsg_alloc = sizeof yymsgbuf;
-#endif
+
 
 #define YYPOPSTACK(N)   (yyvsp -= (N), yyssp -= (N))
 
@@ -1184,71 +1078,75 @@ yyparse (void)
      Keep to zero when no symbol should be popped.  */
   int yylen = 0;
 
-  yyssp = yyss = yyssa;
-  yyvsp = yyvs = yyvsa;
-  yystacksize = YYINITDEPTH;
-
   YYDPRINTF ((stderr, "Starting parse\n"));
 
-  yystate = 0;
-  yyerrstatus = 0;
-  yynerrs = 0;
   yychar = YYEMPTY; /* Cause a token to be read.  */
+
   goto yysetstate;
 
+
 /*------------------------------------------------------------.
-| yynewstate -- Push a new state, which is found in yystate.  |
+| yynewstate -- push a new state, which is found in yystate.  |
 `------------------------------------------------------------*/
- yynewstate:
+yynewstate:
   /* In all cases, when you get here, the value and location stacks
      have just been pushed.  So pushing a state here evens the stacks.  */
   yyssp++;
 
- yysetstate:
-  *yyssp = yystate;
+
+/*--------------------------------------------------------------------.
+| yysetstate -- set current state (the top of the stack) to yystate.  |
+`--------------------------------------------------------------------*/
+yysetstate:
+  YYDPRINTF ((stderr, "Entering state %d\n", yystate));
+  YY_ASSERT (0 <= yystate && yystate < YYNSTATES);
+  YY_IGNORE_USELESS_CAST_BEGIN
+  *yyssp = YY_CAST (yy_state_t, yystate);
+  YY_IGNORE_USELESS_CAST_END
+  YY_STACK_PRINT (yyss, yyssp);
 
   if (yyss + yystacksize - 1 <= yyssp)
+#if !defined yyoverflow && !defined YYSTACK_RELOCATE
+    YYNOMEM;
+#else
     {
       /* Get the current used size of the three stacks, in elements.  */
-      YYSIZE_T yysize = yyssp - yyss + 1;
+      YYPTRDIFF_T yysize = yyssp - yyss + 1;
 
-#ifdef yyoverflow
+# if defined yyoverflow
       {
         /* Give user a chance to reallocate the stack.  Use copies of
            these so that the &'s don't force the real ones into
            memory.  */
+        yy_state_t *yyss1 = yyss;
         YYSTYPE *yyvs1 = yyvs;
-        yytype_int16 *yyss1 = yyss;
 
         /* Each stack pointer address is followed by the size of the
            data in use in that stack, in bytes.  This used to be a
            conditional around just the two extra args, but that might
            be undefined if yyoverflow is a macro.  */
         yyoverflow (YY_("memory exhausted"),
-                    &yyss1, yysize * sizeof (*yyssp),
-                    &yyvs1, yysize * sizeof (*yyvsp),
+                    &yyss1, yysize * YYSIZEOF (*yyssp),
+                    &yyvs1, yysize * YYSIZEOF (*yyvsp),
                     &yystacksize);
-
         yyss = yyss1;
         yyvs = yyvs1;
       }
-#else /* no yyoverflow */
-# ifndef YYSTACK_RELOCATE
-      goto yyexhaustedlab;
-# else
+# else /* defined YYSTACK_RELOCATE */
       /* Extend the stack our own way.  */
       if (YYMAXDEPTH <= yystacksize)
-        goto yyexhaustedlab;
+        YYNOMEM;
       yystacksize *= 2;
       if (YYMAXDEPTH < yystacksize)
         yystacksize = YYMAXDEPTH;
 
       {
-        yytype_int16 *yyss1 = yyss;
+        yy_state_t *yyss1 = yyss;
         union yyalloc *yyptr =
-          (union yyalloc *) YYSTACK_ALLOC (YYSTACK_BYTES (yystacksize));
+          YY_CAST (union yyalloc *,
+                   YYSTACK_ALLOC (YY_CAST (YYSIZE_T, YYSTACK_BYTES (yystacksize))));
         if (! yyptr)
-          goto yyexhaustedlab;
+          YYNOMEM;
         YYSTACK_RELOCATE (yyss_alloc, yyss);
         YYSTACK_RELOCATE (yyvs_alloc, yyvs);
 #  undef YYSTACK_RELOCATE
@@ -1256,30 +1154,31 @@ yyparse (void)
           YYSTACK_FREE (yyss1);
       }
 # endif
-#endif /* no yyoverflow */
 
       yyssp = yyss + yysize - 1;
       yyvsp = yyvs + yysize - 1;
 
-      YYDPRINTF ((stderr, "Stack size increased to %lu\n",
-                  (unsigned long int) yystacksize));
+      YY_IGNORE_USELESS_CAST_BEGIN
+      YYDPRINTF ((stderr, "Stack size increased to %ld\n",
+                  YY_CAST (long, yystacksize)));
+      YY_IGNORE_USELESS_CAST_END
 
       if (yyss + yystacksize - 1 <= yyssp)
         YYABORT;
     }
+#endif /* !defined yyoverflow && !defined YYSTACK_RELOCATE */
 
-  YYDPRINTF ((stderr, "Entering state %d\n", yystate));
 
   if (yystate == YYFINAL)
     YYACCEPT;
 
   goto yybackup;
 
+
 /*-----------.
 | yybackup.  |
 `-----------*/
 yybackup:
-
   /* Do appropriate processing given the current state.  Read a
      lookahead token if we need one and don't already have one.  */
 
@@ -1290,17 +1189,28 @@ yybackup:
 
   /* Not known => get a lookahead token if don't already have one.  */
 
-  /* YYCHAR is either YYEMPTY or YYEOF or a valid lookahead symbol.  */
+  /* YYCHAR is either empty, or end-of-input, or a valid lookahead.  */
   if (yychar == YYEMPTY)
     {
-      YYDPRINTF ((stderr, "Reading a token: "));
+      YYDPRINTF ((stderr, "Reading a token\n"));
       yychar = yylex ();
     }
 
   if (yychar <= YYEOF)
     {
-      yychar = yytoken = YYEOF;
+      yychar = YYEOF;
+      yytoken = YYSYMBOL_YYEOF;
       YYDPRINTF ((stderr, "Now at end of input.\n"));
+    }
+  else if (yychar == YYerror)
+    {
+      /* The scanner already issued an error message, process directly
+         to error recovery.  But do not keep the error token as
+         lookahead, it is too special and may lead us to an endless
+         loop in error recovery. */
+      yychar = YYUNDEF;
+      yytoken = YYSYMBOL_YYerror;
+      goto yyerrlab1;
     }
   else
     {
@@ -1329,15 +1239,13 @@ yybackup:
 
   /* Shift the lookahead token.  */
   YY_SYMBOL_PRINT ("Shifting", yytoken, &yylval, &yylloc);
-
-  /* Discard the shifted token.  */
-  yychar = YYEMPTY;
-
   yystate = yyn;
   YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
   *++yyvsp = yylval;
   YY_IGNORE_MAYBE_UNINITIALIZED_END
 
+  /* Discard the shifted token.  */
+  yychar = YYEMPTY;
   goto yynewstate;
 
 
@@ -1352,7 +1260,7 @@ yydefault:
 
 
 /*-----------------------------.
-| yyreduce -- Do a reduction.  |
+| yyreduce -- do a reduction.  |
 `-----------------------------*/
 yyreduce:
   /* yyn is the number of a rule to reduce with.  */
@@ -1372,45 +1280,45 @@ yyreduce:
   YY_REDUCE_PRINT (yyn);
   switch (yyn)
     {
-        case 2:
-#line 117 "ncgen.y" /* yacc.c:1646  */
-    { init_netcdf(); }
-#line 1379 "ncgeny.c" /* yacc.c:1646  */
+  case 2: /* $@1: %empty  */
+#line 117 "ncgen3/ncgen.y"
+                   { init_netcdf(); }
+#line 1287 "ncgeny.c"
     break;
 
-  case 3:
-#line 120 "ncgen.y" /* yacc.c:1646  */
-    {
+  case 3: /* $@2: %empty  */
+#line 120 "ncgen3/ncgen.y"
+                   {
 		       if (derror_count == 0)
 			 define_netcdf(netcdfname);
 		       if (derror_count > 0)
 			   exit(6);
 		   }
-#line 1390 "ncgeny.c" /* yacc.c:1646  */
+#line 1298 "ncgeny.c"
     break;
 
-  case 4:
-#line 128 "ncgen.y" /* yacc.c:1646  */
-    {
+  case 4: /* ncdesc: NETCDF '{' $@1 dimsection vasection $@2 datasection '}'  */
+#line 128 "ncgen3/ncgen.y"
+                   {
 		       if (derror_count == 0)
 			 close_netcdf();
 		   }
-#line 1399 "ncgeny.c" /* yacc.c:1646  */
+#line 1307 "ncgeny.c"
     break;
 
-  case 11:
-#line 143 "ncgen.y" /* yacc.c:1646  */
-    { if (int_val <= 0)
+  case 11: /* dimdecl: dimd '=' INT_CONST  */
+#line 143 "ncgen3/ncgen.y"
+                   { if (int_val <= 0)
 			 derror("dimension length must be positive");
 		     dims[ndims].size = int_val;
 		     ndims++;
 		   }
-#line 1409 "ncgeny.c" /* yacc.c:1646  */
+#line 1317 "ncgeny.c"
     break;
 
-  case 12:
-#line 149 "ncgen.y" /* yacc.c:1646  */
-    { /* for rare case where 2^31 < dimsize < 2^32 */
+  case 12: /* dimdecl: dimd '=' DOUBLE_CONST  */
+#line 149 "ncgen3/ncgen.y"
+                   { /* for rare case where 2^31 < dimsize < 2^32 */
 		       if (double_val <= 0)
 			 derror("dimension length must be positive");
 		       if (double_val > 4294967295.0)
@@ -1420,79 +1328,79 @@ yyreduce:
 		       dims[ndims].size = (size_t) double_val;
 		       ndims++;
                    }
-#line 1424 "ncgeny.c" /* yacc.c:1646  */
+#line 1332 "ncgeny.c"
     break;
 
-  case 13:
-#line 160 "ncgen.y" /* yacc.c:1646  */
-    {  if (rec_dim != -1)
+  case 13: /* dimdecl: dimd '=' NC_UNLIMITED_K  */
+#line 160 "ncgen3/ncgen.y"
+                   {  if (rec_dim != -1)
 			 derror("only one NC_UNLIMITED dimension allowed");
 		     rec_dim = ndims; /* the unlimited (record) dimension */
 		     dims[ndims].size = NC_UNLIMITED;
 		     ndims++;
 		   }
-#line 1435 "ncgeny.c" /* yacc.c:1646  */
+#line 1343 "ncgeny.c"
     break;
 
-  case 14:
-#line 168 "ncgen.y" /* yacc.c:1646  */
-    {
-		    if ((yyvsp[0])->is_dim == 1) {
+  case 14: /* dimd: dim  */
+#line 168 "ncgen3/ncgen.y"
+                   {
+		    if (yyvsp[0]->is_dim == 1) {
 		        derror( "duplicate dimension declaration for %s",
-		                (yyvsp[0])->name);
+		                yyvsp[0]->name);
 		     }
-	             (yyvsp[0])->is_dim = 1;
-		     (yyvsp[0])->dnum = ndims;
+	             yyvsp[0]->is_dim = 1;
+		     yyvsp[0]->dnum = ndims;
 		     /* make sure dims array will hold dimensions */
 		     grow_darray(ndims,  /* must hold ndims+1 dims */
 				 &dims); /* grow as needed */
-		     dims[ndims].name = (char *) emalloc(strlen((yyvsp[0])->name)+1);
-		     (void) strcpy(dims[ndims].name, (yyvsp[0])->name);
+		     dims[ndims].name = (char *) emalloc(strlen(yyvsp[0]->name)+1);
+		     (void) strcpy(dims[ndims].name, yyvsp[0]->name);
 		     /* name for use in generated Fortran and C variables */
-		     dims[ndims].lname = decodify((yyvsp[0])->name);
+		     dims[ndims].lname = decodify(yyvsp[0]->name);
 		   }
-#line 1455 "ncgeny.c" /* yacc.c:1646  */
+#line 1363 "ncgeny.c"
     break;
 
-  case 27:
-#line 200 "ncgen.y" /* yacc.c:1646  */
-    { type_code = NC_BYTE; }
-#line 1461 "ncgeny.c" /* yacc.c:1646  */
+  case 27: /* type: BYTE_K  */
+#line 200 "ncgen3/ncgen.y"
+                          { type_code = NC_BYTE; }
+#line 1369 "ncgeny.c"
     break;
 
-  case 28:
-#line 201 "ncgen.y" /* yacc.c:1646  */
-    { type_code = NC_CHAR; }
-#line 1467 "ncgeny.c" /* yacc.c:1646  */
+  case 28: /* type: CHAR_K  */
+#line 201 "ncgen3/ncgen.y"
+                          { type_code = NC_CHAR; }
+#line 1375 "ncgeny.c"
     break;
 
-  case 29:
-#line 202 "ncgen.y" /* yacc.c:1646  */
-    { type_code = NC_SHORT; }
-#line 1473 "ncgeny.c" /* yacc.c:1646  */
+  case 29: /* type: SHORT_K  */
+#line 202 "ncgen3/ncgen.y"
+                          { type_code = NC_SHORT; }
+#line 1381 "ncgeny.c"
     break;
 
-  case 30:
-#line 203 "ncgen.y" /* yacc.c:1646  */
-    { type_code = NC_INT; }
-#line 1479 "ncgeny.c" /* yacc.c:1646  */
+  case 30: /* type: INT_K  */
+#line 203 "ncgen3/ncgen.y"
+                          { type_code = NC_INT; }
+#line 1387 "ncgeny.c"
     break;
 
-  case 31:
-#line 204 "ncgen.y" /* yacc.c:1646  */
-    { type_code = NC_FLOAT; }
-#line 1485 "ncgeny.c" /* yacc.c:1646  */
+  case 31: /* type: FLOAT_K  */
+#line 204 "ncgen3/ncgen.y"
+                          { type_code = NC_FLOAT; }
+#line 1393 "ncgeny.c"
     break;
 
-  case 32:
-#line 205 "ncgen.y" /* yacc.c:1646  */
-    { type_code = NC_DOUBLE; }
-#line 1491 "ncgeny.c" /* yacc.c:1646  */
+  case 32: /* type: DOUBLE_K  */
+#line 205 "ncgen3/ncgen.y"
+                          { type_code = NC_DOUBLE; }
+#line 1399 "ncgeny.c"
     break;
 
-  case 35:
-#line 211 "ncgen.y" /* yacc.c:1646  */
-    {
+  case 35: /* $@3: %empty  */
+#line 211 "ncgen3/ncgen.y"
+                   {
 		    static struct vars dummyvar;
 
 		    dummyvar.name = "dummy";
@@ -1504,49 +1412,49 @@ yyreduce:
 
 		    nvdims = 0;
 		    /* make sure variable not re-declared */
-		    if ((yyvsp[0])->is_var == 1) {
+		    if (yyvsp[0]->is_var == 1) {
 		       derror( "duplicate variable declaration for %s",
-		               (yyvsp[0])->name);
+		               yyvsp[0]->name);
 		    }
-	            (yyvsp[0])->is_var = 1;
-		    (yyvsp[0])->vnum = nvars;
+	            yyvsp[0]->is_var = 1;
+		    yyvsp[0]->vnum = nvars;
 		    /* make sure vars array will hold variables */
 		    grow_varray(nvars,  /* must hold nvars+1 vars */
 				&vars); /* grow as needed */
 		    vars[nvars] = dummyvar; /* to make Purify happy */
-		    vars[nvars].name = (char *) emalloc(strlen((yyvsp[0])->name)+1);
-		    (void) strcpy(vars[nvars].name, (yyvsp[0])->name);
+		    vars[nvars].name = (char *) emalloc(strlen(yyvsp[0]->name)+1);
+		    (void) strcpy(vars[nvars].name, yyvsp[0]->name);
 		    /* name for use in generated Fortran and C variables */
-		    vars[nvars].lname = decodify((yyvsp[0])->name);
+		    vars[nvars].lname = decodify(yyvsp[0]->name);
 		    vars[nvars].type = type_code;
 		    /* set default fill value.  You can override this with
 		     * the variable attribute "_FillValue". */
 		    nc_getfill(type_code, &vars[nvars].fill_value);
 		    vars[nvars].has_data = 0; /* has no data (yet) */
 		   }
-#line 1528 "ncgeny.c" /* yacc.c:1646  */
+#line 1436 "ncgeny.c"
     break;
 
-  case 36:
-#line 244 "ncgen.y" /* yacc.c:1646  */
-    {
+  case 36: /* varspec: var $@3 dimspec  */
+#line 244 "ncgen3/ncgen.y"
+                   {
 		    vars[nvars].ndims = nvdims;
 		    nvars++;
 		   }
-#line 1537 "ncgeny.c" /* yacc.c:1646  */
+#line 1445 "ncgeny.c"
     break;
 
-  case 42:
-#line 258 "ncgen.y" /* yacc.c:1646  */
-    {
+  case 42: /* vdim: dim  */
+#line 258 "ncgen3/ncgen.y"
+                   {
 		    if (nvdims >= NC_MAX_VAR_DIMS) {
 		       derror("%s has too many dimensions",vars[nvars].name);
 		    }
-		    if ((yyvsp[0])->is_dim == 1)
-		       dimnum = (yyvsp[0])->dnum;
+		    if (yyvsp[0]->is_dim == 1)
+		       dimnum = yyvsp[0]->dnum;
 		    else {
 		       derror( "%s is not declared as a dimension",
-			       (yyvsp[0])->name);
+			       yyvsp[0]->name);
 	               dimnum = ndims;
 		    }
 		    if (rec_dim != -1 && dimnum == rec_dim && nvdims != 0) {
@@ -1557,100 +1465,100 @@ yyreduce:
 		    vars[nvars].dims[nvdims] = dimnum;
                     nvdims++;
 		   }
-#line 1561 "ncgeny.c" /* yacc.c:1646  */
+#line 1469 "ncgeny.c"
     break;
 
-  case 43:
-#line 279 "ncgen.y" /* yacc.c:1646  */
-    {
+  case 43: /* $@4: %empty  */
+#line 279 "ncgen3/ncgen.y"
+                   {
                    defatt();
 		   }
-#line 1569 "ncgeny.c" /* yacc.c:1646  */
+#line 1477 "ncgeny.c"
     break;
 
-  case 44:
-#line 283 "ncgen.y" /* yacc.c:1646  */
-    {
+  case 44: /* attdecl: att $@4 '=' attvallist  */
+#line 283 "ncgen3/ncgen.y"
+                   {
                    equalatt();
 		   }
-#line 1577 "ncgeny.c" /* yacc.c:1646  */
+#line 1485 "ncgeny.c"
     break;
 
-  case 45:
-#line 288 "ncgen.y" /* yacc.c:1646  */
-    {
+  case 45: /* $@5: %empty  */
+#line 288 "ncgen3/ncgen.y"
+                   {
                    defatt();
 		   }
-#line 1585 "ncgeny.c" /* yacc.c:1646  */
+#line 1493 "ncgeny.c"
     break;
 
-  case 46:
-#line 292 "ncgen.y" /* yacc.c:1646  */
-    {
+  case 46: /* gattdecl: gatt $@5 '=' attvallist  */
+#line 292 "ncgen3/ncgen.y"
+                   {
                    equalatt();
 		   }
-#line 1593 "ncgeny.c" /* yacc.c:1646  */
+#line 1501 "ncgeny.c"
     break;
 
-  case 48:
-#line 300 "ncgen.y" /* yacc.c:1646  */
-    {
+  case 48: /* gatt: ':' attr  */
+#line 300 "ncgen3/ncgen.y"
+                   {
 		    varnum = NC_GLOBAL;  /* handle of "global" attribute */
 		   }
-#line 1601 "ncgeny.c" /* yacc.c:1646  */
+#line 1509 "ncgeny.c"
     break;
 
-  case 49:
-#line 306 "ncgen.y" /* yacc.c:1646  */
-    { if ((yyvsp[0])->is_var == 1)
-		       varnum = (yyvsp[0])->vnum;
+  case 49: /* avar: var  */
+#line 306 "ncgen3/ncgen.y"
+                   { if (yyvsp[0]->is_var == 1)
+		       varnum = yyvsp[0]->vnum;
 		    else {
 		      derror("%s not declared as a variable, fatal error",
-			     (yyvsp[0])->name);
+			     yyvsp[0]->name);
 		      YYABORT;
 		      }
 		   }
-#line 1614 "ncgeny.c" /* yacc.c:1646  */
+#line 1522 "ncgeny.c"
     break;
 
-  case 50:
-#line 316 "ncgen.y" /* yacc.c:1646  */
-    {
+  case 50: /* attr: IDENT  */
+#line 316 "ncgen3/ncgen.y"
+                   {
 		       /* make sure atts array will hold attributes */
 		       grow_aarray(natts,  /* must hold natts+1 atts */
 				   &atts); /* grow as needed */
-		       atts[natts].name = (char *) emalloc(strlen((yyvsp[0])->name)+1);
-		       (void) strcpy(atts[natts].name,(yyvsp[0])->name);
+		       atts[natts].name = (char *) emalloc(strlen(yyvsp[0]->name)+1);
+		       (void) strcpy(atts[natts].name,yyvsp[0]->name);
 		       /* name for use in generated Fortran and C variables */
-		       atts[natts].lname = decodify((yyvsp[0])->name);
+		       atts[natts].lname = decodify(yyvsp[0]->name);
 		   }
-#line 1628 "ncgeny.c" /* yacc.c:1646  */
+#line 1536 "ncgeny.c"
     break;
 
-  case 53:
-#line 330 "ncgen.y" /* yacc.c:1646  */
-    {
+  case 53: /* aconst: attconst  */
+#line 330 "ncgen3/ncgen.y"
+                   {
 		    if (valtype == NC_UNSPECIFIED)
 		      valtype = atype_code;
 		    if (valtype != atype_code)
 		      derror("values for attribute must be all of same type");
 		   }
-#line 1639 "ncgeny.c" /* yacc.c:1646  */
+#line 1547 "ncgeny.c"
     break;
 
-  case 54:
-#line 339 "ncgen.y" /* yacc.c:1646  */
-    {
+  case 54: /* attconst: CHAR_CONST  */
+#line 339 "ncgen3/ncgen.y"
+                   {
 		       atype_code = NC_CHAR;
 		       *char_valp++ = char_val;
 		       valnum++;
 		   }
-#line 1649 "ncgeny.c" /* yacc.c:1646  */
+#line 1557 "ncgeny.c"
     break;
 
-  case 55:
-#line 345 "ncgen.y" /* yacc.c:1646  */
-    {
+  case 55: /* attconst: TERMSTRING  */
+#line 345 "ncgen3/ncgen.y"
+                   {
 		       atype_code = NC_CHAR;
 		       {
 			   /* don't null-terminate attribute strings */
@@ -1662,62 +1570,62 @@ yyreduce:
 			   char_valp += len;
 		       }
 		   }
-#line 1666 "ncgeny.c" /* yacc.c:1646  */
+#line 1574 "ncgeny.c"
     break;
 
-  case 56:
-#line 358 "ncgen.y" /* yacc.c:1646  */
-    {
+  case 56: /* attconst: BYTE_CONST  */
+#line 358 "ncgen3/ncgen.y"
+                   {
 		       atype_code = NC_BYTE;
 		       *byte_valp++ = byte_val;
 		       valnum++;
 		   }
-#line 1676 "ncgeny.c" /* yacc.c:1646  */
+#line 1584 "ncgeny.c"
     break;
 
-  case 57:
-#line 364 "ncgen.y" /* yacc.c:1646  */
-    {
+  case 57: /* attconst: SHORT_CONST  */
+#line 364 "ncgen3/ncgen.y"
+                   {
 		       atype_code = NC_SHORT;
 		       *short_valp++ = short_val;
 		       valnum++;
 		   }
-#line 1686 "ncgeny.c" /* yacc.c:1646  */
+#line 1594 "ncgeny.c"
     break;
 
-  case 58:
-#line 370 "ncgen.y" /* yacc.c:1646  */
-    {
+  case 58: /* attconst: INT_CONST  */
+#line 370 "ncgen3/ncgen.y"
+                   {
 		       atype_code = NC_INT;
 		       *int_valp++ = int_val;
 		       valnum++;
 		   }
-#line 1696 "ncgeny.c" /* yacc.c:1646  */
+#line 1604 "ncgeny.c"
     break;
 
-  case 59:
-#line 376 "ncgen.y" /* yacc.c:1646  */
-    {
+  case 59: /* attconst: FLOAT_CONST  */
+#line 376 "ncgen3/ncgen.y"
+                   {
 		       atype_code = NC_FLOAT;
 		       *float_valp++ = float_val;
 		       valnum++;
 		   }
-#line 1706 "ncgeny.c" /* yacc.c:1646  */
+#line 1614 "ncgeny.c"
     break;
 
-  case 60:
-#line 382 "ncgen.y" /* yacc.c:1646  */
-    {
+  case 60: /* attconst: DOUBLE_CONST  */
+#line 382 "ncgen3/ncgen.y"
+                   {
 		       atype_code = NC_DOUBLE;
 		       *double_valp++ = double_val;
 		       valnum++;
 		   }
-#line 1716 "ncgeny.c" /* yacc.c:1646  */
+#line 1624 "ncgeny.c"
     break;
 
-  case 66:
-#line 398 "ncgen.y" /* yacc.c:1646  */
-    {
+  case 66: /* $@6: %empty  */
+#line 398 "ncgen3/ncgen.y"
+                   {
 		       valtype = vars[varnum].type; /* variable type */
 		       valnum = 0;	/* values accumulated for variable */
 		       vars[varnum].has_data = 1;
@@ -1767,12 +1675,12 @@ yyreduce:
 			 default: break;
 		       }
 		 }
-#line 1771 "ncgeny.c" /* yacc.c:1646  */
+#line 1679 "ncgeny.c"
     break;
 
-  case 67:
-#line 449 "ncgen.y" /* yacc.c:1646  */
-    {
+  case 67: /* datadecl: avar $@6 '=' constlist  */
+#line 449 "ncgen3/ncgen.y"
+                   {
 		       if (valnum < var_len) { /* leftovers */
 			   nc_fill(valtype,
 				    var_len - valnum,
@@ -1786,12 +1694,12 @@ yyreduce:
 			   put_variable(rec_start);
 		       free ((char *) rec_start);
 		 }
-#line 1790 "ncgeny.c" /* yacc.c:1646  */
+#line 1698 "ncgeny.c"
     break;
 
-  case 70:
-#line 468 "ncgen.y" /* yacc.c:1646  */
-    {
+  case 70: /* $@7: %empty  */
+#line 468 "ncgen3/ncgen.y"
+                   {
 		       if(valnum >= var_len) {
 			   if (vars[varnum].dims[0] != rec_dim) { /* not recvar */
 			       derror("too many values for this variable, %d >= %d",
@@ -1815,12 +1723,12 @@ yyreduce:
 		       }
 		       not_a_string = 1;
                    }
-#line 1819 "ncgeny.c" /* yacc.c:1646  */
+#line 1727 "ncgeny.c"
     break;
 
-  case 71:
-#line 493 "ncgen.y" /* yacc.c:1646  */
-    {
+  case 71: /* dconst: $@7 const  */
+#line 493 "ncgen3/ncgen.y"
+                   {
 		       if (not_a_string) {
 			   switch (valtype) {
 			     case NC_CHAR:
@@ -1845,12 +1753,12 @@ yyreduce:
 			   }
 		       }
 		   }
-#line 1849 "ncgeny.c" /* yacc.c:1646  */
+#line 1757 "ncgeny.c"
     break;
 
-  case 72:
-#line 521 "ncgen.y" /* yacc.c:1646  */
-    {
+  case 72: /* const: CHAR_CONST  */
+#line 521 "ncgen3/ncgen.y"
+                   {
 		       atype_code = NC_CHAR;
 		       switch (valtype) {
 			 case NC_CHAR:
@@ -1875,12 +1783,12 @@ yyreduce:
 		       }
 		       valnum++;
 		   }
-#line 1879 "ncgeny.c" /* yacc.c:1646  */
+#line 1787 "ncgeny.c"
     break;
 
-  case 73:
-#line 547 "ncgen.y" /* yacc.c:1646  */
-    {
+  case 73: /* const: TERMSTRING  */
+#line 547 "ncgen3/ncgen.y"
+                   {
 		       not_a_string = 0;
 		       atype_code = NC_CHAR;
 		       {
@@ -1934,12 +1842,12 @@ yyreduce:
 			   }
 		       }
 		   }
-#line 1938 "ncgeny.c" /* yacc.c:1646  */
+#line 1846 "ncgeny.c"
     break;
 
-  case 74:
-#line 602 "ncgen.y" /* yacc.c:1646  */
-    {
+  case 74: /* const: BYTE_CONST  */
+#line 602 "ncgen3/ncgen.y"
+                   {
 		       atype_code = NC_BYTE;
 		       switch (valtype) {
 			 case NC_CHAR:
@@ -1964,12 +1872,12 @@ yyreduce:
 		       }
 		       valnum++;
 		   }
-#line 1968 "ncgeny.c" /* yacc.c:1646  */
+#line 1876 "ncgeny.c"
     break;
 
-  case 75:
-#line 628 "ncgen.y" /* yacc.c:1646  */
-    {
+  case 75: /* const: SHORT_CONST  */
+#line 628 "ncgen3/ncgen.y"
+                   {
 		       atype_code = NC_SHORT;
 		       switch (valtype) {
 			 case NC_CHAR:
@@ -1994,12 +1902,12 @@ yyreduce:
 		       }
 		       valnum++;
 		   }
-#line 1998 "ncgeny.c" /* yacc.c:1646  */
+#line 1906 "ncgeny.c"
     break;
 
-  case 76:
-#line 654 "ncgen.y" /* yacc.c:1646  */
-    {
+  case 76: /* const: INT_CONST  */
+#line 654 "ncgen3/ncgen.y"
+                   {
 		       atype_code = NC_INT;
 		       switch (valtype) {
 			 case NC_CHAR:
@@ -2024,12 +1932,12 @@ yyreduce:
 		       }
 		       valnum++;
 		   }
-#line 2028 "ncgeny.c" /* yacc.c:1646  */
+#line 1936 "ncgeny.c"
     break;
 
-  case 77:
-#line 680 "ncgen.y" /* yacc.c:1646  */
-    {
+  case 77: /* const: FLOAT_CONST  */
+#line 680 "ncgen3/ncgen.y"
+                   {
 		       atype_code = NC_FLOAT;
 		       switch (valtype) {
 			 case NC_CHAR:
@@ -2054,12 +1962,12 @@ yyreduce:
 		       }
 		       valnum++;
 		   }
-#line 2058 "ncgeny.c" /* yacc.c:1646  */
+#line 1966 "ncgeny.c"
     break;
 
-  case 78:
-#line 706 "ncgen.y" /* yacc.c:1646  */
-    {
+  case 78: /* const: DOUBLE_CONST  */
+#line 706 "ncgen3/ncgen.y"
+                   {
 		       atype_code = NC_DOUBLE;
 		       switch (valtype) {
 			 case NC_CHAR:
@@ -2087,12 +1995,12 @@ yyreduce:
 		       }
 		       valnum++;
 		   }
-#line 2091 "ncgeny.c" /* yacc.c:1646  */
+#line 1999 "ncgeny.c"
     break;
 
-  case 79:
-#line 735 "ncgen.y" /* yacc.c:1646  */
-    {
+  case 79: /* const: FILLVALUE  */
+#line 735 "ncgen3/ncgen.y"
+                   {
 		       /* store fill_value */
 		       switch (valtype) {
 		       case NC_CHAR:
@@ -2123,11 +2031,12 @@ yyreduce:
 		       }
 		       valnum++;
 		   }
-#line 2127 "ncgeny.c" /* yacc.c:1646  */
+#line 2035 "ncgeny.c"
     break;
 
 
-#line 2131 "ncgeny.c" /* yacc.c:1646  */
+#line 2039 "ncgeny.c"
+
       default: break;
     }
   /* User semantic actions sometimes alter yychar, and that requires
@@ -2141,25 +2050,23 @@ yyreduce:
      case of YYERROR or YYBACKUP, subsequent parser actions might lead
      to an incorrect destructor call or verbose syntax error message
      before the lookahead is translated.  */
-  YY_SYMBOL_PRINT ("-> $$ =", yyr1[yyn], &yyval, &yyloc);
+  YY_SYMBOL_PRINT ("-> $$ =", YY_CAST (yysymbol_kind_t, yyr1[yyn]), &yyval, &yyloc);
 
   YYPOPSTACK (yylen);
   yylen = 0;
-  YY_STACK_PRINT (yyss, yyssp);
 
   *++yyvsp = yyval;
 
   /* Now 'shift' the result of the reduction.  Determine what state
      that goes to, based on the state we popped back to and the rule
      number reduced by.  */
-
-  yyn = yyr1[yyn];
-
-  yystate = yypgoto[yyn - YYNTOKENS] + *yyssp;
-  if (0 <= yystate && yystate <= YYLAST && yycheck[yystate] == *yyssp)
-    yystate = yytable[yystate];
-  else
-    yystate = yydefgoto[yyn - YYNTOKENS];
+  {
+    const int yylhs = yyr1[yyn] - YYNTOKENS;
+    const int yyi = yypgoto[yylhs] + *yyssp;
+    yystate = (0 <= yyi && yyi <= YYLAST && yycheck[yyi] == *yyssp
+               ? yytable[yyi]
+               : yydefgoto[yylhs]);
+  }
 
   goto yynewstate;
 
@@ -2170,49 +2077,13 @@ yyreduce:
 yyerrlab:
   /* Make sure we have latest lookahead translation.  See comments at
      user semantic actions for why this is necessary.  */
-  yytoken = yychar == YYEMPTY ? YYEMPTY : YYTRANSLATE (yychar);
-
+  yytoken = yychar == YYEMPTY ? YYSYMBOL_YYEMPTY : YYTRANSLATE (yychar);
   /* If not already recovering from an error, report this error.  */
   if (!yyerrstatus)
     {
       ++yynerrs;
-#if ! YYERROR_VERBOSE
       yyerror (YY_("syntax error"));
-#else
-# define YYSYNTAX_ERROR yysyntax_error (&yymsg_alloc, &yymsg, \
-                                        yyssp, yytoken)
-      {
-        char const *yymsgp = YY_("syntax error");
-        int yysyntax_error_status;
-        yysyntax_error_status = YYSYNTAX_ERROR;
-        if (yysyntax_error_status == 0)
-          yymsgp = yymsg;
-        else if (yysyntax_error_status == 1)
-          {
-            if (yymsg != yymsgbuf)
-              YYSTACK_FREE (yymsg);
-            yymsg = (char *) YYSTACK_ALLOC (yymsg_alloc);
-            if (!yymsg)
-              {
-                yymsg = yymsgbuf;
-                yymsg_alloc = sizeof yymsgbuf;
-                yysyntax_error_status = 2;
-              }
-            else
-              {
-                yysyntax_error_status = YYSYNTAX_ERROR;
-                yymsgp = yymsg;
-              }
-          }
-        yyerror (yymsgp);
-        if (yysyntax_error_status == 2)
-          goto yyexhaustedlab;
-      }
-# undef YYSYNTAX_ERROR
-#endif
     }
-
-
 
   if (yyerrstatus == 3)
     {
@@ -2242,12 +2113,11 @@ yyerrlab:
 | yyerrorlab -- error raised explicitly by YYERROR.  |
 `---------------------------------------------------*/
 yyerrorlab:
-
-  /* Pacify compilers like GCC when the user code never invokes
-     YYERROR and the label yyerrorlab therefore never appears in user
-     code.  */
-  if (/*CONSTCOND*/ 0)
-     goto yyerrorlab;
+  /* Pacify compilers when the user code never invokes YYERROR and the
+     label yyerrorlab therefore never appears in user code.  */
+  if (0)
+    YYERROR;
+  ++yynerrs;
 
   /* Do not reclaim the symbols of the rule whose action triggered
      this YYERROR.  */
@@ -2264,13 +2134,14 @@ yyerrorlab:
 yyerrlab1:
   yyerrstatus = 3;      /* Each real token shifted decrements this.  */
 
+  /* Pop stack until we find a state that shifts the error token.  */
   for (;;)
     {
       yyn = yypact[yystate];
       if (!yypact_value_is_default (yyn))
         {
-          yyn += YYTERROR;
-          if (0 <= yyn && yyn <= YYLAST && yycheck[yyn] == YYTERROR)
+          yyn += YYSYMBOL_YYerror;
+          if (0 <= yyn && yyn <= YYLAST && yycheck[yyn] == YYSYMBOL_YYerror)
             {
               yyn = yytable[yyn];
               if (0 < yyn)
@@ -2284,7 +2155,7 @@ yyerrlab1:
 
 
       yydestruct ("Error: popping",
-                  yystos[yystate], yyvsp);
+                  YY_ACCESSING_SYMBOL (yystate), yyvsp);
       YYPOPSTACK (1);
       yystate = *yyssp;
       YY_STACK_PRINT (yyss, yyssp);
@@ -2296,7 +2167,7 @@ yyerrlab1:
 
 
   /* Shift the error token.  */
-  YY_SYMBOL_PRINT ("Shifting", yystos[yyn], yyvsp, yylsp);
+  YY_SYMBOL_PRINT ("Shifting", YY_ACCESSING_SYMBOL (yyn), yyvsp, yylsp);
 
   yystate = yyn;
   goto yynewstate;
@@ -2307,26 +2178,30 @@ yyerrlab1:
 `-------------------------------------*/
 yyacceptlab:
   yyresult = 0;
-  goto yyreturn;
+  goto yyreturnlab;
+
 
 /*-----------------------------------.
 | yyabortlab -- YYABORT comes here.  |
 `-----------------------------------*/
 yyabortlab:
   yyresult = 1;
-  goto yyreturn;
+  goto yyreturnlab;
 
-#if !defined yyoverflow || YYERROR_VERBOSE
-/*-------------------------------------------------.
-| yyexhaustedlab -- memory exhaustion comes here.  |
-`-------------------------------------------------*/
+
+/*-----------------------------------------------------------.
+| yyexhaustedlab -- YYNOMEM (memory exhaustion) comes here.  |
+`-----------------------------------------------------------*/
 yyexhaustedlab:
   yyerror (YY_("memory exhausted"));
   yyresult = 2;
-  /* Fall through.  */
-#endif
+  goto yyreturnlab;
 
-yyreturn:
+
+/*----------------------------------------------------------.
+| yyreturnlab -- parsing is finished, clean up and return.  |
+`----------------------------------------------------------*/
+yyreturnlab:
   if (yychar != YYEMPTY)
     {
       /* Make sure we have latest lookahead translation.  See comments at
@@ -2342,20 +2217,18 @@ yyreturn:
   while (yyssp != yyss)
     {
       yydestruct ("Cleanup: popping",
-                  yystos[*yyssp], yyvsp);
+                  YY_ACCESSING_SYMBOL (+*yyssp), yyvsp);
       YYPOPSTACK (1);
     }
 #ifndef yyoverflow
   if (yyss != yyssa)
     YYSTACK_FREE (yyss);
 #endif
-#if YYERROR_VERBOSE
-  if (yymsg != yymsgbuf)
-    YYSTACK_FREE (yymsg);
-#endif
+
   return yyresult;
 }
-#line 770 "ncgen.y" /* yacc.c:1906  */
+
+#line 770 "ncgen3/ncgen.y"
 
 
 /* HELPER PROGRAMS */

--- a/ncgen3/ncgeny.h
+++ b/ncgen3/ncgeny.h
@@ -1,8 +1,9 @@
-/* A Bison parser, made by GNU Bison 3.0.4.  */
+/* A Bison parser, made by GNU Bison 3.8.2.  */
 
 /* Bison interface for Yacc-like parsers in C
 
-   Copyright (C) 1984, 1989-1990, 2000-2015 Free Software Foundation, Inc.
+   Copyright (C) 1984, 1989-1990, 2000-2015, 2018-2021 Free Software Foundation,
+   Inc.
 
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -15,7 +16,7 @@
    GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License
-   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.  */
 
 /* As a special exception, you may create a larger work that contains
    part or all of the Bison parser skeleton and distribute that work
@@ -30,6 +31,10 @@
    This special exception was added by the Free Software Foundation in
    version 2.2 of Bison.  */
 
+/* DO NOT RELY ON FEATURES THAT ARE NOT DOCUMENTED in the manual,
+   especially those whose name start with YY_ or yy_.  They are
+   private implementation details that can be changed or removed.  */
+
 #ifndef YY_NCG_NCGEN_TAB_H_INCLUDED
 # define YY_NCG_NCGEN_TAB_H_INCLUDED
 /* Debug traces.  */
@@ -40,32 +45,37 @@
 extern int ncgdebug;
 #endif
 
-/* Token type.  */
+/* Token kinds.  */
 #ifndef YYTOKENTYPE
 # define YYTOKENTYPE
   enum yytokentype
   {
-    NC_UNLIMITED_K = 258,
-    BYTE_K = 259,
-    CHAR_K = 260,
-    SHORT_K = 261,
-    INT_K = 262,
-    FLOAT_K = 263,
-    DOUBLE_K = 264,
-    IDENT = 265,
-    TERMSTRING = 266,
-    BYTE_CONST = 267,
-    CHAR_CONST = 268,
-    SHORT_CONST = 269,
-    INT_CONST = 270,
-    FLOAT_CONST = 271,
-    DOUBLE_CONST = 272,
-    DIMENSIONS = 273,
-    VARIABLES = 274,
-    NETCDF = 275,
-    DATA = 276,
-    FILLVALUE = 277
+    YYEMPTY = -2,
+    YYEOF = 0,                     /* "end of file"  */
+    YYerror = 256,                 /* error  */
+    YYUNDEF = 257,                 /* "invalid token"  */
+    NC_UNLIMITED_K = 258,          /* NC_UNLIMITED_K  */
+    BYTE_K = 259,                  /* BYTE_K  */
+    CHAR_K = 260,                  /* CHAR_K  */
+    SHORT_K = 261,                 /* SHORT_K  */
+    INT_K = 262,                   /* INT_K  */
+    FLOAT_K = 263,                 /* FLOAT_K  */
+    DOUBLE_K = 264,                /* DOUBLE_K  */
+    IDENT = 265,                   /* IDENT  */
+    TERMSTRING = 266,              /* TERMSTRING  */
+    BYTE_CONST = 267,              /* BYTE_CONST  */
+    CHAR_CONST = 268,              /* CHAR_CONST  */
+    SHORT_CONST = 269,             /* SHORT_CONST  */
+    INT_CONST = 270,               /* INT_CONST  */
+    FLOAT_CONST = 271,             /* FLOAT_CONST  */
+    DOUBLE_CONST = 272,            /* DOUBLE_CONST  */
+    DIMENSIONS = 273,              /* DIMENSIONS  */
+    VARIABLES = 274,               /* VARIABLES  */
+    NETCDF = 275,                  /* NETCDF  */
+    DATA = 276,                    /* DATA  */
+    FILLVALUE = 277                /* FILLVALUE  */
   };
+  typedef enum yytokentype yytoken_kind_t;
 #endif
 
 /* Value type.  */
@@ -78,6 +88,8 @@ typedef int YYSTYPE;
 
 extern YYSTYPE ncglval;
 
+
 int ncgparse (void);
+
 
 #endif /* !YY_NCG_NCGEN_TAB_H_INCLUDED  */


### PR DESCRIPTION
This is a large change due to regenerating the generated files in `ncgen3` using a more recent version of flex/bison