### PR TITLE
Modernize CURL in netCDF cmake

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -218,25 +218,23 @@ endif(USE_HDF5)
 ################################
 # See if we have libcurl
 find_package(CURL)
-target_compile_options(netcdf
-  PRIVATE
-    -DCURL_STATICLIB=1
-)
-target_include_directories(netcdf
-  PRIVATE
-    ${CURL_INCLUDE_DIRS}
-)
-
-
-
-MESSAGE(STATUS "Found CURL_INCLUDE_DIRS: ${CURL_INCLUDE_DIRS}")
-# Define a test flag for have curl library
-if(CURL_LIBRARIES OR CURL_LIBRARY)
+#target_compile_options(netcdf
+#  PRIVATE
+#    -DCURL_STATICLIB=1
+#)
+#target_include_directories(netcdf
+#  PRIVATE
+#    ${CURL_INCLUDE_DIRS}
+#)
+if(CURL_FOUND)
   set(FOUND_CURL TRUE)
+  target_link_libraries(netcdf
+  PRIVATE
+  CURL::libcurl
+)
 else()
   set(FOUND_CURL FALSE)
-endif()
-set(FOUND_CURL ${FOUND_CURL} TRUE )
+endif(CURL_FOUND)
 
 # Start disabling if curl not found
 if(NOT FOUND_CURL)

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -234,6 +234,10 @@ if(CURL_FOUND)
 )
 else()
   set(FOUND_CURL FALSE)
+  set(NETCDF_ENABLE_DAP2 OFF)
+  set(NETCDF_ENABLE_DAP4 OFF)
+  set(NETCDF_ENABLE_BYTERANGE OFF)
+  set(NETCDF_ENABLE_S3 OFF)
 endif(CURL_FOUND)
 
 # Start disabling if curl not found

--- a/libdap2/CMakeLists.txt
+++ b/libdap2/CMakeLists.txt
@@ -27,7 +27,7 @@ set_property(SOURCE ncd2dispatch.c
 add_library(dap2 OBJECT ${dap2_SOURCES})
 
 
-target_link_libraries(dap2 PUBLIC ${CURL_LIBRARIES})
+target_link_libraries(dap2 PUBLIC CURL::libcurl ${CURL_LIBRARIES})
 target_include_directories(dap2 PUBLIC ${CURL_INCLUDE_DIRS})
 target_compile_options(dap2
   PRIVATE

--- a/libdap4/CMakeLists.txt
+++ b/libdap4/CMakeLists.txt
@@ -20,7 +20,7 @@ set_property(SOURCE d4meta.c
     SKIP_UNITY_BUILD_INCLUSION ON)
 
 add_library(dap4 OBJECT ${dap4_SOURCES})
-target_link_libraries(dap4 PUBLIC ${CURL_LIBRARIES})
+target_link_libraries(dap4 PUBLIC CURL::libcurl ${CURL_LIBRARIES})
 target_include_directories(dap4 PUBLIC ${CURL_INCLUDE_DIRS})
 target_compile_options(dap4
   PRIVATE

--- a/liblib/CMakeLists.txt
+++ b/liblib/CMakeLists.txt
@@ -42,6 +42,10 @@ if(USE_HDF4)
   )
 endif()
 
+if(FOUND_CURL)
+  target_link_libraries(netcdf PRIVATE CURL::libcurl)
+endif()
+
 if(NETCDF_ENABLE_DAP2)
   target_sources(netcdf
     PRIVATE
@@ -144,7 +148,7 @@ if(USE_HDF5)
 endif()
 
 if(FOUND_CURL)
-  set(TLL_LIBS ${TLL_LIBS} ${CURL_LIBRARIES})
+  set(TLL_LIBS ${TLL_LIBS} CURL::libcurl ${CURL_LIBRARIES})
 endif()
 
 if(USE_HDF4)

--- a/libsrc/CMakeLists.txt
+++ b/libsrc/CMakeLists.txt
@@ -42,6 +42,7 @@ ENDif (USE_FFIO)
 
 if (NETCDF_ENABLE_BYTERANGE)
   list(APPEND libsrc_SOURCES httpio.c)
+
 if (NETCDF_ENABLE_S3)
   list(APPEND libsrc_SOURCES s3io.c)
 endif(NETCDF_ENABLE_S3)
@@ -55,6 +56,7 @@ endif()
 
 if (NETCDF_ENABLE_BYTERANGE)
   target_include_directories(netcdf3 PUBLIC ${CURL_INCLUDE_DIRS})
+  target_link_libraries(netcdf3 PUBLIC CURL::libcurl)
   target_compile_options(netcdf3
     PRIVATE
       -DCURL_STATICLIB=1

--- a/oc2/CMakeLists.txt
+++ b/oc2/CMakeLists.txt
@@ -15,7 +15,7 @@ endif()
 if(STATUS_PARALLEL)
   target_link_libraries(oc2 PUBLIC MPI::MPI_C)
 endif(STATUS_PARALLEL)
-target_link_libraries(oc2 PUBLIC ${CURL_LIBRARIES})
+target_link_libraries(oc2 PUBLIC CURL::libcurl ${CURL_LIBRARIES})
 target_include_directories(oc2 PUBLIC ${CURL_INCLUDE_DIRS})
 target_compile_options(oc2
   PRIVATE


### PR DESCRIPTION
Bumping to the most recent version of `libcurl` under Windows+Visual Studio unearthed some issues, so I've taken a stab at modernizing the cmake-based infrastructure. The pressure for this release has hit critical mass, so we will be releasing pretty soon, after this and other recent PRs have been reviewed, some documentation gets updated, etc.  We will also be coordinating a Fortran release to happen at/near the same time, followed by a refresh of the C++ interface library.