### PR TITLE
CI: Switch from miniconda to micromamba

### DIFF
--- a/.github/workflows/main-cmake.yml
+++ b/.github/workflows/main-cmake.yml
@@ -60,8 +60,9 @@ jobs:
         #- run: echo "CTEST_OUTPUT_ON_FAILURE=1" >> $GITHUB_ENV
        
         - name: Install Dependencies using Micromamba
+          # Zlib (instead of libzlib) needed to get dev header/cmake file
           run: |
-            micromamba install --yes hdf5=${{ matrix.hdf5 }} m2-m4 libxml2
+            micromamba install --yes hdf5=${{ matrix.hdf5 }} m2-m4 libxml2 zlib
           shell: bash -el {0}
 
         # Double-check something


### PR DESCRIPTION
This uses a different conda-compatible package manager to install the dependencies. The biggest benefit is that this only uses conda-forge packages and avoids any potential terms/license issues with base Anaconda packages. Hopefully fixes #3332.