### PR TITLE
Change order of operations so that data is not referenced after being freed.

### DIFF
--- a/libdap4/d4varx.c
+++ b/libdap4/d4varx.c
@@ -225,9 +225,9 @@ validated:
     if(varp) *varp = var;
 done:
     if(dapmeta) NCD4_reclaimMeta(dapmeta);
-    ncurifree(ceuri);
     if(dapresp != NULL && dapresp->error.message != NULL)
-	NCD4_reporterror(dapresp,ceuri);    /* Make sure the user sees this */
+    	NCD4_reporterror(dapresp,ceuri);    /* Make sure the user sees this */
+    ncurifree(ceuri);
     return THROW(ret);    
 }
 


### PR DESCRIPTION
* Fixes #3145 