### PR TITLE
 Add NC_FORMAT_EXPLICIT mode flag to skip format detection on nc_open

### DIFF
--- a/include/netcdf.h
+++ b/include/netcdf.h
@@ -132,7 +132,7 @@ extern "C" {
 
 #define NC_NOWRITE       0x0000 /**< Set read-only access for nc_open(). */
 #define NC_WRITE         0x0001 /**< Set read-write access for nc_open(). */
-#define NC_FORMAT_OVERRIDE 0x0002 /**< Skip file format detection; use mode flags to determine format. Mode flag for nc_open(). */
+#define NC_FORMAT_EXPLICIT 0x0002 /**< Explicitly specify the file format via mode flags; foregoes all format checking. Mode flag for nc_open(). */
 
 #define NC_CLOBBER       0x0000 /**< Destroy existing file. Mode flag for nc_create(). */
 #define NC_NOCLOBBER     0x0004 /**< Don't destroy existing file. Mode flag for nc_create(). */

--- a/libdispatch/dfile.c
+++ b/libdispatch/dfile.c
@@ -2060,8 +2060,8 @@ NC_open(const char *path0, int omode, int basepe, size_t *chunksizehintp,
     /* mmap is not allowed for netcdf-4 */
     if(use_mmap && (omode & NC_NETCDF4)) {stat = NC_EINVAL; goto done;}
 
-    /* NC_FORMAT_OVERRIDE requires a format flag so the library knows which dispatch to use */
-    if((omode & NC_FORMAT_OVERRIDE) && !(omode & NC_FORMAT_ALL)) {stat = NC_EINVAL; goto done;}
+    /* NC_FORMAT_EXPLICIT requires a format flag so the library knows which dispatch to use */
+    if((omode & NC_FORMAT_EXPLICIT) && !(omode & NC_FORMAT_ALL)) {stat = NC_EINVAL; goto done;}
 
     /* Attempt to do file path conversion: note that this will do
        nothing if path is a 'file:...' url, so it will need to be

--- a/libdispatch/dinfermodel.c
+++ b/libdispatch/dinfermodel.c
@@ -1015,10 +1015,10 @@ NC_infermodel(const char* path, int* omodep, int iscreate, int useparallel, void
            previous decisions. Note that we do this last
            because we need previously determined model info
            to guess if this file is readable.
-           If NC_FORMAT_OVERRIDE is set, skip the magic number check
-           and rely on mode flags from Phase 8 instead.
+           If NC_FORMAT_EXPLICIT is set, the caller has specified the
+           format via mode flags; forego all format checking.
         */
-        if(!iscreate && !fIsSet(omode,NC_FORMAT_OVERRIDE) && isreadable(uri,model)) {
+        if(!iscreate && !fIsSet(omode,NC_FORMAT_EXPLICIT) && isreadable(uri,model)) {
 	     /* Ok, we need to try to read the file */
             if((stat = check_file_type(path, omode, useparallel, params, model, uri))) goto done;
         }


### PR DESCRIPTION
Allow users to bypass magic number file detection  by passing
 NC_FORMAT_EXPLICIT with a format flag (e.g., NC_NETCDF4) to nc_open().

 This lets the library open files whose magic bytes are missing or non-standard (e.g., HDF5 terminal VOLs, such as ADIOS, DAOS, misc.  non-HDF5 file formatted VOLs), relying on the caller-specified format instead.

Open to your suggestions and any feedback you may have.
