### PR TITLE
Modify provenance check "_IsNetcdf4" to check for existence of "_NCProperties"

### DIFF
--- a/include/hdf5internal.h
+++ b/include/hdf5internal.h
@@ -44,6 +44,10 @@
  * file must follow strict netCDF classic format rules. */
 #define NC3_STRICT_ATT_NAME NC_ATT_NC3_STRICT_NAME
 
+/* An attribute in the HDF5 root group of this name provides
+ * provenance information for Netcdf-4 files. */
+#define NC_STRICT_ATT_NAME NC_ATT_NC3_STRICT_NAME
+
 /* If this attribute is present on a dimscale variable, use the value
  * as the netCDF dimid. */
 #define NC_DIMID_ATT_NAME NC_ATT_DIMID_NAME /*See nc4internal.h*/

--- a/libsrc4/nc4internal.c
+++ b/libsrc4/nc4internal.c
@@ -53,7 +53,6 @@ static NC_reservedatt NC_reserved[] = {
     {NC_ATT_DIMID_NAME, READONLYFLAG|HIDDENATTRFLAG},			/*_Netcdf4Dimid*/
     {SUPERBLOCKATT, READONLYFLAG|NAMEONLYFLAG|VIRTUALFLAG},		/*_SuperblockVersion*/
     {NC_ATT_NC3_STRICT_NAME, READONLYFLAG},				/*_nc3_strict*/
-    {NC_ATT_NC3_STRICT_NAME, READONLYFLAG},				/*_nc3_strict*/
     {NC_NCZARR_ATTR, READONLYFLAG|HIDDENATTRFLAG},			/*_nczarr_attr */
     {NC_NCZARR_GROUP, READONLYFLAG|HIDDENATTRFLAG},			/*_nczarr_group */
     {NC_NCZARR_ARRAY, READONLYFLAG|HIDDENATTRFLAG},			/*_nczarr_array */


### PR DESCRIPTION
re: https://github.com/Unidata/netcdf-c/discussions/3085

This PR adds a check for _NCProperties provenance as part of _IsNetcdf4 test. This simplifies what the user needs to check to determine if a file is Netcdf-4. It also reduces the number of false negatives.

The primary change is to libhdf5/nc4hdf4.c. This change changes NC4_strict_att_exists to NC4_root_att_exists. This is used to check for root attributes whose existence indicate that a file is a Netcdf-4 file.