### PR TITLE
Fix: CMAKE_MODULE_PATH contents is being overriden with -D contents, not merged with

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,9 +17,7 @@ project(netCDF
 )
 
 #Add custom CMake Module
-
-set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules/;${PROJECT_SOURCE_DIR}/cmake"
-  CACHE INTERNAL "Location of our custom CMake modules.")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules" "${PROJECT_SOURCE_DIR}/cmake")
 
 set(PACKAGE "netCDF" CACHE STRING "")
 


### PR DESCRIPTION
Current code defines the CMAKE_MODULE_PATH as a cache variable[1]. As a result, if one passes the `-DCMAKE_MODULE_PATH=<something>` to the cmake invocation, its contents override the paths to netcdf-bundled cmake modules. Based on code and attempt to use Shell-PATH-like expansion, it looks as unintended behavior. Moreover, it's quite common in CI/CD systems to pass extra cmake module paths (e.g., we have to do so for AWS SDKs, on which netcdf depends optionally). This tiny fix replaces that with `list(APPEND)` which adds paths to netcdf-provided modules to the user-passed -DCMAKE_MODULE_PATH. At the same time, if user doesn't passes this variable - the previous behavior is preserved, as netcdf paths will be added to that CMAKE_MODULE_PATH currently holds (if netcdf is built as standalone project and not as a subproject of our project - it's an empty list).



References:
[1] https://github.com/Unidata/netcdf-c/blob/d694d38823719575f81ae541f16ccda32f537060/CMakeLists.txt#L21


