### PR TITLE
Part 7 - Zarr consolidated metadata

### DIFF
--- a/include/ncconfigure.h
+++ b/include/ncconfigure.h
@@ -67,6 +67,12 @@ char* strdup(const char*);
 #endif
 #endif
 
+#ifndef HAVE_STRNDUP
+#ifndef strndup
+char *strndup(const char *s, size_t len);
+#endif
+#endif
+
 #ifndef HAVE_STRLCAT
 #ifndef strlcat
 #define strlcat nc_strlcat

--- a/include/ncuri.h
+++ b/include/ncuri.h
@@ -59,11 +59,6 @@ typedef struct NCURI {
 extern "C" {
 #endif
 
-#ifndef HAVE_STRNDUP
-#define strndup ncstrndup
-/* Not all systems have strndup, so provide one*/
-char *ncstrndup(const char *s, size_t len);
-#endif
 
 EXTERNL int ncuriparse(const char* s, NCURI** ncuri);
 EXTERNL void ncurifree(NCURI* ncuri);

--- a/include/ncuri.h
+++ b/include/ncuri.h
@@ -59,6 +59,12 @@ typedef struct NCURI {
 extern "C" {
 #endif
 
+#ifndef HAVE_STRNDUP
+#define strndup ncstrndup
+/* Not all systems have strndup, so provide one*/
+char *ncstrndup(const char *s, size_t len);
+#endif
+
 EXTERNL int ncuriparse(const char* s, NCURI** ncuri);
 EXTERNL void ncurifree(NCURI* ncuri);
 

--- a/include/netcdf.h
+++ b/include/netcdf.h
@@ -531,8 +531,10 @@ by the desired type. */
 #define NC_EOBJECT       (-140)    /**< Some object exists when it should not */
 #define NC_ENOOBJECT     (-141)    /**< Some object not found */
 #define NC_EPLUGIN       (-142)    /**< Unclassified failure in accessing a dynamically loaded plugin> */
+#define NC_ENOTZARR      (-143)    /**< Malformed (NC)Zarr file */
+#define NC_EZARRMETA     (-144)    /**< Invalid (NC)Zarr file consolidated metadata */
 
-#define NC4_LAST_ERROR   (-142)    /**< @internal All netCDF errors > this. */
+#define NC4_LAST_ERROR   (-144)    /**< @internal All netCDF errors > this. */
 
 /*
  * Don't forget to update docs/all-error-codes.md if adding new error codes here!
@@ -964,7 +966,7 @@ nc_inq_var_endian(int ncid, int varid, int *endianp);
 
 /* Define a filter for a variable */
 EXTERNL int
-nc_def_var_filter(int ncid, int varid, unsigned int id, size_t nparams, const unsigned int* params);
+nc_def_var_filter(int ncid, int varid, unsigned int id, size_t nparams, const unsigned int* parms);
 
 /* Learn about the first filter on a variable */
 EXTERNL int

--- a/libdispatch/dmissing.c
+++ b/libdispatch/dmissing.c
@@ -43,6 +43,20 @@ strdup(const char* s)
 }
 #endif
 
+#ifndef HAVE_STRNDUP
+char*
+strndup(const char* s, size_t len)
+{
+    char* dup;
+    if(s == NULL) return NULL;
+    dup = (char*)malloc(len+1);
+    if(dup == NULL) return NULL;
+    memcpy((void*)dup,s,len);
+    dup[len] = '\0';
+    return dup;
+}
+#endif
+
 #if !defined(_MSC_VER) && !defined(WIN32)
 
 #ifndef HAVE_STRLCAT

--- a/libdispatch/ncuri.c
+++ b/libdispatch/ncuri.c
@@ -79,7 +79,6 @@ static const char* userpwdallow =
 "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!$&'()*+,-.;=_~?#/";
 
 #ifndef HAVE_STRNDUP
-#define strndup ncstrndup
 /* Not all systems have strndup, so provide one*/
 char*
 ncstrndup(const char* s, size_t len)

--- a/libdispatch/ncuri.c
+++ b/libdispatch/ncuri.c
@@ -78,20 +78,6 @@ static const char* queryallow =
 static const char* userpwdallow =
 "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!$&'()*+,-.;=_~?#/";
 
-#ifndef HAVE_STRNDUP
-/* Not all systems have strndup, so provide one*/
-char*
-ncstrndup(const char* s, size_t len)
-{
-    char* dup;
-    if(s == NULL) return NULL;
-    dup = (char*)malloc(len+1);
-    if(dup == NULL) return NULL;
-    memcpy((void*)dup,s,len);
-    dup[len] = '\0';
-    return dup;
-}
-#endif
 /* Forward */
 static int collectprefixparams(char* text, char** nextp);
 static void freestringlist(NClist* list);

--- a/libnczarr/CMakeLists.txt
+++ b/libnczarr/CMakeLists.txt
@@ -23,6 +23,8 @@ zgrp.c
 zinternal.c
 zmap.c
 zmap_file.c
+zmetadata.c
+zmetadata2.c
 zodom.c
 zopen.c
 zprov.c

--- a/libnczarr/CMakeLists.txt
+++ b/libnczarr/CMakeLists.txt
@@ -39,6 +39,7 @@ zdispatch.h
 zincludes.h
 zinternal.h
 zmap.h
+zmetadata.h
 zodom.h
 zprovenance.h
 zplugins.h

--- a/libnczarr/Makefile.am
+++ b/libnczarr/Makefile.am
@@ -43,6 +43,8 @@ zgrp.c \
 zinternal.c \
 zmap.c \
 zmap_file.c \
+zmetadata.c \
+zmetadata2.c\
 zodom.c \
 zopen.c \
 zprov.c \

--- a/libnczarr/Makefile.am
+++ b/libnczarr/Makefile.am
@@ -59,6 +59,7 @@ zdispatch.h \
 zincludes.h \
 zinternal.h \
 zmap.h \
+zmetadata.h \
 zodom.h \
 zprovenance.h \
 zplugins.h \

--- a/libnczarr/zarr.c
+++ b/libnczarr/zarr.c
@@ -79,6 +79,10 @@ ncz_create_dataset(NC_FILE_INFO_T* file, NC_GRP_INFO_T* root, NClist* controls)
     if((stat = nczmap_create(zinfo->controls.mapimpl,nc->path,nc->mode,zinfo->controls.flags,NULL,&zinfo->map)))
 	goto done;
 
+    if((stat = NCZMD_set_metadata_handler(zinfo))){
+        goto done;
+    }
+
 done:
     ncurifree(uri);
     NCJreclaim(json);

--- a/libnczarr/zarr.c
+++ b/libnczarr/zarr.c
@@ -143,6 +143,10 @@ ncz_open_dataset(NC_FILE_INFO_T* file, NClist* controls)
     if((stat = nczmap_open(zinfo->controls.mapimpl,nc->path,mode,zinfo->controls.flags,NULL,&zinfo->map)))
 	goto done;
 
+    if((stat = NCZMD_set_metadata_handler(zinfo))) {
+        goto done;
+    }
+
     /* Ok, try to read superblock */
     if((stat = ncz_read_superblock(file,&nczarr_version,&zarr_format))) goto done;
 

--- a/libnczarr/zarr.c
+++ b/libnczarr/zarr.c
@@ -276,6 +276,7 @@ applycontrols(NCZ_FILE_INFO_T* zinfo)
     /* Process the modelist first */
     zinfo->controls.mapimpl = NCZM_DEFAULT;
     zinfo->controls.flags |= FLAG_XARRAYDIMS; /* Always support XArray convention where possible */
+    zinfo->controls.flags |= (NCZARR_CONSOLIDATED_DEFAULT ? FLAG_CONSOLIDATED : 0);
     for(i=0;i<nclistlength(modelist);i++) {
         const char* p = nclistget(modelist,i);
 	if(strcasecmp(p,PUREZARRCONTROL)==0)
@@ -287,6 +288,10 @@ applycontrols(NCZ_FILE_INFO_T* zinfo)
 	else if(strcasecmp(p,"zip")==0) zinfo->controls.mapimpl = NCZM_ZIP;
 	else if(strcasecmp(p,"file")==0) zinfo->controls.mapimpl = NCZM_FILE;
 	else if(strcasecmp(p,"s3")==0) zinfo->controls.mapimpl = NCZM_S3;
+	else if(strcasecmp(p,"csl") == 0 \
+	    || strcasecmp(p,"consolidate") == 0 \
+	    || strcasecmp(p,"consolidated") == 0)
+	        zinfo->controls.flags |= FLAG_CONSOLIDATED;
     }
     /* Apply negative controls by turning off negative flags */
     /* This is necessary to avoid order dependence of mode flags when both positive and negative flags are defined */

--- a/libnczarr/zarr.c
+++ b/libnczarr/zarr.c
@@ -288,9 +288,7 @@ applycontrols(NCZ_FILE_INFO_T* zinfo)
 	else if(strcasecmp(p,"zip")==0) zinfo->controls.mapimpl = NCZM_ZIP;
 	else if(strcasecmp(p,"file")==0) zinfo->controls.mapimpl = NCZM_FILE;
 	else if(strcasecmp(p,"s3")==0) zinfo->controls.mapimpl = NCZM_S3;
-	else if(strcasecmp(p,"csl") == 0 \
-	    || strcasecmp(p,"consolidate") == 0 \
-	    || strcasecmp(p,"consolidated") == 0)
+	else if(strcasecmp(p,"consolidated") == 0)
 	        zinfo->controls.flags |= FLAG_CONSOLIDATED;
     }
     /* Apply negative controls by turning off negative flags */

--- a/libnczarr/zarr.h
+++ b/libnczarr/zarr.h
@@ -69,7 +69,7 @@ EXTERNL int NCZ_inferattrtype(const NCjson* value, nc_type typehint, nc_type* ty
 EXTERNL int NCZ_inferinttype(unsigned long long u64, int negative);
 EXTERNL int ncz_fill_value_sort(nc_type nctype, int*);
 EXTERNL int NCZ_createobject(NCZMAP* zmap, const char* key, size64_t size);
-EXTERNL int NCZ_uploadjson(NCZMAP* zmap, const char* key, NCjson* json);
+EXTERNL int NCZ_uploadjson(NCZMAP* zmap, const char* key, const NCjson* json);
 EXTERNL int NCZ_downloadjson(NCZMAP* zmap, const char* key, NCjson** jsonp);
 EXTERNL int NCZ_subobjects(NCZMAP* map, const char* prefix, const char* tag, char dimsep, NClist* objlist);
 EXTERNL int NCZ_grpname_full(int gid, char** pathp);

--- a/libnczarr/zclose.c
+++ b/libnczarr/zclose.c
@@ -51,6 +51,7 @@ ncz_close_file(NC_FILE_INFO_T* file, int abort)
 	goto done;
     nclistfreeall(zinfo->controllist);
     NC_authfree(zinfo->auth);
+    NCZMD_free_metadata_handler(&(zinfo->metadata));
     nullfree(zinfo);
 
 done:

--- a/libnczarr/zincludes.h
+++ b/libnczarr/zincludes.h
@@ -51,6 +51,7 @@ extern "C" {
 #include "ncutil.h"
 
 #include "zmap.h"
+#include "zmetadata.h"
 #include "zinternal.h"
 #include "zdispatch.h"
 #include "zprovenance.h"

--- a/libnczarr/zinternal.h
+++ b/libnczarr/zinternal.h
@@ -141,6 +141,7 @@ typedef struct NCZ_FILE_INFO {
 #		define FLAG_LOGGING     4
 #		define FLAG_XARRAYDIMS  8
 #		define FLAG_NCZARR_KEY  16 /* _nczarr_xxx keys are stored in object and not in _nczarr_attrs */
+#		define FLAG_CONSOLIDATED 32
 	NCZM_IMPL mapimpl;
     } controls;
     int default_maxstrlen; /* default max str size for variables of type string */

--- a/libnczarr/zinternal.h
+++ b/libnczarr/zinternal.h
@@ -122,6 +122,7 @@ typedef struct NCZ_FILE_INFO {
     NCZcommon common;
     struct NCZMAP* map; /* implementation */
     struct NCauth* auth;
+    struct NCZ_Metadata metadata;
     struct nczarr {
 	int zarr_version;
 	struct {

--- a/libnczarr/zinternal.h
+++ b/libnczarr/zinternal.h
@@ -38,11 +38,10 @@
 #  endif
 #endif
 
-#define ZMETAROOT "/.zgroup"
-#define ZMETAATTR "/.zattrs"
-#define ZGROUP ".zgroup"
-#define ZATTRS ".zattrs"
-#define ZARRAY ".zarray"
+#define Z2GROUPROOT "/.zgroup"
+#define Z2GROUP ".zgroup"
+#define Z2ATTRS ".zattrs"
+#define Z2ARRAY ".zarray"
 
 /* V2 Reserved Attributes */
 /*

--- a/libnczarr/zmetadata.c
+++ b/libnczarr/zmetadata.c
@@ -1,0 +1,102 @@
+/*********************************************************************
+ *   Copyright 2018, UCAR/Unidata
+ *   See netcdf/COPYRIGHT file for copying and redistribution conditions.
+ *********************************************************************/
+
+#include "zincludes.h"
+
+static int
+cmpstrings(const void* a1, const void* a2)
+{
+    const char** s1 = (const char**)a1;
+    const char** s2 = (const char**)a2;
+    return strcmp(*s1,*s2);
+}
+
+int NCZMD_list_nodes(NCZ_FILE_INFO_T *zfile, const char * key, NClist *groups, NClist *vars)
+{
+    int stat = NC_NOERR;
+    if((stat = zfile->metadata.list_nodes(zfile,key, groups, vars))){
+        return stat;
+    }
+    qsort(groups->content, groups->length, sizeof(char*), cmpstrings);
+    qsort(vars->content, vars->length, sizeof(char*), cmpstrings);
+    return stat;
+}
+
+int NCZMD_list_groups(NCZ_FILE_INFO_T *zfile, const char * key, NClist *subgrpnames)
+{
+    int stat = NC_NOERR;
+    if((stat = zfile->metadata.list_groups(zfile,key, subgrpnames))){
+        return stat;
+    }
+    qsort(subgrpnames->content, subgrpnames->length, sizeof(char*), cmpstrings);
+    return stat;
+}
+
+int NCZMD_list_variables(NCZ_FILE_INFO_T *zfile, const char * key, NClist *varnames)
+{
+	int stat = NC_NOERR;
+    if((stat = zfile->metadata.list_variables(zfile, key, varnames))){
+        return stat;
+    }
+    qsort(varnames->content, varnames->length, sizeof(char*), cmpstrings);
+    return stat;
+}
+
+int NCZMD_fetch_json_group(NCZ_FILE_INFO_T *zfile, const char *key, NCjson **jgroup) {
+	return zfile->metadata.fetch_json_content(zfile, NCZMD_GROUP, key, jgroup);
+}
+
+int NCZMD_fetch_json_attrs(NCZ_FILE_INFO_T *zfile, const char *key, NCjson **jattrs) {
+	return  zfile->metadata.fetch_json_content(zfile, NCZMD_ATTRS, key, jattrs);
+}
+
+int NCZMD_fetch_json_array(NCZ_FILE_INFO_T *zfile, const char *key, NCjson **jarray) {
+	return zfile->metadata.fetch_json_content(zfile, NCZMD_ARRAY, key, jarray);
+}
+
+int NCZMD_update_json_group(NCZ_FILE_INFO_T *zfile, const char *key, const NCjson *jgroup) {
+	return zfile->metadata.update_json_content(zfile, NCZMD_GROUP, key, jgroup);
+}
+
+int NCZMD_update_json_attrs(NCZ_FILE_INFO_T *zfile, const char *key, const NCjson *jattrs) {
+	return zfile->metadata.update_json_content(zfile, NCZMD_ATTRS, key , jattrs);
+}
+
+int NCZMD_update_json_array(NCZ_FILE_INFO_T *zfile, const char *key, const NCjson *jarray) {
+	return zfile->metadata.update_json_content(zfile, NCZMD_ARRAY, key, jarray);
+}
+
+int NCZMD_get_metadata_format(NCZ_FILE_INFO_T *zfile, int *zarrformat)
+{
+    NCZ_Metadata *zmd = &(zfile->metadata);
+
+	if (zmd->zarr_format >= ZARRFORMAT2)
+	{
+		*zarrformat = zmd->zarr_format;
+		return NC_NOERR;
+	}
+
+	if (!nczmap_exists(zfile->map, "/" Z2ATTRS) && !nczmap_exists(zfile->map, "/" Z2GROUP) && !nczmap_exists(zfile->map, "/" Z2ARRAY))
+	{
+		return NC_ENOTZARR;
+	}
+
+	*zarrformat = ZARRFORMAT2;
+	return NC_NOERR;
+}
+
+
+int NCZMD_set_metadata_handler(NCZ_FILE_INFO_T *zfile)
+{
+  zfile->metadata = *NCZ_metadata_handler2;
+  zfile->metadata.jcsl = NULL;
+  return NC_NOERR;
+}
+
+void NCZMD_free_metadata_handler(NCZ_Metadata * zmd){
+	if (zmd == NULL) return;
+	NCJreclaim(zmd->jcsl);
+    zmd->jcsl = NULL;
+}

--- a/libnczarr/zmetadata.c
+++ b/libnczarr/zmetadata.c
@@ -100,3 +100,11 @@ void NCZMD_free_metadata_handler(NCZ_Metadata * zmd){
 	NCJreclaim(zmd->jcsl);
     zmd->jcsl = NULL;
 }
+
+int NCZMD_consolidate(NCZ_FILE_INFO_T *zfile) {
+	int stat = NC_NOERR;
+	if (zfile->creating == 1 && zfile->metadata.jcsl !=NULL){
+		stat = NCZ_uploadjson(zfile->map, Z2METADATA ,zfile->metadata.jcsl);
+	}
+	return stat;
+}

--- a/libnczarr/zmetadata.c
+++ b/libnczarr/zmetadata.c
@@ -136,7 +136,8 @@ void NCZMD_free_metadata_handler(NCZ_Metadata * zmd){
     zmd->jcsl = NULL;
 }
 
-int NCZMD_consolidate(NCZ_FILE_INFO_T *zfile) {
+int NCZMD_consolidate(NCZ_FILE_INFO_T *zfile)
+{
 	int stat = NC_NOERR;
 	if (zfile->creating == 1 && zfile->metadata.jcsl !=NULL){
 		stat = NCZ_uploadjson(zfile->map, Z2METADATA ,zfile->metadata.jcsl);

--- a/libnczarr/zmetadata.h
+++ b/libnczarr/zmetadata.h
@@ -24,6 +24,8 @@ Note: This will also be the case of zarr v3
 
 #ifndef ZMETADATA_H
 #define ZMETADATA_H
+
+/* Opaque */
 struct NCZ_FILE_INFO;
 
 #if defined(__cplusplus)
@@ -97,56 +99,56 @@ extern int NCZMD_consolidate(struct NCZ_FILE_INFO* zfile) {
 /// @param groups - Pointer to NClist to receive group names, NULL to skip
 /// @param vars - Pointer to NClist to receive variable names, NULL to skip
 /// @return NO_ERROR on success, error code on failure
-extern int NCZMD_list_nodes(struct NCZ_FILE_INFO*zfile, const char * key, NClist *groups, NClist *vars);
+extern int NCZMD_list_nodes(struct NCZ_FILE_INFO *zfile, const char * key, NClist *groups, NClist *vars);
 
 /// @brief Lists groups under a given group key.
 /// @param zfile - The zarr file info structure
 /// @param key - The group key within which to list groups
 /// @param groups - Pointer to NClist to receive group names
 /// @return NO_ERROR on success, error code on failure
-extern int NCZMD_list_groups(struct NCZ_FILE_INFO*zfile, const char * key, NClist *groups);
+extern int NCZMD_list_groups(struct NCZ_FILE_INFO *zfile, const char * key, NClist *groups);
 
 /// @brief Lists variables under a given group key.
 /// @param zfile - The zarr file info structure
 /// @param key - The group key within which to list variables
 /// @param variables - Pointer to NClist to receive variable names
 /// @return NO_ERROR on success, error code on failure
-extern int NCZMD_list_variables(struct NCZ_FILE_INFO*zfile, const char * key, NClist *variables);
+extern int NCZMD_list_variables(struct NCZ_FILE_INFO *zfile, const char * key, NClist *variables);
 
 /// @brief Fetches the JSON metadata a group given a group key.
 /// @param zfile - The zarr file info structure
 /// @param key - The group key whose metadata to fetch
 /// @param jgroup -	Pointer to NCjson to receive the group metadata
 /// @return NO_ERROR on success, error code on failure
-extern int NCZMD_fetch_json_group(struct NCZ_FILE_INFO*zfile, const char *key, NCjson **jgroup);
+extern int NCZMD_fetch_json_group(struct NCZ_FILE_INFO *zfile, const char *key, NCjson **jgroup);
 
 /// @brief Fetches the JSON attributes given a key, either of group or array.
 /// @param zfile - The zarr file info structure
 /// @param key - The key whose attributes to fetch
 /// @param jattrs - Pointer to NCjson to receive the attributes
 /// @return NO_ERROR on success, error code on failure
-extern int NCZMD_fetch_json_attrs(struct NCZ_FILE_INFO*zfile, const char *key, NCjson **jattrs);
+extern int NCZMD_fetch_json_attrs(struct NCZ_FILE_INFO *zfile, const char *key, NCjson **jattrs);
 
 /// @brief Fetches the JSON metadata of an array given its key.
 /// @param zfile - The zarr file info structure
 /// @param key - The array key whose metadata to fetch
 /// @param jarrays - Pointer to NCjson to receive the array metadata
 /// @return NO_ERROR on success, error code on failure
-extern int NCZMD_fetch_json_array(struct NCZ_FILE_INFO*zfile, const char *key, NCjson **jarrays);
+extern int NCZMD_fetch_json_array(struct NCZ_FILE_INFO *zfile, const char *key, NCjson **jarrays);
 
 /// @brief Updates the JSON metadata of a group given a group key.
 /// @param zfile - The zarr file info structure
 /// @param key - The group key whose metadata to update
 /// @param jgroup -	The NCjson containing the new group metadata
 /// @return NO_ERROR on success, error code on failure
-extern int NCZMD_update_json_group(struct NCZ_FILE_INFO*zfile, const char *key, const NCjson *jgroup);
+extern int NCZMD_update_json_group(struct NCZ_FILE_INFO *zfile, const char *key, const NCjson *jgroup);
 
 /// @brief Updates the JSON attributes given a key, either of group or array.
 /// @param zfile - The zarr file info structure
 /// @param key - The key whose attributes to update
 /// @param jattrs - The NCjson containing the new attributes
 /// @return NO_ERROR on success, error code on failure
-extern int NCZMD_update_json_attrs(struct NCZ_FILE_INFO*zfile, const char *key, const NCjson *jattrs);
+extern int NCZMD_update_json_attrs(struct NCZ_FILE_INFO *zfile, const char *key, const NCjson *jattrs);
 
 /// @brief Updates the JSON metadata of an array given its key.
 /// @param zfile - The zarr file info structure

--- a/libnczarr/zmetadata.h
+++ b/libnczarr/zmetadata.h
@@ -91,7 +91,7 @@ extern void NCZMD_free_metadata_handler(NCZ_Metadata * zmd);
 
 /// @brief Upload the .zmetadata object
 /// @param zfile - The zarr file info structure
-extern int NCZMD_consolidate(struct NCZ_FILE_INFO* zfile) {
+extern int NCZMD_consolidate(struct NCZ_FILE_INFO* zfile);
 
 /// @brief Lists groups and/or variables under a given group key.
 /// @param zfile - The zarr file info structure

--- a/libnczarr/zmetadata.h
+++ b/libnczarr/zmetadata.h
@@ -89,7 +89,7 @@ extern void NCZMD_free_metadata_handler(NCZ_Metadata * zmd);
 
 /// @brief Upload the .zmetadata object
 /// @param zfile - The zarr file info structure
-extern int NCZMD_consolidate(NCZ_FILE_INFO_T *zfile) {
+extern int NCZMD_consolidate(struct NCZ_FILE_INFO_T *zfile) {
 
 /// @brief Lists groups and/or variables under a given group key.
 /// @param zfile - The zarr file info structure

--- a/libnczarr/zmetadata.h
+++ b/libnczarr/zmetadata.h
@@ -89,7 +89,7 @@ extern void NCZMD_free_metadata_handler(NCZ_Metadata * zmd);
 
 /// @brief Upload the .zmetadata object
 /// @param zfile - The zarr file info structure
-externint NCZMD_consolidate(NCZ_FILE_INFO_T *zfile) {
+extern int NCZMD_consolidate(NCZ_FILE_INFO_T *zfile) {
 
 /// @brief Lists groups and/or variables under a given group key.
 /// @param zfile - The zarr file info structure

--- a/libnczarr/zmetadata.h
+++ b/libnczarr/zmetadata.h
@@ -145,6 +145,10 @@ extern int NCZMD_update_json_attrs(struct NCZ_FILE_INFO*zfile, const char *key, 
 /// @return NO_ERROR on success, error code on failure
 extern int NCZMD_update_json_array(struct NCZ_FILE_INFO *zfile, const char *key, const NCjson *jarrays);
 
+/// @brief Consolidates dataset by updating the storage
+/// @param zfile The zarr file info structure
+/// @return `NC_NOERR` On sucess, other error code on failure
+int NCZMD_consolidate(struct NCZ_FILE_INFO *zfile);
 #if defined(__cplusplus)
 }
 #endif

--- a/libnczarr/zmetadata.h
+++ b/libnczarr/zmetadata.h
@@ -81,7 +81,7 @@ extern int NCZMD_set_metadata_handler(struct NCZ_FILE_INFO *zfile);
 /// 	probing the dataset for the existence of zarr metadata objects (.z*).
 /// @param zfile - The zarr file info structure
 /// @param zarrformat - Pointer to int to receive the zarr format version
-extern int NCZMD_get_metadata_format(struct NCZ_FILE_INFO*zfile, int *zarrformat);
+extern int NCZMD_get_metadata_format(struct NCZ_FILE_INFO* zfile, int *zarrformat);
 
 /// @brief Frees any resources associated with the metadata handler
 /// @param zmd - Potinter to the metadata handler structure
@@ -89,7 +89,7 @@ extern void NCZMD_free_metadata_handler(NCZ_Metadata * zmd);
 
 /// @brief Upload the .zmetadata object
 /// @param zfile - The zarr file info structure
-extern int NCZMD_consolidate(struct NCZ_FILE_INFO_T *zfile) {
+extern int NCZMD_consolidate(struct NCZ_FILE_INFO* zfile) {
 
 /// @brief Lists groups and/or variables under a given group key.
 /// @param zfile - The zarr file info structure

--- a/libnczarr/zmetadata.h
+++ b/libnczarr/zmetadata.h
@@ -87,6 +87,10 @@ extern int NCZMD_get_metadata_format(struct NCZ_FILE_INFO*zfile, int *zarrformat
 /// @param zmd - Potinter to the metadata handler structure
 extern void NCZMD_free_metadata_handler(NCZ_Metadata * zmd);
 
+/// @brief Upload the .zmetadata object
+/// @param zfile - The zarr file info structure
+externint NCZMD_consolidate(NCZ_FILE_INFO_T *zfile) {
+
 /// @brief Lists groups and/or variables under a given group key.
 /// @param zfile - The zarr file info structure
 /// @param key - The group key within which to list nodes

--- a/libnczarr/zmetadata.h
+++ b/libnczarr/zmetadata.h
@@ -39,6 +39,11 @@ extern "C"
 #define Z2METADATA "/.zmetadata"
 #define ZARRFORMAT2 2
 
+/* The name of the env var for controlling .zmetadata use*/
+#define NCZARR_CONSOLIDATED_KEY_ENV "NCZARR_METADATA_CONSOLIDATED_KEY"
+#define NCZARR_CONSOLIDATED_ENV "NCZARR_CONSOLIDATED"
+#define NCZARR_CONSOLIDATED_DEFAULT 0 /* default to consolidated metadata */
+
 #define ZARR_NOT_CONSOLIDATED 0
 #define ZARR_CONSOLIDATED 1
 

--- a/libnczarr/zmetadata.h
+++ b/libnczarr/zmetadata.h
@@ -69,6 +69,7 @@ typedef struct NCZ_Metadata
 } NCZ_Metadata;
 
 extern const NCZ_Metadata *NCZ_metadata_handler2;
+extern const NCZ_Metadata *NCZ_csl_metadata_handler2;
 
 /// @brief Sets the metadata handler for the given zarr file based on
 /// 	environment variables, file creation mode, and dataset contents.

--- a/libnczarr/zmetadata.h
+++ b/libnczarr/zmetadata.h
@@ -1,0 +1,105 @@
+/* Copyright 2018-2018 University Corporation for Atmospheric
+   Research/Unidata. */
+
+/*
+Zarr Metadata Handling
+
+Encapsulates Zarr metadata operations across versions, supporting both
+consolidated access and per-file access. Provides a common interface
+for metadata operations.
+
+The dispatcher is defined by the type NCZ_Metadata.
+It offers 2 types of operations that allow decoupling/abstract
+filesystem access, content reading of the JSON metadata files
+1. Listings: (involves either listing or parsing consolidated view)
+ - variables within a group
+ - groups withing a group
+2. Retrieve JSON representation of (sub)groups, arrays and attributes.
+	Directly read from filesystem/objectstore or retrieve the JSON
+	object from the consolidated view respective to the group or variable
+
+Note: This will also be the case of zarr v3
+(the elements will be extracted from zarr.json instead)
+*/
+
+#ifndef ZMETADATA_H
+#define ZMETADATA_H
+struct NCZ_FILE_INFO;
+
+#if defined(__cplusplus)
+extern "C"
+{
+#endif
+/* This is the version of the metadata table. It should be changed
+ * when new functions are added to the metadata table. */
+#ifndef NCZ_METADATA_VERSION
+#define NCZ_METADATA_VERSION 1
+#endif /*NCZ_METADATA_VERSION*/
+
+#define Z2METADATA "/.zmetadata"
+#define ZARRFORMAT2 2
+
+#define ZARR_NOT_CONSOLIDATED 0
+#define ZARR_CONSOLIDATED 1
+
+typedef enum {
+	NCZMD_NULL,
+	NCZMD_GROUP,
+	NCZMD_ATTRS,
+	NCZMD_ARRAY
+} NCZMD_MetadataType;
+
+typedef struct NCZ_Metadata
+{
+	int zarr_format;		/* Zarr format version */
+	int dispatch_version;   /* Dispatch table version*/
+	size64_t flags;			/* Metadata handling flags */
+	NCjson *jcsl; // Consolidated JSON view or NULL
+	int (*list_nodes)(struct NCZ_FILE_INFO*, const char * key, NClist *groups, NClist *vars);
+	int (*list_groups)(struct NCZ_FILE_INFO*, const char * key, NClist *subgrpnames);
+	int (*list_variables)(struct NCZ_FILE_INFO*, const char * key, NClist *varnames);
+	int (*fetch_json_content)(struct NCZ_FILE_INFO*, NCZMD_MetadataType, const char *name, NCjson **jobj);
+	int (*update_json_content)(struct NCZ_FILE_INFO*, NCZMD_MetadataType, const char *name, const NCjson *jobj);
+	int (*validate_consolidated)(const NCjson *jobj);
+} NCZ_Metadata;
+
+extern const NCZ_Metadata *NCZ_metadata_handler2;
+
+extern int NCZMD_set_metadata_handler(struct NCZ_FILE_INFO *zfile);
+extern int NCZMD_get_metadata_format(struct NCZ_FILE_INFO*zfile, int *zarrformat);
+extern void NCZMD_free_metadata_handler(NCZ_Metadata * zmd);
+
+extern int NCZMD_list_nodes(struct NCZ_FILE_INFO*zfile, const char * key, NClist *groups, NClist *vars);
+
+/// @brief Lists groups under a given group key.
+/// @param zfile - The zarr file info structure
+/// @param key - The group key within which to list groups
+/// @param groups - Pointer to NClist to receive group names
+/// @return NO_ERROR on success, error code on failure
+extern int NCZMD_list_groups(struct NCZ_FILE_INFO*zfile, const char * key, NClist *groups);
+
+/// @brief Lists variables under a given group key.
+/// @param zfile - The zarr file info structure
+/// @param key - The group key within which to list variables
+/// @param variables - Pointer to NClist to receive variable names
+/// @return NO_ERROR on success, error code on failure
+extern int NCZMD_list_variables(struct NCZ_FILE_INFO*zfile, const char * key, NClist *variables);
+
+/// @brief Fetches the JSON metadata a group given a group key.
+/// @param zfile - The zarr file info structure
+/// @param key - The group key whose metadata to fetch
+/// @param jgroup -	Pointer to NCjson to receive the group metadata
+/// @return NO_ERROR on success, error code on failure
+extern int NCZMD_fetch_json_group(struct NCZ_FILE_INFO*zfile, const char *key, NCjson **jgroup);
+extern int NCZMD_fetch_json_attrs(struct NCZ_FILE_INFO*zfile, const char *key, NCjson **jattrs);
+extern int NCZMD_fetch_json_array(struct NCZ_FILE_INFO*zfile, const char *key, NCjson **jarrays);
+
+extern int NCZMD_update_json_group(struct NCZ_FILE_INFO*zfile, const char *key, const NCjson *jgroup);
+extern int NCZMD_update_json_attrs(struct NCZ_FILE_INFO*zfile, const char *key, const NCjson *jattrs);
+extern int NCZMD_update_json_array(struct NCZ_FILE_INFO *zfile, const char *key, const NCjson *jarrays);
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /* ZMETADATA_H */

--- a/libnczarr/zmetadata.h
+++ b/libnczarr/zmetadata.h
@@ -65,10 +65,28 @@ typedef struct NCZ_Metadata
 
 extern const NCZ_Metadata *NCZ_metadata_handler2;
 
+/// @brief Sets the metadata handler for the given zarr file based on
+/// 	environment variables, file creation mode, and dataset contents.
+/// @param zfile - The zarr file info structure
+/// @return NC_NOERR on success, NC_EZARRMETA on failure
 extern int NCZMD_set_metadata_handler(struct NCZ_FILE_INFO *zfile);
+
+/// @brief Determines the Zarr format version set on the metadata handler or by
+/// 	probing the dataset for the existence of zarr metadata objects (.z*).
+/// @param zfile - The zarr file info structure
+/// @param zarrformat - Pointer to int to receive the zarr format version
 extern int NCZMD_get_metadata_format(struct NCZ_FILE_INFO*zfile, int *zarrformat);
+
+/// @brief Frees any resources associated with the metadata handler
+/// @param zmd - Potinter to the metadata handler structure
 extern void NCZMD_free_metadata_handler(NCZ_Metadata * zmd);
 
+/// @brief Lists groups and/or variables under a given group key.
+/// @param zfile - The zarr file info structure
+/// @param key - The group key within which to list nodes
+/// @param groups - Pointer to NClist to receive group names, NULL to skip
+/// @param vars - Pointer to NClist to receive variable names, NULL to skip
+/// @return NO_ERROR on success, error code on failure
 extern int NCZMD_list_nodes(struct NCZ_FILE_INFO*zfile, const char * key, NClist *groups, NClist *vars);
 
 /// @brief Lists groups under a given group key.
@@ -91,11 +109,40 @@ extern int NCZMD_list_variables(struct NCZ_FILE_INFO*zfile, const char * key, NC
 /// @param jgroup -	Pointer to NCjson to receive the group metadata
 /// @return NO_ERROR on success, error code on failure
 extern int NCZMD_fetch_json_group(struct NCZ_FILE_INFO*zfile, const char *key, NCjson **jgroup);
+
+/// @brief Fetches the JSON attributes given a key, either of group or array.
+/// @param zfile - The zarr file info structure
+/// @param key - The key whose attributes to fetch
+/// @param jattrs - Pointer to NCjson to receive the attributes
+/// @return NO_ERROR on success, error code on failure
 extern int NCZMD_fetch_json_attrs(struct NCZ_FILE_INFO*zfile, const char *key, NCjson **jattrs);
+
+/// @brief Fetches the JSON metadata of an array given its key.
+/// @param zfile - The zarr file info structure
+/// @param key - The array key whose metadata to fetch
+/// @param jarrays - Pointer to NCjson to receive the array metadata
+/// @return NO_ERROR on success, error code on failure
 extern int NCZMD_fetch_json_array(struct NCZ_FILE_INFO*zfile, const char *key, NCjson **jarrays);
 
+/// @brief Updates the JSON metadata of a group given a group key.
+/// @param zfile - The zarr file info structure
+/// @param key - The group key whose metadata to update
+/// @param jgroup -	The NCjson containing the new group metadata
+/// @return NO_ERROR on success, error code on failure
 extern int NCZMD_update_json_group(struct NCZ_FILE_INFO*zfile, const char *key, const NCjson *jgroup);
+
+/// @brief Updates the JSON attributes given a key, either of group or array.
+/// @param zfile - The zarr file info structure
+/// @param key - The key whose attributes to update
+/// @param jattrs - The NCjson containing the new attributes
+/// @return NO_ERROR on success, error code on failure
 extern int NCZMD_update_json_attrs(struct NCZ_FILE_INFO*zfile, const char *key, const NCjson *jattrs);
+
+/// @brief Updates the JSON metadata of an array given its key.
+/// @param zfile - The zarr file info structure
+/// @param key - The array key whose metadata to update
+/// @param jarrays - The NCjson containing the new array metadata
+/// @return NO_ERROR on success, error code on failure
 extern int NCZMD_update_json_array(struct NCZ_FILE_INFO *zfile, const char *key, const NCjson *jarrays);
 
 #if defined(__cplusplus)

--- a/libnczarr/zmetadata2.c
+++ b/libnczarr/zmetadata2.c
@@ -127,6 +127,8 @@ static const NCZ_Metadata NCZ_csl_md2_table = {
     .validate_consolidated = validate_consolidated_json_v2,
 };
 
+const NCZ_Metadata *NCZ_csl_metadata_handler2 = &NCZ_csl_md2_table;
+
 int NCZMD_v2_list_nodes(NCZ_FILE_INFO_T *zfile, const char * key, NClist *groups, NClist *variables)
 {
 	size_t i;

--- a/libnczarr/zmetadata2.c
+++ b/libnczarr/zmetadata2.c
@@ -7,8 +7,7 @@
 
 #define  MINIMIM_CSL_REP_RAW "{\"metadata\":{},\"zarr_consolidated_format\":1}"
 
-/// @brief Retrieve the group and variable names contained within a group specified by `key`.
-///  The order of the names may be arbitrary
+/// @brief Retrieve the group and variable names contained within a group specified by `key` on the storage. The order of the names may be arbitrary
 /// @param zfile - The zarr file info structure
 /// @param key - the key of the node - group
 /// @param groups - NClist where names will be added
@@ -16,26 +15,40 @@
 /// @return `NC_NOERR` if succeeding
 int NCZMD_v2_list_nodes(NCZ_FILE_INFO_T *zfile, const char * key, NClist *groups, NClist *vars);
 
+/// @brief Retrieve the group and variable names contained within a group specified by `key` on the consolidated representation. The order of the names may be arbitrary
+/// @param zfile - The zarr file info structure
+/// @param key - the key of the node - group
+/// @param groups - NClist where names will be added
+/// @param variables - NClist where names will be added
+/// @return `NC_NOERR` if succeeding
 int NCZMD_v2_csl_list_nodes(NCZ_FILE_INFO_T *zfile, const char * key, NClist *groups, NClist *vars);
 
-/// @brief Retrieve the group names contained within a group specified by `key`.
-///  The order of the names may be arbitrary
+/// @brief Retrieve the group names contained within a group specified by `key` on the storage. The order of the names may be arbitrary
 /// @param zfile - The zarr file info structure
 /// @param key - the key of the node - group
 /// @param groups - NClist where names will be added
 /// @return `NC_NOERR` if succeeding
 int NCZMD_v2_list_groups(NCZ_FILE_INFO_T *zfile, const char * key, NClist *groups);
 
+/// @brief Retrieve the group names contained within a group specified by `key` on the consolidated represention. The order of the names may be arbitrary
+/// @param zfile - The zarr file info structure
+/// @param key - the key of the node - group
+/// @param groups - NClist where names will be added
+/// @return `NC_NOERR` if succeeding
 int NCZMD_v2_csl_list_groups(NCZ_FILE_INFO_T *zfile, const char * key, NClist *groups);
 
-/// @brief Retrieve the variable names contained by a group specified by `key`.
-///  The order of the names may be arbitrary
+/// @brief Retrieve the variable names contained by a group specified by `key` on the storage. The order of the names may be arbitrary
 /// @param zfile - The zarr file info structure
 /// @param key - the key of the node - group
 /// @param variables - NClist where names will be added
 /// @return `NC_NOERR` if succeeding
 int NCZMD_v2_list_variables(NCZ_FILE_INFO_T *zfile, const char * key, NClist * variables);
 
+/// @brief Retrieve the variable names contained by a group specified by `key` on the consolidated representation. The order of the names may be arbitrary
+/// @param zfile - The zarr file info structure
+/// @param key - the key of the node - group
+/// @param variables - NClist where names will be added
+/// @return `NC_NOERR` if succeeding
 int NCZMD_v2_csl_list_variables(NCZ_FILE_INFO_T *zfile, const char * key, NClist *groups);
 
 /// @brief Retrieve JSON metadata of a given type for the specified `key` from the storage
@@ -46,6 +59,12 @@ int NCZMD_v2_csl_list_variables(NCZ_FILE_INFO_T *zfile, const char * key, NClist
 /// @return `NC_NOERR` if succeeding
 int fetch_json_content_v2(NCZ_FILE_INFO_T *zfile, NCZMD_MetadataType zarr_obj_type, const char *key, NCjson **jobj);
 
+/// @brief Retrieve JSON metadata of a given type for the specified `key` from the consolidate representation
+/// @param zfile - The zarr file info structure
+///	@param zobj - The type of metadata to set
+/// @param key - the key of the node - group or array
+/// @param jobj - JSON to be written
+/// @return `NC_NOERR` if succeeding
 int fetch_csl_json_content_v2(NCZ_FILE_INFO_T *zfile, NCZMD_MetadataType zarr_obj_type, const char *key, NCjson **jobj);
 
 /// @brief Write JSON metadata of a given type for the specified `key` to the storage
@@ -56,6 +75,12 @@ int fetch_csl_json_content_v2(NCZ_FILE_INFO_T *zfile, NCZMD_MetadataType zarr_ob
 /// @return `NC_NOERR` if succeeding
 int update_json_content_v2(NCZ_FILE_INFO_T *zfile, NCZMD_MetadataType zobj, const char *key, const NCjson *jobj);
 
+/// @brief Updates the JSON metadata of a given type for the specified `key` to the consolidated representation
+/// @param zfile - The zarr file info structure
+///	@param zobj - The type of metadata to set
+/// @param key - the key of the node - group or array
+/// @param jobj - JSON to be written
+/// @return `NC_NOERR` if succeeding
 int update_csl_json_content_v2(NCZ_FILE_INFO_T *zfile, NCZMD_MetadataType zobj, const char *key, const NCjson *jobj);
 
 /// @brief Place holder for non consolidated handler
@@ -63,6 +88,11 @@ int update_csl_json_content_v2(NCZ_FILE_INFO_T *zfile, NCZMD_MetadataType zobj, 
 /// @return `NC_NOERR` always
 int validate_consolidated_json_noop_v2(const NCjson *json);
 
+///@brief Checks if `json` is a compliant to what .zmetadata expects
+///		- non empty `{}` in "metadata"
+/// 	- `zarr_consolidated_format` exists and is `1`
+/// @param json corresponding to the full .zmetadata content
+/// @return `NC_NOERR` if valid, `NC_EZARRMETA` otherwise
 int validate_consolidated_json_v2(const NCjson *json);
 
 static const NCZ_Metadata NCZ_md2_table = {

--- a/libnczarr/zmetadata2.c
+++ b/libnczarr/zmetadata2.c
@@ -1,0 +1,144 @@
+/*********************************************************************
+ *   Copyright 2018, UCAR/Unidata
+ *   See netcdf/COPYRIGHT file for copying and redistribution conditions.
+ *********************************************************************/
+
+#include "zincludes.h"
+
+#define  MINIMIM_CSL_REP_RAW "{\"metadata\":{},\"zarr_consolidated_format\":1}"
+
+int NCZMD_v2_list_nodes(NCZ_FILE_INFO_T *zfile, const char * key, NClist *groups, NClist *vars);
+
+int NCZMD_v2_list_groups(NCZ_FILE_INFO_T *zfile, const char * key, NClist *groups);
+int NCZMD_v2_list_variables(NCZ_FILE_INFO_T *zfile, const char * key, NClist * variables);
+int fetch_json_content_v2(NCZ_FILE_INFO_T *zfile, NCZMD_MetadataType zarr_obj_type, const char *key, NCjson **jobj);
+
+int update_json_content_v2(NCZ_FILE_INFO_T *zfile, NCZMD_MetadataType zobj, const char *key, const NCjson *jobj);
+
+int validate_consolidated_json_noop_v2(const NCjson *json);
+
+static const NCZ_Metadata NCZ_md2_table = {
+	ZARRFORMAT2,
+	NCZ_METADATA_VERSION,
+	ZARR_NOT_CONSOLIDATED,
+	.jcsl = NULL,
+
+	.list_nodes = NCZMD_v2_list_nodes,
+	.list_groups = NCZMD_v2_list_groups,
+	.list_variables = NCZMD_v2_list_variables,
+
+	.fetch_json_content = fetch_json_content_v2,
+	.update_json_content = update_json_content_v2,
+    .validate_consolidated = validate_consolidated_json_noop_v2,
+};
+
+const NCZ_Metadata *NCZ_metadata_handler2 = &NCZ_md2_table;
+
+int NCZMD_v2_list_nodes(NCZ_FILE_INFO_T *zfile, const char * key, NClist *groups, NClist *variables)
+{
+	size_t i;
+	int stat = NC_NOERR;
+	char *subkey = NULL;
+	char *zkey = NULL;
+	NClist *matches = nclistnew();
+
+	if ((stat = nczmap_search(zfile->map, key, matches)))
+		goto done;
+	for (i = 0; i < nclistlength(matches); i++)
+	{
+		const char *name = nclistget(matches, i);
+		if (name[0] == NCZM_DOT)
+			continue;
+		if ((stat = nczm_concat(key, name, &subkey)))
+			goto done;
+		if ((stat = nczm_concat(subkey, Z2GROUP, &zkey)))
+			goto done;
+		if (NC_NOERR == nczmap_exists(zfile->map, zkey) && groups != NULL)
+			nclistpush(groups, strdup(name));
+
+		nullfree(zkey);
+		zkey = NULL;
+		if ((stat = nczm_concat(subkey, Z2ARRAY, &zkey)))
+			goto done;
+		if (NC_NOERR == nczmap_exists(zfile->map, zkey) && variables != NULL)
+			nclistpush(variables, strdup(name));
+		stat = NC_NOERR;
+
+		nullfree(subkey);
+		subkey = NULL;
+		nullfree(zkey);
+		zkey = NULL;
+	}
+
+done:
+	nullfree(subkey);
+	nullfree(zkey);
+	nclistfreeall(matches);
+	return stat;
+}
+
+
+int NCZMD_v2_list_groups(NCZ_FILE_INFO_T *zfile, const char * key, NClist *groups)
+{
+	return NCZMD_v2_list_nodes(zfile, key, groups, NULL);
+}
+
+int NCZMD_v2_list_variables(NCZ_FILE_INFO_T *zfile, const char * key, NClist *variables)
+{
+	return NCZMD_v2_list_nodes(zfile, key, NULL, variables);
+}
+
+static int zarr_obj_type2suffix(NCZMD_MetadataType zarr_obj_type, const char **suffix){
+	switch (zarr_obj_type)
+	{
+		case NCZMD_GROUP:
+			*suffix = Z2GROUP;
+			break;
+		case NCZMD_ATTRS:
+			*suffix = Z2ATTRS;
+			break;
+		case NCZMD_ARRAY:
+			*suffix = Z2ARRAY;
+			break;
+		default:
+			return NC_EINVAL;
+	}
+	return NC_NOERR;
+}
+
+int fetch_json_content_v2(NCZ_FILE_INFO_T *zfile, NCZMD_MetadataType zobj, const char *prefix, NCjson **jobj)
+{
+	int stat = NC_NOERR;
+	const char *suffix;
+	char * key = NULL;
+	if ((stat = zarr_obj_type2suffix(zobj, &suffix))
+		|| (stat = nczm_concat(prefix, suffix, &key))){
+		goto done;
+	}
+
+	stat = NCZ_downloadjson(zfile->map, key, jobj);
+done:
+	nullfree(key);
+	return stat;
+}
+
+int update_json_content_v2(NCZ_FILE_INFO_T *zfile, NCZMD_MetadataType zobj, const char *prefix, const NCjson *jobj)
+{
+	int stat = NC_NOERR;
+	const char *suffix;
+	char * key = NULL;
+	if ((stat = zarr_obj_type2suffix(zobj, &suffix))
+		|| (stat = nczm_concat(prefix, suffix, &key))){
+		goto done;
+	}
+
+	stat = NCZ_uploadjson(zfile->map, key, jobj);
+done:
+	nullfree(key);
+	return stat;
+}
+
+int validate_consolidated_json_noop_v2(const NCjson *json){
+    NC_UNUSED(json);
+    return NC_NOERR;
+}

--- a/libnczarr/zmetadata2.c
+++ b/libnczarr/zmetadata2.c
@@ -7,14 +7,51 @@
 
 #define  MINIMIM_CSL_REP_RAW "{\"metadata\":{},\"zarr_consolidated_format\":1}"
 
+/// @brief Retrieve the group and variable names contained within a group specified by `key`.
+///  The order of the names may be arbitrary
+/// @param zfile - The zarr file info structure
+/// @param key - the key of the node - group
+/// @param groups - NClist where names will be added
+/// @param variables - NClist where names will be added
+/// @return `NC_NOERR` if succeeding
 int NCZMD_v2_list_nodes(NCZ_FILE_INFO_T *zfile, const char * key, NClist *groups, NClist *vars);
 
+/// @brief Retrieve the group names contained within a group specified by `key`.
+///  The order of the names may be arbitrary
+/// @param zfile - The zarr file info structure
+/// @param key - the key of the node - group
+/// @param groups - NClist where names will be added
+/// @return `NC_NOERR` if succeeding
 int NCZMD_v2_list_groups(NCZ_FILE_INFO_T *zfile, const char * key, NClist *groups);
+
+/// @brief Retrieve the variable names contained by a group specified by `key`.
+///  The order of the names may be arbitrary
+/// @param zfile - The zarr file info structure
+/// @param key - the key of the node - group
+/// @param variables - NClist where names will be added
+/// @return `NC_NOERR` if succeeding
 int NCZMD_v2_list_variables(NCZ_FILE_INFO_T *zfile, const char * key, NClist * variables);
+
+/// @brief Retrieve JSON metadata of a given type for the specified `key` from the storage
+/// @param zfile - The zarr file info structure
+///	@param zobj - The type of metadata to set
+/// @param key - the key of the node - group or array
+/// @param jobj - JSON to be written
+/// @return `NC_NOERR` if succeeding
 int fetch_json_content_v2(NCZ_FILE_INFO_T *zfile, NCZMD_MetadataType zarr_obj_type, const char *key, NCjson **jobj);
 
+/// @brief Write JSON metadata of a given type for the specified `key` to the storage
+/// @param zfile - The zarr file info structure
+///	@param zobj - The type of metadata to set
+/// @param key - the key of the node - group or array
+/// @param jobj - JSON to be written
+/// @return `NC_NOERR` if succeeding
 int update_json_content_v2(NCZ_FILE_INFO_T *zfile, NCZMD_MetadataType zobj, const char *key, const NCjson *jobj);
 
+
+/// @brief Place holder for non consolidated handler
+/// @param json - Not used!
+/// @return `NC_NOERR` always
 int validate_consolidated_json_noop_v2(const NCjson *json);
 
 static const NCZ_Metadata NCZ_md2_table = {

--- a/libnczarr/zsync.c
+++ b/libnczarr/zsync.c
@@ -182,13 +182,13 @@ ncz_sync_grp(NC_FILE_INFO_T* file, NC_GRP_INFO_T* grp, int isclose)
     if((stat = NCZ_grpkey(grp,&fullpath)))
         goto done;
 
-    /* build ZGROUP contents */
+    /* build Z2GROUP contents */
     NCJnew(NCJ_DICT,&jgroup);
     snprintf(version,sizeof(version),"%d",zinfo->zarr.zarr_version);
     if((stat = NCJaddstring(jgroup,NCJ_STRING,"zarr_format"))<0) {stat = NC_EINVAL; goto done;}
     if((stat = NCJaddstring(jgroup,NCJ_INT,version))<0) {stat = NC_EINVAL; goto done;}
-    /* build ZGROUP path */
-    if((stat = nczm_concat(fullpath,ZGROUP,&key)))
+    /* build Z2GROUP path */
+    if((stat = nczm_concat(fullpath,Z2GROUP,&key)))
 	goto done;
     /* Write to map */
     if((stat=NCZ_uploadjson(map,key,jgroup))) goto done;
@@ -487,7 +487,7 @@ ncz_sync_var_meta(NC_FILE_INFO_T* file, NC_VAR_INFO_T* var, int isclose)
     }
 
     /* build .zarray path */
-    if((stat = nczm_concat(fullpath,ZARRAY,&key)))
+    if((stat = nczm_concat(fullpath,Z2ARRAY,&key)))
 	goto done;
 
     /* Write to map */
@@ -1145,7 +1145,7 @@ define_grp(NC_FILE_INFO_T* file, NC_GRP_INFO_T* grp)
     if((stat = NCZ_grpkey(grp,&fullpath))) goto done;
 
     /* Download .zgroup and .zattrs */
-    if((stat = downloadzarrobj(file,&zgrp->zgroup,fullpath,ZGROUP))) goto done;
+    if((stat = downloadzarrobj(file,&zgrp->zgroup,fullpath,Z2GROUP))) goto done;
     jgroup = zgrp->zgroup.obj;
     jattrs = zgrp->zgroup.atts;
 
@@ -1451,7 +1451,7 @@ define_var1(NC_FILE_INFO_T* file, NC_GRP_INFO_T* grp, const char* varname)
 	goto done;
 
     /* Download */
-    if((stat = downloadzarrobj(file,&zvar->zarray,varpath,ZARRAY))) goto done;
+    if((stat = downloadzarrobj(file,&zvar->zarray,varpath,Z2ARRAY))) goto done;
     jvar = zvar->zarray.obj;
     jatts = zvar->zarray.atts;
     assert(jvar == NULL || NCJsort(jvar) == NCJ_DICT);
@@ -1822,7 +1822,7 @@ ncz_read_superblock(NC_FILE_INFO_T* file, char** nczarrvp, char** zarrfp)
     if((stat = NCZ_grpkey(root,&fullpath))) goto done;
 
     /* Download the root group .zgroup and associated .zattrs */
-    if((stat = downloadzarrobj(file, &zroot->zgroup, fullpath, ZGROUP))) goto done;
+    if((stat = downloadzarrobj(file, &zroot->zgroup, fullpath, Z2GROUP))) goto done;
     jzgroup = zroot->zgroup.obj;    
 
     /* Look for superblock; first in .zattrs and then in .zgroup */
@@ -1988,7 +1988,7 @@ searchvars(NCZ_FILE_INFO_T* zfile, NC_GRP_INFO_T* grp, NClist* varnames)
 	if(name[0] == NCZM_DOT) continue; /* zarr/nczarr specific */
 	/* See if name/.zarray exists */
 	if((stat = nczm_concat(grpkey,name,&varkey))) goto done;
-	if((stat = nczm_concat(varkey,ZARRAY,&zarray))) goto done;
+	if((stat = nczm_concat(varkey,Z2ARRAY,&zarray))) goto done;
 	if((stat = nczmap_exists(zfile->map,zarray)) == NC_NOERR)
 	    nclistpush(varnames,strdup(name));
 	stat = NC_NOERR;
@@ -2023,7 +2023,7 @@ searchsubgrps(NCZ_FILE_INFO_T* zfile, NC_GRP_INFO_T* grp, NClist* subgrpnames)
 	if(name[0] == NCZM_DOT) continue; /* zarr/nczarr specific */
 	/* See if name/.zgroup exists */
 	if((stat = nczm_concat(grpkey,name,&subkey))) goto done;
-	if((stat = nczm_concat(subkey,ZGROUP,&zgroup))) goto done;
+	if((stat = nczm_concat(subkey,Z2GROUP,&zgroup))) goto done;
 	if((stat = nczmap_exists(zfile->map,zgroup)) == NC_NOERR)
 	    nclistpush(subgrpnames,strdup(name));
 	stat = NC_NOERR;
@@ -2502,7 +2502,7 @@ upload_attrs(NC_FILE_INFO_T* file, NC_OBJ* container, NCjson* jatts)
     if(stat) goto done;
 
     /* write .zattrs*/
-    if((stat = nczm_concat(fullpath,ZATTRS,&key))) goto done;
+    if((stat = nczm_concat(fullpath,Z2ATTRS,&key))) goto done;
     if((stat=NCZ_uploadjson(map,key,jatts))) goto done;
     nullfree(key); key = NULL;
 
@@ -2603,7 +2603,7 @@ downloadzarrobj(NC_FILE_INFO_T* file, struct ZARROBJ* zobj, const char* fullpath
     if((stat = nczm_concat(fullpath,objname,&key))) goto done;
     if((stat=NCZ_downloadjson(map,key,&zobj->obj))) goto done;
     nullfree(key); key = NULL;
-    if((stat = nczm_concat(fullpath,ZATTRS,&key))) goto done;
+    if((stat = nczm_concat(fullpath,Z2ATTRS,&key))) goto done;
     if((stat=NCZ_downloadjson(map,key,&zobj->atts))) goto done;
 done:
     nullfree(key);

--- a/libnczarr/zsync.c
+++ b/libnczarr/zsync.c
@@ -1136,6 +1136,10 @@ define_grp(NC_FILE_INFO_T* file, NC_GRP_INFO_T* grp)
     if((stat = NCZ_grpkey(grp,&key))) goto done;
 
     /* Download .zgroup and .zattrs */
+    nullfree(zgrp->zgroup.prefix);
+    zgrp->zgroup.prefix = strdup(key);
+    NCJreclaim(zgrp->zgroup.obj);
+    NCJreclaim(zgrp->zgroup.atts);
     if ((stat = NCZMD_fetch_json_group(zinfo, key, &zgrp->zgroup.obj)) \
     || (stat = NCZMD_fetch_json_attrs(zinfo, key, &zgrp->zgroup.atts))) {
         goto done;

--- a/libnczarr/zsync.c
+++ b/libnczarr/zsync.c
@@ -83,6 +83,7 @@ ncz_sync_file(NC_FILE_INFO_T* file, int isclose)
     if((stat = ncz_sync_grp(file, file->root_grp, isclose)))
         goto done;
 
+    stat = NCZMD_consolidate((NCZ_FILE_INFO_T*)file->format_file_info);
 done:
     NCJreclaim(json);
     return ZUNTRACE(stat);

--- a/libnczarr/zsync.c
+++ b/libnczarr/zsync.c
@@ -1135,7 +1135,10 @@ define_grp(NC_FILE_INFO_T* file, NC_GRP_INFO_T* grp)
     if((stat = NCZ_grpkey(grp,&key))) goto done;
 
     /* Download .zgroup and .zattrs */
-    if((stat = downloadzarrobj(file,&zgrp->zgroup,key,Z2GROUP))) goto done;
+    if ((stat = NCZMD_fetch_json_group(zinfo, key, &zgrp->zgroup.obj)) \
+    || (stat = NCZMD_fetch_json_attrs(zinfo, key, &zgrp->zgroup.atts))) {
+        goto done;
+    }
     jgroup = zgrp->zgroup.obj;
     jattrs = zgrp->zgroup.atts;
 
@@ -1438,8 +1441,10 @@ define_var1(NC_FILE_INFO_T* file, NC_GRP_INFO_T* grp, const char* varname)
     if((stat = NCZ_varkey(var,&key)))
 	goto done;
 
-    /* Download */
-    if((stat = downloadzarrobj(file,&zvar->zarray,key,Z2ARRAY))) goto done;
+    if ((stat = NCZMD_fetch_json_array(zinfo, key, &zvar->zarray.obj)) \
+    || (stat = NCZMD_fetch_json_attrs(zinfo, key, &zvar->zarray.atts))) {
+        goto done;
+    }
     jvar = zvar->zarray.obj;
     jatts = zvar->zarray.atts;
     assert(jvar == NULL || NCJsort(jvar) == NCJ_DICT);
@@ -1808,8 +1813,10 @@ ncz_read_superblock(NC_FILE_INFO_T* file, char** nczarrvp, char** zarrfp)
     /* Construct grp key */
     if((stat = NCZ_grpkey(root,&key))) goto done;
 
-    /* Download the root group .zgroup and associated .zattrs */
-    if((stat = downloadzarrobj(file, &zroot->zgroup, key, Z2GROUP))) goto done;
+    if((stat = NCZMD_fetch_json_group(zinfo, key, &zroot->zgroup.obj)) \
+        || NCZMD_fetch_json_attrs(zinfo, key, &zroot->zgroup.atts)) {
+            goto done;
+    }
     jzgroup = zroot->zgroup.obj;    
 
     /* Look for superblock; first in .zattrs and then in .zgroup */

--- a/libnczarr/zsync.c
+++ b/libnczarr/zsync.c
@@ -1398,7 +1398,6 @@ define_var1(NC_FILE_INFO_T* file, NC_GRP_INFO_T* grp, const char* varname)
     const NCjson* jncvar = NULL;
     const NCjson* jdimrefs = NULL;
     const NCjson* jvalue = NULL;
-    char* varpath = NULL;
     char* key = NULL;
     size64_t* shapes = NULL;
     NClist* dimnames = NULL;
@@ -1438,11 +1437,11 @@ define_var1(NC_FILE_INFO_T* file, NC_GRP_INFO_T* grp, const char* varname)
     var->quantize_mode = -1;
 
     /* Construct var path */
-    if((stat = NCZ_varkey(var,&varpath)))
+    if((stat = NCZ_varkey(var,&key)))
 	goto done;
 
     /* Download */
-    if((stat = downloadzarrobj(file,&zvar->zarray,varpath,Z2ARRAY))) goto done;
+    if((stat = downloadzarrobj(file,&zvar->zarray,key,Z2ARRAY))) goto done;
     jvar = zvar->zarray.obj;
     jatts = zvar->zarray.atts;
     assert(jvar == NULL || NCJsort(jvar) == NCJ_DICT);
@@ -1705,7 +1704,6 @@ suppressvar:
 
 done:
     nclistfreeall(dimnames); dimnames = NULL;
-    nullfree(varpath); varpath = NULL;
     nullfree(shapes); shapes = NULL;
     nullfree(key); key = NULL;
     return ZUNTRACE(stat);

--- a/libnczarr/zutil.c
+++ b/libnczarr/zutil.c
@@ -272,7 +272,7 @@ done:
 @author Dennis Heimbigner
 */
 int
-NCZ_uploadjson(NCZMAP* zmap, const char* key, NCjson* json)
+NCZ_uploadjson(NCZMAP* zmap, const char* key, const NCjson* json)
 {
     int stat = NC_NOERR;
     char* content = NULL;

--- a/nczarr_test/run_newformat.sh
+++ b/nczarr_test/run_newformat.sh
@@ -40,9 +40,27 @@ ${NCDUMP} -n ref_oldformat "file://tmp_newformat.file#mode=zarr,file" > ./tmp_ne
 diff -w ${srcdir}/ref_newformatpure.cdl ./tmp_newpure.cdl
 }
 
+testcaseconsolidated() {
+echo "*** Test old format to new format consolidated nczarr copy"
+zext=$1
+set -x
+fileargs ${srcdir}/ref_oldformat
+NCZARR_CONSOLIDATED=TRUE ${NCCOPY} "$fileurl" "file://tmp_newformat_consolidated.file#mode=nczarr,file"
+test -f tmp_newformat_consolidated.file/.zmetadata
+NCZARR_CONSOLIDATED=TRUE ${NCDUMP} -n ref_oldformat "file://tmp_newformat_consolidated.file#mode=nczarr,file" > ./tmp_oldformat_consolidated.cdl
+diff -w ${srcdir}/ref_oldformat.cdl ./tmp_oldformat_consolidated.cdl
+NCZARR_CONSOLIDATED=FALSE ${NCDUMP} -n ref_oldformat "file://tmp_newformat_consolidated.file#mode=nczarr,file" > ./tmp_oldformat_non_consolidated.cdl
+diff -w ${srcdir}/ref_oldformat.cdl ./tmp_oldformat_non_consolidated.cdl
+NCZARR_CONSOLIDATED=TRUE ${NCDUMP} -n ref_oldformat "file://tmp_newformat_consolidated.file#mode=zarr,file" > ./tmp_pure_consolidated.cdl
+NCZARR_CONSOLIDATED=FALSE ${NCDUMP} -n ref_oldformat "file://tmp_newformat_consolidated.file#mode=zarr,file" > ./tmp_pure_non_consolidated.cdl
+diff -w ./tmp_pure_consolidated.cdl ./tmp_pure_non_consolidated.cdl
+set +x
+}
+
 # Do zip tests only
 if test "x$FEATURE_NCZARR_ZIP" = xyes ; then
     testcaseold zip
     testcasecvt zip
     testcasepure zip
+    testcaseconsolidated zip
 fi

--- a/nczarr_test/run_newformat.sh
+++ b/nczarr_test/run_newformat.sh
@@ -54,6 +54,10 @@ diff -w ${srcdir}/ref_oldformat.cdl ./tmp_oldformat_non_consolidated.cdl
 NCZARR_CONSOLIDATED=TRUE ${NCDUMP} -n ref_oldformat "file://tmp_newformat_consolidated.file#mode=zarr,file" > ./tmp_pure_consolidated.cdl
 NCZARR_CONSOLIDATED=FALSE ${NCDUMP} -n ref_oldformat "file://tmp_newformat_consolidated.file#mode=zarr,file" > ./tmp_pure_non_consolidated.cdl
 diff -w ./tmp_pure_consolidated.cdl ./tmp_pure_non_consolidated.cdl
+rm ./tmp_pure_consolidated.cdl ./tmp_pure_non_consolidated.cdl
+${NCDUMP} -n ref_oldformat "file://tmp_newformat_consolidated.file#mode=zarr,file,consolidated" > ./tmp_pure_consolidated.cdl
+${NCDUMP} -n ref_oldformat "file://tmp_newformat_consolidated.file#mode=zarr,file" > ./tmp_pure_non_consolidated.cdl
+diff -w ./tmp_pure_consolidated.cdl ./tmp_pure_non_consolidated.cdl
 set +x
 }
 

--- a/nczarr_test/ut_map.c
+++ b/nczarr_test/ut_map.c
@@ -95,7 +95,7 @@ simplecreate(void)
     if((stat = nczmap_create(impl,url,0,0,NULL,&map)))
 	goto done;
 
-    if((stat=nczm_concat(NULL,ZMETAROOT,&path)))
+    if((stat=nczm_concat(NULL,Z2GROUPROOT,&path)))
 	goto done;
 
     /* Write empty metadata content */
@@ -135,7 +135,7 @@ writemeta(void)
     if((stat = nczmap_open(impl,url,NC_WRITE,0,NULL,&map)))
 	goto done;
 
-    if((stat=nczm_concat(META1,ZARRAY,&path)))
+    if((stat=nczm_concat(META1,Z2ARRAY,&path)))
 	goto done;
     if((stat = nczmap_write(map, path, strlen(metadata1), metadata1)))
 	goto done;
@@ -158,7 +158,7 @@ writemeta2(void)
     if((stat = nczmap_open(impl,url,NC_WRITE,0,NULL,&map)))
 	goto done;
 
-    if((stat=nczm_concat(META2,ZARRAY,&path)))
+    if((stat=nczm_concat(META2,Z2ARRAY,&path)))
 	goto done;
     if((stat = nczmap_write(map, path, strlen(metadata2), metadata2)))
 	goto done;
@@ -212,7 +212,7 @@ readmeta(void)
     if((stat = nczmap_open(impl,url,0,0,NULL,&map)))
 	goto done;
 
-    if((stat = readkey(map,META1,ZARRAY))) goto done;
+    if((stat = readkey(map,META1,Z2ARRAY))) goto done;
 
 done:
     (void)nczmap_close(map,0);
@@ -228,7 +228,7 @@ readmeta2(void)
     if((stat = nczmap_open(impl,url,0,0,NULL,&map)))
 	goto done;
 
-    if((stat = readkey(map,META2,ZARRAY)))
+    if((stat = readkey(map,META2,Z2ARRAY)))
         goto done;
 
 done:

--- a/nczarr_test/ut_mapapi.c
+++ b/nczarr_test/ut_mapapi.c
@@ -99,7 +99,7 @@ simplecreate(void)
     
     printf("Pass: create: create: %s\n",url);
 
-    truekey = makekey(ZMETAROOT);
+    truekey = makekey(Z2GROUPROOT);
     if((stat = nczmap_write(map, truekey, 0, NULL)))
 	goto done;
     printf("Pass: create: defineobj: %s\n",truekey);
@@ -184,13 +184,13 @@ simplemeta(void)
     report(PASS,"open",map);
 	
     /* Make sure .nczarr exists (from simplecreate) */
-    truekey = makekey(ZMETAROOT);
+    truekey = makekey(Z2GROUPROOT);
     if((stat = nczmap_exists(map,truekey)))
 	goto done;
     report(PASS,".nczarr: exists",map);
     free(truekey); truekey = NULL;
 
-    if((stat=nczm_concat(META1,ZARRAY,&key)))
+    if((stat=nczm_concat(META1,Z2ARRAY,&key)))
 	goto done;
     truekey = makekey(key);
     nullfree(key); key = NULL;
@@ -199,13 +199,13 @@ simplemeta(void)
     report(PASS,".zarray: def",map);
     free(truekey); truekey = NULL;
 
-    truekey = makekey(ZMETAROOT);
+    truekey = makekey(Z2GROUPROOT);
     if((stat = nczmap_write(map, truekey, strlen(metadata1), metadata1)))
 	goto done;
     report(PASS,".nczarr: writemetadata",map);
     free(truekey); truekey = NULL;
     
-    if((stat=nczm_concat(META1,ZARRAY,&key)))
+    if((stat=nczm_concat(META1,Z2ARRAY,&key)))
 	goto done;
     truekey = makekey(key);
     free(key); key = NULL;    
@@ -225,7 +225,7 @@ simplemeta(void)
     report(PASS,"re-open",map);
 
     /* Read previously written */
-    truekey = makekey(ZMETAROOT);
+    truekey = makekey(Z2GROUPROOT);
     if((stat = nczmap_exists(map, truekey)))
 	goto done;
     report(PASS,".nczarr: exists",map);
@@ -245,7 +245,7 @@ simplemeta(void)
     else report(PASS,".nczarr: content verify",map);
     nullfree(content); content = NULL;
 
-    if((stat=nczm_concat(META1,ZARRAY,&key)))
+    if((stat=nczm_concat(META1,Z2ARRAY,&key)))
 	goto done;
     truekey = makekey(key);
     nullfree(key); key = NULL;


### PR DESCRIPTION
This PR follows up on #3224 :
 - Adds `mode` control parameters `csl`,`consolidate`,`consolidated` to select the use of consolitated metadata.
 - Adds directives to control the via environment varibles the use of consolidated metadata.
 - Modifies the `NCZMD_set_metadata_handler` to select the handler based on the settings, and presence of consolidated metadata.
 - Extends the tests to confirm the correct usage of consolidated metadata