### PR TITLE
Fix bug in copying compound types with variable length fields.

### DIFF
--- a/libdispatch/dinstance.c
+++ b/libdispatch/dinstance.c
@@ -284,6 +284,7 @@ done:
 @param xtype type id
 @param memory ptr to top-level memory to dump
 @param count number of instances of the type in memory block
+@param bufp return ptr to a buffer of dump'd data
 @return error code
 */
 

--- a/libdispatch/dinstance_intern.c
+++ b/libdispatch/dinstance_intern.c
@@ -439,8 +439,8 @@ copy_datar(NC_FILE_INFO_T* file, NC_TYPE_INFO_T* utype, Position src, Position d
 
 	    /* optimize: string field type */
 	    if(field->nc_typeid == NC_STRING) {
-	        char** srcstrvec = (char**)src.memory;
-	        char** dststrvec = (char**)dst.memory;
+	        char** srcstrvec = (char**)fsrc.memory;
+	        char** dststrvec = (char**)fdst.memory;
 		for(i=0;i<arraycount;i++) 
 		    {if(srcstrvec[i] != NULL) {dststrvec[i] = strdup(srcstrvec[i]);} else {dststrvec[i] = NULL;}}
 		continue; /* move to next field */

--- a/unit_test/Makefile.am
+++ b/unit_test/Makefile.am
@@ -70,8 +70,8 @@ EXTRA_DIST += nctest_netcdf4_classic.nc reclaim_tests.cdl
 EXTRA_DIST += ref_get.txt ref_set.txt
 EXTRA_DIST += ref_xget.txt ref_xset.txt
 EXTRA_DIST += ref_provparse.txt
-
-CLEANFILES = reclaim_tests*.txt reclaim_tests.nc tmp_*.txt
+EXTRA_DIST += reclaim_tests.baseline
+CLEANFILES = reclaim_tests*.txt reclaim_tests.nc reclaim_tests.dmp tmp_*.txt
 
 # If valgrind is present, add valgrind targets.
 @VALGRIND_CHECK_RULES@

--- a/unit_test/reclaim_tests.baseline
+++ b/unit_test/reclaim_tests.baseline
@@ -1,0 +1,94 @@
+netcdf reclaim_tests {
+types:
+  int(*) vint_t ;
+  string(*) vstr_t ;
+  compound cmpd_atomic_t {
+    int f1 ;
+    float f2(2, 2) ;
+  }; // cmpd_atomic_t
+  compound cmpd_str_t {
+    string f1(3) ;
+  }; // cmpd_str_t
+  compound cmpd_str_att_t {
+    string field0 ;
+    int field1 ;
+    string fields2 ;
+  }; // cmpd_str_att_t
+  vint_t(*) vvint_t ;
+  vstr_t(*) vvstr_t ;
+  compound cmpd_vlen_t {
+    vint_t f1(2) ;
+  }; // cmpd_vlen_t
+  compound cmpd_cmpd_t {
+    vstr_t f1(2) ;
+    cmpd_vlen_t f2(2) ;
+  }; // cmpd_cmpd_t
+  cmpd_atomic_t(*) vcmpd_atomic_t ;
+  cmpd_str_t(*) vcmpd_str_t ;
+  cmpd_vlen_t(*) vcmpd_vlen_t ;
+  cmpd_cmpd_t(*) vcmpd_cmpd_t ;
+dimensions:
+	d1 = 1 ;
+	d2 = 2 ;
+	d3 = 3 ;
+	d4 = 4 ;
+variables:
+	int intvar(d4) ;
+	string strvar(d4) ;
+	vint_t vintvar(d4) ;
+	vstr_t vstrvar(d4) ;
+	vvint_t vvintvar(d4) ;
+	vvstr_t vvstrvar(d4) ;
+	cmpd_atomic_t catomvar(d2) ;
+	cmpd_str_t cstrvar(d2) ;
+	cmpd_vlen_t cvlenvar(d2) ;
+	cmpd_cmpd_t ccmpdvar(d2) ;
+	vcmpd_atomic_t vcatomvar ;
+	vcmpd_str_t vcstrvar(d2) ;
+	vcmpd_vlen_t vcvlenvar(d3) ;
+	vcmpd_cmpd_t vccmpdvar ;
+	int int3110 ;
+		cmpd_str_att_t int3110:stratt = {"field0", 31, "field3"} ;
+data:
+
+ intvar = 17, 13, 11, 7 ;
+
+ strvar = "a", "ab", "abc", "abcd" ;
+
+ vintvar = {1}, {1, 2}, {1, 2, 3}, {1, 2, 3, 4} ;
+
+ vstrvar = {"a", "ab", "abc", "abcd"}, {"abcd", "abc", "ab"}, {"a", "ab"}, 
+    {"abcd"} ;
+
+ vvintvar = {{1}, {1, 2}}, {{1, 2, 3}}, {{1, 2, 3, 4}}, 
+    {{17, 13}, {11, 7}, {5, 3}, {2, 1}} ;
+
+ vvstrvar = {{"1"}, {"1", "2"}}, {{"1", "2", "3"}}, {{"1", "2", "3", "4"}}, 
+    {{"17", "13"}, {"11", "7"}, {"5", "3"}, {"2", "1"}} ;
+
+ catomvar = {17, {1.1, 2.2, 3.3, 4.4}}, {27, {4.1, 3.2, 3.3, 1.4}} ;
+
+ cstrvar = {{"a", "abc", "abcd"}}, {{"x", "yz", "ijkl"}} ;
+
+ cvlenvar = {{{17, 13}, {11}}}, {{{3, 5}, {7, 11}}} ;
+
+ ccmpdvar = 
+    {{{"xxx"}, {"yyy"}}, {{{{17, 13}, {12, 9}}}, {{{1, 3}, {2, 11}}}}}, 
+    {{{"uv"}, {"w"}}, {{{{117, 113}, {112, 119}}}, {{{111, 113}, {112, 1111}}}}} ;
+
+ vcatomvar = {{17, {1.1, 2.2, 3.3, 4.4}}, {27, {4.1, 3.2, 3.3, 1.4}}} ;
+
+ vcstrvar = 
+    {{{"c11a", "c12a", "c13a"}}, {{"c11b", "c12b", "c13b"}}, {{"c11c", "c12c", "c13c"}}, {{"c11d", "c12d", "c13d"}}}, 
+    {{{"c21a", "c22a", "c23a"}}, {{"c21b", "c22b", "c23b"}}, {{"c21c", "c22c", "c23c"}}, {{"c21d", "c22d", "c23d"}}} ;
+
+ vcvlenvar = 
+    {{{{117, 113}, {111}}}, {{{13, 15}, {17, 111}}}, {{{217, 213}, {211}}}, {{{23, 25}, {27, 211}}}}, 
+    {{{{2117, 2113}, {2211}}}, {{{2223, 2215}, {2227, 22111}}}, {{{22217, 22213}, {22211}}}, {{{2223, 2225}, {2227, 22211}}}}, 
+    {{{{33117, 33113}, {33111}}}, {{{3313, 3315}, {3317, 33111}}}, {{{33217, 33213}, {33211}}}, {{{3323, 3325}, {3327, 33211}}}} ;
+
+ vccmpdvar = 
+    {{{{"xxx"}, {"yyy"}}, {{{{17, 13}, {12, 9}}}, {{{1, 3}, {2, 11}}}}}, {{{"uv"}, {"w"}}, {{{{117, 113}, {112, 119}}}, {{{111, 113}, {112, 1111}}}}}} ;
+
+ int3110 = 117 ;
+}

--- a/unit_test/reclaim_tests.cdl
+++ b/unit_test/reclaim_tests.cdl
@@ -19,6 +19,13 @@ types:
         vstr_t f1(2) ;
 	cmpd_vlen_t f2(2);
     };
+    /* Specific test types */
+    /* ref: Issue https://github.com/Unidata/netcdf-c/issues/3110 */
+    compound cmpd_str_att_t { /* compound with separate string typed field(s) */
+	string field0 ;
+	int field1 ;
+	string fields2 ;
+    };
 
     cmpd_atomic_t(*) vcmpd_atomic_t;
     cmpd_str_t(*) vcmpd_str_t;
@@ -54,6 +61,10 @@ variables:
     vcmpd_vlen_t vcvlenvar(d3);
     vcmpd_cmpd_t vccmpdvar;
 
+    /* Special cases */
+    int int3110;
+	cmpd_str_att_t int3110:stratt = {"field0", 31, "field3"} ;
+
 data:
     intvar = 17, 13, 11, 7 ;
     strvar = "a", "ab", "abc", "abcd" ; 
@@ -69,6 +80,9 @@ data:
     vcstrvar = {{{"c11a","c12a","c13a"}},{{"c11b","c12b","c13b"}},{{"c11c","c12c","c13c"}},{{"c11d","c12d","c13d"}}},{{{"c21a","c22a","c23a"}},{{"c21b","c22b","c23b"}},{{"c21c","c22c","c23c"}},{{"c21d","c22d","c23d"}}};
     vcvlenvar = {{{{117,113},{111}}}, {{{13,15},{17,111}}},{{{217,213},{211}}}, {{{23,25},{27,211}}}}, {{{{2117,2113},{2211}}}, {{{2223,2215},{2227,22111}}},{{{22217,22213},{22211}}}, {{{2223,2225},{2227,22211}}}}, {{{{33117,33113},{33111}}}, {{{3313,3315},{3317,33111}}},{{{33217,33213},{33211}}}, {{{3323,3325},{3327,33211}}}};
     vccmpdvar = {{{{"xxx"},{"yyy"}},{{{{17,13},{12,9}}},{{{1,3},{2,11}}}}}, {{{"uv"},{"w"}},{{{{117,113},{112,119}}},{{{111,113},{112,1111}}}}}};
+
+    /* Special cases */
+    int3110 = 117;
 
 } //reclaim_tests
 

--- a/unit_test/run_reclaim_tests.sh
+++ b/unit_test/run_reclaim_tests.sh
@@ -11,6 +11,10 @@ ${execdir}/tst_reclaim > reclaim_tests.txt
 sed -e '/^(o)/p' -ed reclaim_tests.txt | sed -e 's/^(o) //' > reclaim_tests_o.txt
 sed -e '/^(c)/p' -ed reclaim_tests.txt | sed -e 's/^(c) //' > reclaim_tests_c.txt
 diff reclaim_tests_o.txt reclaim_tests_c.txt
+# Also test using ncdump 
+${NCDUMP} reclaim_tests.nc > reclaim_tests.dmp
+diff reclaim_tests.dmp ${srcdir}/reclaim_tests.baseline
+
 
     
 


### PR DESCRIPTION
re: Issue https://github.com/Unidata/netcdf-c/issues/3110

There was a two-line typo in the code in netcdf-c/libdispatch/distance_intern.c. This PR fixes it and adds a test case in netcdf-c/unit_test/tst_reclaim.c.