### PR TITLE
Broken S3 implementation for netcdf files on non-AWS + Authenticated buckets

### DIFF
--- a/include/ncs3sdk.h
+++ b/include/ncs3sdk.h
@@ -71,6 +71,7 @@ EXTERNL const char* NC_s3dumps3info(NCS3INFO* info);
 EXTERNL void NC_s3freeprofilelist(struct NClist* profiles);
 EXTERNL int NC_getactives3profile(NCURI* uri, const char** profilep);
 EXTERNL int NC_s3profilelookup(const char* profile, const char* key, const char** valuep);
+EXTERNL void NC_s3getcredentials(const char *profile, const char **region, const char **accessid, const char **accesskey);
 EXTERNL int NC_authgets3profile(const char* profile, struct AWSprofile** profilep);
 EXTERNL int NC_iss3(NCURI* uri, enum NCS3SVC*);
 EXTERNL int NC_s3urlrebuild(NCURI* url, struct NCS3INFO* s3, NCURI** newurlp);

--- a/libdispatch/dhttp.c
+++ b/libdispatch/dhttp.c
@@ -96,9 +96,12 @@ nc_http_open_verbose(const char* path, int verbose, NC_HTTP_STATE** statep)
     ncuriparse(path,&uri);
     if(uri == NULL) {stat = NCTHROW(NC_EURL); goto done;}
 
+    char *cleanpath = ncuribuild(uri, NULL, NULL, NCURISVC);
+    if(cleanpath == NULL) {stat = NCTHROW(NC_EURL); goto done;}
+
     if((state = calloc(1,sizeof(NC_HTTP_STATE))) == NULL)
         {stat = NCTHROW(NC_ENOMEM); goto done;}
-    state->path = strdup(path);
+    state->path = cleanpath;
     state->url = uri; uri = NULL;    
 #ifdef NETCDF_ENABLE_S3
     state->format = (NC_iss3(state->url,NULL)?HTTPS3:HTTPCURL);

--- a/libdispatch/dinfermodel.c
+++ b/libdispatch/dinfermodel.c
@@ -1342,7 +1342,7 @@ openmagic(struct MagicFile* file)
 	/* Construct a URL minus any fragment */
         file->curlurl = ncuribuild(file->uri,NULL,NULL,NCURISVC);
 	/* Open the curl handle */
-        if((status=nc_http_open(file->curlurl, &file->state))) goto done;
+        if((status=nc_http_open(file->path, &file->state))) goto done;
 	if((status=nc_http_size(file->state,&file->filelen))) goto done;
 #else /*!BYTERANGE*/
 	{status = NC_ENOTBUILT;}

--- a/libdispatch/ds3util.c
+++ b/libdispatch/ds3util.c
@@ -568,6 +568,34 @@ NC_s3profilelookup(const char* profile, const char* key, const char** valuep)
     if(valuep) *valuep = value;
     return stat;
 }
+/**
+ * Get the credentials for a given profile or load them from environment.
+ @param profile name to use to look for credentials
+ @param region return region from profile or env
+ @param accessid return accessid from progile or env
+ @param accesskey return accesskey from profile or env
+ */
+void NC_s3getcredentials(const char *profile, const char **region, const char** accessid, const char** accesskey) {
+    if(profile != NULL && strcmp(profile,"no") != 0) {
+        NC_s3profilelookup(profile, "aws_access_key_id", accessid);
+        NC_s3profilelookup(profile, "aws_secret_access_key", accesskey);
+        NC_s3profilelookup(profile, "region", region);
+    }
+    else
+    { // We load from env if not in profile
+        NCglobalstate* gstate = NC_getglobalstate();
+        if(gstate->aws.access_key_id != NULL && accessid){
+            *accessid = gstate->aws.access_key_id;
+        }
+        if (gstate->aws.secret_access_key != NULL && accesskey){
+            *accesskey = gstate->aws.secret_access_key;
+        }
+        if(gstate->aws.default_region != NULL && region){
+            *region = gstate->aws.default_region;
+        }
+    }
+}
+
 
 /**************************************************/
 /*

--- a/libdispatch/ncs3sdk_h5.c
+++ b/libdispatch/ncs3sdk_h5.c
@@ -182,10 +182,8 @@ NC_s3sdkcreateclient(NCS3INFO* info)
 
     s3client = (NCS3CLIENT*)calloc(1,sizeof(NCS3CLIENT));
     if(s3client == NULL) goto done;
-    if(info->profile != NULL) {
-        if((stat = NC_s3profilelookup(info->profile, "aws_access_key_id", &accessid))) goto done;
-        if((stat = NC_s3profilelookup(info->profile, "aws_secret_access_key", &accesskey))) goto done;
-    }
+    // We load credentials from env if not in profile
+    NC_s3getcredentials(info->profile, NULL, &accessid, &accesskey);
     if((s3client->rooturl = makes3rooturl(info))==NULL) {stat = NC_ENOMEM; goto done;}
     s3client->h5s3client = NCH5_s3comms_s3r_open(s3client->rooturl,info->svc,info->region,accessid,accesskey);
     if(s3client->h5s3client == NULL) {stat = NC_ES3; goto done;}

--- a/libnczarr/zmap_s3sdk.c
+++ b/libnczarr/zmap_s3sdk.c
@@ -221,6 +221,9 @@ zs3open(const char *path, int mode, size64_t flags, void* parameters, NCZMAP** m
         {stat = NC_EURL; goto done;}
 
     z3map->s3client = NC_s3sdkcreateclient(&z3map->s3);
+    if(z3map->s3client == NULL) {
+        stat = NC_ES3; goto done;
+    }
 
     /* Search the root for content */
     content = nclistnew();


### PR DESCRIPTION
I stumble upon this when trying to read a netcdf file from a  **non-AWS** S3 bucket that requires authorization.
```
$ ncdump -L 11  -v time  "https://play.min.io/unidata/u_4km.nc#mode=bytes,s3&aws.profile=play"
        log_level changed to 11
        HDF5 error messages have been turned off.
ncdump/ncdump: https://play.min.io/unidata/u_4km.nc#mode=bytes,s3&aws.profile=play: NetCDF: Unknown file format
                                        NC4_clear_provenance
                                        NCZ_clear_provenance
```

I used [minio public testing S3 server](https://min.io/docs/minio/linux/administration/minio-console.html#id6) (~/.aws/credentials)
```
[play]
aws_access_key_id = Q3AM3UQ867SPQQA43P2F
aws_secret_access_key = zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG
```

It seems that this is working for publicly available netcdf files in AWS S3 like the ones on the used on the `nczarr_test/run_external.sh`

I fixed this with 7a11d8c51d8361f0068e6ad90a81add44aaa0ac5

But I also noticed that one must always have a profile defined in order to make it work, so c791ddbf49af16725248a02a7fc9e358d5fe3cef will load try to load `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_REGION` from the environment if the profile is not set & there is no default profile (which is a valid case).
  
 I'd like to add this as a test but I really think relying on the play.min.io is not the way to go. Perhaps a github actions workflow where minio-server gets deployed and serves the S3 tests.
