### PR TITLE
Creat PR to support refactor of drc.c code.

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -10,7 +10,7 @@
 
 include_HEADERS = netcdf.h netcdf_meta.h netcdf_mem.h netcdf_aux.h	\
 netcdf_filter.h netcdf_filter_build.h netcdf_filter_hdf5_build.h 	\
-netcdf_dispatch.h
+netcdf_dispatch.h netcdf_vutils.h
 
 include_HEADERS += netcdf_json.h netcdf_proplist.h
 
@@ -25,7 +25,7 @@ nc4internal.h nctime.h nc3internal.h onstack.h ncrc.h ncauth.h		\
 ncoffsets.h nctestserver.h nc4dispatch.h nc3dispatch.h ncexternl.h	\
 ncpathmgr.h ncindex.h hdf4dispatch.h hdf5internal.h nc_provenance.h	\
 hdf5dispatch.h ncmodel.h isnan.h nccrc.h ncexhash.h ncxcache.h          \
-ncjson.h ncxml.h ncs3sdk.h ncproplist.h ncplugins.h
+ncjson.h ncxml.h ncs3sdk.h ncproplist.h ncplugins.h ncutil.h
 
 if USE_DAP
 noinst_HEADERS += ncdap.h

--- a/include/ncrc.h
+++ b/include/ncrc.h
@@ -12,10 +12,10 @@ and accessing rc files (e.g. .daprc).
 #define NCRC_H
 
 /* Need these support includes */
+#include <stdio.h>
 #include "ncuri.h"
 #include "nclist.h"
 #include "ncbytes.h"
-#include <stdio.h>
 
 /* getenv() keys */
 #define NCRCENVIGNORE "NCRCENV_IGNORE"
@@ -46,6 +46,7 @@ typedef struct NCRCinfo {
 
 /* Opaque structures */
 struct NCS3INFO;
+enum NCS3SVC;
 
 #if defined(__cplusplus)
 extern "C" {
@@ -66,23 +67,6 @@ EXTERNL NCRCentry* NC_rcfile_ith(NCRCinfo*,size_t);
 /* For internal use */
 EXTERNL void NC_rcclear(NCRCinfo* info);
 EXTERNL void NC_rcclear(NCRCinfo* info);
-
-/* From dutil.c (Might later move to e.g. nc.h */
-EXTERNL int NC__testurl(const char* path, char** basenamep);
-EXTERNL int NC_isLittleEndian(void);
-EXTERNL char* NC_entityescape(const char* s);
-EXTERNL int NC_readfile(const char* filename, NCbytes* content);
-EXTERNL int NC_readfilen(const char* filename, NCbytes* content, long long len);
-EXTERNL int NC_readfileF(FILE* fp, NCbytes* content, long long len);
-EXTERNL int NC_writefile(const char* filename, size_t size, void* content);
-EXTERNL char* NC_mktmp(const char* base);
-EXTERNL int NC_getmodelist(const char* modestr, NClist** modelistp);
-EXTERNL int NC_testmode(NCURI* uri, const char* tag);
-EXTERNL int NC_testpathmode(const char* path, const char* tag);
-EXTERNL int NC_addmodetag(NCURI* uri, const char* tag);
-EXTERNL int NC_split_delim(const char* path, char delim, NClist* segments);
-EXTERNL int NC_join(struct NClist* segments, char** pathp);
-EXTERNL int NC_joinwith(NClist* segments, const char* sep, const char* prefix, const char* suffix, char** pathp);
 
 #if defined(__cplusplus)
 }

--- a/include/ncutil.h
+++ b/include/ncutil.h
@@ -1,0 +1,94 @@
+/*
+Copyright (c) 1998-2018 University Corporation for Atmospheric Research/Unidata
+See COPYRIGHT for license information.
+*/
+
+/**
+API for libdispatch/dutil.c
+*/
+
+#ifndef NCUTIL_H
+#define NCUTIL_H
+
+/**************************************************/
+
+/* signature: void swapinline16(void* ip) */
+#define swapinline16(ip) \
+{ \
+    char b[2]; \
+    char* src = (char*)(ip); \
+    b[0] = src[1]; \
+    b[1] = src[0]; \
+    memcpy(ip, b, 2); \
+}
+
+/* signature: void swapinline32(void* ip) */
+#define swapinline32(ip) \
+{ \
+    char b[4]; \
+    char* src = (char*)(ip); \
+    b[0] = src[3]; \
+    b[1] = src[2]; \
+    b[2] = src[1]; \
+    b[3] = src[0]; \
+    memcpy(ip, b, 4); \
+}
+
+/* signature: void swapinline64(void* ip) */
+#define swapinline64(ip) \
+{ \
+    char b[8]; \
+    char* src = (char*)(ip); \
+    b[0] = src[7]; \
+    b[1] = src[6]; \
+    b[2] = src[5]; \
+    b[3] = src[4]; \
+    b[4] = src[3]; \
+    b[5] = src[2]; \
+    b[6] = src[1]; \
+    b[7] = src[0]; \
+    memcpy(ip, b, 8); \
+}
+
+/**************************************************/
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/* Opaque */
+struct NClist;
+struct NCbytes;
+struct NCURI;
+
+EXTERNL int NC__testurl(const char* path, char** basenamep);
+EXTERNL int NC_isLittleEndian(void);
+EXTERNL char* NC_backslashEscape(const char* s);
+EXTERNL char* NC_backslashUnescape(const char* esc);
+EXTERNL char* NC_entityescape(const char* s);
+EXTERNL char* NC_shellUnescape(const char* esc);
+EXTERNL int NC_mktmp(const char* base, char** tmpfile);
+EXTERNL int NC_readfile(const char* filename, struct NCbytes* content);
+EXTERNL int NC_readfilen(const char* filename, struct NCbytes* content, long long amount);
+EXTERNL int NC_readfileF(FILE* stream, struct NCbytes* content, long long amount);
+EXTERNL int NC_writefile(const char* filename, size_t size, void* content);
+EXTERNL int NC_getmodelist(const char* modestr, struct NClist** modelistp);
+EXTERNL int NC_testpathmode(const char* path, const char* tag);
+EXTERNL int NC_testmode(struct NCURI* uri, const char* tag);
+EXTERNL int NC_addmodetag(struct NCURI* uri, const char* tag);
+EXTERNL int NC_isinf(double x);
+EXTERNL int NC_isnan(double x);
+EXTERNL int NC_split_delim(const char* arg, char delim, struct NClist* segments);
+EXTERNL int NC_join(struct NClist* segments, char** pathp);
+EXTERNL int NC_joinwith(struct NClist* segments, const char* sep, const char* prefix, const char* suffix, char** pathp);
+EXTERNL void NC_sortenvv(size_t n, char** envv);
+EXTERNL void NC_sortlist(struct NClist* l);
+EXTERNL void NC_freeenvv(size_t nkeys, char** keys);
+EXTERNL int NC_swapatomicdata(size_t datalen, void* data, int typesize);
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /*NCUTIL_H*/
+

--- a/include/netcdf_vutils.h
+++ b/include/netcdf_vutils.h
@@ -1,8 +1,8 @@
-/* Copyright 2018, UCAR/Unidata and OPeNDAP, Inc.
+/* Copyright 2018, UCAR/Unidata
    See the COPYRIGHT file for more information. */
 
-#ifndef UTILS_H
-#define UTILS_H 1
+#ifndef NCVUTILS_H
+#define NCVUTILS_H 1
 
 /* Define a header-only simple version of a dynamically expandable list and byte buffer */
 /* To be used in code that should be independent of libnetcdf */
@@ -15,8 +15,8 @@ typedef struct VList {
 
 typedef struct VString {
   int nonextendible; /* 1 => fail if an attempt is made to extend this string*/
-  unsigned int alloc;
-  unsigned int length;
+  unsigned alloc;
+  unsigned length;
   char* content;
 } VString;
 
@@ -55,7 +55,7 @@ static void
 vlistexpand(VList* l)
 {
   void** newcontent = NULL;
-  size_t newsz;
+  unsigned newsz;
 
   if(l == NULL) return;
   newsz = (l->length * 2) + 1; /* basically double allocated space */
@@ -132,11 +132,11 @@ static void
 vsexpand(VString* vs)
 {
   char* newcontent = NULL;
-  size_t newsz;
+  unsigned newsz;
 
   if(vs == NULL) return;
   assert(vs->nonextendible == 0);
-  newsz = (vs->alloc + VSTRALLOC); /* basically double allocated space */
+  newsz = (vs->alloc + VSTRALLOC); /* increase allocated space */
   if(vs->alloc >= newsz) return; /* space already allocated */
   newcontent=(char*)calloc(1,newsz+1);/* always room for nul term */
   assert(newcontent != NULL);
@@ -154,7 +154,7 @@ vsappendn(VString* vs, const char* elem, unsigned n)
 {
   size_t need;
   assert(vs != NULL && elem != NULL);
-  if(n == 0) {n = strlen(elem);}
+  if(n == 0) {n = (unsigned)strlen(elem);}
   need = vs->length + n;
   if(vs->nonextendible) {
      /* Space must already be available */
@@ -166,7 +166,7 @@ vsappendn(VString* vs, const char* elem, unsigned n)
   memcpy(&vs->content[vs->length],elem,n);
   vs->length += n;
   if(!vs->nonextendible)
-      vs->content[vs->length] = '\0';
+      vs->content[vs->length] = '\0'; /* guarantee nul term */
 }
 
 static void
@@ -196,7 +196,12 @@ static char*
 vsextract(VString* vs)
 {
     char* x = NULL;
-    if(vs == NULL || vs->content == NULL) return NULL;
+    if(vs == NULL) return NULL;
+    if(vs->content == NULL) {
+	/* guarantee content existence and nul terminated */
+	if((vs->content = calloc(1,sizeof(char)))==NULL) return NULL;
+	vs->length = 0;
+    }
     x = vs->content;
     vs->content = NULL;
     vs->length = 0;
@@ -229,14 +234,14 @@ util_initialize(void)
 
 /* Following are always "in-lined"*/
 #define vlistcontents(l)  ((l)==NULL?NULL:(l)->content)
-#define vlistlength(l)  ((l)==NULL?0:(int)(l)->length)
+#define vlistlength(l)  ((l)==NULL?0:(l)->length)
 #define vlistclear(l)  vlistsetlength(l,0)
 #define vlistsetlength(l,len)  do{if((l)!=NULL) (l)->length=len;} while(0)
 
 #define vscontents(vs)  ((vs)==NULL?NULL:(vs)->content)
-#define vslength(vs)  ((vs)==NULL?0:(int)(vs)->length)
+#define vslength(vs)  ((vs)==NULL?0:(vs)->length)
 #define vscat(vs,s)  vsappendn(vs,s,0)
 #define vsclear(vs)  vssetlength(vs,0)
 #define vssetlength(vs,len)  do{if((vs)!=NULL) (vs)->length=len;} while(0)
 
-#endif /*UTILS_H*/
+#endif /*NCVUTIL_H*/

--- a/libdap4/d4file.c
+++ b/libdap4/d4file.c
@@ -316,7 +316,7 @@ set_curl_properties(NCD4INFO* d4info)
         if(path == NULL) return NC_ENOMEM;
 	snprintf(path,len,"%s/nc4cookies",globalstate->tempdir);
 	/* Create the unique cookie file name */
-        newpath = NC_mktmp(path);
+        if((ret=NC_mktmp(path,&newpath))) goto fail;
         free(path);
 	if(newpath == NULL) {
 	    fprintf(stderr,"Cannot create cookie file\n");

--- a/libdap4/d4includes.h
+++ b/libdap4/d4includes.h
@@ -43,6 +43,7 @@
 #include "nclog.h"
 #include "ncdap.h"
 #include "ncpathmgr.h"
+#include "ncutil.h"
 
 #include "d4util.h"
 

--- a/libdispatch/Makefile.am
+++ b/libdispatch/Makefile.am
@@ -51,7 +51,7 @@ endif # NETCDF_ENABLE_BYTERANGE
 if NETCDF_ENABLE_S3
 if NETCDF_ENABLE_S3_INTERNAL
 # Renamed to avoid conflicts with the HDF5 files
-libdispatch_la_SOURCES += ncs3sdk_h5.c nch5s3comms.c nch5s3comms.h ncutil.h nccurl_setup.h \
+libdispatch_la_SOURCES += ncs3sdk_h5.c nch5s3comms.c nch5s3comms.h nccurl_setup.h \
 			  nccurl_sha256.c nccurl_sha256.h nccurl_hmac.c nccurl_hmac.h
 AM_CPPFLAGS += -I$(top_srcdir)/libncxml
 libdispatch_la_CPPFLAGS += ${AM_CPPFLAGS}

--- a/libdispatch/daux.c
+++ b/libdispatch/daux.c
@@ -32,6 +32,7 @@ See COPYRIGHT for license information.
 #include "netcdf_filter.h"
 #include "ncpathmgr.h"
 #include "nclist.h"
+#include "ncutil.h"
 
 struct NCAUX_FIELD {
     char* name;
@@ -953,6 +954,8 @@ This function is just a wrapper around nc_dump__data.
 @return error code
 */
 
+EXTERNL int nc_dump_data(int ncid, nc_type xtype, void* memory, size_t count, char** bufp);
+
 EXTERNL int
 ncaux_dump_data(int ncid, int xtype, void* memory, size_t count, char** bufp)
 {
@@ -1209,7 +1212,7 @@ ncaux_plugin_path_stringlen(void)
     if((stat = nc_plugin_path_get(&npl))) goto done;
     /* Convert to a string path separated by ';' */
     if((stat = ncaux_plugin_path_tostring(&npl,';',&buf))) goto done;
-    len = nulllen(buf);
+    len = (int)nulllen(buf);
 
 done:
     if(npl.dirs != NULL) {(void)ncaux_plugin_path_clear(&npl);}

--- a/libdispatch/dinfermodel.c
+++ b/libdispatch/dinfermodel.c
@@ -33,7 +33,7 @@
 #include "ncbytes.h"
 #include "nclist.h"
 #include "nclog.h"
-#include "ncrc.h"
+#include "ncutil.h"
 #include "nchttp.h"
 #ifdef NETCDF_ENABLE_S3
 #include "ncs3sdk.h"

--- a/libdispatch/ds3util.c
+++ b/libdispatch/ds3util.c
@@ -27,6 +27,7 @@
 #include "nclist.h"
 #include "ncrc.h"
 #include "nclog.h"
+#include "ncutil.h"
 #include "ncs3sdk.h"
 
 #undef AWSDEBUG

--- a/libdispatch/dutil.c
+++ b/libdispatch/dutil.c
@@ -28,11 +28,17 @@
 #include "nclog.h"
 #include "ncrc.h"
 #include "ncpathmgr.h"
+#include "ncutil.h"
 
 #define NC_MAX_PATH 4096
 #ifndef nulldup
  #define nulldup(x) ((x)?strdup(x):(x))
 #endif
+
+
+/* Forward */
+static int lexical_compare(const void* arg1, const void* arg2);
+
 /**************************************************/
 /** \internal
  * Provide a hidden interface to allow utilities
@@ -199,19 +205,17 @@ NC_shellUnescape(const char* esc)
 }
 
 /** \internal
-Wrap mktmp and return the generated path,
+Wrap mktmp and return the generated path
 or null if failed.
-Base is the base file path. XXXXX is appended
-to allow mktmp add its unique id.
-Return the generated path.
+@param base is the base file path. XXXXX is appended to allow mktmp add its unique id.
+@param tmpfile store the generated string in this.
+@return NC_NOERR|NC_EXXX
 */
-
-char*
-NC_mktmp(const char* base)
+int
+NC_mktmp(const char* base, char** tmpfile)
 {
     int fd = -1;
-    char* tmp = NULL;
-    size_t len;
+    char tmp[8192];
 #ifndef HAVE_MKSTEMP
     int tries;
 #define MAXTRIES 4
@@ -219,12 +223,8 @@ NC_mktmp(const char* base)
     mode_t mask;
 #endif
 
-    len = strlen(base)+6+1;
-    if((tmp = (char*)calloc(1,len))==NULL)
-        goto done;
 #ifdef HAVE_MKSTEMP
-    strlcat(tmp,base,len);
-    strlcat(tmp, "XXXXXX", len);
+    snprintf(tmp,sizeof(tmp),"%sXXXXXX",base);
     mask=umask(0077);
     fd = NCmkstemp(tmp);
     (void)umask(mask);
@@ -234,10 +234,8 @@ NC_mktmp(const char* base)
 	int rno = rand();
 	char spid[7];
 	if(rno < 0) rno = -rno;
-	tmp[0] = '\0';
-        strlcat(tmp,base,len);
         snprintf(spid,sizeof(spid),"%06d",rno);
-        strlcat(tmp,spid,len);
+	snprintf(tmp,sizeof(tmp),"%s%s",base,spid);
         fd=NCopen3(tmp,O_RDWR|O_CREAT, _S_IREAD|_S_IWRITE);
 	if(fd >= 0) break; /* sucess */
 	fd = -1; /* try again */
@@ -245,13 +243,12 @@ NC_mktmp(const char* base)
 #endif /* !HAVE_MKSTEMP */
     if(fd < 0) {
         nclog(NCLOGERR, "Could not create temp file: %s",tmp);
-        nullfree(tmp);
-	tmp = NULL;
-        goto done;
+	return NC_EINVAL;
+    } else {
+	if(fd >= 0) close(fd);
+	if(tmpfile) {*tmpfile = strdup(tmp);}
+	return NC_NOERR;
     }
-done:
-    if(fd >= 0) close(fd);
-    return tmp;
 }
 
 /** \internal */
@@ -282,14 +279,14 @@ NC_readfileF(FILE* stream, NCbytes* content, long long amount)
 {
 #define READ_BLOCK_SIZE 4194304
     int ret = NC_NOERR;
-    size_t red = 0;
+    long long red = 0;
     char *part = (char*) malloc(READ_BLOCK_SIZE);
 
     while(amount < 0 || red < amount) {
 	size_t count = fread(part, 1, READ_BLOCK_SIZE, stream);
 	if(ferror(stream)) {ret = NC_EIO; goto done;}
 	if(count > 0) ncbytesappendn(content,part,(unsigned long)count);
-	red += count;
+	red += (long long)count;
     if (feof(stream)) break;
     }
     /* Keep only amount */
@@ -437,6 +434,7 @@ done:
 #if defined __APPLE__ 
 /** \internal */
 
+#if 0
 #if ! defined HAVE_DECL_ISINF
 
 int isinf(double x)
@@ -460,7 +458,7 @@ int isnan(double x)
 }
 
 #endif /* HAVE_DECL_ISNAN */
-
+#endif
 #endif /*APPLE*/
 #endif /*!_INTEL_COMPILER*/
 
@@ -537,5 +535,74 @@ NC_joinwith(NClist* segments, const char* sep, const char* prefix, const char* s
     if(pathp) *pathp = ncbytesextract(buf);
 done:
     ncbytesfree(buf);
+    return stat;
+}
+
+static int
+lexical_compare(const void* arg1, const void* arg2)
+{
+    char* s1 = *((char**)arg1);
+    char* s2 = *((char**)arg2);
+    int slen1 = (int)nulllen(s1);
+    int slen2 = (int)nulllen(s2);
+    if(slen1 != slen2) return (slen1 - slen2);
+    return strcmp(s1,s2);
+}
+
+/**
+Sort a vector of strings.
+@param n Number of strings to sort
+@param env vector of strings to sort
+*/
+void
+NC_sortenvv(size_t n, char** envv)
+{
+    if(n <= 1) return;
+    qsort(envv, n, sizeof(char*), lexical_compare);
+}
+
+/**
+Sort a nclist of strings.
+@param l NClist of strings
+*/
+void
+NC_sortlist(NClist* l)
+{
+    if(l == NULL || nclistlength(l) == 0) return;
+    NC_sortenvv(nclistlength(l),(char**)nclistcontents(l));
+}
+
+/* Free up a vector of strings */
+void
+NC_freeenvv(size_t nkeys, char** keys)
+{
+    size_t i;
+    for(i=0;i<nkeys;i++)
+	nullfree(keys[i]);
+    nullfree(keys);
+}
+
+int
+NC_swapatomicdata(size_t datalen, void* data, int typesize)
+{
+    int stat = NC_NOERR;
+    size_t i;
+
+    assert(datalen % (size_t)typesize == 0);
+
+    if(typesize == 1) goto done;
+
+    /*(typesize > 1)*/
+    for(i=0;i<datalen;) {
+	char* p = ((char*)data) + i;
+        switch (typesize) {
+        case 2: swapinline16(p); break;
+        case 4: swapinline32(p); break;
+        case 8: swapinline64(p); break;
+        default: break;
+	}
+	i += (size_t)typesize;
+    }
+done:
     return stat;
 }

--- a/libdispatch/nch5s3comms.c
+++ b/libdispatch/nch5s3comms.c
@@ -93,6 +93,7 @@
 #include "netcdf.h"
 #include "ncuri.h"
 #include "ncutil.h"
+#include "netcdf_vutils.h"
 
 /*****************/
 

--- a/libhdf5/hdf5open.c
+++ b/libhdf5/hdf5open.c
@@ -10,6 +10,7 @@
  */
 
 #include "config.h"
+#include <stddef.h>
 #include "hdf5internal.h"
 #include "hdf5err.h"
 #include "hdf5debug.h"
@@ -18,7 +19,7 @@
 #include "ncauth.h"
 #include "ncmodel.h"
 #include "ncpathmgr.h"
-#include <stddef.h>
+#include "ncutil.h"
 
 #ifdef NETCDF_ENABLE_BYTERANGE
 #include "H5FDhttp.h"

--- a/libnczarr/zincludes.h
+++ b/libnczarr/zincludes.h
@@ -46,6 +46,8 @@ extern "C" {
 #include "ncs3sdk.h"
 #include "ncindex.h"
 #include "ncjson.h"
+#include "ncproplist.h"
+#include "ncutil.h"
 
 #include "zmap.h"
 #include "zinternal.h"

--- a/libnczarr/zutil.c
+++ b/libnczarr/zutil.c
@@ -770,6 +770,7 @@ done:
 }
 
 /**************************************************/
+#if 0
 /* Endianness support */
 /* signature: void swapinline16(void* ip) */
 #define swapinline16(ip) \
@@ -833,6 +834,7 @@ NCZ_swapatomicdata(size_t datalen, void* data, int typesize)
 done:
     return THROW(stat);
 }
+#endif /*0*/
 
 char**
 NCZ_clonestringvec(size_t len, const char** vec)

--- a/libnczarr/zwalk.c
+++ b/libnczarr/zwalk.c
@@ -517,7 +517,7 @@ transfern(const struct Common* common, unsigned char* slpptr, unsigned char* mem
 	    }
 	}
         if(common->swap && xtype < NC_STRING)
-            NCZ_swapatomicdata(len,memptr,common->typesize);
+            NC_swapatomicdata(len,memptr,common->typesize);
     } else { /*writing*/
 unsigned char* srcbase = (common->reading?chunkdata:common->memory);
 unsigned srcoff = (unsigned)(memptr - srcbase);
@@ -534,7 +534,7 @@ unsigned srcidx = srcoff / sizeof(unsigned); (void)srcidx;
 	    }
 	}
         if(common->swap && xtype < NC_STRING)
-            NCZ_swapatomicdata(len,slpptr,common->typesize);
+            NC_swapatomicdata(len,slpptr,common->typesize);
     }
 done:
     return THROW(stat);

--- a/libsrc/memio.c
+++ b/libsrc/memio.c
@@ -31,6 +31,7 @@
 #include "ncpathmgr.h"
 #include "ncrc.h"
 #include "ncbytes.h"
+#include "ncutil.h"
 
 #undef DEBUG
 

--- a/libsrc/ncio.c
+++ b/libsrc/ncio.c
@@ -14,6 +14,7 @@
 #include "fbits.h"
 #include "ncuri.h"
 #include "ncrc.h"
+#include "ncutil.h"
 
 /* With the advent of diskless io, we need to provide
    for multiple ncio packages at the same time,

--- a/nc_test/tst_inmemory.c
+++ b/nc_test/tst_inmemory.c
@@ -18,6 +18,7 @@ redistribution conditions.
 #include "netcdf_mem.h"
 #include "ncbytes.h"
 #include "ncpathmgr.h"
+#include "ncutil.h"
 #include "nc_tests.h"
 #include "err_macros.h"
 

--- a/oc2/ocdata.c
+++ b/oc2/ocdata.c
@@ -5,6 +5,7 @@
 #include "ocinternal.h"
 #include "ocdebug.h"
 #include "ocdump.h"
+#include "ncutil.h"
 
 /* Forward*/
 static OCerror ocread(OCdata*, XXDR*, char*, size_t, size_t, size_t);

--- a/oc2/ocdump.c
+++ b/oc2/ocdump.c
@@ -12,6 +12,7 @@
 
 #include "ocinternal.h"
 #include "ocdebug.h"
+#include "ncutil.h"
 
 #define MAXLEVEL 1
 

--- a/oc2/ocread.c
+++ b/oc2/ocread.c
@@ -27,6 +27,7 @@
 #include "ocread.h"
 #include "occurlfunctions.h"
 #include "ncpathmgr.h"
+#include "ncutil.h"
 
 /*Forward*/
 static int readpacket(OCstate* state, NCURI*, NCbytes*, OCdxd, OCflags, long*);

--- a/oc2/xxdr.c
+++ b/oc2/xxdr.c
@@ -66,6 +66,8 @@
 #include <arpa/inet.h>
 #endif
 
+#include "ncexternl.h"
+#include "ncutil.h"
 #include "xxdr.h"
 
 int xxdr_network_order; /* network order is big endian */

--- a/oc2/xxdr.h
+++ b/oc2/xxdr.h
@@ -55,6 +55,7 @@
     * XDRUNIT))
 #endif
 
+#if 0
 /* signature: void swapinline16(unsigned short* sp) */
 #define swapinline16(ip) \
 { \
@@ -92,7 +93,7 @@
     dst[7] = src[0]; \
     *ip = *((unsigned long long*)dst); \
 }
-
+#endif /*0*/
 
 #ifdef OCIGNORE
 /* Warning dst and src should not be the same memory (assert &iswap != &i) */

--- a/plugins/NCZhdf5filters.c
+++ b/plugins/NCZhdf5filters.c
@@ -20,6 +20,7 @@ Author: Dennis Heimbigner
 #include "netcdf_filter.h"
 #include "netcdf_filter_build.h"
 #include "netcdf_json.h"
+#include "netcdf_vutils.h"
 
 #ifdef HAVE_SZ
 #include <szlib.h>


### PR DESCRIPTION
re: PR https://github.com/Unidata/netcdf-c/pull/3068

Affects files:
* libdispatch/ncutil.[ch]
* libdispatch/drc.c
* include/ncutil.h
* include/ncrc.h
* include/netcdf_vutils.h plus any files that use the above modified .h files.

Part of splitting PR 3068

1. move libdispatch/ncutil.h to include/netcdf_vutils.h and rename uses.
2. Refactor code to move and unify various functions from libdispatch/drc.c into ncutil.h and ncutil.c.
3. Modify file includes to use ncutil.h.