### PR TITLE
Fix Clang -Wenum-conversion warnings

### DIFF
--- a/libdap2/dceconstraints.c
+++ b/libdap2/dceconstraints.c
@@ -675,7 +675,7 @@ dcedump(DCEnode* node, NCbytes* buf)
     case CES_SELECT: {
 	DCEselection* sel = (DCEselection*)node;
 	dcetobuffer((DCEnode*)sel->lhs,buf);
-        if(sel->operator == CES_NIL) break;
+        if(sel->operator == CEO_NIL) break;
         ncbytescat(buf,opstrings[(int)sel->operator]);
         if(nclistlength(sel->rhs) > 1)
             ncbytescat(buf,"{");
@@ -1129,7 +1129,7 @@ dcedumpraw(DCEnode* node, NCbytes* buf)
 	DCEselection* sel = (DCEselection*)node;
 	ncbytescat(buf," ");
 	dcedumpraw((DCEnode*)sel->lhs,buf);
-        if(sel->operator == CES_NIL) break;
+        if(sel->operator == CEO_NIL) break;
         ncbytescat(buf,opstrings[(int)sel->operator]);
         if(nclistlength(sel->rhs) > 1)
             ncbytescat(buf,"{");

--- a/libdap2/dceconstraints.h
+++ b/libdap2/dceconstraints.h
@@ -69,7 +69,7 @@ typedef struct DCEvalue {
 
 typedef struct DCEselection {
     DCEnode node;
-    CEsort operator;
+    CEops operator;
     DCEvalue* lhs;
     NClist* rhs;
 } DCEselection;

--- a/libdap2/dceparse.c
+++ b/libdap2/dceparse.c
@@ -181,7 +181,7 @@ sel_clause(DCEparsestate* state, int selcase,
 	   Object lhs, Object relop0, Object values)
 {
     DCEselection* sel = (DCEselection*)dcecreate(CES_SELECT);
-    sel->operator = (CEsort)relop0;
+    sel->operator = (CEops)relop0;
     sel->lhs = (DCEvalue*)lhs;
     if(selcase == 2) {/*singleton value*/
 	sel->rhs = nclistnew();
@@ -318,7 +318,7 @@ collectlist(Object list0, Object decl)
 }
 
 Object
-makeselectiontag(CEsort tag)
+makeselectiontag(CEops tag)
 {
     return (Object) tag;
 }

--- a/libdap2/dceparselex.h
+++ b/libdap2/dceparselex.h
@@ -76,7 +76,7 @@ extern Object function(DCEparsestate* state, Object fcnname, Object args);
 extern Object arg_list(DCEparsestate* state, Object list0, Object decl);
 extern Object value_list(DCEparsestate* state, Object list0, Object decl);
 extern Object value(DCEparsestate* state, Object value);
-extern Object makeselectiontag(CEsort);
+extern Object makeselectiontag(CEops);
 extern Object indexer(DCEparsestate* state, Object name, Object indices);
 extern Object indexpath(DCEparsestate* state, Object list0, Object index);
 extern Object var(DCEparsestate* state, Object indexpath);


### PR DESCRIPTION
Looks like two similar enums were confused. Luckily, there should be no behaviour change because the only used constants were both zero, matching the zero of the other enum.