### PR TITLE
Fix UBSan warnings about out-of-range assignment

### DIFF
--- a/nc_test/test_put.m4
+++ b/nc_test/test_put.m4
@@ -1398,7 +1398,7 @@ TestFunc(att)_text(AttVarArgs)
     int i, j, err, ncid, nok=0;
     double dtmp;
     IntType k, ndx[1];
-    text value[MAX_NELS];
+    unsigned char value[MAX_NELS];
 
     err = FileCreate(scratch, NC_NOCLOBBER);
     IF (err != NC_NOERR) {
@@ -1434,7 +1434,7 @@ TestFunc(att)_text(AttVarArgs)
             if (ATT_TYPE(i,j) == NC_CHAR) {
                 assert(ATT_LEN(i,j) <= MAX_NELS);
 
-                err = PutAtt(text)(ncid, BAD_VARID, ATT_NAME(i,j), ATT_LEN(i,j), value);
+                err = PutAtt(text)(ncid, BAD_VARID, ATT_NAME(i,j), ATT_LEN(i,j), (char*)value);
                 IF (err != NC_ENOTVAR)
                     EXPECT_ERR(NC_ENOTVAR, err)
                 ELSE_NOK
@@ -1442,9 +1442,9 @@ TestFunc(att)_text(AttVarArgs)
                 for (k = 0; k < ATT_LEN(i,j); k++) {
                     ndx[0] = k;
                     dtmp = hash(ATT_TYPE(i,j), -1, ndx);
-                    value[k] = (text)dtmp;
+                    value[k] = (unsigned char)dtmp;
                 }
-                err = PutAtt(text)(ncid, i, ATT_NAME(i,j), ATT_LEN(i,j), value);
+                err = PutAtt(text)(ncid, i, ATT_NAME(i,j), ATT_LEN(i,j), (char*)value);
                 IF (err != NC_NOERR)
                     EXPECT_ERR(NC_NOERR, err)
                 ELSE_NOK

--- a/nc_test/test_write.m4
+++ b/nc_test/test_write.m4
@@ -1925,7 +1925,7 @@ TestFunc(rename_att)(AttVarArgs)
     nc_type atttype;
     IntType length;
     IntType attlength;
-    char  text[MAX_NELS];
+    unsigned char text[MAX_NELS];
     double value[MAX_NELS];
     double expect;
 
@@ -1997,13 +1997,13 @@ TestFunc(rename_att)(AttVarArgs)
             IF (length != attlength)
                 error("inq_att: unexpected length");
             if (datatype == NC_CHAR) {
-                err = APIFunc(get_att_text)(ncid, varid, name, text);
+                err = APIFunc(get_att_text)(ncid, varid, name, (char*)text);
                 IF (err != NC_NOERR)
                     error("get_att_text: %s", APIFunc(strerror)(err));
                 for (k = 0; k < attlength; k++) {
                     ndx[0] = k;
                     expect = hash(datatype, -1, ndx);
-                    IF (text[k] != (char)expect)
+                    IF (text[k] != (unsigned char)expect)
                         error("get_att_text: unexpected value");
                 }
             } else {

--- a/nc_test/util.c
+++ b/nc_test/util.c
@@ -833,16 +833,17 @@ put_atts(int ncid)
     int  j;		/* index of attribute */
     int  allInRange;
     double att[MAX_NELS];
-    char catt[MAX_NELS];
+    unsigned char catt[MAX_NELS];
 
     for (i = -1; i < numVars; i++) {
 	for (j = 0; j < NATTS(i); j++) {
 	    if (ATT_TYPE(i,j) == NC_CHAR) {
 		for (k = 0; k < ATT_LEN(i,j); k++) {
-                    catt[k] = (char) hash(ATT_TYPE(i,j), -1, &k);
+			double dtmp = hash(ATT_TYPE(i,j), -1, &k);
+			catt[k] = (unsigned char) dtmp;
 		}
 		err = nc_put_att_text(ncid, i, ATT_NAME(i,j),
-		    ATT_LEN(i,j), catt);
+		    ATT_LEN(i,j), (char*)catt);
 		IF (err)
 		    error("nc_put_att_text: %s", nc_strerror(err));
 	    } else {
@@ -874,7 +875,7 @@ put_vars(int ncid)
     int  i;
     size_t  j;
     double value[MAX_NELS];
-    char text[MAX_NELS];
+    unsigned char text[MAX_NELS];
     int  allInRange;
 
     for (j = 0; j < MAX_RANK; j++)
@@ -884,14 +885,15 @@ put_vars(int ncid)
 	    err = toMixedBase(j, var_rank[i], var_shape[i], index);
 	    IF (err) error("toMixedBase");
 	    if (var_name[i][0] == 'c') {
-		text[j] = (char) hash(var_type[i], var_rank[i], index);
+		double dtmp = hash(var_type[i], var_rank[i], index);
+		text[j] = (unsigned char) dtmp;
 	    } else {
 		value[j]  = hash(var_type[i], var_rank[i], index);
 		allInRange = allInRange && inRange(value[j], var_type[i]);
 	    }
 	}
 	if (var_name[i][0] == 'c') {
-	    err = nc_put_vara_text(ncid, i, start, var_shape[i], text);
+	    err = nc_put_vara_text(ncid, i, start, var_shape[i], (char*)text);
 	    IF (err)
 		error("nc_put_vara_text: %s", nc_strerror(err));
 	} else {


### PR DESCRIPTION
The hash() function is returning 255, but char is usually signed and so 255 is too big. Use unsigned instead, then cast back to char* afterwards.

Warnings were:

46: *** testing nc_rename_att ... nc_test/test_write.c:1875:21: runtime error: 255 is outside the range of representable values of type 'char'
46: SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior nc_test/test_write.c:1875:21

46: *** testing nc_put_att_text ... nc_test/test_put.c:12894:32: runtime error: 255 is outside the range of representable values of type 'char'
46: SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior nc_test/test_put.c:12894:32

46: nc_test/util.c:844:14: runtime error: 255 is outside the range of representable values of type 'char'
46: SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior nc_test/util.c:844:14

46: nc_test/util.c:890:13: runtime error: 255 is outside the range of representable values of type 'char'
46: SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior nc_test/util.c:890:13