### PR TITLE
fix ncuriparse error,Correctly remove leading and trailing whitespace

### DIFF
--- a/libdispatch/ncuri.c
+++ b/libdispatch/ncuri.c
@@ -176,7 +176,7 @@ ncuriparse(const char* uri0, NCURI** durip)
     p = uri;
     while(*p == ' ') p++;
     for(q=uri;*p;p++) {if((*p == '\\' && p[1] == '\\')) {continue;} else {*q++ = *p;}}
-    while(*(q - 1) == ' ' && (q - 1) >= uri) q--;
+    while((q - 1) >= uri && *(q - 1) == ' ') q--;
     *q = '\0';
 
     p = uri;

--- a/libdispatch/ncuri.c
+++ b/libdispatch/ncuri.c
@@ -173,7 +173,10 @@ ncuriparse(const char* uri0, NCURI** durip)
 	2. convert all '\\' -> '\' (Temp hack to remove escape characters
                                     inserted by Windows or MinGW)
     */
-    for(q=uri,p=uri;*p;p++) {if((*p == '\\' && p[1] == '\\') || *p < ' ') {continue;} else {*q++ = *p;}}
+    p = uri;
+    while(*p == ' ') p++;
+    for(q=uri;*p;p++) {if((*p == '\\' && p[1] == '\\')) {continue;} else {*q++ = *p;}}
+    while(*(q - 1) == ' ' && (q - 1) >= uri) q--;
     *q = '\0';
 
     p = uri;


### PR DESCRIPTION
fix ncuriparse error,Correctly remove leading and trailing whitespace.
When I use netcdf-c to connect to the nc file at the following path (D:/文档/test.nc), netcdf-c prompts me with a parameter error. After my investigation, I found that the error is caused by the ncuriparse function incorrectly interpreting the file path as a URI.