### PR TITLE
Fix S3 internal configuration error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1468,10 +1468,6 @@ endif()
 
 if(NETCDF_ENABLE_DAP4)
   add_subdirectory(libdap4)
-else()
-  if(NETCDF_ENABLE_S3_INTERNAL)
-    add_subdirectory(libncxml)
-  endif()
 endif()
 
 if (NETCDF_ENABLE_DAP4 OR NETCDF_ENABLE_S3_INTERNAL OR NETCDF_ENABLE_NCZARR OR NETCDF_ENABLE_LIBXML2)


### PR DESCRIPTION
If `NETCDF_ENABLE_S3_INTERNAL` is enabled, but `NETCDF_ENABLE_DAP4` is disabled, then the command `add_subdirectory(libncxml)` was specified twice which caused the following error:

```
CMake Error at CMakeLists.txt:1478 (add_subdirectory):
  The binary directory

    /Users/src/seacas.s3/TPL/netcdf/netcdf-c/build/libncxml

  is already used to build a source directory.  It cannot be used to build
  source directory

    /Users/src/seacas.s3/TPL/netcdf/netcdf-c/libncxml

  Specify a unique binary directory name.
```