### PR TITLE
Fix out-of-tree builds generating netcdf_json.h and netcdf_proplist.h

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -52,17 +52,17 @@ BUILT_SOURCES = netcdf_json.h netcdf_proplist.h
 
 # Give the recipe for building netcdf_json.h
 netcdf_json.h: ${top_srcdir}/libdispatch/ncjson.c ${top_srcdir}/include/ncjson.h ${top_srcdir}/include/ncexternl.h
-	rm -fr ${srcdir}/netcdf_json.h
-	cat ${srcdir}/ncjson.h | sed -e 's/NCJSON_H/NETCDF_JSON_H/' >> ${srcdir}/netcdf_json.h
-	echo '#ifdef NETCDF_JSON_H' >> netcdf_json.h
-	sed -e '/ncjson.h/d' < ${srcdir}/../libdispatch/ncjson.c >> ${srcdir}/netcdf_json.h
-	echo '#endif /*NETCDF_JSON_H*/' >> ${srcdir}/netcdf_json.h
+	rm -fr ${builddir}/netcdf_json.h
+	cat ${srcdir}/ncjson.h | sed -e 's/NCJSON_H/NETCDF_JSON_H/' >> ${builddir}/netcdf_json.h
+	echo '#ifdef NETCDF_JSON_H' >> ${builddir}/netcdf_json.h
+	sed -e '/ncjson.h/d' < ${srcdir}/../libdispatch/ncjson.c >> ${builddir}/netcdf_json.h
+	echo '#endif /*NETCDF_JSON_H*/' >> ${builddir}/netcdf_json.h
 
 # netcdf_proplist is analogous to netcdf_json but, of course, using libdispatch/ncproplist.c and include/ncproplist.h
 # Give the recipe for building netcdf_proplist.h. Basically same as for netcdf_json.h
 netcdf_proplist.h: ${top_srcdir}/libdispatch/ncproplist.c ${top_srcdir}/include/ncproplist.h ${top_srcdir}/include/ncexternl.h
-	rm -fr ${srcdir}/netcdf_proplist.h
-	cat ${srcdir}/ncproplist.h | sed -e 's/NCPROPLIST_H/NETCDF_PROPLIST_H/' >> ${srcdir}/netcdf_proplist.h
-	echo '#ifdef NETCDF_PROPLIST_H' >> netcdf_proplist.h
-	sed -e '/ncproplist.h/d' < ${srcdir}/../libdispatch/ncproplist.c >> ${srcdir}/netcdf_proplist.h
-	echo '#endif /*NETCDF_PROPLIST_H*/' >> ${srcdir}/netcdf_proplist.h
+	rm -fr ${builddir}/netcdf_proplist.h
+	cat ${srcdir}/ncproplist.h | sed -e 's/NCPROPLIST_H/NETCDF_PROPLIST_H/' >> ${builddir}/netcdf_proplist.h
+	echo '#ifdef NETCDF_PROPLIST_H' >> ${builddir}/netcdf_proplist.h
+	sed -e '/ncproplist.h/d' < ${srcdir}/../libdispatch/ncproplist.c >> ${builddir}/netcdf_proplist.h
+	echo '#endif /*NETCDF_PROPLIST_H*/' >> ${builddir}/netcdf_proplist.h

--- a/nc_test4/run_par_warn_test.sh.in
+++ b/nc_test4/run_par_warn_test.sh.in
@@ -16,5 +16,5 @@ echo
 echo "Testing MPI parallel I/O with various other mode flags..."
 @MPIEXEC@ -n 1 ./tst_warn > tmp_tst_warn_out.txt 2>&1
 cat tmp_tst_warn_out.txt
-diff -w tmp_tst_warn_out.txt ref_tmp_tst_warn_out.txt
+diff -w tmp_tst_warn_out.txt ${srcdir}/ref_tmp_tst_warn_out.txt
 


### PR DESCRIPTION
Without this, `build/include/netcdf_json.h` and `build/include_netcdf_proplist.h` simply contain the initial `#ifdev` line.