### PR TITLE
Simplify FORTRAN access to the new plugin path mechanism

### DIFF
--- a/include/netcdf_aux.h
+++ b/include/netcdf_aux.h
@@ -103,7 +103,7 @@ EXTERNL int ncaux_add_field(void* tag,  const char *name, nc_type field_type,
 struct NCPluginList;
 
 /**
-Parse a string into a sequence of path directories.
+Parse a counted string into a sequence of path directories.
 
 The pathlist argument has the following syntax:
     paths := <empty> | dirlist
@@ -111,6 +111,7 @@ The pathlist argument has the following syntax:
     separator := ';' | ':'
     dir := <OS specific directory path>
 
+@param pathlen length of pathlist arg
 @param pathlist a string encoding a list of directories
 @param sep  one of ';' | ':' | '\0' where '\0' means use the platform's default separator.
 @param dirs a pointer to an  NCPluginPath object for returning the number and vector of directories from the parse.
@@ -121,6 +122,17 @@ will allocate the space for the vector of directory path.
 The user is then responsible for free'ing that vector
 (or call ncaux_plugin_path_reclaim).
 
+Author: Dennis Heimbigner
+*/
+EXTERNL int ncaux_plugin_path_parsen(size_t pathlen, const char* pathlist, char sep, struct NCPluginList* dirs);
+
+/**
+Parse a nul-terminated string into a sequence of path directories.
+@param pathlist a string encoding a list of directories
+@param sep  one of ';' | ':' | '\0' where '\0' means use the platform's default separator.
+@param dirs a pointer to an  NCPluginPath object for returning the number and vector of directories from the parse.
+@return ::NC_NOERR | NC_EXXX
+See also the comments for ncaux_plugin_path_parsen
 Author: Dennis Heimbigner
 */
 EXTERNL int ncaux_plugin_path_parse(const char* pathlist, char sep, struct NCPluginList* dirs);
@@ -191,6 +203,47 @@ Modify a plugin path set to prepend a new directory to the front.
 Author: Dennis Heimbigner
 */
 EXTERNL int ncaux_plugin_path_prepend(struct NCPluginList* dirs, const char* dir);
+
+/**************************************************/
+/* FORTRAN is not good at manipulating C char** vectors,
+   so provide some wrappers for use by netcdf-fortran
+   that read/write plugin path as a single string.
+   For simplicity, the path separator is always semi-colon.
+*/
+
+/**
+ * Return the length (as in strlen) of the current plugin path directories encoded as a string.
+ * @return length of the string encoded plugin path.
+ * @author Dennis Heimbigner
+ *
+ * @author: Dennis Heimbigner
+*/
+EXTERNL int ncaux_plugin_path_stringlen(void);
+
+/**
+ * Return the current sequence of directories in the internal global
+ * plugin path list encoded as a string path using ';' as a path separator.
+ * @param pathlen the length of the path argument.
+ * @param path a string into which the current plugin paths are encodeded.
+ * @return NC_NOERR | NC_EXXX
+ * @author Dennis Heimbigner
+ *
+ * @author: Dennis Heimbigner
+*/
+EXTERNL int ncaux_plugin_path_stringget(int pathlen, char* path);
+
+/**
+ * Set the current sequence of directories in the internal global
+ * plugin path list to the sequence of directories encoded as a
+ * string path using ';' as a path separator.
+ * @param pathlen the length of the path argument.
+ * @param path a string encoding the sequence of directories and using ';' to separate them.
+ * @return NC_NOERR | NC_EXXX
+ * @author Dennis Heimbigner
+ *
+ * @author: Dennis Heimbigner
+*/
+EXTERNL int ncaux_plugin_path_stringset(int pathlen, const char* path);
 
 #if defined(__cplusplus)
 }

--- a/unit_test/Makefile.am
+++ b/unit_test/Makefile.am
@@ -63,6 +63,7 @@ endif
 EXTRA_DIST = CMakeLists.txt run_s3sdk.sh run_reclaim_tests.sh run_aws_config.sh run_pluginpaths.sh run_dfaltpluginpath.sh
 EXTRA_DIST += nctest_netcdf4_classic.nc reclaim_tests.cdl
 EXTRA_DIST += ref_get.txt ref_set.txt
+EXTRA_DIST += ref_xget.txt ref_xset.txt
 
 CLEANFILES = reclaim_tests*.txt reclaim_tests.nc tmp_*.txt
 

--- a/unit_test/ref_xget.txt
+++ b/unit_test/ref_xget.txt
@@ -1,0 +1,1 @@
+testxget(global): /zero;/one;/two;/three;/four

--- a/unit_test/ref_xset.txt
+++ b/unit_test/ref_xset.txt
@@ -1,0 +1,2 @@
+testxset(global): before: /zero;/one;/two;/three;/four
+testxset(global): after: /zero;/one;/mod;/two;/three;/four

--- a/unit_test/run_pluginpaths.sh
+++ b/unit_test/run_pluginpaths.sh
@@ -86,6 +86,20 @@ testset() {
     printf "testset(nczarr): after: %s\n" `${TP} -x "set:${DFALT},set:${DFALTSET},get:nczarr"` >> ${filename}.txt
 }                           
 
+# Test the ncaux set/get/clear functions */
+testxget() {
+    filenamefor tmp xget
+    # print out the global state
+    printf "testxget(global): %s\n" `${TP} -x "xset:${DFALT},xget:global"` >> ${filename}.txt
+}                           
+
+testxset() {
+    filenamefor tmp xset
+    # print out the global state, modify it and print again
+    printf "testxset(global): before: %s\n" `${TP} -x "xset:${DFALT},xget:global"` >> ${filename}.txt
+    printf "testxset(global): after: %s\n" `${TP} -x "xset:${DFALT},xset:${DFALTSET},xget:global"` >> ${filename}.txt
+}
+
 #########################
 
 cleanup() {
@@ -98,7 +112,7 @@ init() {
 
 # Verify output for a specific action
 verify() {
-    for action in get set ; do
+    for action in get set xget xset; do
         if diff -wBb ${srcdir}/ref_${action}.txt tmp_${action}.txt ; then
 	    echo "***PASS: $action"
 	else
@@ -111,5 +125,7 @@ verify() {
 init
 testget
 testset
+testxget
+testxset
 verify
 cleanup


### PR DESCRIPTION
The new plugin path API uses char** to represent a variable lenght vector of variable length strings. FORTRAN is not capable of accessing such structures. So, this PR extends the API to provide a counted string-based API to the plugin path functionality.

The new functions are inserted in the netcdf_aux.h/daux.c files. The new functions are just wrappers around other plugin path API function; they are just (I hope) more convenient for FORTRAN users. The new functions are as follows:

### *ncaux_plugin_path_stringlen(void)*
* Return the length (as in strlen) of the current plugin path directories encoded as a string. Return -1 if the request fails.

### *int ncaux_plugin_path_stringget(int pathlen, char* path)*
* Get the current sequence of directories in the internal global plugin path list encoded as a string path using ';' as a path separator. As an example, it might return "/a/b/c;/home/user/me;/tmp". The arguments are as follows:
    * *pathlen* -- the length of the path argument.
    * *path* -- a string into which the current plugin path as a string is stored.
* Return NC_NOERR | NC_EINVAL

### *int ncaux_plugin_path_stringset(int pathlen, const char* path)*
* Set the current sequence of directories in the internal global plugin path list. As an example, it might take "/a/b/c;/home/user/me;/tmp". The arguments are as follows:
    * *pathlen* -- the length of the path argument.
    * *path* -- a string that is parsed to obtain the sequence of directories for the current plugin path.
* Return NC_NOERR | NC_EINVAL