### PR TITLE
Give `config.h` a higher precedence.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1429,7 +1429,7 @@ configure_file("${netCDF_SOURCE_DIR}/config.h.cmake.in"
 
 add_definitions(-DHAVE_CONFIG_H)
 
-include_directories(${netCDF_BINARY_DIR})
+include_directories(BEFORE ${netCDF_BINARY_DIR})
 # End autotools-style checks for config.h
 
 #####


### PR DESCRIPTION
This fixes a bug on 4.9.2 where an installed non-netcdf `config.h` (I think this was pulled in from a system library - unfortunately I don't have access to that machine myself) was included instead of netcdf's `config.h` due to the order of `-I` statements.

Another nice effect of this is it makes the order of `-I`s for cmake more similar to those generated by `./configure`.