### PR TITLE
Fixed UBSan warnings about left shifts into the sign bit

### DIFF
--- a/libsrc/ncx.m4
+++ b/libsrc/ncx.m4
@@ -915,10 +915,10 @@ get_ix_uint(const void *xp, ix_uint *ip)
 {
 	const uchar *cp = (const uchar *) xp;
 
-	*ip = (ix_uint)(*cp++ << 24);
-	*ip = (ix_uint)(*ip | (ix_uint)(*cp++ << 16));
-	*ip = (ix_uint)(*ip | (ix_uint)(*cp++ << 8));
-	*ip = (ix_uint)(*ip | *cp);
+	*ip =       (ix_uint)(*cp++) << 24;
+	*ip = *ip | (ix_uint)(*cp++) << 16;
+	*ip = *ip | (ix_uint)(*cp++) << 8;
+	*ip = *ip | (ix_uint)(*cp);
 }
 
 static void
@@ -1865,14 +1865,14 @@ get_ix_int64(const void *xp, ix_int64 *ip)
 {
     const uchar *cp = (const uchar *) xp;
 
-    *ip  = ((ix_int64)(*cp++) << 56);
-    *ip |= ((ix_int64)(*cp++) << 48);
-    *ip |= ((ix_int64)(*cp++) << 40);
-    *ip |= ((ix_int64)(*cp++) << 32);
-    *ip |= ((ix_int64)(*cp++) << 24);
-    *ip |= ((ix_int64)(*cp++) << 16);
-    *ip |= ((ix_int64)(*cp++) <<  8);
-    *ip |=  (ix_int64)*cp;
+    *ip  = (ix_int64)((uint64_t)(*cp++) << 56);
+    *ip |= (ix_int64)((uint64_t)(*cp++) << 48);
+    *ip |= (ix_int64)((uint64_t)(*cp++) << 40);
+    *ip |= (ix_int64)((uint64_t)(*cp++) << 32);
+    *ip |= (ix_int64)((uint64_t)(*cp++) << 24);
+    *ip |= (ix_int64)((uint64_t)(*cp++) << 16);
+    *ip |= (ix_int64)((uint64_t)(*cp++) <<  8);
+    *ip |= (ix_int64)*cp;
 }
 
 static void


### PR DESCRIPTION
Added casts to unsigned to make it well-defined.

Example warnings:

libsrc/ncx.c:4054:31: runtime error: left shift of 255 by 56 places cannot be represented in type 'ix_int64' (aka 'long long')

libsrc/ncx.c:2087:24: runtime error: left shift of 255 by 24 places cannot be represented in type 'int'