### PR TITLE
Provide an auxilliary function that allows users to parse the _NCProperties attribute.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,7 +7,7 @@ This file contains a high-level description of this package's evolution. Release
 
 ## 4.9.4 - TBD
 
-* Provide an auxilliary function that allows users to parse the _NCProperties attribute. See [Github #????](https://github.com/Unidata/netcdf-c/pull/????) for more information.
+* Provide an auxilliary function that allows users to parse the _NCProperties attribute. See [Github #3088](https://github.com/Unidata/netcdf-c/pull/3088) for more information.
 
 ## 4.9.3 - February 7, 2025
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,10 @@ Release Notes       {#RELEASE_NOTES}
 
 This file contains a high-level description of this package's evolution. Releases are in reverse chronological order (most recent first). Note that, as of netcdf 4.2, the `netcdf-c++` and `netcdf-fortran` libraries have been separated into their own libraries.
 
+## 4.9.4 - TBD
+
+* Provide an auxilliary function that allows users to parse the _NCProperties attribute. See [Github #????](https://github.com/Unidata/netcdf-c/pull/????) for more information.
+
 ## 4.9.3 - February 7, 2025
 
 ## Known Issues

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,9 +5,9 @@ Release Notes       {#RELEASE_NOTES}
 
 This file contains a high-level description of this package's evolution. Releases are in reverse chronological order (most recent first). Note that, as of netcdf 4.2, the `netcdf-c++` and `netcdf-fortran` libraries have been separated into their own libraries.
 
-## 4.9.4 - TBD
+## 4.10.0 - TBD
 
-* Provide an auxilliary function that allows users to parse the _NCProperties attribute. See [Github #3088](https://github.com/Unidata/netcdf-c/pull/3088) for more information.
+* Provide an auxilliary function, `ncaux_parse_provenance()`, that allows users to parse the _NCProperties attribute into a collection of character pointers. See [Github #3088](https://github.com/Unidata/netcdf-c/pull/3088) for more information.
 
 ## 4.9.3 - February 7, 2025
 

--- a/include/netcdf_aux.h
+++ b/include/netcdf_aux.h
@@ -245,6 +245,13 @@ EXTERNL int ncaux_plugin_path_stringget(int pathlen, char* path);
 */
 EXTERNL int ncaux_plugin_path_stringset(int pathlen, const char* path);
 
+/* Provide a parser for _NCProperties attribute.
+ * @param ncprop the contents of the _NCProperties attribute.
+ * @param pairsp allocate and return a pointer to a NULL terminated vector of (key,value) pairs.
+ * @return NC_NOERR | NC_EXXX
+ */
+EXTERNL int ncaux_parse_provenance(const char* ncprop, char*** pairsp);
+
 #if defined(__cplusplus)
 }
 #endif

--- a/ncdap_test/Makefile.am
+++ b/ncdap_test/Makefile.am
@@ -66,7 +66,6 @@ endif
 
 if NETCDF_ENABLE_DAP_LONG_TESTS
 test_manyurls_SOURCES = test_manyurls.c manyurls.h
-check_PROGRAMS += test_manyurls
 test_manyurls.log: tst_longremote3.log
 TESTS += test_manyurls
 endif

--- a/unit_test/Makefile.am
+++ b/unit_test/Makefile.am
@@ -60,10 +60,16 @@ check_PROGRAMS += aws_config
 TESTS += run_aws_config.sh
 endif
 
+# Test misc. netcdf_aux functions
+check_PROGRAMS += test_auxmisc
+TESTS += run_auxmisc.sh
+
 EXTRA_DIST = CMakeLists.txt run_s3sdk.sh run_reclaim_tests.sh run_aws_config.sh run_pluginpaths.sh run_dfaltpluginpath.sh
+EXTRA_DIST += run_auxmisc.sh
 EXTRA_DIST += nctest_netcdf4_classic.nc reclaim_tests.cdl
 EXTRA_DIST += ref_get.txt ref_set.txt
 EXTRA_DIST += ref_xget.txt ref_xset.txt
+EXTRA_DIST += ref_provparse.txt
 
 CLEANFILES = reclaim_tests*.txt reclaim_tests.nc tmp_*.txt
 

--- a/unit_test/ref_provparse.txt
+++ b/unit_test/ref_provparse.txt
@@ -1,0 +1,4 @@
+abc=2\|z\=17,yyy=|zzz ->  (/abc/,/2|z=17/) (/yyy/,//) (/zzz/,//)
+version=2,netcdf=4.7.4-development,hdf5=1.10.4 ->  (/version/,/2/) (/netcdf/,/4.7.4-development/) (/hdf5/,/1.10.4/)
+version=2,netcdf=4.6.2-development,hdf5=1.10.1 ->  (/version/,/2/) (/netcdf/,/4.6.2-development/) (/hdf5/,/1.10.1/)
+version=1|netcdf=4.6.2-development|hdf5=1.8.1 ->  (/version/,/1/) (/netcdf/,/4.6.2-development/) (/hdf5/,/1.8.1/)

--- a/unit_test/run_auxmisc.sh
+++ b/unit_test/run_auxmisc.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+if test "x$srcdir" = x ; then srcdir=`pwd`; fi 
+. ../test_common.sh
+
+set -e
+
+# List of provenance strings to parse
+# Start with some edge cases
+TESTS=
+TESTS="$TESTS abc=2\|z\=17,yyy=|zzz"
+TESTS="$TESTS version=2,netcdf=4.7.4-development,hdf5=1.10.4"
+TESTS="$TESTS version=2,netcdf=4.6.2-development,hdf5=1.10.1"
+TESTS="$TESTS version=1|netcdf=4.6.2-development|hdf5=1.8.1"
+
+# Test provenance parsing
+testprov() {
+rm -f tmp_provparse.txt
+for t in $TESTS ; do
+${execdir}/test_auxmisc -P ${t} >> tmp_provparse.txt
+done
+echo "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@"
+cat ${srcdir}/ref_provparse.txt
+echo "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@"
+cat tmp_provparse.txt
+echo "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@"
+# Verify
+#diff ref_provparse.txt tmp_provparse.txt
+}
+
+testprov

--- a/unit_test/test_auxmisc.c
+++ b/unit_test/test_auxmisc.c
@@ -1,0 +1,111 @@
+/*********************************************************************
+ *   Copyright 2018, UCAR/Unidata
+ *   See netcdf/COPYRIGHT file for copying and redistribution conditions.
+ *********************************************************************/
+
+/**
+Test miscellaneous netcdf_aux functions.
+*/
+
+#include "config.h"
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+#include "netcdf.h"
+#include "netcdf_aux.h"
+
+#define NCCATCH
+#include "nclog.h"
+
+#ifdef HAVE_GETOPT_H
+#include <getopt.h>
+#endif
+
+#if defined(_WIN32) && !defined(__MINGW32__)
+#include "XGetopt.h"
+#endif
+
+#define DEBUG
+
+typedef enum CMD {cmd_none=0, cmd_prov=1} CMD;
+
+struct Options {
+    int debug;
+    CMD cmd;
+    int argc;
+    char** argv;
+} options;
+
+#define CHECK(code) do {stat = check(code,__func__,__LINE__); if(stat) {goto done;}} while(0)
+
+static int
+check(int code, const char* fcn, int line)
+{
+    if(code == NC_NOERR) return code;
+    fprintf(stderr,"***fail: (%d) %s @ %s:%d\n",code,nc_strerror(code),fcn,line);
+#ifdef debug
+    abort();
+#endif
+    exit(1);
+}
+
+static void
+testprov(void)
+{
+    int stat = NC_NOERR;
+    int i;
+    char** list = NULL;
+    assert(options.argc > 0);
+    for(i=0;i<options.argc;i++) {
+        char** p;
+	CHECK(ncaux_parse_provenance(options.argv[i],&list));
+	/* Print and reclaim */
+	printf("%s -> ",options.argv[i]);
+	for(p=list;*p;p+=2) {
+	    printf(" (/%s/,/%s/)",p[0],p[1]);
+	    free(p[0]);
+	    if(p[1]) free(p[1]);
+	}
+	printf("\n");
+	free(list); list = NULL;
+    }
+done:
+    return;
+}
+
+int
+main(int argc, char** argv)
+{
+    int stat = NC_NOERR;
+    int c;
+    /* Init options */
+    memset((void*)&options,0,sizeof(options));
+
+    while ((c = getopt(argc, argv, "dP")) != EOF) {
+        switch(c) {
+        case 'd':
+            options.debug = 1;
+            break;
+	case 'P':
+	    options.cmd = cmd_prov;
+	    break;	    
+        case '?':
+           fprintf(stderr,"unknown option\n");
+           stat = NC_EINVAL;
+           goto done;
+        }
+    }
+ 
+    /* Setup args */
+    argc -= optind;
+    argv += optind;
+    options.argc = argc;
+    options.argv = argv;
+    switch (options.cmd) {
+    case cmd_prov: testprov(); break;
+    default: fprintf(stderr,"Unknown cmd\n"); abort(); break;
+    }
+done:
+    return (stat?1:0);
+}


### PR DESCRIPTION
re: Discussion https://github.com/Unidata/netcdf-c/discussions/3085

This discussion raised the issue of the best way to distinguish a netcdfd-c created file and an HDF5 created file. The recommended way is to use the _NCProperties attribute.  In order for users to process this attribute, I have added a parser for the attribute to the netcdf_aux.h file.