### PR TITLE
Honor CMAKE_INSTALL_MANDIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1520,6 +1520,9 @@ configure_file(
 ###
 # Create pkgconfig files.
 ###
+if(NOT DEFINED CMAKE_INSTALL_MANDIR)
+  set(CMAKE_INSTALL_MANDIR "${CMAKE_INSTALL_PREFIX}/share/man/")
+endif()
 
 if(NOT DEFINED CMAKE_INSTALL_LIBDIR)
   set(CMAKE_INSTALL_LIBDIR lib)

--- a/libsrc/CMakeLists.txt
+++ b/libsrc/CMakeLists.txt
@@ -96,8 +96,8 @@ if(HAVE_M4)
       COMMAND ${NC_M4} ${ARGS_MANPAGE} "${CMAKE_CURRENT_BINARY_DIR}/netcdf.m4" > "${CMAKE_CURRENT_BINARY_DIR}/netcdf.3"
       WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
     )
-
-    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/netcdf.3" DESTINATION "share/man/man3" COMPONENT documentation)
+    
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/netcdf.3" DESTINATION "${CMAKE_INSTALL_MANDIR}/man3" COMPONENT documentation)
   endif(NOT MSVC)
 
 endif()

--- a/ncdump/CMakeLists.txt
+++ b/ncdump/CMakeLists.txt
@@ -355,5 +355,5 @@ add_subdirectory(expected)
 set_directory_properties(PROPERTIES ADDITIONAL_MAKE_CLEAN_FILES "${CLEANFILES}")
 
 if(NOT MSVC)
-  install(FILES ${MAN_FILES} DESTINATION "share/man/man1" COMPONENT documentation)
+  install(FILES ${MAN_FILES} DESTINATION "${CMAKE_INSTALL_MANDIR}/man1" COMPONENT documentation)
 endif()

--- a/ncgen/CMakeLists.txt
+++ b/ncgen/CMakeLists.txt
@@ -86,7 +86,7 @@ ENDIF()
 
 SET(MAN_FILES ncgen.1)
 IF(NOT MSVC)
-  INSTALL(FILES ${MAN_FILES} DESTINATION "share/man/man1"
+  INSTALL(FILES ${MAN_FILES} DESTINATION "${CMAKE_INSTALL_MANDIR}/man1"
     COMPONENT documentation)
 ENDIF()
 SET(CLEANFILES c0.nc c0_64.nc c0_4.nc c0_4c.nc ref_camrun.c)

--- a/ncgen3/CMakeLists.txt
+++ b/ncgen3/CMakeLists.txt
@@ -75,7 +75,7 @@ INSTALL(TARGETS ncgen3 DESTINATION bin COMPONENT utilities)
 
 SET(MAN_FILES ncgen3.1)
 IF(NOT MSVC)
-  INSTALL(FILES ${MAN_FILES} DESTINATION "share/man/man1" COMPONENT documentation)
+  INSTALL(FILES ${MAN_FILES} DESTINATION "${CMAKE_INSTALL_MANDIR}/man1" COMPONENT documentation)
 ENDIF()
 
 ## Specify files to be distributed by 'make dist'


### PR DESCRIPTION
* Fixes #2920 

Modify `CMakeLists.txt` files to honor [`CMAKE_INSTALL_MANDIR`](https://cmake.org/cmake/help/latest/command/install.html).