### PR TITLE
Check for libcurl should only happen if DAP and/or ncZarr are enabled.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -211,10 +211,10 @@ test "x$enable_remote_functionality" = xno || enable_remote_functionality=yes
 AC_MSG_RESULT($enable_remote_functionality)
 
 # We need curl for remote operations
-AC_CHECK_LIB([curl],[curl_easy_setopt],[found_curl=yes],[found_curl=no])
-if test "x$found_curl" = "xyes" ; then
-   AC_SEARCH_LIBS([curl_easy_setopt],[curl curl.dll cygcurl.dll], [],[])
-fi
+AC_MSG_CHECKING([whether we need to look for libcurl])
+AC_ARG_ENABLE([curl],
+   [AS_HELP_STRING([--enable-curl],
+                   [look for and link against libcurl])])
 
 ## Capture the state of the --enable-dap flag => enable dap2+dap4
 AC_MSG_CHECKING([whether DAP client(s) are to be built])
@@ -229,11 +229,6 @@ if test "x$enable_remote_functionality" = xno ; then
   enable_dap=no
 fi
 
-if test "x$enable_dap" = xyes & test "x$found_curl" = xno ; then
-  AC_MSG_WARN([curl required for dap access. DAP support disabled.])
-  enable_dap=no
-fi
-
 AC_MSG_CHECKING([whether netcdf zarr storage format should be disabled])
 AC_ARG_ENABLE([nczarr],
               [AS_HELP_STRING([--disable-nczarr],
@@ -243,7 +238,7 @@ AC_MSG_RESULT($enable_nczarr)
 
 # HDF5 | HDF4 | NCZarr => netcdf-4
 if test "x$enable_hdf5" = xyes || test "x$enable_hdf4" = xyes || test "x$enable_nczarr" = xyes ; then
-enable_netcdf4=yes
+   enable_netcdf4=yes
 fi
 
 AC_MSG_NOTICE([checking user options])
@@ -476,91 +471,122 @@ fi
 # CURL_MAX_READ_SIZE is not defined until 7.59
 
 # Save/restore CFLAGS
-SAVECFLAGS="$CFLAGS"
-CFLAGS="${curl_cflags}"
-
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
-[#include "curl/curl.h"],
-[[int x = CURLOPT_USERNAME;]])],
-                   [haveusername=yes],
-                   [haveusername=no])
-AC_MSG_CHECKING([whether CURLOPT_USERNAME is defined])
-AC_MSG_RESULT([${haveusername}])
-if test $haveusername = yes; then
-  AC_DEFINE([HAVE_CURLOPT_USERNAME],[1],[Is CURLOPT_USERNAME defined])
+if test "x$enable_dap" = xyes || test "x$enable_nczarr" = xyes; then 
+   enable_curl=yes
 fi
 
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
-[#include "curl/curl.h"],
-[[int x = CURLOPT_PASSWORD;]])],
-                   [havepassword=yes],
-                   [havepassword=no])
-AC_MSG_CHECKING([whether CURLOPT_PASSWORD is defined])
-AC_MSG_RESULT([${havepassword}])
-if test $havepassword = yes; then
-  AC_DEFINE([HAVE_CURLOPT_PASSWORD],[1],[Is CURLOPT_PASSWORD defined])
+if test "x$enable_curl" = xyes; then
+
+   if test "x$enable_dap" = xyes & test "x$found_curl" = xno ; then
+      AC_MSG_WARN([curl required for dap access. DAP support disabled.])
+      enable_dap=no
+   fi
+
+   # Need curl for byte ranges
+   if test "x$found_curl" = xno && test "x$enable_byterange" = xyes ; then
+   AC_MSG_ERROR([curl required for byte range support. Install curl or build without --enable-byterange.])
+   enable_byterange=no
+   fi
+
+   if test "x$enable_byterange" = xyes; then
+      AC_DEFINE([NETCDF_ENABLE_BYTERANGE], [1], [if true, support byte-range read of remote datasets.])
+   fi
+
+   AC_CHECK_LIB([curl],[curl_easy_setopt],[found_curl=yes],[found_curl=no])
+   if test "x$found_curl" = "xyes" ; then
+      AC_SEARCH_LIBS([curl_easy_setopt],[curl curl.dll cygcurl.dll], [],[])
+   fi 
+
+   if test "x$enable_dap" = xyes & test "x$found_curl" = xno ; then
+   AC_MSG_WARN([curl required for dap access. DAP support disabled.])
+   enable_dap=no
+   fi
+
+   SAVECFLAGS="$CFLAGS"
+   CFLAGS="${curl_cflags}"
+
+   AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
+   [#include "curl/curl.h"],
+   [[int x = CURLOPT_USERNAME;]])],
+                     [haveusername=yes],
+                     [haveusername=no])
+   AC_MSG_CHECKING([whether CURLOPT_USERNAME is defined])
+   AC_MSG_RESULT([${haveusername}])
+   if test $haveusername = yes; then
+   AC_DEFINE([HAVE_CURLOPT_USERNAME],[1],[Is CURLOPT_USERNAME defined])
+   fi
+
+   AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
+   [#include "curl/curl.h"],
+   [[int x = CURLOPT_PASSWORD;]])],
+                     [havepassword=yes],
+                     [havepassword=no])
+   AC_MSG_CHECKING([whether CURLOPT_PASSWORD is defined])
+   AC_MSG_RESULT([${havepassword}])
+   if test $havepassword = yes; then
+   AC_DEFINE([HAVE_CURLOPT_PASSWORD],[1],[Is CURLOPT_PASSWORD defined])
+   fi
+
+   AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
+   [#include "curl/curl.h"],
+   [[int x = CURLOPT_KEYPASSWD;]])],
+                     [havekeypassword=yes],
+                     [havekeypassword=no])
+   AC_MSG_CHECKING([whether CURLOPT_KEYPASSWD is defined])
+   AC_MSG_RESULT([${havekeypassword}])
+   if test $havekeypassword = yes; then
+   AC_DEFINE([HAVE_CURLOPT_KEYPASSWD],[1],[Is CURLOPT_KEYPASSWD defined])
+   fi
+
+   AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
+   [#include "curl/curl.h"],
+   [[int x = CURLINFO_RESPONSE_CODE;]])],
+                     [haveresponsecode=yes],
+                     [haveresponsecode=no])
+   AC_MSG_CHECKING([whether CURLINFO_RESPONSE_CODE is defined])
+   AC_MSG_RESULT([${haveresponsecode}])
+   if test $haveresponsecode = yes; then
+   AC_DEFINE([HAVE_CURLINFO_RESPONSE_CODE],[1],[Is CURLINFO_RESPONSE_CODE defined])
+   fi
+
+   AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
+   [#include "curl/curl.h"],
+   [[int x = CURLOPT_BUFFERSIZE;]])],
+                     [havecurloption=yes],
+                     [havecurloption=no])
+   AC_MSG_CHECKING([whether CURLOPT_BUFFERSIZE is defined])
+   AC_MSG_RESULT([${havecurloption}])
+   if test $havecurloption = yes; then
+   AC_DEFINE([HAVE_CURLOPT_BUFFERSIZE],[1],[Is CURLOPT_BUFFERSIZE defined])
+   fi
+
+   AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
+   [#include "curl/curl.h"],
+   [[int x = CURLOPT_TCP_KEEPALIVE;]])],
+                     [havecurloption=yes],
+                     [havecurloption=no])
+   AC_MSG_CHECKING([whether CURLOPT_TCP_KEEPALIVE is defined])
+   AC_MSG_RESULT([${havecurloption}])
+   if test $havecurloption = yes; then
+   AC_DEFINE([HAVE_CURLOPT_KEEPALIVE],[1],[Is CURLOPT_TCP_KEEPALIVE defined])
+   fi
+
+   # CURLOPT_VERIFYHOST semantics differ depending on version
+   AC_MSG_CHECKING([whether libcurl is version 7.66 or later?])
+   AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
+   [#include "curl/curl.h"],
+   [[
+   #if !CURL_AT_LEAST_VERSION(7,66,0)
+   error "<7.66";
+   #endif
+   ]])], [libcurl766=yes], [libcurl766=no])
+   AC_MSG_RESULT([$libcurl766])
+   if test x$libcurl766 = xyes; then
+   AC_DEFINE([HAVE_LIBCURL_766],[1],[libcurl version is 7.66 or later])
+   fi
+
+   CFLAGS="$SAVECFLAGS"
 fi
-
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
-[#include "curl/curl.h"],
-[[int x = CURLOPT_KEYPASSWD;]])],
-                   [havekeypassword=yes],
-                   [havekeypassword=no])
-AC_MSG_CHECKING([whether CURLOPT_KEYPASSWD is defined])
-AC_MSG_RESULT([${havekeypassword}])
-if test $havekeypassword = yes; then
-  AC_DEFINE([HAVE_CURLOPT_KEYPASSWD],[1],[Is CURLOPT_KEYPASSWD defined])
-fi
-
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
-[#include "curl/curl.h"],
-[[int x = CURLINFO_RESPONSE_CODE;]])],
-                   [haveresponsecode=yes],
-                   [haveresponsecode=no])
-AC_MSG_CHECKING([whether CURLINFO_RESPONSE_CODE is defined])
-AC_MSG_RESULT([${haveresponsecode}])
-if test $haveresponsecode = yes; then
-  AC_DEFINE([HAVE_CURLINFO_RESPONSE_CODE],[1],[Is CURLINFO_RESPONSE_CODE defined])
-fi
-
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
-[#include "curl/curl.h"],
-[[int x = CURLOPT_BUFFERSIZE;]])],
-                   [havecurloption=yes],
-                   [havecurloption=no])
-AC_MSG_CHECKING([whether CURLOPT_BUFFERSIZE is defined])
-AC_MSG_RESULT([${havecurloption}])
-if test $havecurloption = yes; then
-  AC_DEFINE([HAVE_CURLOPT_BUFFERSIZE],[1],[Is CURLOPT_BUFFERSIZE defined])
-fi
-
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
-[#include "curl/curl.h"],
-[[int x = CURLOPT_TCP_KEEPALIVE;]])],
-                   [havecurloption=yes],
-                   [havecurloption=no])
-AC_MSG_CHECKING([whether CURLOPT_TCP_KEEPALIVE is defined])
-AC_MSG_RESULT([${havecurloption}])
-if test $havecurloption = yes; then
-  AC_DEFINE([HAVE_CURLOPT_KEEPALIVE],[1],[Is CURLOPT_TCP_KEEPALIVE defined])
-fi
-
-# CURLOPT_VERIFYHOST semantics differ depending on version
-AC_MSG_CHECKING([whether libcurl is version 7.66 or later?])
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
-[#include "curl/curl.h"],
-[[
-#if !CURL_AT_LEAST_VERSION(7,66,0)
-error "<7.66";
-#endif
-]])], [libcurl766=yes], [libcurl766=no])
-AC_MSG_RESULT([$libcurl766])
-if test x$libcurl766 = xyes; then
-AC_DEFINE([HAVE_LIBCURL_766],[1],[libcurl version is 7.66 or later])
-fi
-
-CFLAGS="$SAVECFLAGS"
-
 ###
 # Libxml2 control block.
 ###
@@ -1390,15 +1416,6 @@ if test "x$enable_remote_functionality" = xno ; then
   enable_byterange=no
 fi
 
-# Need curl for byte ranges
-if test "x$found_curl" = xno && test "x$enable_byterange" = xyes ; then
-  AC_MSG_ERROR([curl required for byte range support. Install curl or build without --enable-byterange.])
-  enable_byterange=no
-fi
-
-if test "x$enable_byterange" = xyes; then
-    AC_DEFINE([NETCDF_ENABLE_BYTERANGE], [1], [if true, support byte-range read of remote datasets.])
-fi
 
 # Does the user want to disable atexit?
 AC_MSG_CHECKING([whether nc_finalize should be invoked at exit])

--- a/configure.ac
+++ b/configure.ac
@@ -462,29 +462,39 @@ else
    enable_set_log_level=no
 fi
 
+# Does the user want to allow reading of remote data via range headers?
+AC_MSG_CHECKING([whether byte range support is enabled])
+AC_ARG_ENABLE([byterange],
+              [AS_HELP_STRING([--disable-byterange],
+                              [allow byte-range I/O])])
+test "x$enable_byterange" = xno || enable_byterange=yes
+AC_MSG_RESULT($enable_byterange)
 
-# CURLOPT_USERNAME is not defined until curl version 7.19.1
-# CURLOPT_PASSWORD is not defined until curl version 7.19.1
-# CURLOPT_KEYPASSWD is not defined until curl version 7.16.4
-# CURLINFO_RESPONSE_CODE is not defined until curl version 7.10.7
-# CURLOPT_CHUNK_BGN_FUNCTION is not defined until curl version 7.21.0
-# CURL_MAX_READ_SIZE is not defined until 7.59
+if test "x$enable_dap" = xno && test "x$enable_byterange" = xyes; then 
+   AC_MSG_WARN([DAP required for byterange. Byterange support disabled.])
+   enable_byterange=no
+fi
 
-# Save/restore CFLAGS
+###
+# Stanza to check for functionality which requires linking against
+# libcurl.
+###
+
 if test "x$enable_dap" = xyes || test "x$enable_nczarr" = xyes; then 
    enable_curl=yes
 fi
 
 if test "x$enable_curl" = xyes; then
 
-   if test "x$enable_dap" = xyes & test "x$found_curl" = xno ; then
+
+   if test "x$enable_dap" = xyes && test "x$found_curl" = xno ; then
       AC_MSG_WARN([curl required for dap access. DAP support disabled.])
       enable_dap=no
    fi
 
    # Need curl for byte ranges
    if test "x$found_curl" = xno && test "x$enable_byterange" = xyes ; then
-   AC_MSG_ERROR([curl required for byte range support. Install curl or build without --enable-byterange.])
+   AC_MSG_WARN([curl required for byte range support. Install curl or build without --enable-byterange.])
    enable_byterange=no
    fi
 
@@ -502,8 +512,16 @@ if test "x$enable_curl" = xyes; then
    enable_dap=no
    fi
 
+   # Save/restore CFLAGS
    SAVECFLAGS="$CFLAGS"
    CFLAGS="${curl_cflags}"
+
+   # CURLOPT_USERNAME is not defined until curl version 7.19.1
+   # CURLOPT_PASSWORD is not defined until curl version 7.19.1
+   # CURLOPT_KEYPASSWD is not defined until curl version 7.16.4
+   # CURLINFO_RESPONSE_CODE is not defined until curl version 7.10.7
+   # CURLOPT_CHUNK_BGN_FUNCTION is not defined until curl version 7.21.0
+   # CURL_MAX_READ_SIZE is not defined until 7.59
 
    AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
    [#include "curl/curl.h"],
@@ -587,6 +605,11 @@ if test "x$enable_curl" = xyes; then
 
    CFLAGS="$SAVECFLAGS"
 fi
+
+###
+# End libcurl-related stanza
+###
+
 ###
 # Libxml2 control block.
 ###
@@ -1403,13 +1426,7 @@ if test "x$enable_mmap" = xyes; then
     AC_DEFINE([USE_MMAP], [1], [if true, use mmap for in-memory files])
 fi
 
-# Does the user want to allow reading of remote data via range headers?
-AC_MSG_CHECKING([whether byte range support is enabled])
-AC_ARG_ENABLE([byterange],
-              [AS_HELP_STRING([--disable-byterange],
-                              [allow byte-range I/O])])
-test "x$enable_byterange" = xno || enable_byterange=yes
-AC_MSG_RESULT($enable_byterange)
+
 
 if test "x$enable_remote_functionality" = xno ; then
   AC_MSG_WARN([--disable-remote-functionality => --disable-byterange])


### PR DESCRIPTION
* Fixes #3016 

Thanks to @edwardhartnett for pointing out that #2907 only addressed `cmake-based` builds.