### PR TITLE
`oc2: bound DAP lexer scan pointer against the strdup buffer end`

### DIFF
--- a/oc2/daplex.c
+++ b/oc2/daplex.c
@@ -132,13 +132,17 @@ daplex(YYSTYPE* lvalp, DAPparsestate* state)
     int c;
     unsigned int i;
     char* p;
+    char* end;
     char* tmp;
     YYSTYPE lval = NULL;
 
     token = 0;
     ncbytesclear(lexstate->yytext);
+    /* lexstate->input is allocated via strdup, so the trailing NUL sits at
+     * input + strlen(input). p must never advance past that NUL. */
+    end = lexstate->input + strlen(lexstate->input);
     /* invariant: p always points to current char */
-    for(p=lexstate->next;token==0&&(c=*p);p++) {
+    for(p=lexstate->next;token==0&&p<=end&&(c=*p);p++) {
 	if(c == '\n') {
 	    lexstate->lineno++;
 	} else if(c <= ' ' || c == '\177') {
@@ -262,6 +266,9 @@ daplex(YYSTYPE* lvalp, DAPparsestate* state)
 	} else { /* illegal */
 	}
     }
+    /* The for-loop's post-increment can leave p one past end; clamp so the
+     * stored pointer is always within the strdup'd buffer. */
+    if(p > end) p = end;
     lexstate->next = p;
     strncpy(lexstate->lasttokentext,ncbytescontents(lexstate->yytext),MAX_TOKEN_LENGTH);
     lexstate->lasttoken = token;


### PR DESCRIPTION
## Summary

`daplex()` in `oc2/daplex.c` advances its scan pointer past the trailing NUL of the strdup'd input buffer when it consumes a malformed token, then reads one byte past the buffer in the for-loop's `(c=*p)` condition. ASan flags a 1-byte heap-buffer-overflow READ at `oc2/daplex.c:141` on a 3-byte malformed DAS/DDS body. The same post-buffer pointer is later stored into `lexstate->next`, so `dap_parse_error()`'s `strlen(lexstate->next)` (`oc2/dapparse.c:454`) walks further into adjacent heap and copies what it finds into the `"context: ..."` line printed to stderr.

Reachable through the public API by opening any `dap://server/path` URL whose DAS/DDS response contains the trigger bytes -- `nc_open()` -> `NCD2_open` -> `dap_fetch` -> `DAPparse` -> `daplex`.

## Reproducer

A Python mock DAP server returning the 3-byte body is enough.

`mock_dap_server.py`:

```python
import http.server, socketserver

PAYLOAD = b"\x99\x23\x8d"

class MockDAP(http.server.BaseHTTPRequestHandler):
    def do_GET(self):
        self.send_response(200)
        self.send_header("Content-Type", "text/plain")
        self.send_header("Content-Length", str(len(PAYLOAD)))
        self.end_headers()
        self.wfile.write(PAYLOAD)
    def log_message(self, *a, **k): pass

with socketserver.TCPServer(("127.0.0.1", 18080), MockDAP) as srv:
    srv.serve_forever()
```

`poc.c`:

```c
#include <stdio.h>
#include <netcdf.h>
int main(void) {
    int ncid;
    int rc = nc_open("http://127.0.0.1:18080/data", 0, &ncid);
    fprintf(stderr, "nc_open returned %d\n", rc);
    if (rc == NC_NOERR) nc_close(ncid);
    return 0;
}
```

```
python3 mock_dap_server.py &
clang -fsanitize=address -g -O1 poc.c $(pkg-config --cflags --libs netcdf libcurl) -o poc
./poc
```

ASan output (current main):

```
==...==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x602000005974
READ of size 1 at 0x602000005974 thread T0
    #0 daplex                  oc2/daplex.c:141:39
    #1 dapparse                build/oc2/dapy.c:1494
    #2 DAPparse                oc2/dapparse.c:503
    #3 ocfetch                 oc2/ocinternal.c:236
    #4 oc_fetch                oc2/oc.c:129
    #5 dap_fetch               libdap2/daputil.c:851
    #6 fetchpatternmetadata    libdap2/ncd2dispatch.c:2071
    #7 NCD2_open               libdap2/ncd2dispatch.c:450
    #8 NC_open                 libdispatch/dfile.c:2262
    #9 nc_open                 libdispatch/dfile.c:700

0x602000005974 is located 0 bytes to the right of 4-byte region
allocated by thread T0 here:
    #0 strdup
    #1 daplexinit              oc2/daplex.c:343
```

## Fix

Compute the strdup buffer's NUL position once in `daplex`, bound the outer for-loop with `p<=end`, and clamp `p` before assigning it back into `lexstate->next` so the secondary `strlen` in `dap_parse_error` also stays in-buffer.

## Notes

`oc2/dapparse.c:444-464` is `git blame`d to 2012-07-31, and the lexer loop has been similarly stable, so older release branches are likely affected too. I've only verified against current `main`.
