### PR TITLE
Fix pointer type on 64-bit Windows

### DIFF
--- a/include/ncpathmgr.h
+++ b/include/ncpathmgr.h
@@ -90,9 +90,7 @@ Notes:
 */
 
 #ifndef WINPATH
-#if defined _WIN32 && defined __MINGW32__
-#define WINPATH 1
-#elif defined _WIN64 && defined __MINGW32__
+#if defined _WIN32 || defined __MINGW32__
 #define WINPATH 1
 #endif
 #endif

--- a/include/ncpathmgr.h
+++ b/include/ncpathmgr.h
@@ -90,9 +90,17 @@ Notes:
 */
 
 #ifndef WINPATH
-#if defined _WIN32 || defined __MINGW32__
+#if defined _WIN32 && defined __MINGW32__
+#define WINPATH 1
+#elif defined _WIN64 && defined __MINGW32__
 #define WINPATH 1
 #endif
+#endif
+
+#ifdef _WIN64
+#define STAT struct _stat64 *
+#else
+#define STAT struct _stat *
 #endif
 
 /* Define wrapper constants for use with NCaccess */
@@ -190,7 +198,7 @@ EXTERNL char* NCgetcwd(char* cwdbuf, size_t len);
 EXTERNL int NCmkstemp(char* buf);
 
 #ifdef HAVE_SYS_STAT_H
-EXTERNL int NCstat(const char* path, struct stat* buf);
+EXTERNL int NCstat(const char* path, STAT buf);
 #endif
 #ifdef HAVE_DIRENT_H
 EXTERNL DIR* NCopendir(const char* path);

--- a/libdap4/ncd4.h
+++ b/libdap4/ncd4.h
@@ -58,8 +58,9 @@ defined here, including function-like #defines.
 #ifndef nullfree
 #define nullfree(m) ((m)==NULL?NULL:(free(m),NULL))
 #endif
+#ifndef nulldup 
 #define nulldup(s) ((s)==NULL?NULL:strdup(s))
-
+#endif
 /**************************************************/
 /* DSP API wrappers */
 

--- a/libdispatch/dpathmgr.c
+++ b/libdispatch/dpathmgr.c
@@ -687,7 +687,7 @@ done:
 #ifdef HAVE_SYS_STAT_H
 EXTERNL
 int
-NCstat(const char* path, struct stat* buf)
+NCstat(const char* path, STAT buf)
 {
     int status = 0;
     char* cvtpath = NULL;

--- a/libncxml/ncxml_xml2.c
+++ b/libncxml/ncxml_xml2.c
@@ -1,13 +1,12 @@
 /* Copyright 2018-2018 University Corporation for Atmospheric  Research/Unidata. */
 
 #include <stddef.h>
-#ifdef HAVE_STDLIB_H
 #include <stdlib.h>
-#endif
 #include <string.h>
 #include <libxml2/libxml/parser.h>
 #include <libxml/tree.h>
 #include "ncxml.h"
+
 
 #ifndef nulldup
 #define nulldup(s) ((s)?strdup(s):NULL)

--- a/libncxml/ncxml_xml2.c
+++ b/libncxml/ncxml_xml2.c
@@ -1,7 +1,9 @@
 /* Copyright 2018-2018 University Corporation for Atmospheric  Research/Unidata. */
 
 #include <stddef.h>
+#ifdef HAVE_STDLIB_H
 #include <stdlib.h>
+#endif
 #include <string.h>
 #include <libxml2/libxml/parser.h>
 #include <libxml/tree.h>

--- a/libnczarr/zmap_file.c
+++ b/libnczarr/zmap_file.c
@@ -685,8 +685,12 @@ static int
 platformtestcontentbearing(const char* canonpath)
 {
     int ret = 0;
-    struct stat buf;
-    
+    #ifdef _WIN64
+        struct _stat64 buf;
+    #else
+        struct stat buf;
+    #endif
+
     ZTRACE(6,"map=%s canonpath=%s",zfmap->map.url,canonpath);
 
     errno = 0;
@@ -1166,7 +1170,11 @@ static int
 verify(const char* path, int isdir)
 {
     int ret = 0;
-    struct stat buf;
+    #ifdef _WIN64
+        struct _stat64 buf;
+    #else
+        struct stat buf;
+    #endif 
 
     ret = NCaccess(path,ACCESS_MODE_EXISTS);
     if(ret < 0)
@@ -1182,7 +1190,11 @@ static int
 verifykey(const char* key, int isdir)
 {
     int ret = 0;
-    struct stat buf;
+    #ifdef _WIN64
+        struct _stat64 buf;
+    #else
+        struct stat buf;
+    #endif 
 
     if(key[0] == '/') key++; /* Want relative name */
 

--- a/libnczarr/zplugins.c
+++ b/libnczarr/zplugins.c
@@ -221,7 +221,11 @@ NCZ_load_all_plugins(void)
     int ret = NC_NOERR;
     size_t i,j;
     struct NCglobalstate* gs = NC_getglobalstate();
-    struct stat buf;
+    #ifdef _WIN64
+        struct _stat64 buf;
+    #else
+        struct stat buf;
+    #endif
     NClist* dirs = nclistnew();
     char* defaultpluginpath = NULL;
 


### PR DESCRIPTION
* Fixes #3139 

Something changed in the MSYS2/MinGW64-based runners, resulting in failures due to a pointer type mismatch (`stat` vs. `_stat64`).  This PR corrects this, although a little more testing is needed to make sure it's comprehensive. 