### PR TITLE
Only conditionally copy test files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1475,20 +1475,6 @@ endif()
 
 if(NETCDF_ENABLE_NCZARR)
   add_subdirectory(libnczarr)
-  file(COPY ${netCDF_SOURCE_DIR}/unit_test/timer_utils.h
-       DESTINATION ${netCDF_BINARY_DIR}/nczarr_test/)
-  file(COPY ${netCDF_SOURCE_DIR}/unit_test/timer_utils.c
-       DESTINATION ${netCDF_BINARY_DIR}/nczarr_test/)
-  file(COPY ${netCDF_SOURCE_DIR}/nc_test4/test_filter.c
-       DESTINATION ${netCDF_BINARY_DIR}/nczarr_test/)
-  file(COPY ${netCDF_SOURCE_DIR}/nc_test4/test_filter_misc.c
-       DESTINATION ${netCDF_BINARY_DIR}/nczarr_test/)
-  file(COPY ${netCDF_SOURCE_DIR}/nc_test4/test_filter_repeat.c
-       DESTINATION ${netCDF_BINARY_DIR}/nczarr_test/)
-  file(COPY ${netCDF_SOURCE_DIR}/nc_test4/test_filter_order.c
-       DESTINATION ${netCDF_BINARY_DIR}/nczarr_test/)
-  file(COPY ${netCDF_SOURCE_DIR}/nc_test4/tst_multifilter.c
-       DESTINATION ${netCDF_BINARY_DIR}/nczarr_test/)
 endif()
 
 # Tests and files which depend on libnetcdf must be included
@@ -1537,6 +1523,20 @@ if(NETCDF_ENABLE_TESTS)
     add_subdirectory(unit_test)
   endif(NETCDF_ENABLE_UNIT_TESTS)
   if(NETCDF_ENABLE_NCZARR)
+    file(COPY ${netCDF_SOURCE_DIR}/unit_test/timer_utils.h
+         DESTINATION ${netCDF_BINARY_DIR}/nczarr_test/)
+    file(COPY ${netCDF_SOURCE_DIR}/unit_test/timer_utils.c
+         DESTINATION ${netCDF_BINARY_DIR}/nczarr_test/)
+    file(COPY ${netCDF_SOURCE_DIR}/nc_test4/test_filter.c
+         DESTINATION ${netCDF_BINARY_DIR}/nczarr_test/)
+    file(COPY ${netCDF_SOURCE_DIR}/nc_test4/test_filter_misc.c
+         DESTINATION ${netCDF_BINARY_DIR}/nczarr_test/)
+    file(COPY ${netCDF_SOURCE_DIR}/nc_test4/test_filter_repeat.c
+         DESTINATION ${netCDF_BINARY_DIR}/nczarr_test/)
+    file(COPY ${netCDF_SOURCE_DIR}/nc_test4/test_filter_order.c
+         DESTINATION ${netCDF_BINARY_DIR}/nczarr_test/)
+    file(COPY ${netCDF_SOURCE_DIR}/nc_test4/tst_multifilter.c
+         DESTINATION ${netCDF_BINARY_DIR}/nczarr_test/)
     include_directories(nczarr_test)
     add_subdirectory(nczarr_test)
   endif()


### PR DESCRIPTION
Moves the block copying nczarr tests data to be under `NETCDF_ENABLE_TESTS`