### PR TITLE
Fix "applying non-zero offset 4 to null pointer" UB

### DIFF
--- a/libdispatch/utf8proc.c
+++ b/libdispatch/utf8proc.c
@@ -388,7 +388,8 @@ static nc_utf8proc_ssize_t nc_seqindex_write_char_decomposed(nc_utf8proc_uint16_
   for (; len >= 0; entry++, len--) {
     nc_utf8proc_int32_t entry_cp = nc_seqindex_decode_entry(&entry);
 
-    written += nc_utf8proc_decompose_char(entry_cp, dst+written,
+    /* ASSERT: bufsize || bufsize == 0 */
+    written += nc_utf8proc_decompose_char(entry_cp, dst ? dst+written : NULL,
       (bufsize > written) ? (bufsize - written) : 0, options,
     last_boundclass);
     if (written < 0) return UTF8PROC_ERROR_OVERFLOW;
@@ -573,8 +574,9 @@ nc_utf8proc_ssize_t nc_utf8proc_decompose_custom(
       if (custom_func != NULL) {
         uc = custom_func(uc, custom_data);   /* user-specified custom mapping */
       }
+      /* ASSERT: dst || bufsize == 0 */
       decomp_result = nc_utf8proc_decompose_char(
-        uc, buffer + wpos, (bufsize > wpos) ? (bufsize - wpos) : 0, options,
+        uc, buffer ? buffer + wpos : NULL, (bufsize > wpos) ? (bufsize - wpos) : 0, options,
         &boundclass
       );
       if (decomp_result < 0) return decomp_result;


### PR DESCRIPTION
Detected with
```
cmake .. -GNinja \
  -DCMAKE_C_FLAGS="-fsanitize=pointer-overflow -fno-sanitize-trap=pointer-overflow -fno-sanitize-recover=pointer-overflow" \
  -DCMAKE_CXX_FLAGS="-fsanitize=pointer-overflow -fno-sanitize-trap=pointer-overflow -fno-sanitize-recover=pointer-overflow" \
  -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=pointer-overflow" -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++

ninja
ninja test
```