### PR TITLE
Address logging via environmental variable issues.

### DIFF
--- a/libdispatch/nclog.c
+++ b/libdispatch/nclog.c
@@ -49,7 +49,6 @@ static const char* nctagset[] = {"OFF","ERR","WARN","NOTE","DEBUG",NULL};
 /* Forward */
 static const char* nctagname(int tag);
 static int nctagforname(const char* tag);
-int nc_set_log_level(int level);
 /*!\defgroup NClog NClog Management
 @{*/
 
@@ -72,7 +71,6 @@ ncloginit(void)
     if(envv != NULL) {
 	int level = nctagforname(envv);
         if(level > 0) {
-            nc_set_log_level(level);
             ncsetloglevel(NCLOGNOTE);
         }
     }

--- a/libsrc4/nc4dispatch.c
+++ b/libsrc4/nc4dispatch.c
@@ -59,8 +59,9 @@ NC4_initialize(void)
         char* slevel = getenv(NCLOGLEVELENV);
         long level = atol(slevel);
 #ifdef USE_NETCDF4
-        if(level >= 0)
+        if(level >= 0) {
             nc_set_log_level((int)level);
+        }
     }
 #endif
 #endif

--- a/libsrc4/nc4internal.c
+++ b/libsrc4/nc4internal.c
@@ -70,6 +70,8 @@ static int sortcmp(const void* arg1, const void* arg2);
    severity 0 for errors, 1 for important log messages, 2 for less
    important, etc. */
 int nc_log_level = NC_TURN_OFF_LOGGING;
+
+
 #if NC_HAS_PARALLEL4
 /* File pointer for the parallel I/O log file. */
 FILE *LOG_FILE = NULL;
@@ -94,6 +96,12 @@ nc_log(int severity, const char *fmt, ...)
     va_list argp;
     int t;
     FILE *f = stderr;
+
+    const char* envv = NULL;
+    envv = getenv("NC4LOGGING");
+    if(envv != NULL) {
+        nc_log_level = atoi(envv);
+    }
 
     /* If the severity is greater than the log level, we don't print
      * this message. */


### PR DESCRIPTION
This issue was discovered while setting up to debug #3154 

Correct issue when trying to use environmental variables NCLOGGING and NCTRACING.  Need to reconcile difference between nc_set_log_level and ncsetloglevel, still. But for now, this change brings the expected behavior in line with `ncdump -L`

As it stands, without this change, I was not seeing *any* logging occurring when `NCLOGGING` was set.  