### PR TITLE
Fix the list of libraries expended in the pc file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1642,6 +1642,9 @@ endforeach()
 
 if(NC_LIBS)
   string(REPLACE ";" " " NC_LIBS "${NC_LIBS}")
+  string(REGEX REPLACE " -l[^ :]*::" " -l" NC_LIBS " ${NC_LIBS}")
+  string(REPLACE " -lHDF5" " -lhdf5" NC_LIBS "${NC_LIBS}")
+  string(REPLACE " -llibcurl" " -lcurl" NC_LIBS "${NC_LIBS}")
 endif()
 
 string(REPLACE ";" " " LINKFLAGS "${LINKFLAGS}")


### PR DESCRIPTION
Modifies the private dependency string created from CMake targets to ensure that the names of the libraries listed in the generated pc file are not CMake-defined target names. They must correctly refer to the libraries on disk, as expected by the "-l" link option.

Note that this issue appears to be recurring and occurs frequently, in fact every time CMake targets change their naming convention.