### PR TITLE
fix: use nbytes instead of buf_size as input length in H5Zzstd filter

### DIFF
--- a/plugins/H5Zzstd.c
+++ b/plugins/H5Zzstd.c
@@ -99,7 +99,7 @@ H5Z_filter_zstd(unsigned int flags, size_t cd_nelmts,
   }
 
   /* Prepare the input buffer. */
-  inbuflen = *buf_size;
+  inbuflen = nbytes;
   inbuf = (char*)*buf;
 
   if (flags & H5Z_FLAG_REVERSE) { /** Decompress data. */


### PR DESCRIPTION
The HDF5 filter API distinguishes between nbytes (the amount of valid data in the buffer) and *buf_size (the total allocated capacity of the buffer). The zstd filter used *buf_size as the input length for both ZSTD_getFrameContentSize and ZSTD_decompress, which worked because the two values were always equal on the read path.

However, there is ongoing work to pre-size the chunk buffer to the uncompressed chunk_size before calling the filter pipeline, so *buf_size can be larger than nbytes (the actual compressed data size). Passing the oversized *buf_size to ZSTD_decompress causes it to read past the valid compressed frame into uninitialized memory, resulting in a failure.

Fix by using nbytes as the input buffer length, which correctly reflects the amount of compressed data to be processed.