### PR TITLE
Clean up some `-` vs `_` in some comments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -445,14 +445,14 @@ endif()
 
 # As a long term goal, and because it is now the case that
 # -DNETCDF_ENABLE_NCZARR => USE_NETCDF4, so make the external options
-# -DNETCDF_ENABLE-NETCDF-4 and _DNETCDF_ENABLE-NETCDF4 obsolete
-# in favor of --NETCDF_ENABLE-HDF5.
+# -DNETCDF_ENABLE_NETCDF_4 and _DNETCDF_ENABLE_NETCDF4 obsolete
+# in favor of --NETCDF_ENABLE_HDF5.
 # We will do the following for one more release cycle.
-# 1. Make --NETCDF_ENABLE-NETCDF-4 be an alias for --NETCDF_ENABLE-NETCDF4.
-# 2. Make --NETCDF_ENABLE-NETCDF4 an alias for --NETCDF_ENABLE-HDF5.
+# 1. Make -DNETCDF_ENABLE_NETCDF_4 be an alias for -DNETCDF_ENABLE_NETCDF4.
+# 2. Make -DNETCDF_ENABLE_NETCDF4 an alias for -DNETCDF_ENABLE_HDF5.
 # 3. Internally, convert most (but not all) uses of USE_NETCDF_4 and USE_NETCDF4 to USE_HDF5.
 
-# Collect the values of -DNETCDF_ENABLE-NETCDF-4, -DNETCDF_ENABLE-NETCDF4, and -DNETCDF_ENABLE-HDF5.
+# Collect the values of -DNETCDF_ENABLE_NETCDF_4, -DNETCDF_ENABLE_NETCDF4, and -DNETCDF_ENABLE_HDF5.
 
 # Figure out which options are defined and process options
 if(DEFINED NETCDF_ENABLE_NETCDF_4)
@@ -496,8 +496,8 @@ if(UNDEF_HDF5)
 set(NETCDF_ENABLE_HDF5 ON CACHE BOOL "" FORCE) 
 endif()
 
-# Turn off enable_netcdf4 because it will be used
-# as a shorthand for ENABLE_HDF5|ENABLE_HDF4|ENABLE_NCZARR
+# Turn off NETCDF_ENABLE_NETCDF4 because it will be used
+# as a shorthand for NETCDF_ENABLE_HDF5|NETCDF_ENABLE_HDF4|NETCDF_ENABLE_NCZARR
 set(NETCDF_ENABLE_NETCDF4 OFF CACHE BOOL "" FORCE)
 option(NETCDF_ENABLE_DAP "Enable DAP2 and DAP4 Client." ON)
 option(NETCDF_ENABLE_NCZARR "Enable NCZarr Client." ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -444,15 +444,15 @@ endif()
 ################################
 
 # As a long term goal, and because it is now the case that
-# -DNETCDF_ENABLE_NCZARR => USE_NETCDF4, so make the external options
-# -DNETCDF_ENABLE_NETCDF_4 and -DNETCDF_ENABLE_NETCDF4 obsolete
-# in favor of -DNETCDF_ENABLE_HDF5.
+# NETCDF_ENABLE_NCZARR => USE_NETCDF4, so make the external options
+# NETCDF_ENABLE_NETCDF_4 and NETCDF_ENABLE_NETCDF4 obsolete
+# in favor of NETCDF_ENABLE_HDF5.
 # We will do the following for one more release cycle.
-# 1. Make -DNETCDF_ENABLE_NETCDF_4 be an alias for -DNETCDF_ENABLE_NETCDF4.
-# 2. Make -DNETCDF_ENABLE_NETCDF4 an alias for -DNETCDF_ENABLE_HDF5.
+# 1. Make NETCDF_ENABLE_NETCDF_4 be an alias for NETCDF_ENABLE_NETCDF4.
+# 2. Make NETCDF_ENABLE_NETCDF4 an alias for NETCDF_ENABLE_HDF5.
 # 3. Internally, convert most (but not all) uses of USE_NETCDF_4 and USE_NETCDF4 to USE_HDF5.
 
-# Collect the values of -DNETCDF_ENABLE_NETCDF_4, -DNETCDF_ENABLE_NETCDF4, and -DNETCDF_ENABLE_HDF5.
+# Collect the values of NETCDF_ENABLE_NETCDF_4, NETCDF_ENABLE_NETCDF4, and NETCDF_ENABLE_HDF5.
 
 # Figure out which options are defined and process options
 if(DEFINED NETCDF_ENABLE_NETCDF_4)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -445,8 +445,8 @@ endif()
 
 # As a long term goal, and because it is now the case that
 # -DNETCDF_ENABLE_NCZARR => USE_NETCDF4, so make the external options
-# -DNETCDF_ENABLE_NETCDF_4 and _DNETCDF_ENABLE_NETCDF4 obsolete
-# in favor of --NETCDF_ENABLE_HDF5.
+# -DNETCDF_ENABLE_NETCDF_4 and -DNETCDF_ENABLE_NETCDF4 obsolete
+# in favor of -DNETCDF_ENABLE_HDF5.
 # We will do the following for one more release cycle.
 # 1. Make -DNETCDF_ENABLE_NETCDF_4 be an alias for -DNETCDF_ENABLE_NETCDF4.
 # 2. Make -DNETCDF_ENABLE_NETCDF4 an alias for -DNETCDF_ENABLE_HDF5.


### PR DESCRIPTION
Some symbols in the comments about deprecated symbols were using `-` instead of `_`