### PR TITLE
Cleanup handling of NETCDF_ENABLE_SET_LOG_LEVEL and NETCDF_ENABLE_SET_LOG_LEVEL_FUNC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -532,20 +532,20 @@ else()
   set(NETCDF_ENABLE_HDF4 OFF)
 endif()
 
-# Option Logging, only valid for netcdf4.
+# Option Logging, only valid for netcdf4 dispatchers.
 option(NETCDF_ENABLE_LOGGING "Enable Logging." OFF)
 if(NOT NETCDF_ENABLE_NETCDF4)
 set(NETCDF_ENABLE_LOGGING OFF)
 endif()
 if(NETCDF_ENABLE_LOGGING)
-  target_compile_definitions(netcdf PRIVATE LOGGING NETCDF_ENABLE_SET_LOG_LEVEL)
-  set(LOGGING ON)
-  set(NETCDF_ENABLE_SET_LOG_LEVEL ON)
+  set(LOGGING ON CACHE BOOL "") # Alias
 endif()
+
 option(NETCDF_ENABLE_SET_LOG_LEVEL_FUNC "Enable definition of nc_set_log_level()." ON)
-if(NETCDF_ENABLE_NETCDF4 AND NOT NETCDF_ENABLE_LOGGING AND NETCDF_ENABLE_SET_LOG_LEVEL_FUNC)
-  target_compile_definitions(netcdf PRIVATE -DNETCDF_ENABLE_SET_LOG_LEVEL)
-  set(NETCDF_ENABLE_SET_LOG_LEVEL ON)
+if(LOGGING AND NETCDF_ENABLE_SET_LOG_LEVEL_FUNC)
+  set(NETCDF_ENABLE_SET_LOG_LEVEL ON CACHE BOOL "")
+else()
+  set(NETCDF_ENABLE_SET_LOG_LEVEL OFF CACHE BOOL "")
 endif()
 
 # Option to allow for strict null file padding.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -535,18 +535,11 @@ endif()
 # Option Logging, only valid for netcdf4 dispatchers.
 option(NETCDF_ENABLE_LOGGING "Enable Logging." OFF)
 if(NOT NETCDF_ENABLE_NETCDF4)
-set(NETCDF_ENABLE_LOGGING OFF)
-endif()
-if(NETCDF_ENABLE_LOGGING)
-  set(LOGGING ON CACHE BOOL "") # Alias
+  set(NETCDF_ENABLE_LOGGING OFF)
 endif()
 
-option(NETCDF_ENABLE_SET_LOG_LEVEL_FUNC "Enable definition of nc_set_log_level()." ON)
-if(LOGGING AND NETCDF_ENABLE_SET_LOG_LEVEL_FUNC)
-  set(NETCDF_ENABLE_SET_LOG_LEVEL ON CACHE BOOL "")
-else()
-  set(NETCDF_ENABLE_SET_LOG_LEVEL OFF CACHE BOOL "")
-endif()
+set(LOGGING ${NETCDF_ENABLE_LOGGING})
+set(NETCDF_ENABLE_SET_LOG_LEVEL ${NETCDF_ENABLE_LOGGING})
 
 # Option to allow for strict null file padding.
 # See https://github.com/Unidata/netcdf-c/issues/657 for more information

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,8 @@ This file contains a high-level description of this package's evolution. Release
 
 ## 4.9.3 - TBD
 
+* Cleanup the option code for NETCDF_ENABLE_SET_LOG_LEVEL\[_FUNC\] See [Github #2931](https://github.com/Unidata/netcdf-c/issues/2931) for more information.
+* Fix duplicate definition when using aws-sdk-cpp. See [Github #2928](https://github.com/Unidata/netcdf-c/issues/2928) for more information.
 * Cleanup various obsolete options and do some code refactoring. See [Github #2926](https://github.com/Unidata/netcdf-c/issues/2926) for more information.
 * Convert the Zarr-related ENABLE_XXX options to NETCDF_ENABLE_XXX options (part of the cmake overhaul). See [Github #2923](https://github.com/Unidata/netcdf-c/issues/2923) for more information.
 * Refactor macro `_FillValue` to `NC_FillValue` to avoid conflict with libc++ headers. See [Github #2858](https://github.com/Unidata/netcdf-c/issues/2858) for more information.

--- a/config.h.cmake.in
+++ b/config.h.cmake.in
@@ -475,10 +475,7 @@ with zip */
 #cmakedefine LOGGING 1
 
 /* If true, define nc_set_log_level. */
-#cmakedefine ENABLE_SET_LOG_LEVEL 1
-
-/* If true, define nc_set_log_level_func */
-#cmakedefine NETCDF_ENABLE_SET_LOG_LEVEL_FUNC 1
+#cmakedefine NETCDF_ENABLE_SET_LOG_LEVEL 1
 
 /* min blocksize for posixio. */
 #cmakedefine NCIO_MINBLOCKSIZE ${NCIO_MINBLOCKSIZE}

--- a/config.h.cmake.in
+++ b/config.h.cmake.in
@@ -475,6 +475,7 @@ with zip */
 #cmakedefine LOGGING 1
 
 /* If true, define nc_set_log_level. */
+#cmakedefine NETCDF_ENABLE_LOGGING 1
 #cmakedefine NETCDF_ENABLE_SET_LOG_LEVEL 1
 
 /* min blocksize for posixio. */

--- a/configure.ac
+++ b/configure.ac
@@ -451,16 +451,26 @@ AC_ARG_ENABLE([logging],
 test "x$enable_logging" = xyes || enable_logging=no
 AC_MSG_RESULT([$enable_logging])
 
-# Does the user want to turn off nc_set_log_level() function? (It will
-# always be defined if --enable-logging is used.)
-AC_MSG_CHECKING([whether nc_set_log_level() function is included (will do nothing unless enable-logging is also used)])
-AC_ARG_ENABLE([set_log_level_func], [AS_HELP_STRING([--disable-set-log-level-func],
+# Does the user want to disable the nc_set_log_level() function? (It will
+# always be defined (possibly as a no-op) if --enable-logging is used.)
+AC_MSG_CHECKING([whether nc_set_log_level() function is enabled (will do nothing unless enable-logging is also used)])
+AC_ARG_ENABLE([set-log-level-func], [AS_HELP_STRING([--disable-set-log-level-func],
               [disable the nc_set_log_level function])])
-test "x$enable_set_log_level_func" = xno -a "x$enable_logging" = xno || enable_set_log_level_func=yes
-if test "x$enable_set_log_level_func" = xyes -a "x$enable_hdf5" = xyes; then
-   AC_DEFINE([ENABLE_SET_LOG_LEVEL], 1, [If true, define nc_set_log_level.])
+test "x$enable_set_log_level_func" = xno || enable_set_log_level_func=yes
+if test "x$enable_logging" = xno; then
+enable_set_log_level_func=no
 fi
-AC_MSG_RESULT($enable_set_log_level_func)
+
+# alias to enable_set_log_level
+if test "x$enable_set_log_level_func" = xyes; then
+enable_set_log_level=yes
+else
+enable_set_log_level=no
+fi
+AC_MSG_RESULT($enable_set_log_level)
+if test "x$enable_set_log_level" = xyes ; then
+   AC_DEFINE([NETCDF_ENABLE_SET_LOG_LEVEL], 1, [If true, enable nc_set_log_level function.])
+fi
 
 # CURLOPT_USERNAME is not defined until curl version 7.19.1
 # CURLOPT_PASSWORD is not defined until curl version 7.19.1

--- a/configure.ac
+++ b/configure.ac
@@ -450,27 +450,15 @@ AC_ARG_ENABLE([logging],
 			      Ignored if netCDF-4 is not enabled.])])
 test "x$enable_logging" = xyes || enable_logging=no
 AC_MSG_RESULT([$enable_logging])
-
-# Does the user want to disable the nc_set_log_level() function? (It will
-# always be defined (possibly as a no-op) if --enable-logging is used.)
-AC_MSG_CHECKING([whether nc_set_log_level() function is enabled (will do nothing unless enable-logging is also used)])
-AC_ARG_ENABLE([set-log-level-func], [AS_HELP_STRING([--disable-set-log-level-func],
-              [disable the nc_set_log_level function])])
-test "x$enable_set_log_level_func" = xno || enable_set_log_level_func=yes
-if test "x$enable_logging" = xno; then
-enable_set_log_level_func=no
-fi
-
-# alias to enable_set_log_level
-if test "x$enable_set_log_level_func" = xyes; then
-enable_set_log_level=yes
-else
-enable_set_log_level=no
-fi
-AC_MSG_RESULT($enable_set_log_level)
-if test "x$enable_set_log_level" = xyes ; then
+if test "x$enable_logging" = xyes; then
+   enable_set_log_level_func=yes
+   enable_set_log_level=yes
    AC_DEFINE([NETCDF_ENABLE_SET_LOG_LEVEL], 1, [If true, enable nc_set_log_level function.])
+else
+   enable_set_log_level_func=no
+   enable_set_log_level=no
 fi
+
 
 # CURLOPT_USERNAME is not defined until curl version 7.19.1
 # CURLOPT_PASSWORD is not defined until curl version 7.19.1

--- a/include/nc_logging.h
+++ b/include/nc_logging.h
@@ -52,12 +52,10 @@ void nc_log(int severity, const char *fmt, ...);
 
 #define BAIL_QUIET BAIL
 
-#ifdef USE_NETCDF4
-#ifndef ENABLE_SET_LOG_LEVEL
+#ifndef NETCDF_ENABLE_SET_LOG_LEVEL
 /* Define away any calls to nc_set_log_level(), if its not enabled. */
 #define nc_set_log_level(e)
-#endif /* ENABLE_SET_LOG_LEVEL */
-#endif
+#endif /* NETCDF_ENABLE_SET_LOG_LEVEL */
 
 #endif /* LOGGING */
 

--- a/libsrc4/nc4internal.c
+++ b/libsrc4/nc4internal.c
@@ -1711,7 +1711,7 @@ nc4_normalize_name(const char *name, char *norm_name)
     return NC_NOERR;
 }
 
-#ifdef ENABLE_SET_LOG_LEVEL
+#ifdef NETCDF_ENABLE_SET_LOG_LEVEL
 
 /**
  * Initialize parallel I/O logging. For parallel I/O builds, open log
@@ -1812,7 +1812,7 @@ nc_set_log_level(int new_level)
     
     return NC_NOERR;
 }
-#endif /* ENABLE_SET_LOG_LEVEL */
+#endif /* NETCDF_ENABLE_SET_LOG_LEVEL */
 
 #if LOGGING
 #define MAX_NESTS 10


### PR DESCRIPTION
The NETCDF_ENABLE_SET_LOG_LEVEL_FUNC option is apparently not used directly. But it is effectively used to set NETCDF_ENABLE_SET_LOG_LEVEL. This is not clear from the build files CMakeLists.txt and configure.ac. So this PR cleanups the code to make it more clear what is going on.