### PR TITLE
Take into account that attach_dimscales can fail when dimensions and variables are named inconsistently

### DIFF
--- a/libhdf5/nc4hdf.c
+++ b/libhdf5/nc4hdf.c
@@ -1449,7 +1449,9 @@ attach_dimscales(NC_GRP_INFO_T *grp)
                         dsid = ((NC_HDF5_VAR_INFO_T *)(var->dim[d]->coord_var->format_var_info))->hdf_datasetid;
                     else
                         dsid = ((NC_HDF5_DIM_INFO_T *)var->dim[d]->format_dim_info)->hdf_dimscaleid;
-                    assert(dsid > 0);
+
+                    if (dsid <= 0)
+                        return NC_EDIMSCALE;
 
                     /* Attach the scale. */
                     if (H5DSattach_scale(hdf5_var->hdf_datasetid, dsid, d) < 0)


### PR DESCRIPTION
This PR addresses issue #2962.

All tests pass locally:
```
...
227/231 Test #227: nczarr_test_run_fillonlyz .................   Passed    0.08 sec
        Start 228: nczarr_test_run_nczfilter
228/231 Test #228: nczarr_test_run_nczfilter .................   Passed    0.07 sec
        Start 229: nczarr_test_run_filter
229/231 Test #229: nczarr_test_run_filter ....................   Passed    0.39 sec
        Start 230: nczarr_test_run_specific_filters
230/231 Test #230: nczarr_test_run_specific_filters ..........   Passed    0.43 sec
        Start 231: nczarr_test_run_filter_vlen
231/231 Test #231: nczarr_test_run_filter_vlen ...............   Passed    0.13 sec

100% tests passed, 0 tests failed out of 231

Total Test time (real) = 219.58 sec
```