### PR TITLE
hdf5open.c: Handle null dataspace gracefully

### DIFF
--- a/libhdf5/hdf5open.c
+++ b/libhdf5/hdf5open.c
@@ -443,8 +443,10 @@ create_phony_dims(NC_GRP_INFO_T *grp, hid_t hdf_datasetid, NC_VAR_INFO_T *var)
     }
     else
     {
-        /* Make sure it's scalar. */
-        assert(H5Sget_simple_extent_type(spaceid) == H5S_SCALAR);
+        /* Make sure it's scalar.  Null data space is possible in HDF5,
+         * but not allowed in netcdf data model. */
+        if (H5Sget_simple_extent_type(spaceid) != H5S_SCALAR)
+            BAIL(NC_EHDFERR);
     }
 
     /* Create a phony dimension for each dimension in the dataset,


### PR DESCRIPTION
Change null dataspace detection from abort to HDF error.

Null dataspace is legal in an HDF5 file, but not in the netcdf data model.

As a side effect, the underlying error return H5S_NO_CLASS is also changed from assertion failure and abort, to a normal error return to the caller.

Closes #3128.