### PR TITLE
CMake: handle _INCLUDE_DIR not leveraged at compile time 

### DIFF
--- a/libdispatch/CMakeLists.txt
+++ b/libdispatch/CMakeLists.txt
@@ -5,6 +5,7 @@
 
 # See netcdf-c/COPYRIGHT file for more info.
 add_library(dispatch OBJECT)
+target_include_directories(dispatch PUBLIC ${CURL_INCLUDE_DIRS})
 
 target_sources(dispatch 
   PRIVATE

--- a/libhdf4/CMakeLists.txt
+++ b/libhdf4/CMakeLists.txt
@@ -9,6 +9,7 @@
 # Build the HDF4 dispatch layer as a library that will be included in
 # the netCDF library.
 add_library(netcdfhdf4 OBJECT ${libhdf4_SOURCES})
+target_include_directories(netcdfhdf4 PUBLIC ${MFHDF_H_INCLUDE_DIR})
 
 target_sources(netcdfhdf4
     PRIVATE

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -68,6 +68,7 @@ macro(buildplugin TARGET TARGETLIB)
     if(MPI_C_INCLUDE_PATH)
       target_include_directories(${TARGET} PRIVATE ${MPI_C_INCLUDE_PATH})
     endif(MPI_C_INCLUDE_PATH)
+    target_include_directories(${TARGET} PRIVATE ${ZLIB_INCLUDE_DIRS})
   endif()
 
   if(STATUS_PARALLEL)


### PR DESCRIPTION
## Background

- the issue affects those on Windows compiling their own libraries, but also pointing to their include folders separately, with CMake's `xxx_INCLUDE_DIR` setting for each of their dependent libraries
- since the 3.9.3 release those include dir settings have not been leveraged by CMake at compile time (meaning: all libs will be reported as found by CMake, but then at compile time, CMake will not find the include files)
  - many common packaging systems get around the CMake xxx_INCLUDE_DIR not finding include files by keeping all include files in the same directory (so something like the path of `curl/curl.h` can always be found by any other library's files)
    - most likely your test environment here uses Conda or vcpkg or some other system that does exactly that
- so you might have been noticing Windows users since the 4.9.3 release saying "hi I compile all my libraries myself but recently I have this compile error for netcdf-c of 'zlib.h - no such file or directory',      or ''zlib.h',             or 'mfhdf.h', etc
  - similar to https://github.com/Unidata/netcdf-c/issues/3099

## Environment

- Windows & Visual Studio compiler
- compiled all dependent external libraries myself/themselves
  - in my case: such as hdf4 & hdf5 (git master from today), curl, zlib, etc etc
- testing with today's netcdf-c git main

## Error messages during compile

- with Curl enabled
```
C:\netcdf-c-git-jmckenna\libdispatch\ddispatch.c(28): fatal error C1083: Cannot open include file: 'curl/curl.h': No such file or directory
```

- with HDF4 enabled
```
C:\netcdf-c-git-jmckenna\libhdf4\hdf4file.c(14): fatal error C1083: Cannot open include file: 'mfhdf.h': No such file or directory
```

- with zlib enabled
```
C:\netcdf-c-git-jmckenna\plugins\H5Zdeflate.c(23): fatal error C1083: Cannot open include file: 'zlib.h': No such file or directory
```

# Workarounds

- see this pull request for the workarounds
- this pull request as-is will fix the user reported compile errors
  - however, most likely there is a more elegant way to handle this
    - such as moving that `target_include_directories` statement from CMakeLists.txt from the top, down into some other `if (NETCDF_ENABLE_xxx` section of that CMakeLists.txt)
       - I just don't know which plugins etc require these includes, so it will need input here from the netcdf-c maintainers

My goal here is to post my workaround, and hopefully help other packagers, and maybe, just maybe, get these changes included in the next netcdf-c release

Thanks again,
