### PR TITLE
run_zero_len_att_test.sh: Improve error message

### DIFF
--- a/nc_test4/run_zero_len_att_test.sh
+++ b/nc_test4/run_zero_len_att_test.sh
@@ -46,11 +46,11 @@ EOF
   
   CHECKVAL=$(h5dump -a comment zero-len-attribute-test.nc \
     | grep -e STRSIZE -e DATASPACE -e \:  \
-    | tr -s '\n ' ' ' | cut -d ' ' -f 5 | xargs)
+    | tr -s '\n ' ' ' | cut -d ' ' -f 4,5 | xargs)
 
-    if [ "${CHECKVAL}" != "NULL" ]; then
+    if [ "${CHECKVAL}" != "DATASPACE NULL" ]; then
       echo ""
-      echo "ERROR: N size ${n}, expected NULL, received ${CHECKVAL}"
+      echo "ERROR: N size ${n}, expected DATASPACE NULL, received ${CHECKVAL}"
       echo "Exiting"
       echo ""
       exit -1


### PR DESCRIPTION
Show a bit more of the HDF5 context, since we are diagnosing at that level.  Will look like this.
```
ERROR: N size ${n}, expected DATASPACE NULL, received DATASPACE SCALAR
```