### PR TITLE
Rename the vendored strlcat symbol

### DIFF
--- a/include/ncconfigure.h
+++ b/include/ncconfigure.h
@@ -69,7 +69,8 @@ char* strdup(const char*);
 
 #ifndef HAVE_STRLCAT
 #ifndef strlcat
-size_t strlcat(char*,const char*,size_t);
+#define strlcat nc_strlcat
+size_t nc_strlcat(char*,const char*,size_t);
 #endif
 #endif
 

--- a/libdispatch/dmissing.c
+++ b/libdispatch/dmissing.c
@@ -117,7 +117,7 @@ strlcpy(char *dst, const char* src, size_t dsize)
  * If retval >= dsize, truncation occurred.
  */
 size_t
-strlcat(char* dst, const char* src, size_t dsize)
+nc_strlcat(char* dst, const char* src, size_t dsize)
 {
 	const char *odst = dst;
 	const char *osrc = src;


### PR DESCRIPTION
This allows to statically link libnetcdf into binaries that already contain this symbol from another location.


Fixes #927