### PR TITLE
CMAKE: Address #3055 - install plugins filters

### DIFF
--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -138,6 +138,17 @@ if(Blosc_FOUND)
   installplugin(h5blosc)
 endif()
 
+  installplugin(h5shuffle)
+  installplugin(h5fletcher32)
+  installplugin(h5deflate)
+
+  installplugin(zhdf5filters)
+  installplugin(zstdfilters)
+  
+  if(Szip_FOUND)
+    installplugin(h5szip)
+  endif()
+
 # Copy some test files from current source dir to out-of-tree build dir.
 file(COPY ${COPY_FILES} DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/)
 if(MSVC)


### PR DESCRIPTION
This PR reverts the removal of the installation of necessary "base" plugins https://github.com/Unidata/netcdf-c/pull/3034/files#diff-1abf564a84becf73b24c833a7300a9fcaf5ff9df6427cb54fd53b297806669a0L141.

One could simple build and install a747f5ea761d494ec5135ca4c57ba495c921a7ef and with that the base plugins would be installed one last time, and if they stay in the system, this problem might go unnoticed for the following builds.