### PR TITLE
`libsrc: return NC_ENOTNC instead of asserting in nc_get_NC`

### DIFF
--- a/libsrc/v1hpg.c
+++ b/libsrc/v1hpg.c
@@ -1546,7 +1546,13 @@ nc_get_NC(NC3_INFO* ncp)
 	NC_set_numrecs(ncp, nrecs);
 	}
 
-	assert((char *)gs.pos < (char *)gs.end);
+	/* Header truncated: numrecs consumed the remaining buffer; the dim/attr/var
+	 * array parsers below would read past gs.end.  Used to be an assert(),
+	 * which aborts on malformed input -- return NC_ENOTNC instead. */
+	if((char *)gs.pos >= (char *)gs.end) {
+		status = NC_ENOTNC;
+		goto unwind_get;
+	}
 
 	status = v1h_get_NC_dimarray(&gs, &ncp->dims);
     if(status != NC_NOERR)


### PR DESCRIPTION
## Summary

`nc_get_NC()` in `libsrc/v1hpg.c` does

```c
assert((char *)gs.pos < (char *)gs.end);
```

between consuming `numrecs` and parsing the dim/attr/var arrays. The assertion is reachable from any malformed CDF v1/v2/v5 file: a 13-byte input where the `numrecs` field consumes every remaining buffer byte trips it and aborts the process with SIGABRT. Single-input DoS for any process that opens user-supplied `.nc` files.

## Reproducer

13 bytes -- public API, no other setup needed:

```c
#include <stdio.h>
#include <netcdf.h>
#include <netcdf_mem.h>

int main(void) {
    unsigned char buf[] = {
        0x43,0x44,0x46,0x01, 0x00,0x00,0x00,0xb9,
        0x8d,0xff,0xff,0x08, 0xdb
    };
    int ncid;
    nc_open_mem("/tmp/poc.nc", 0, sizeof(buf), buf, &ncid);
    return 0;
}
```

```
clang -g poc.c $(pkg-config --cflags --libs netcdf) -o poc
./poc
# poc: libsrc/v1hpg.c:1549: int nc_get_NC(NC3_INFO *):
#      Assertion `(char *)gs.pos < (char *)gs.end' failed.
# Aborted (core dumped)
```

`ncdump` against the same bytes aborts identically:

```
echo -ne '\x43\x44\x46\x01\x00\x00\x00\xb9\x8d\xff\xff\x08\xdb' > /tmp/poc.nc
ncdump /tmp/poc.nc
```

Stack:

```
nc_get_NC               libsrc/v1hpg.c:1549
NC3_open                libsrc/nc3internal.c:1198
NC_open                 libdispatch/dfile.c:2262
nc_open_mem             libdispatch/dfile.c:823
```

## Build-flag scope

Only triggers on builds without `-DNDEBUG`, which covers:

- the project's CMake default (`CMAKE_BUILD_TYPE=DEBUG`, `CMakeLists.txt:172-175`)
- Debian/Ubuntu's `libnetcdf` package (`dpkg-buildflags` reports `CFLAGS=-g -O2 ...` with no `-DNDEBUG`; verified against Ubuntu 22.04's `libnetcdf-dev 1:4.8.1-1`)
- typical autotools builds (`configure.ac` doesn't set `NDEBUG`)

CMake `Release` (`-O3 -DNDEBUG`) compiles the assert to a no-op; in that case `v1h_get_NC_dimarray` runs with `gs.pos == gs.end` and returns an error gracefully -- the crash is gone but the latent unchecked read remains, which this patch also closes.

## Fix

Replace the assertion with the equivalent guarded return through the existing `unwind_get` path:

```c
if((char *)gs.pos >= (char *)gs.end) {
    status = NC_ENOTNC;
    goto unwind_get;
}
```