### PR TITLE
Draft: Add mode to read consolidated ZARR datasets

### DIFF
--- a/libdispatch/ds3util.c
+++ b/libdispatch/ds3util.c
@@ -309,7 +309,13 @@ NC_s3urlprocess(NCURI* url, NCS3INFO* s3, NCURI** newurlp)
 
     /* Rebuild the URL to path format and get a usable region and optional bucket*/
     if((stat = NC_s3urlrebuild(url,s3,&url2))) goto done;
-    s3->host = strdup(url2->host);
+    if(url2->port){
+        s3->host = strndup(url2->host,strlen(url2->host) + 1 + strlen(url2->port) +1);
+        s3->host = strcat(s3->host, ":");
+        s3->host = strcat(s3->host, url2->port);
+    }else{
+        s3->host = strdup(url2->host);
+    }
     /* construct the rootkey minus the leading bucket */
     pathsegments = nclistnew();
     if((stat = NC_split_delim(url2->path,'/',pathsegments))) goto done;

--- a/libnczarr/zarr.c
+++ b/libnczarr/zarr.c
@@ -122,7 +122,7 @@ ncz_open_dataset(NC_FILE_INFO_T* file, NClist* controls)
     if (!(file->format_file_info = calloc(1, sizeof(NCZ_FILE_INFO_T))))
         {stat = NC_ENOMEM; goto done;}
     zinfo = file->format_file_info;
-
+	zinfo->consolidated = NULL;
     /* Fill in NCZ_FILE_INFO_T */
     zinfo->creating = 0;
     zinfo->common.file = file;
@@ -279,6 +279,7 @@ applycontrols(NCZ_FILE_INFO_T* zinfo)
 	else if(strcasecmp(p,"zip")==0) zinfo->controls.mapimpl = NCZM_ZIP;
 	else if(strcasecmp(p,"file")==0) zinfo->controls.mapimpl = NCZM_FILE;
 	else if(strcasecmp(p,"s3")==0) zinfo->controls.mapimpl = NCZM_S3;
+    else if(strcasecmp(p,"consolidated")==0) zinfo->controls.flags |= FLAG_CONSOLIDATED;
     }
     /* Apply negative controls by turning off negative flags */
     /* This is necessary to avoid order dependence of mode flags when both positive and negative flags are defined */

--- a/libnczarr/zclose.c
+++ b/libnczarr/zclose.c
@@ -50,6 +50,7 @@ ncz_close_file(NC_FILE_INFO_T* file, int abort)
     if((stat = nczmap_close(zinfo->map,(abort && zinfo->creating)?1:0)))
 	goto done;
     nclistfreeall(zinfo->controllist);
+    NCJreclaim(zinfo->consolidated);
     NC_authfree(zinfo->auth);
     nullfree(zinfo);
 

--- a/libnczarr/zinternal.h
+++ b/libnczarr/zinternal.h
@@ -37,12 +37,14 @@
 #    define NC_MAX_PATH 4096
 #  endif
 #endif
-
-#define ZMETAROOT "/.zgroup"
-#define ZMETAATTR "/.zattrs"
-#define ZGROUP ".zgroup"
-#define ZATTRS ".zattrs"
-#define ZARRAY ".zarray"
+#define ZMETAROOT   "/.zgroup"
+#define ZMETAGROUP  "/.zgroup"
+#define ZMETAATTR   "/.zattrs"
+#define ZMETAARRAY  "/.zarray"
+#define ZMETADATA   ".zmetadata"
+#define ZGROUP  ".zgroup"
+#define ZATTRS  ".zattrs"
+#define ZARRAY  ".zarray"
 
 /* V2 Reserved Attributes */
 /*
@@ -101,6 +103,7 @@ Inserted into any .zattrs
 #define ncidforx(file,grpid) ((file)->controller->ext_ncid | (grpid))
 #define ncidfor(var) ncidforx((var)->container->nc4_info,(var)->container->hdr.id)
 
+#define isconsolidaded(var) ( (var)->controls.flags & (FLAG_CONSOLIDATED) )
 /**************************************************/
 /* Forward */
 
@@ -134,13 +137,15 @@ typedef struct NCZ_FILE_INFO {
     int creating; /* 1=> created 0=>open */
     int native_endianness; /* NC_ENDIAN_LITTLE | NC_ENDIAN_BIG */
     NClist* controllist; /* Envv format */
+    NCjson * consolidated;
     struct Controls {
         size64_t flags;
-#		define FLAG_PUREZARR    1
-#		define FLAG_SHOWFETCH   2
-#		define FLAG_LOGGING     4
-#		define FLAG_XARRAYDIMS  8
-#		define FLAG_NCZARR_KEY  16 /* _nczarr_xxx keys are stored in object and not in _nczarr_attrs */
+#		define FLAG_PUREZARR        1
+#		define FLAG_SHOWFETCH       2
+#		define FLAG_LOGGING         4
+#		define FLAG_XARRAYDIMS      8
+#		define FLAG_NCZARR_KEY      16 /* _nczarr_xxx keys are stored in object and not in _nczarr_attrs */
+#       define FLAG_CONSOLIDATED    32
 	NCZM_IMPL mapimpl;
     } controls;
     int default_maxstrlen; /* default max str size for variables of type string */

--- a/libnczarr/zmap_s3sdk.c
+++ b/libnczarr/zmap_s3sdk.c
@@ -182,7 +182,11 @@ done:
 /* The problem with open is that there
 no obvious way to test for existence.
 So, we assume that the dataset must have
-some content. We look for that */
+some content. We look for that ....
+UNLESS flags has CONSOLIDATED, 
+this means that we try to access
+a single, unified metadata file (.zmetadata)
+*/
 static int
 zs3open(const char *path, int mode, size64_t flags, void* parameters, NCZMAP** mapp)
 {
@@ -221,15 +225,19 @@ zs3open(const char *path, int mode, size64_t flags, void* parameters, NCZMAP** m
         {stat = NC_EURL; goto done;}
 
     z3map->s3client = NC_s3sdkcreateclient(&z3map->s3);
-
-    /* Search the root for content */
-    content = nclistnew();
-    if((stat = NC_s3sdkgetkeys(z3map->s3client,z3map->s3.bucket,z3map->s3.rootkey,&nkeys,NULL,&z3map->errmsg)))
-	goto done;
-    if(nkeys == 0) {
-	/* dataset does not actually exist; we choose to return ENOOBJECT instead of EEMPTY */
-	stat = NC_ENOOBJECT;
-	goto done;
+    
+    if (flags & FLAG_CONSOLIDATED == 0){
+        /* Search the root for content */
+        content = nclistnew();
+        if((stat = NC_s3sdkgetkeys(z3map->s3client,z3map->s3.bucket,z3map->s3.rootkey,&nkeys,NULL,&z3map->errmsg)))
+        goto done;
+        if(nkeys == 0) {
+        /* dataset does not actually exist; we choose to return ENOOBJECT instead of EEMPTY */
+        stat = NC_ENOOBJECT;
+        goto done;
+        }
+    }else {
+        // Lazy open, we don't need to make use at this stage that we have something usefull on the path, we only implement reads...
     }
     if(mapp) *mapp = (NCZMAP*)z3map;    
 


### PR DESCRIPTION
This changes add a mode option `mode=consolidated` (perhaps best to do it by default when reading and fallback if fails) that will fetch a possibly existing `.zmetadata` file from the root of the dataset. That could serve as unified representation to be used whenever needing group or variable metadata further down the code path.

This is a WIP motivated by #2987 and lacks (at least):
- [ ] Unit testing
- [ ] Functional testing
- [ ] Robustness when open `consolitaded` not available
- [ ] Support Zarr V3
