### PR TITLE
libsrc: bound nchars against the v1hs stream before allocating NC_string

### DIFF
--- a/libsrc/v1hpg.c
+++ b/libsrc/v1hpg.c
@@ -316,22 +316,19 @@ v1h_get_NC_string(v1hs *gsp, NC_string **ncstrpp)
 	if(status != NC_NOERR)
 		return status;
 
+	/* Bound nchars against the input before allocating; otherwise a
+	 * malformed header that declares a multi-GB string makes us malloc
+	 * before we check whether the bytes are actually there.  check_v1hs
+	 * is what the post-allocation path used to call -- just move it up. */
+	status = check_v1hs(gsp, _RNDUP(nchars, X_ALIGN));
+	if(status != NC_NOERR)
+		return status;
+
 	ncstrp = new_NC_string(nchars, NULL);
 	if(ncstrp == NULL)
 	{
 		return NC_ENOMEM;
 	}
-
-#if 0
-/* assert(ncstrp->nchars == nchars || ncstrp->nchars - nchars < X_ALIGN); */
-	assert(ncstrp->nchars % X_ALIGN == 0);
-	status = check_v1hs(gsp, ncstrp->nchars);
-#else
-
-	status = check_v1hs(gsp, _RNDUP(ncstrp->nchars, X_ALIGN));
-#endif
-	if(status != NC_NOERR)
-		goto unwind_alloc;
 
 	status = ncx_pad_getn_text((const void **)(&gsp->pos),
 		 nchars, ncstrp->cp);


### PR DESCRIPTION
## Summary

`v1h_get_NC_string()` reads `nchars` from the header via `v1h_get_size_t()` and immediately calls `new_NC_string(nchars, NULL)`, which `malloc`s `nchars + sizeof(NC_string) + 1` bytes. The proportionality check against the v1hs stream (`check_v1hs(gsp, _RNDUP(nchars, X_ALIGN))`) only runs *after* the allocation. A 193-byte CDF v2 file that declares a 4 GB attribute name therefore issues a `malloc(0x100000010)` before we ever notice the bytes aren't there. On default Linux the kernel OOM-kills the process; with overcommit, the read fills the buffer.

PR #3153 added a `SIZE_MAX` overflow guard inside `new_NC_string`, but that only catches raw `size_t` overflow -- a 4 GB `nchars` passes through and asks the allocator for ~4 GB.

## Reproducer

193 bytes via the public API:

```c
#include <stdio.h>
#include <netcdf.h>
#include <netcdf_mem.h>

static unsigned char poc[193] = {
    0x43,0x44,0x46,0x02, 0x00,0x2f,0x00,0x4c, 0xff,0xef,0x01,0x00, 0x00,0x00,0x00,0x00,
    0x00,0x00,0x00,0x0c, 0x0c,0x0c,0x0c,0x0c, 0xff,0xff,0xff,0xff, 0xff,0xff,0xff,0xff,
    0xff,0xff,0xff,0xff, 0xff,0xff,0xff,0xff, 0xff,0xff,0xff,0x00, 0x00,0x00,0x00,0x00,
    0xd0,0x90,0x90,0x90, 0x90,0x90,0x01,0x00, 0x01,0x00,0x6e,0x00, 0x00,0x00,0x00,0x00,
};

int main(void) {
    int ncid;
    nc_open_mem("/tmp/poc.nc", 0, sizeof(poc), poc, &ncid);
    return 0;
}
```

```
clang -fsanitize=address -g -O1 poc.c $(pkg-config --cflags --libs netcdf) -o poc
ASAN_OPTIONS=allocator_may_return_null=1:max_allocation_size_mb=2048 ./poc
```

ASan output (current main):

```
==...==WARNING: AddressSanitizer failed to allocate 0x100000010 bytes
    #7 malloc
    #8 new_NC_string                libdispatch/dstring.c:245
    #9 v1h_get_NC_string            libsrc/v1hpg.c:319
    #10 v1h_get_NC_attr             libsrc/v1hpg.c:755
    #11 v1h_get_NC_attrarray        libsrc/v1hpg.c:904
    #12 nc_get_NC                   libsrc/v1hpg.c:1555
    #13 NC3_open                    libsrc/nc3internal.c:1198
    #14 nc_open_mem                 libdispatch/dfile.c:823
```

`malloc(0x100000010) ≈ slen 0xFFFFFFEF + sizeof(NC_string) + 1`. `slen` is the `nchars` field that the malformed header declares for one of the attribute names.

## Fix

Move the existing `check_v1hs(gsp, _RNDUP(nchars, X_ALIGN))` call *before* `new_NC_string`. No new logic -- the check that used to run after the malloc just runs first. Catches the bomb at the source without changing any other behavior; the post-allocation `check_v1hs` becomes redundant and is removed.

This complements PR #3153 rather than replaces it; the `SIZE_MAX` overflow guard added there is still a useful last line of defense.
