### PR TITLE
CMake Builder Docs: document m4 dependency

### DIFF
--- a/docs/building-with-cmake.md
+++ b/docs/building-with-cmake.md
@@ -22,6 +22,7 @@ The following packages are required to build netCDF-C using CMake.
 
 * netCDF-C Source Code
 * CMake version 2.8.12 or greater.
+* m4
 * Optional Requirements:
 	* HDF5 Libraries for netCDF4/HDF5 support.
 	* libcurl for DAP support.


### PR DESCRIPTION
The CMake build evidently depends on m4 when not on a release branch. Document that requirement.

As a Windows developer, I do wish there was a way to sidestep this requirement, as it's not always straightfoward/viable to have m4 available on a Windows system.
If folks have ideas on how to accomplish that, I am more than happy to put in the work myself.