### PR TITLE
Address ordering issue with HTTP VFD, H5FDunregister

### DIFF
--- a/libhdf5/H5FDhttp.c
+++ b/libhdf5/H5FDhttp.c
@@ -257,7 +257,7 @@ EXTERNL hid_t
 H5FD_http_finalize(void)
 {
     /* Reset VFL ID */
-    if (H5FD_HTTP_g)
+    if (H5FD_HTTP_g && (H5Iis_valid(H5FD_HTTP_g) > 0))
          H5FDunregister(H5FD_HTTP_g);
     H5FD_HTTP_g = 0;
 


### PR DESCRIPTION
* Fixes #2990 

[Based on the feedback on from @jhendersonHDF](https://github.com/Unidata/netcdf-c/issues/2990#issuecomment-2310882647), I was able to eliminate in the error stack messages related to H5FDunregister, in my own environment (Ubuntu 22.04). I am testing this in other environments/compiler combinations, and I will integrate the PR @edwardhartnett put up to integrate a test for this issue, #3012, before final merge.  