### PR TITLE
Re-introduce targets into netCDFConfig.cmake.in

### DIFF
--- a/netCDFConfig.cmake.in
+++ b/netCDFConfig.cmake.in
@@ -5,7 +5,9 @@
 @PACKAGE_INIT@
 
 set(NetCDFVersion "@PACKAGE_VERSION@")
-
+set_and_check(netCDF_INSTALL_PREFIX "@CMAKE_INSTALL_PREFIX@")
+set_and_check(netCDF_INCLUDE_DIR "@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_INCLUDEDIR@")
+set_and_check(netCDF_LIB_DIR "@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@")
 set(netCDF_LIBRARIES netCDF::netcdf)
 
 # include target information


### PR DESCRIPTION
Changes in `5ee66e87ac52b5c626afefdcd96833c2b055008b` broke netCDF Fortran cmake-based builds.  The fault likes in netCDF-Fortran, undoubtedly, but until we can refresh netCDF Fortran's cmake configuration, we'll need to accommodate that.  This does not appear to introduce any conflicts with `netCDFTargets.cmake`. 