### PR TITLE
nc4hdf.c: Fix overwrite with zero-length attribute

### DIFF
--- a/libhdf5/nc4hdf.c
+++ b/libhdf5/nc4hdf.c
@@ -511,31 +511,28 @@ put_att_grpa(NC_GRP_INFO_T *grp, int varid, NC_ATT_INFO_T *att)
         }
     }
 
-    /* Does the att exists already? */
+    /* Does the att exist already? */
     if ((attr_exists = H5Aexists(locid, att->hdr.name)) < 0)
         BAIL(NC_EHDFERR);
     if (attr_exists)
     {
-        hssize_t npoints;
-
-        /* Open the attribute. */
+        /* Open the existing attribute. */
         if ((existing_attid = H5Aopen(locid, att->hdr.name, H5P_DEFAULT)) < 0)
             BAIL(NC_EATTMETA);
 
-        /* Find the type of the existing attribute. */
+        /* Get the type of the existing attribute. */
         if ((existing_att_typeid = H5Aget_type(existing_attid)) < 0)
             BAIL(NC_EATTMETA);
 
-        /* How big is the attribute? */
+        /* Get the dataspace of the existing attribute. */
         if ((existing_spaceid = H5Aget_space(existing_attid)) < 0)
             BAIL(NC_EATTMETA);
-        if ((npoints = H5Sget_simple_extent_npoints(existing_spaceid)) < 0)
-            BAIL(NC_EATTMETA);
 
-        /* For text attributes the size is specified in the datatype
-           and it is enough to compare types using H5Tequal(). */
+        /* Is new attribute the same datatype and size as previous?
+         * For text attributes the size is embedded in the datatype, not the dataspace.
+         * H5Sextent_equal will also do the right thing with NULL dataspace cases. */
         if (!H5Tequal(file_typeid, existing_att_typeid) ||
-            (att->nc_typeid != NC_CHAR && npoints != att->len))
+            (!H5Sextent_equal(spaceid, existing_spaceid)))
         {
             /* The attribute exists but we cannot re-use it. */
 

--- a/libhdf5/nc4hdf.c
+++ b/libhdf5/nc4hdf.c
@@ -520,11 +520,11 @@ put_att_grpa(NC_GRP_INFO_T *grp, int varid, NC_ATT_INFO_T *att)
         if ((existing_attid = H5Aopen(locid, att->hdr.name, H5P_DEFAULT)) < 0)
             BAIL(NC_EATTMETA);
 
-        /* Get the type of the existing attribute. */
+        /* Get the HDF5 datatype of the existing attribute. */
         if ((existing_att_typeid = H5Aget_type(existing_attid)) < 0)
             BAIL(NC_EATTMETA);
 
-        /* Get the dataspace of the existing attribute. */
+        /* Get the HDF5 dataspace of the existing attribute. */
         if ((existing_spaceid = H5Aget_space(existing_attid)) < 0)
             BAIL(NC_EATTMETA);
 

--- a/nc_test4/CMakeLists.txt
+++ b/nc_test4/CMakeLists.txt
@@ -43,6 +43,10 @@ IF(NETCDF_BUILD_UTILITIES)
 # H5 and nczarr Fixed string support
   build_bin_test(build_fixedstring)
   ADD_SH_TEST(nc_test4 tst_fixedstring)
+# H5 and zeor len attribute test
+# See https://github.com/Unidata/netcdf-c/issues/3154
+  build_bin_test(tst_zero_len_att)
+  add_sh_test(nc_test4 run_zero_len_att_test)
 IF(USE_HDF5 AND NETCDF_ENABLE_FILTER_TESTING)
   build_bin_test(tst_filterparser)
   build_bin_test(test_filter)
@@ -57,6 +61,7 @@ IF(USE_HDF5 AND NETCDF_ENABLE_FILTER_TESTING)
   ADD_SH_TEST(nc_test4 tst_specific_filters)
   ADD_SH_TEST(nc_test4 tst_bloscfail)
   ADD_SH_TEST(nc_test4 tst_filter_vlen)
+
   IF(FALSE)
     # This test is too dangerous to run in a parallel make environment.
     # It causes race conditions. So suppress and only test by hand.

--- a/nc_test4/Makefile.am
+++ b/nc_test4/Makefile.am
@@ -148,7 +148,7 @@ noop1.cdl unknown.cdl tst_broken_files.c ref_bloscx.cdl			\
 tst_bloscfail.sh tst_fixedstring.sh					\
 ref_fixedstring.cdl tst_filterinstall.sh tst_filter_vlen.sh		\
 tst_filter_misc.sh run_zstd_test.sh run_par_warn_test.sh.in		\
-ref_tmp_tst_warn_out.txt run_empty_vlen_test.sh 
+ref_tmp_tst_warn_out.txt run_zero_len_att_test.sh
 
 CLEANFILES = tst_mpi_parallel.bin cdm_sea_soundings.nc bm_chunking.nc	\
 tst_floats_1D.cdl floats_1D_3.nc floats_1D.cdl tst_*.nc tmp_*.txt       \

--- a/nc_test4/Makefile.am
+++ b/nc_test4/Makefile.am
@@ -148,7 +148,7 @@ noop1.cdl unknown.cdl tst_broken_files.c ref_bloscx.cdl			\
 tst_bloscfail.sh tst_fixedstring.sh					\
 ref_fixedstring.cdl tst_filterinstall.sh tst_filter_vlen.sh		\
 tst_filter_misc.sh run_zstd_test.sh run_par_warn_test.sh.in		\
-ref_tmp_tst_warn_out.txt 
+ref_tmp_tst_warn_out.txt run_empty_vlen_test.sh 
 
 CLEANFILES = tst_mpi_parallel.bin cdm_sea_soundings.nc bm_chunking.nc	\
 tst_floats_1D.cdl floats_1D_3.nc floats_1D.cdl tst_*.nc tmp_*.txt       \

--- a/nc_test4/Makefile.am
+++ b/nc_test4/Makefile.am
@@ -44,8 +44,9 @@ endif
 NC4_TESTS += tst_h_strbug tst_h_refs
 
 # Build test programs plus programs used in test scripts.
-check_PROGRAMS = $(NC4_TESTS) tst_empty_vlen_unlim tst_charvlenbug tst_vlenstr
-TESTS = $(NC4_TESTS) run_empty_vlen_test.sh
+check_PROGRAMS = $(NC4_TESTS) tst_empty_vlen_unlim tst_charvlenbug \ 
+tst_vlenstr tst_zero_len_att
+TESTS = $(NC4_TESTS) run_empty_vlen_test.sh run_zero_len_att_test.sh
 XFAIL_TESTS =
 
 # Add these if large file tests are turned on.
@@ -147,7 +148,7 @@ noop1.cdl unknown.cdl tst_broken_files.c ref_bloscx.cdl			\
 tst_bloscfail.sh tst_fixedstring.sh					\
 ref_fixedstring.cdl tst_filterinstall.sh tst_filter_vlen.sh		\
 tst_filter_misc.sh run_zstd_test.sh run_par_warn_test.sh.in		\
-ref_tmp_tst_warn_out.txt
+ref_tmp_tst_warn_out.txt 
 
 CLEANFILES = tst_mpi_parallel.bin cdm_sea_soundings.nc bm_chunking.nc	\
 tst_floats_1D.cdl floats_1D_3.nc floats_1D.cdl tst_*.nc tmp_*.txt       \
@@ -160,7 +161,8 @@ floats*.nc floats*.cdl shorts*.nc shorts*.cdl ints*.nc ints*.cdl        \
 testfilter_reg.nc filterrepeat.txt tmp_fillonly.nc                      \
 testfilter_order.nc crfilterorder.txt rdfilterorder.txt 1               \
 tmp_*.txt tmp_*.nc tmp*.dump tmp*.cdl tmp*.txt tmp*.tmp                 \
-tmp_bzip2.c bzip2.nc noop.nc tmp_*.dmp tmp_*.cdl ref_fixedstring.h5
+tmp_bzip2.c bzip2.nc noop.nc tmp_*.dmp tmp_*.cdl ref_fixedstring.h5 \
+zero-len-attribute-test.nc
 
 DISTCLEANFILES = findplugin.sh run_par_test.sh run_par_warn_test.sh	
 

--- a/nc_test4/run_zero_len_att_test.sh
+++ b/nc_test4/run_zero_len_att_test.sh
@@ -3,6 +3,10 @@
 if test "x$srcdir" = x ; then srcdir=`pwd`; fi
 . ../test_common.sh
 
+if ! command -v h5dump >/dev/null 2>&1; then
+  echo "h5dump not found, skipping."
+  exit 0
+fi
 
 n=0
 

--- a/nc_test4/run_zero_len_att_test.sh
+++ b/nc_test4/run_zero_len_att_test.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+if test "x$srcdir" = x ; then srcdir=`pwd`; fi
+. ../test_common.sh
+
+
+n=0
+
+while [ "$n" -le 4 ]; do
+  echo ''
+
+  if [ $n -eq 0 ]; then
+    value=""
+  else
+    value=$(echo XXXXXXXXXXXXXXXXXXXXXXXXXXXX | cut -c 1-$n)
+  fi
+
+  # Create new netcdf file with character attribute of length N.
+  sed -e "s/STR1/$value/" << EOF | ${NCGEN} -4 -o zero-len-attribute-test.nc
+netcdf zero-len-attribute-test {
+variables:
+  int var1 ;
+
+// global attributes:
+    :comment = "STR1" ;
+}
+EOF
+
+  echo Before:
+    h5dump -a comment zero-len-attribute-test.nc \
+      | grep -e STRSIZE -e DATASPACE -e \:  \
+      | tr -s '\n ' ' '
+
+  echo ''
+
+    # Overwrite the character attribute with length 0.
+    ./tst_zero_len_att
+
+  echo After : 
+  h5dump -a comment zero-len-attribute-test.nc \
+    | grep -e STRSIZE -e DATASPACE -e \:  \
+    | tr -s '\n ' ' '
+  echo ''
+  
+  CHECKVAL=$(h5dump -a comment zero-len-attribute-test.nc \
+    | grep -e STRSIZE -e DATASPACE -e \:  \
+    | tr -s '\n ' ' ' | cut -d ' ' -f 5 | tr -s '\n ' ' ')
+
+  if [ " ${CHECKVAL}" != "NULL" ]; then
+    echo ""
+    echo "ERROR: N size ${n}, expected NULL, received ${CHECKVAL}"
+    echo "Exiting"
+    echo ""
+    exit -1
+  fi
+
+
+  n=$((n + 1))
+done

--- a/nc_test4/run_zero_len_att_test.sh
+++ b/nc_test4/run_zero_len_att_test.sh
@@ -44,15 +44,15 @@ EOF
   
   CHECKVAL=$(h5dump -a comment zero-len-attribute-test.nc \
     | grep -e STRSIZE -e DATASPACE -e \:  \
-    | tr -s '\n ' ' ' | cut -d ' ' -f 5 | tr -s '\n ' ' ')
+    | tr -s '\n ' ' ' | cut -d ' ' -f 5 | xargs)
 
-  if [ " ${CHECKVAL}" != "NULL" ]; then
-    echo ""
-    echo "ERROR: N size ${n}, expected NULL, received ${CHECKVAL}"
-    echo "Exiting"
-    echo ""
-    exit -1
-  fi
+    if [ "${CHECKVAL}" != "NULL" ]; then
+      echo ""
+      echo "ERROR: N size ${n}, expected NULL, received ${CHECKVAL_STRIPPED}"
+      echo "Exiting"
+      echo ""
+      exit -1
+    fi
 
 
   n=$((n + 1))

--- a/nc_test4/run_zero_len_att_test.sh
+++ b/nc_test4/run_zero_len_att_test.sh
@@ -35,8 +35,6 @@ EOF
       | grep -e STRSIZE -e DATASPACE -e \:  \
       | tr -s '\n ' ' '
 
-  echo ''
-
     # Overwrite the character attribute with length 0.
     ./tst_zero_len_att
 
@@ -52,7 +50,7 @@ EOF
 
     if [ "${CHECKVAL}" != "NULL" ]; then
       echo ""
-      echo "ERROR: N size ${n}, expected NULL, received ${CHECKVAL_STRIPPED}"
+      echo "ERROR: N size ${n}, expected NULL, received ${CHECKVAL}"
       echo "Exiting"
       echo ""
       exit -1

--- a/nc_test4/tst_zero_len_att.c
+++ b/nc_test4/tst_zero_len_att.c
@@ -1,0 +1,33 @@
+#include <netcdf.h>
+#include <stdio.h>
+#include <string.h>
+
+#define FAIL_CODE 2
+#define BAIL(e) do {                                      \
+        printf("NetCDF error in file %s, line %d, %s\n",  \
+               __FILE__, __LINE__, nc_strerror(e));       \
+        return FAIL_CODE;                                  \
+    } while (0)
+
+#define STR1 ""     /* write empty string in this version */
+
+int
+main()
+{
+    int ncid, res, len1;
+
+    /* Open existing file in read/write mode */
+    if ((res = nc_open("zero-len-attribute-test.nc", NC_WRITE, &ncid)))
+        BAIL(res);
+    
+    len1 = strlen (STR1);
+    /* printf ("Write global attribute, strlen = %d\n", len1); */
+
+    if ((res = nc_put_att_text(ncid, NC_GLOBAL, "comment", len1, STR1)))
+        BAIL(res);
+
+    if ((res = nc_close(ncid)))
+        BAIL(res);
+
+    return 0;
+}


### PR DESCRIPTION
Fixes corner case overwriting a 1-character attribute value, with a zero-length string.
Closes issue https://github.com/Unidata/netcdf-c/issues/3154.
See discussion in that issue.