### PR TITLE
Clean up minor issues in DAP2+DAP4 code

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,10 @@ Release Notes       {#RELEASE_NOTES}
 
 This file contains a high-level description of this package's evolution. Releases are in reverse chronological order (most recent first). Note that, as of netcdf 4.2, the `netcdf-c++` and `netcdf-fortran` libraries have been separated into their own libraries.
 
+## 4.9.4 - TBD
+
+* Clean up minor problems with DAP2/DAP4 code. Part of the splitting of PR [Github #3068](https://github.com/Unidata/netcdf-c/pull/3068). See [Github #????](https://github.com/Unidata/netcdf-c/pull/????) for more information.
+
 ## 4.9.3 - February 7, 2025
 
 ## Known Issues

--- a/dap4_test/CMakeLists.txt
+++ b/dap4_test/CMakeLists.txt
@@ -52,7 +52,7 @@ ENDIF()
 
   IF(NETCDF_ENABLE_DAP_REMOTE_TESTS)
       add_sh_test(dap4_test test_remote)
-      add_sh_test(dap4_test test_hyrax)
+#Suppress until reconciled with hyrax: add_sh_test(dap4_test test_hyrax)
       add_sh_test(dap4_test test_dap4url)
     IF(RUN_MANUAL_TESTS)
         # The following test can only be run by hand.

--- a/dap4_test/Makefile.am
+++ b/dap4_test/Makefile.am
@@ -47,7 +47,7 @@ if NETCDF_ENABLE_DAP_REMOTE_TESTS
 
 TESTS += test_remote.sh
 TESTS += test_constraints.sh
-TESTS += test_hyrax.sh
+#Suppress until reconciled with hyrax: TESTS += test_hyrax.sh
 TESTS += test_dap4url.sh
 
 # The following test can only be run by hand.

--- a/dap4_test/test_hyrax.sh
+++ b/dap4_test/test_hyrax.sh
@@ -3,6 +3,7 @@
 if test "x$srcdir" = "x"; then srcdir=`dirname $0`; fi
 export srcdir;
 
+
 . ../test_common.sh
 
 . ${srcdir}/d4test_common.sh
@@ -61,7 +62,8 @@ hyraxsplit() {
     PREFIX=`dirname $P`
 }
 
-if test "x${RESET}" = x1 ; then rm -fr ${BASELINEHY}/*.hyrax ; fi
+# Turn on only if regenerating test baseline
+#if test "x${RESET}" = x1 ; then rm -fr ${BASELINEHY}/*.hyrax ; fi
 for f in $F ; do
   hyraxsplit $f
   makehyraxurl

--- a/libdap2/ncd2dispatch.c
+++ b/libdap2/ncd2dispatch.c
@@ -806,7 +806,7 @@ fprintf(stderr,"\n");
 		NCattribute* att = (NCattribute*)nclistget(var->attributes,j);
 		char* val = NULL;
 		/* Check for _FillValue/Variable mismatch */
-		if(strcmp(att->name,"_FillValue")==0) {
+		if(strcmp(att->name,NC_FillValue)==0) {
 		    /* Special case var is byte, fillvalue is int16 and 
 			unsignedattr == 0;
 			This exception is needed because DAP2 byte type

--- a/libdap4/d4http.c
+++ b/libdap4/d4http.c
@@ -110,8 +110,11 @@ WriteMemoryCallback(void *ptr, size_t size, size_t nmemb, void *data)
         nclog(NCLOGWARN,"WriteMemoryCallback: zero sized chunk");
     /* Optimize for reading potentially large dods datasets */
     while(!ncbytesavail(buf,realsize)) {
-        /* double the size of the packet */
-        ncbytessetalloc(buf,2*ncbytesalloc(buf));
+        /* double the size of the packet (unless the buf is empty) */
+	if(ncbytesalloc(buf) == 0)
+	    ncbytessetalloc(buf,1024);
+	else
+	   ncbytessetalloc(buf,2*ncbytesalloc(buf));
     }
     ncbytesappendn(buf, ptr, realsize);
 #ifdef PROGRESS

--- a/libdap4/d4meta.c
+++ b/libdap4/d4meta.c
@@ -739,7 +739,7 @@ compileAttrValues(NCD4meta* builder, NCD4node* attr, void** memoryp, NClist* blo
     memset((void*)&converter,0,sizeof(converter));
 
     /* Deal with _FillValue */
-    if(container->sort == NCD4_VAR && strcmp(attr->name,"_FillValue")==0) {
+    if(container->sort == NCD4_VAR && strcmp(attr->name,NC_FillValue)==0) {
 	/* Verify or fix or ignore or fail on type mismatch */
 	if(container->basetype != basetype) {/* _FillValue/Variable type mismatch */
 	    int compatible = isfilltypecompatible(container->basetype, basetype);

--- a/libdap4/d4parser.c
+++ b/libdap4/d4parser.c
@@ -65,10 +65,11 @@ static const struct KEYWORDINFO {
 };
 typedef struct KEYWORDINFO KEYWORDINFO;
 
-static const struct ATOMICTYPEINFO {
+/* Warning do not make const because sort will modify */
+static struct ATOMICTYPEINFO {
     char* name; nc_type type; size_t size;
 } atomictypeinfo[] = {
-/* Keep in sorted order for binary search */
+/* Will be sorted on first use */
 /* Use lower case for canonical comparison, but keep proper name here */
 {"Byte",NC_BYTE,sizeof(char)},
 {"Char",NC_CHAR,sizeof(char)},
@@ -85,8 +86,9 @@ static const struct ATOMICTYPEINFO {
 {"UInt64",NC_UINT64,sizeof(unsigned long long)},
 {"UInt8",NC_UBYTE,sizeof(unsigned char)},
 {"Url",NC_STRING,sizeof(char*)},
-{NULL,NC_NAT,0}
 };
+#define NCD4_NATOMICTYPES (sizeof(atomictypeinfo)/sizeof(struct ATOMICTYPEINFO))
+static int atomictypessorted = 0;
 
 /***************************************************/
 
@@ -116,7 +118,7 @@ static NCD4node* getOpaque(NCD4parser*, ncxml_t varxml, NCD4node* group);
 static int getValueStrings(NCD4parser*, NCD4node*, ncxml_t xattr, NClist*);
 static int isReserved(const char* name);
 static const KEYWORDINFO* keyword(const char* name);
-static NCD4node* lookupAtomicType(NClist*, const char* name);
+static NCD4node* lookupAtomicType(NClist*,const char* name);
 static NCD4node* lookFor(NClist* elems, const char* name, NCD4sort sort);
 static NCD4node* lookupFQN(NCD4parser*, const char* sfqn, NCD4sort);
 static int lookupFQNList(NCD4parser*, NClist* fqn, NCD4sort sort, NCD4node** result);
@@ -764,6 +766,7 @@ parseMaps(NCD4parser* parser, NCD4node* var, ncxml_t xml)
     int ret = NC_NOERR;
     ncxml_t x;
 
+    NC_UNUSED(parser);
     for(x=ncxml_child(xml, "Map");x!= NULL;x=ncxml_next(x,"Map")) {
 	char* fqn;
 	fqn = ncxml_attr(x,"name");
@@ -937,6 +940,8 @@ static int
 getValueStrings(NCD4parser* parser, NCD4node* type, ncxml_t xattr, NClist* svalues)
 {
     char* s;
+    NC_UNUSED(parser);
+    NC_UNUSED(type);
     /* See first if we have a "value" xml attribute */
     s = ncxml_attr(xattr,"value");
     if(s != NULL) 
@@ -1249,7 +1254,7 @@ defineBytestringType(NCD4parser* parser)
         if(ret != NC_NOERR) goto done;
         SETNAME(bstring,"_bytestring");
 	bstring->opaque.size = 0;
-	bstring->basetype = lookupAtomicType(parser,"UInt8");
+	bstring->basetype = lookupAtomicType(parser->meta->atomictypes,"UInt8");
         PUSH(parser->metadata->root->types,bstring);
 	parser->metadata->_bytestring = bstring;
     } else
@@ -1259,16 +1264,25 @@ done:
 }
 #endif
 
+static int atisort(const void* a, const void* b)
+{
+    return strcasecmp(((struct ATOMICTYPEINFO*)a)->name,((struct ATOMICTYPEINFO*)b)->name);
+}
+		
 static int
 defineAtomicTypes(NCD4meta* meta, NClist* list)
 {
     int ret = NC_NOERR;
     NCD4node* node;
-    const struct ATOMICTYPEINFO* ati;
+    size_t i;
  
-    if(list == NULL)
-	return THROW(NC_EINTERNAL);
-    for(ati=atomictypeinfo;ati->name;ati++) {
+    if(list == NULL) return THROW(NC_EINTERNAL);
+    if(!atomictypessorted) {
+	qsort((void*)atomictypeinfo, NCD4_NATOMICTYPES,sizeof(struct ATOMICTYPEINFO),atisort);
+	atomictypessorted = 1;
+    }
+    for(i=0;i<NCD4_NATOMICTYPES;i++) {
+	const struct ATOMICTYPEINFO* ati = &atomictypeinfo[i];
         if((ret=makeNodeStatic(meta,NULL,NCD4_TYPE,ati->type,&node))) goto done;
 	SETNAME(node,ati->name);
 	PUSH(list,node);
@@ -1277,29 +1291,26 @@ done:
     return THROW(ret);
 }
 
+static int
+aticmp(const void* a, const void* b)
+{
+    const char* name = (const char*)a;
+    NCD4node** nodebp = (NCD4node**)b;
+    return strcasecmp(name,(*nodebp)->name);
+}
+		
 /* Binary search the set of set of atomictypes */
 static NCD4node*
 lookupAtomicType(NClist* atomictypes, const char* name)
 {
-    size_t n = nclistlength(atomictypes);
-    if (n == 0) return NULL;
-    size_t L = 0;
-    size_t R = n - 1;
-    NCD4node* p;
-
-    for(;;) {
-	if(L > R) break;
-        size_t m = (L + R) / 2;
-	p = (NCD4node*)nclistget(atomictypes,m);
-	int cmp = strcasecmp(p->name,name);
-	if(cmp == 0)
-	    return p;
-	if(cmp < 0)
-	    L = (m + 1);
-	else /*cmp > 0*/
-	    R = (m - 1);
-    }
-    return NULL;
+    void* match = NULL;
+    size_t ntypes = 0;
+    NCD4node** types = NULL;
+    assert(atomictypessorted && nclistlength(atomictypes) > 0);
+    ntypes = nclistlength(atomictypes);
+    types = (NCD4node**)atomictypes->content;
+    match = bsearch((void*)name,(void*)types,ntypes,sizeof(NCD4node*),aticmp);
+    return (match==NULL?NULL:*(NCD4node**)match);
 }
 
 /**************************************************/
@@ -1650,6 +1661,7 @@ parseForwards(NCD4parser* parser, NCD4node* root)
     int ret = NC_NOERR;
     size_t i,j;
 
+    NC_UNUSED(root);
     /* process all vars */
     for(i=0;i<nclistlength(parser->vars);i++) {
         NCD4node* var = (NCD4node*)nclistget(parser->vars,i);

--- a/libncxml/ncxml_tinyxml2.cpp
+++ b/libncxml/ncxml_tinyxml2.cpp
@@ -14,6 +14,10 @@
 
 using namespace tinyxml2;
 
+#ifdef _MSC_VER /*Do not use _WIN32 since this is a visual studio issue */
+#define XMLDocument tinyxml2::XMLDocument
+#endif
+
 static int ncxml_initialized = 0;
 
 void


### PR DESCRIPTION
re: PR https://github.com/Unidata/netcdf-c/pull/3068

Part of splitting PR 3068

1. Libdap2+Libdap4: Update to change "_FillValue" to NC_FillValue constant.
2. Libdap4: Update the algorithm for sizing the packet buffer.
3. Libdap4: Dynamically sort the ATOMICTYPEINFO table so it can be used with binary search in lookupAtomicType function
4. Mark some unused function arguments.
5. Subsume the Hyrax changes in PR https://github.com/Unidata/netcdf-c/pull/3089.