### PR TITLE
changes associated with the removal of the Unidata ftp site.

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -400,9 +400,6 @@ netCDF-4.1.3 with 32- and 64-bit versions, Fortran bindings, and OPeNDAP
 support. The announcement of the availability of that port is
 [here](https://www.unidata.ucar.edu/mailing_lists/archives/netcdfgroup/2011/msg00363.html).
 
-User Veit Eitner has contributed a port of 4.1.1 to Visual Studio,
-including an F90 port to Intel Fortran. Download [source (ftp://ftp.unidata.ucar.edu/pub/netcdf/contrib/win32/netcdf-4.1.1-win32-src.zip)](ftp://ftp.unidata.ucar.edu/pub/netcdf/contrib/win32/netcdf-4.1.1-win32-src.zip) or [binary](https://downloads.unidata.ucar.edu/netcdf-c) versions. This port was done before the code was refactored in 4.1.2.
-
 How can I use netCDF-4 with Windows? {#How-can-I-use-netCDF-4-with-Windows}
 -----------------
 
@@ -418,18 +415,7 @@ utilities and just install them on your system.
 
 Unlike Unix builds, the Visual Studio build **always** requires HDF5,
 zlib, and szlib in all cases. All Windows DLL users must also have the
-HDF5, zlib, and szlib DLLs. These are now available from the Unidata FTP
-site:
-
--   [zlib DLLs for 32-bit Windows](ftp://ftp.unidata.ucar.edu/pub/netcdf/contrib/win32/zlib123-vs2005.zip)
--   [szlib DLLs for 32-bit Windows](ftp://ftp.unidata.ucar.edu/pub/netcdf/contrib/win32/szip21-vs6-enc.zip)
--   [HDF5 DLLs for 32-bit Windows](ftp://ftp.unidata.ucar.edu/pub/netcdf/contrib/win32/5-181-win-vs2005.zip)
-
-Two versions of the netCDF DLLs are available, for different Fortran
-compilers:
-
--   [NetCDF for Intel and Portland Group Fortran compilers.](ftp://ftp.unidata.ucar.edu/pub/netcdf/contrib/win32/win32_vs_PGI_dll_4.0.1.zip)
--   [NetCDF for other Fortran compilers.](ftp://ftp.unidata.ucar.edu/pub/netcdf/contrib/win32/win32_vs_f2c_dll_4.0.1.zip)
+HDF5, zlib, and szlib DLLs. 
 
 To use netCDF, install the DLLs in /system/win32 and the .h files in a
 directory known to your compiler, and define the DLL\_NETCDF
@@ -469,9 +455,6 @@ of the oddities of Windows can be found here:
     Leichter.
 -   [cygwin mailing list explanation of Windows DL requirements.](http://cygwin.com/ml/cygwin/2000-06/msg00688.html)
 -   [-mno-cygwin - Building Mingw executables using Cygwin](http://www.delorie.com/howto/cygwin/mno-cygwin-howto.html)
-
-Once you have the netCDF DLL, you may wish to call it from Visual Basic.
-The [netCDF VB wrapper](ftp://ftp.unidata.ucar.edu/pub/netcdf/contrib/win32/netcdf_vb_net_wrapper.zip) will help you do this.
 
 The SDS ([Scientific DataSet](http://research.microsoft.com/en-us/projects/sds/)) library and tools provide .Net developers a way to read, write and share scalars, vectors, and multidimensional grids using CSV, netCDF, and other file formats. It currently uses netCDF version 4.0.1. In addition to .Net libraries, SDS provides a set of utilities and packages: an sds command line utility, a DataSet Viewer application and an add-in for Microsoft Excel 2007 (and later versions).
 

--- a/docs/attribute_conventions.md
+++ b/docs/attribute_conventions.md
@@ -115,7 +115,7 @@ It is strongly recommended that applicable conventions be followed unless there 
 
 `Conventions`
 
-> If present, 'Conventions' is a global attribute that is a character array for the name of the conventions followed by the dataset. Originally, these conventions were named by a string that was interpreted as a directory name relative to the directory /pub/netcdf/Conventions/ on the host ftp.unidata.ucar.edu. The web page https://www.unidata.ucar.edu/netcdf/conventions.html is now the preferred and authoritative location for registering a URI reference to a set of conventions maintained elsewhere. The FTP site will be preserved for compatibility with existing references, but authors of new conventions should submit a request to support-netcdf@unidata.ucar.edu for listing on the Unidata conventions web page.
+> If present, 'Conventions' is a global attribute that is a character array for the name of the conventions followed by the dataset. Originally, these conventions were named by a string that was interpreted as a directory name relative to the directory /pub/netcdf/Conventions/ on the now defunct host ftp.unidata.ucar.edu. The web page https://www.unidata.ucar.edu/netcdf/conventions.html is now the preferred and authoritative location for registering a URI reference to a set of conventions maintained elsewhere. Authors of new conventions should submit a request to support-netcdf@unidata.ucar.edu for listing on the Unidata conventions web page.
 
 <p>
 

--- a/docs/known_problems.md
+++ b/docs/known_problems.md
@@ -207,8 +207,7 @@ Currently the workarounds are to either
 -   Use netCDF-4.1.2-beta2 or later with HDF5 1.8.6
 
 The HDF5 1.8.5-patch1 release is available from the HDF5 site at
-<http://www.hdfgroup.org/ftp/HDF5/prev-releases/> or from the netCDF-4
-ftp site at <ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-4>.
+<http://www.hdfgroup.org/ftp/HDF5/prev-releases/>.
 
 ### Make tries to regenerate documentation with texi2dvi command {#texi2dvi}
 
@@ -511,8 +510,7 @@ that there is a workaround:
 John Storrs reported a bug using ncdump -v applied to netCDF-4 files, in
 which an erroneous 'group not found' message was displayed for valid
 group/var names. This is fixed in the next release, and the fix is also
-in the [current snapshot
-release](ftp://ftp.unidata.ucar.edu/pub/netcdf/snapshot/).
+in the current snapshot release.
 
 Known Problems with netCDF 4.0
 ------------------------------
@@ -594,8 +592,7 @@ the link flags in the generated Makefiles. Set LDFLAGS to include
 There is a bug in the 4.0 release related to the lengths of dimensions
 when more than one unlimited dimension is used in the same variable.
 
-The bug is fixed in the latest [netCDF-4 snapshot
-release](ftp://ftp.unidata.ucar.edu/pub/netcdf/snapshot/netcdf-4-daily.tar.gz).
+The bug is fixed in the latest netCDF-4 snapshot release.
 
 ### Fortran90 interface Using Intel ifort under Cygwin {#ifort-f90-cygwin}
 
@@ -1245,9 +1242,7 @@ serious bug in using the new large file support in netCDF 3.6.0. Users
 of the new large file facilities are cautioned to either apply [this
 one-line patch to netCDF
 3.6.0](/software/netcdf/patches/patch-3.6.0-cdf2) or to upgrade from
-version 3.6.0 to the current release version 3.6.0-p1, available from
-[netcdf.tar.Z](ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf.tar.Z) or
-[netcdf.tar.gz](ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf.tar.gz).
+version 3.6.0 to the current release version 3.6.0-p1.
 Until you can upgrade, avoid rewriting in place any large (&gt; 2 GiB)
 netCDF files that use the new 64-bit offset format under the conditions
 described below.
@@ -1292,15 +1287,13 @@ format?](/software/netcdf/faq.html#Large%20File%20Support5).
 
 ### Cygwin Build Doesn't Work {#bad-cygwin}
 
-To build on Cygwin, you must get the [latest 3.6.1 beta
-release](ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-beta.tar.gz).
+To build on Cygwin, you must get the latest 3.6.1 beta release.
 
 ### Windows DLL doesn't include F77 API {#dll-fortran}
 
 The netCDF windows DLL doesn't include the Fortran API. We are working
 on this problem for the next release. Meanwhile, if you need the fortran
-API in your DLL, you'll have to use the [netCDF 3.5.1
-DLL](ftp://ftp.unidata.ucar.edu/pub/netcdf/contrib/win32/netcdf-3.5.1-win32dll.zip).
+API in your DLL, you'll have to use the netCDF 3.5.1 DLL.
 
 ### F90 tests fail with Portland F90 compiler {#portland-f90}
 
@@ -1367,8 +1360,8 @@ With some fortran compilers, such as Absoft, the configure script
 stupidly adds a -Df2cFortran to the C preprocessor flags, which causes
 the fortran tests in nf\_test to fail to link.
 
-This problem is fixed in the 3.6.1 beta release. Get the [3.6.1 beta
-release](ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-beta.tar.Z).
+This problem is fixed in the 3.6.1 beta release. Get the 3.6.1 beta
+release.
 
 ### Message: "ncgenyy.c is out-of-date with respect to ncgen.l" {#ncgen-timestamp}
 
@@ -1421,8 +1414,8 @@ is present on the platform. As a result, the C++ interface is never
 built.
 
 This problem is fixed in the 3.6.1 beta release. Cygwin users interested
-in the C++ interface should get the [3.6.1 beta
-release](ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-3.6.1-beta1.tar.Z).
+in the C++ interface should get the 3.6.1 beta
+release.
 
 ### Large file problems in Visual C++ compile {#visualcpp_largefile}
 
@@ -1431,8 +1424,8 @@ correctly in the 3.6.0 release of the code and project files needed to
 compile the netCDF library with Visual C++.NET.
 
 This problem is fixed in the 3.6.1 beta release. Users interested in
-building their own DLL should get the [3.6.1 beta
-release](ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-3.6.1-beta1.tar.Z).
+building their own DLL should get the 3.6.1 beta
+release.
 The DLL offered on the binary release page is 3.6.1 beta.
 
 ### When using TEMP\_LARGE, need a trailing slash {#temp_large}
@@ -1443,8 +1436,8 @@ to work. For example, use 'setenv TEMP\_LARGE /tmp/' instead of 'setenv
 TEMP\_LARGE /tmp', as one would usually expect, and as the documentation
 describes.
 
-This problem is fixed in the [3.6.1 beta
-release](ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-3.6.1-beta1.tar.Z).
+This problem is fixed in the 3.6.1 beta
+release.
 Users of 3.6.0 should specify the trailing slash to use the TEMP\_LARGE
 environment variable in make extra\_test.
 

--- a/docs/static-pages/software.html
+++ b/docs/static-pages/software.html
@@ -783,8 +783,7 @@ or using ECMWF reanalysis on a reduced grid
     for printing selected data from netCDF arrays, copying ASCII data into netCDF
     arrays, and performing various operations (sum, mean, max, min, product, ...)
     on netCDF arrays. A library (fanlib) is also included that supports the use of
-    FAN from C programs. The package is available via anonymous FTP from <a
-    href="ftp://ftp.unidata.ucar.edu/pub/netcdf/contrib/fan.tar.Z">ftp://ftp.unidata.ucar.edu/pub/netcdf/contrib/fan.tar.Z</a>.
+    FAN from C programs. 
     Questions and comments may be sent to Harvey Davies, harvey.davies@csiro.au.
     <p></p>
     <h2><a id="FERRET" name="FERRET">FERRET</a></h2>
@@ -1613,11 +1612,9 @@ or using ECMWF reanalysis on a reduced grid
     <h2><a id="MexEPS" name="MexEPS">MexEPS</a></h2>
     <a href="http://www.pmel.noaa.gov/">PMEL</a> has developed a MATLAB interface, <a
     href="http://www.epic.noaa.gov/epic/software/mexeps.htm">MexEPS</a>, which supports
-    several netCDF file conventions, including <a
-    href="ftp://ftp.unidata.ucar.edu/pub/netcdf/Conventions/PMEL-EPIC/"> those adopted
-    by PMEL</a>. Many styles of time axes are supported and time manipulation routines
-    ease the use of the time axis in MATLAB. The MexEPS package supports the following
-    data formats:
+    several netCDF file conventions, including those adopted by PMEL. Many styles of 
+    time axes are supported and time manipulation routines ease the use of the time axis 
+    in MATLAB. The MexEPS package supports the following data formats:
     <ul>
       <li>
         reading, writing and editing netCDF files;
@@ -3023,13 +3020,9 @@ or using ECMWF reanalysis on a reduced grid
 
     <h1><a id="user" name="user">User-Contributed Software</a></h1>
     <p>
-      Unidata makes available a separate
-      <a href="/software/netcdf/Contrib.html">catalog</a>
-      to a
-      <a href="ftp://ftp.unidata.ucar.edu/pub/netcdf/contrib/">directory</a>
-      of freely available, user-contributed software and documentation related to the
-      netCDF library. This software may be retrieved by anonymous FTP. We haven&#39;t
-      necessarily used or tested this software; we make it available &quot;as is&quot;.
+      Unidata had an archive of user-contributed software and documentation related to the
+      netCDF library. This software is available by request to support-netcdf@unidata.ucar.edu. 
+      We haven&#39;t necessarily used or tested this software; we make it available &quot;as is&quot;.
     </p>
     <p>
       The criteria for inclusion in the netcdf/contrib/ directory of user-contributed

--- a/hdf4_test/run_get_hdf4_files.sh
+++ b/hdf4_test/run_get_hdf4_files.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
-# This shell gets some sample HDF4 files from the netCDF ftp site for
-# testing. Then it runs program tst_interops3 on the test file to
-# check that HDF4 reading works.
+# This shell gets some sample HDF4 files for testing.  
+# Then it runs program tst_interops3 on the test file 
+# to check that HDF4 reading works.
 
 # Ed Hartnett
 
@@ -12,14 +12,14 @@ if test "x$srcdir" = x ; then srcdir=`pwd`; fi
 # Uncomment for quiet wget operation.
 #Q=-q
 
-# Get a file from the ftp site; retry several times
+# Get a file from the resources site; retry several times
 getfile() {
-   FTPFILE="ftp://ftp.unidata.ucar.edu/pub/netcdf/sample_data/hdf4/$1.gz"
+   DATAFILE="https://resources.unidata.ucar.edu/sample_data/hdf4/$1.gz"
 
    for try in 1 2 3 4 ; do # try 4 times
 
      # signal success/failure
-     if wget -c $Q --passive-ftp $FTPFILE || curl -O $FTPFILE ; then
+     if wget -c $Q --passive-ftp $DATAFILE || curl -O $DATAFILE ; then
        return 0 # got it
      fi
      echo "wget failed: try $try"

--- a/nc_perf/run_knmi_bm.sh
+++ b/nc_perf/run_knmi_bm.sh
@@ -15,7 +15,7 @@ echo "Getting KNMI test files $file_list"
 for f1 in $file_list
 do
     if ! test -f $f1; then
-	wget ftp://ftp.unidata.ucar.edu/pub/netcdf/sample_data/$f1.gz
+	wget https://resources.unidata.ucar.edu/sample_data/$f1.gz
 	gunzip $f1.gz
     fi
 done

--- a/nc_perf/run_knmi_bm.sh
+++ b/nc_perf/run_knmi_bm.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# This shell gets some files from the netCDF ftp site for testing,
+# This shell gets some sample data files for testing,
 # then runs the tst_knmi benchmarking program.
 # Ed Hartnett
 


### PR DESCRIPTION
- `/ftp/pub/netcdf/contrib/*` has been archived offline.  We can resurrect it at any time if needed.
- `/ftp/pub/netcdf/sample_data/*` has been moved to:  https://resources.unidata.ucar.edu/sample_data/*
