### PR TITLE
Remove unneeded dependency 

### DIFF
--- a/.github/workflows/docker_regression_testing.yml
+++ b/.github/workflows/docker_regression_testing.yml
@@ -72,6 +72,37 @@ jobs:
             fortran-branch: '${{ matrix.fortran-branch }}'
 
 ###
+# Testing some combinatorics for various options.
+###
+  netcdf-test-matrix-oneoff:
+
+    needs: netcdf-test-matrix-serial
+
+    name: Docker-BAsed NetCDF-C, Fortran Regression Testing (One-Off tests)
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        repo-type: [ 'c' ]
+        h5ver: [ '1.14.6' ]
+        c-compiler: [ 'gcc' ]
+        fortran-branch: [ 'main' ]
+        buildsystem: [ 'both' ]
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Pull and Run netCDF Regression Tests
+        uses: WardF/netcdf-test-action@v1
+        with:
+          repo-type: '${{ matrix.repo-type }}'
+          run-c: 'TRUE'
+          build-system: '${{ matrix.buildsystem }}'
+          hdf5-version: '${{ matrix.h5ver }}'
+          ctest-repeat: 3
+          c-compiler: '${{ matrix.c-compiler }}'
+          run-fortran: 'TRUE'
+          fortran-branch: '${{ matrix.fortran-branch }}'
+          autotools-c-options: '--disable-dap --disable-dap4 --disable-libxml2 --disable-nczarr'
+### 
 # Parallel Testing
 ###          
   netcdf-test-matrix-parallel:

--- a/.github/workflows/docker_regression_testing.yml
+++ b/.github/workflows/docker_regression_testing.yml
@@ -78,7 +78,7 @@ jobs:
 
     needs: netcdf-test-matrix-serial
 
-    name: Docker-Based NetCDF-C, Fortran Regression Testing (One-Off tests)
+    name: Docker-Based NetCDF-C, Fortran Regression Testing (tinyxml2-related one-off tests)
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -102,6 +102,7 @@ jobs:
           run-fortran: 'TRUE'
           fortran-branch: '${{ matrix.fortran-branch }}'
           autotools-c-options: '--disable-dap --disable-dap4 --disable-libxml2 --disable-nczarr'
+          cmake-c-options: '-DNETCDF_ENABLE_LIBXML2=OFF -DNETCDF_ENABLE_DAP4=OFF -DNETCDF_ENABLE_NCZARR=OFF'
 ### 
 # Parallel Testing
 ###          

--- a/.github/workflows/docker_regression_testing.yml
+++ b/.github/workflows/docker_regression_testing.yml
@@ -78,7 +78,7 @@ jobs:
 
     needs: netcdf-test-matrix-serial
 
-    name: Docker-BAsed NetCDF-C, Fortran Regression Testing (One-Off tests)
+    name: Docker-Based NetCDF-C, Fortran Regression Testing (One-Off tests)
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1468,11 +1468,16 @@ endif()
 
 if(NETCDF_ENABLE_DAP4)
   add_subdirectory(libdap4)
-  add_subdirectory(libncxml)
 else()
   if(NETCDF_ENABLE_S3_INTERNAL)
     add_subdirectory(libncxml)
   endif()
+endif()
+
+if (NETCDF_ENABLE_DAP4 OR NETCDF_ENABLE_S3_INTERNAL OR NETCDF_ENABLE_NCZARR OR NETCDF_ENABLE_LIBXML2)
+  add_subdirectory(libncxml)
+else()
+  set(XMLPARSER "none required")
 endif()
 
 if(NETCDF_ENABLE_PLUGINS)

--- a/configure.ac
+++ b/configure.ac
@@ -625,48 +625,6 @@ fi
 # End libcurl-related stanza
 ###
 
-###
-# Libxml2 control block.
-###
-
-AC_MSG_CHECKING([whether to search for and use external libxml2])
-AC_ARG_ENABLE([libxml2],
-              [AS_HELP_STRING([--disable-libxml2],
-                              [disable detection and use of libxml2 in favor of the bundled xml parser])])
-test "x$enable_libxml2" = xno || enable_libxml2=yes
-AC_MSG_RESULT([$enable_libxml2])
-
-# We can optionally use libxml2 for DAP4 and nch5comms, if enabled
-have_libxml2=no
-if test "x$enable_libxml2" = xyes; then
-   AC_CHECK_PROGS([NC_XML2_CONFIG], [xml2-config])
-   if test -z "$NC_XML2_CONFIG"; then
-      AC_MSG_ERROR([Cannot find xml2-config utility. Either install the libxml2 development package, or re-run configure with --disable-libxml2 to use the bundled xml2 parser])
-   fi
-  AC_CHECK_LIB([xml2],[xmlReadMemory],[have_libxml2=yes],[have_libxml2=no])
-  if test "x$have_libxml2" = "xyes" ; then
-      AC_SEARCH_LIBS([xmlReadMemory],[xml2 xml2.dll cygxml2.dll], [],[])
-  fi
-  if test "x$have_libxml2" = xyes; then
-     XML2FLAGS=`xml2-config --cflags`
-     AC_SUBST([XML2FLAGS],${XML2FLAGS})
-     AC_DEFINE([HAVE_LIBXML2], [1], [if true, use libxml2])
-  fi
-fi
-
-if test "x$enable_libxml2" = xyes; then
-XMLPARSER="libxml2"
-else
-XMLPARSER="tinyxml2 (bundled)"
-fi
-
-# Need a condition and subst for this
-AM_CONDITIONAL(NETCDF_ENABLE_LIBXML2, [test "x$enable_libxml2" = xyes])
-AC_SUBST([XMLPARSER],[${XMLPARSER}])
-
-###
-# End Libxml2 block
-###
 
 ##
 # Should quantize be enabled?
@@ -786,6 +744,66 @@ if test "x$enable_nczarr" = xyes; then
    AC_SUBST(NETCDF_ENABLE_NCZARR)
 fi
 AM_CONDITIONAL(NETCDF_ENABLE_NCZARR, [test x$enable_nczarr = xyes])
+
+
+###
+# End nczarr, dap block
+###
+
+###
+# Libxml2 control block.
+###
+
+AC_MSG_CHECKING([whether to search for and use external libxml2])
+AC_ARG_ENABLE([libxml2],
+              [AS_HELP_STRING([--disable-libxml2],
+                              [disable detection and use of libxml2 in favor of the bundled xml parser])])
+test "x$enable_libxml2" = xno || enable_libxml2=yes
+AC_MSG_RESULT([$enable_libxml2])
+
+# We can optionally use libxml2 for DAP4 and nch5comms, if enabled
+have_libxml2=no
+if test "x$enable_libxml2" = xyes; then
+   AC_CHECK_PROGS([NC_XML2_CONFIG], [xml2-config])
+   if test -z "$NC_XML2_CONFIG"; then
+      AC_MSG_ERROR([Cannot find xml2-config utility. Either install the libxml2 development package, or re-run configure with --disable-libxml2 to use the bundled xml2 parser])
+   fi
+  AC_CHECK_LIB([xml2],[xmlReadMemory],[have_libxml2=yes],[have_libxml2=no])
+  if test "x$have_libxml2" = "xyes" ; then
+      AC_SEARCH_LIBS([xmlReadMemory],[xml2 xml2.dll cygxml2.dll], [],[])
+  fi
+  if test "x$have_libxml2" = xyes; then
+     XML2FLAGS=`xml2-config --cflags`
+     AC_SUBST([XML2FLAGS],${XML2FLAGS})
+     AC_DEFINE([HAVE_LIBXML2], [1], [if true, use libxml2])
+  fi
+fi
+
+###
+# See https://github.com/Unidata/netcdf-c/issues/2851
+# There is a condition where we can avoid compiling libxml2 *and* tinyxml2, if we don't need nczarr or DAP4.
+###
+XMLPARSER="none required"
+AM_CONDITIONAL(NETCDF_ENABLE_XML2,[test "$enable_nczarr" = yes || test "$enable_dap4" = yes || test "$enable_libxml2" = yes])
+if test "$enable_nczarr" = yes || test "$enable_dap4" = yes || test "$enable_libxml2" = yes ; then
+
+   if test "x$enable_libxml2" = xyes; then
+      XMLPARSER="libxml2"
+   else 
+      XMLPARSER="tinyxml2 (bundled)"
+   fi
+fi
+
+# Need a condition and subst for this
+AM_CONDITIONAL(NETCDF_ENABLE_LIBXML2, [test "x$enable_libxml2" = xyes])
+
+AC_SUBST([XMLPARSER],[${XMLPARSER}])
+
+###
+# End Libxml2 block
+###
+
+
 
 ##########
 # Look for Standardized libraries

--- a/libncxml/Makefile.am
+++ b/libncxml/Makefile.am
@@ -11,6 +11,11 @@
 
 include $(top_srcdir)/lib_flags.am
 
+EXTRA_DIST = CMakeLists.txt license.txt
+
+# True if DAP4 and/or NCZARR are enabled
+if NETCDF_ENABLE_XML2
+
 if NETCDF_ENABLE_LIBXML2
 AM_CPPFLAGS += ${XML2FLAGS}
 endif
@@ -27,7 +32,7 @@ AM_CXXFLAGS = -std=c++11
 libncxml_la_SOURCES = ncxml_tinyxml2.cpp tinyxml2.cpp tinyxml2.h
 endif
 
-EXTRA_DIST = CMakeLists.txt license.txt
+
 
 # Download and massage the tinyxml2 source
 REPO = https://github.com/leethomason/tinyxml2.git
@@ -52,3 +57,5 @@ tinyxml2::
 	| tr -d '\r' \
 	| cat > ./tinyxml2.cpp
 	rm -fr tinyxml2
+
+endif


### PR DESCRIPTION
* Fixes #2851 

If `libxml2`, `dap4`, and `nczarr` are turned off at configure time, there's no need to download and build tinyxml2.  This PR adds this logic for autotools, cmake, and introduces a one-off docker-based regression test. 