### PR TITLE
Different method for checking HDF5 version requirement

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -134,8 +134,13 @@ if(USE_HDF5)
   #####
   # First, find the C and HL libraries.
   #####
-  find_package(HDF5 ${HDF5_VERSION_REQUIRED} COMPONENTS C HL REQUIRED)
+  find_package(HDF5 COMPONENTS C HL REQUIRED)
 
+  message(STATUS "Found HDF5 version: ${HDF5_VERSION}")
+  if(${HDF5_VERSION} VERSION_LESS ${HDF5_VERSION_REQUIRED})
+     message(FATAL_ERROR "NetCDF requires HDF5 version ${HDF5_VERSION_REQUIRED} or later; found version ${HDF5_VERSION}.")
+  endif()  
+  
   message(STATUS "Using HDF5 include dir: ${HDF5_INCLUDE_DIRS}")
   target_link_libraries(netcdf
     PRIVATE


### PR DESCRIPTION
Not sure if this is the best solution.  Figured I would propose and let people throw arrows at it...

This method works for me when I have a local HDF5 build; the previous method seems to have issues comparing version numbers...  I don't know if the other method is supposed to search multiple HDF5 installs and pick only one that satisfies the version requirement where this version will stop after finding the first installation in its search path and then check the version...

Another benefit is that it prints the version of the HDF5 library that was found which may be useful.

Addresses problem detailed in #2932
