### PR TITLE
Adding new function nc_set_meta_block_size()

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,10 @@ Release Notes       {#RELEASE_NOTES}
 
 This file contains a high-level description of this package's evolution. Releases are in reverse chronological order (most recent first). Note that, as of netcdf 4.2, the `netcdf-c++` and `netcdf-fortran` libraries have been separated into their own libraries.
 
+## 4,10.1 - TBD
+
+* Added new functions `nc_set_meta_block_size()` and `nc_get_meta_block_size()`, to allow for runtime modification of downstream `libhdf5` block size.  See [GitHub 3386](https://github.com/Unidata/netcdf-c/issues/3386) and [Github 3391](https://github.com/Unidata/netcdf-c/pull/3391) for more information.   
+
 ## 4.10.0 - February 25, 2026
 
 * Regularize, cleanup, and refactor various AWS features, especially WRT regularizing AWS-related constants. See [Github 3229](https://github.com/Unidata/netcdf-c/issues/3229) for more information. 

--- a/include/ncglobal.h
+++ b/include/ncglobal.h
@@ -51,6 +51,10 @@ typedef struct NCglobalstate {
 	int threshold;
 	int alignment;
     } alignment;
+    struct MetaBlockSize { /* H5Pset_meta_block_size parameter */
+        int defined; /* 1 => size explicitly set, 0 => use HDF5 default */
+        size_t size; /* minimum metadata block size in bytes */
+    } meta_block_size;
     struct ChunkCache {
         size_t size;     /**< Size in bytes of the var chunk cache. */
         size_t nelems;   /**< Number of slots in var chunk cache. */

--- a/include/netcdf.h
+++ b/include/netcdf.h
@@ -686,6 +686,14 @@ nc_set_alignment(int threshold, int alignment);
 EXTERNL int
 nc_get_alignment(int* thresholdp, int* alignmentp);
 
+/* Set the global minimum HDF5 metadata block size property. */
+EXTERNL int
+nc_set_meta_block_size(size_t size);
+
+/* Get the global minimum HDF5 metadata block size property. */
+EXTERNL int
+nc_get_meta_block_size(size_t* sizep);
+
 EXTERNL int
 nc__create(const char *path, int cmode, size_t initialsz,
          size_t *chunksizehintp, int *ncidp);

--- a/libdispatch/ddispatch.c
+++ b/libdispatch/ddispatch.c
@@ -428,9 +428,6 @@ locked in when the file is opened and forgotten when the file is closed.
 Multiple files with different values can coexist by interleaving
 nc_set_meta_block_size and nc_create/nc_open calls.
 
-This function has no effect on classic, 64-bit offset, or CDF-5 format
-files, which do not use HDF5.
-
 Refer to H5Pset_meta_block_size in the HDF5 documentation for
 implementation specifics, defaults, and interactions with other FAPL
 properties.
@@ -439,7 +436,6 @@ properties.
             HDF5 default (2048 bytes).
 
 @return ::NC_NOERR No error.
-@author See issue https://github.com/Unidata/netcdf-c/issues/3386
 @ingroup datasets
 */
 int
@@ -462,7 +458,6 @@ nc_set_meta_block_size has not been called, or was last called with size
              bytes, or 0 if the override is disabled.
 
 @return ::NC_NOERR No error.
-@author See issue https://github.com/Unidata/netcdf-c/issues/3386
 @ingroup datasets
 */
 int

--- a/libdispatch/ddispatch.c
+++ b/libdispatch/ddispatch.c
@@ -392,3 +392,85 @@ nc_get_alignment(int* thresholdp, int* alignmentp)
 }
 
 /** \} */
+
+
+/**************************************************/
+/** \defgroup meta_block_size Metadata block size functions. */
+
+/** \{
+
+\ingroup meta_block_size
+*/
+
+/**
+Set the global minimum HDF5 metadata block size.
+
+If defined (size > 0), this value is passed as the FAPL meta_block_size
+argument to H5Pset_meta_block_size for every netCDF-4/HDF5 file created
+or opened after this call. Setting size to 0 disables the override and
+allows HDF5 to use its built-in default (2048 bytes).
+
+HDF5 writes metadata — chunk index B-trees, attribute headers, and other
+bookkeeping structures — into a contiguous block at the beginning of the
+file. When the block is exhausted, HDF5 appends a new block after the
+current data and records its address at the end of the previous block,
+creating a linked chain. A reader must issue one additional I/O request
+per link in the chain, which is costly over remote storage. A
+sufficiently large meta_block_size keeps all metadata in a single
+allocation and eliminates that traversal overhead.
+
+Repeated calls overwrite the previous value. The setting is global and
+not per-file; it applies to all files created or opened after this call
+until the process exits or the setting is changed.
+
+Call nc_set_meta_block_size before nc_create or nc_open. The setting is
+locked in when the file is opened and forgotten when the file is closed.
+Multiple files with different values can coexist by interleaving
+nc_set_meta_block_size and nc_create/nc_open calls.
+
+This function has no effect on classic, 64-bit offset, or CDF-5 format
+files, which do not use HDF5.
+
+Refer to H5Pset_meta_block_size in the HDF5 documentation for
+implementation specifics, defaults, and interactions with other FAPL
+properties.
+
+@param size Minimum metadata block size in bytes, or 0 to use the
+            HDF5 default (2048 bytes).
+
+@return ::NC_NOERR No error.
+@author See issue https://github.com/Unidata/netcdf-c/issues/3386
+@ingroup datasets
+*/
+int
+nc_set_meta_block_size(size_t size)
+{
+    NCglobalstate* gs = NC_getglobalstate();
+    gs->meta_block_size.size = size;
+    gs->meta_block_size.defined = (size > 0) ? 1 : 0;
+    return NC_NOERR;
+}
+
+/**
+Retrieve the current global minimum HDF5 metadata block size.
+
+Returns the value most recently set by nc_set_meta_block_size. If
+nc_set_meta_block_size has not been called, or was last called with size
+0, sizep is set to 0 on return.
+
+@param sizep On return, the current minimum metadata block size in
+             bytes, or 0 if the override is disabled.
+
+@return ::NC_NOERR No error.
+@author See issue https://github.com/Unidata/netcdf-c/issues/3386
+@ingroup datasets
+*/
+int
+nc_get_meta_block_size(size_t* sizep)
+{
+    NCglobalstate* gs = NC_getglobalstate();
+    if (sizep) *sizep = gs->meta_block_size.size;
+    return NC_NOERR;
+}
+
+/** \} */

--- a/libhdf5/hdf5create.c
+++ b/libhdf5/hdf5create.c
@@ -169,6 +169,14 @@ nc4_create_file(const char *path, int cmode, size_t initialsz,
 	}
     }
 
+    {
+	NCglobalstate* gs = NC_getglobalstate();
+        if(gs->meta_block_size.defined) {
+            if (H5Pset_meta_block_size(fapl_id, (hsize_t)gs->meta_block_size.size) < 0) {
+                BAIL(NC_EHDFERR);
+            }
+    	}
+    }
     /* Set HDF5 format compatibility in the FILE ACCESS property list.
      * Compatibility is transient and must be reselected every time
      * a file is opened for writing. */

--- a/libhdf5/hdf5open.c
+++ b/libhdf5/hdf5open.c
@@ -841,6 +841,15 @@ nc4_open_file(const char *path, int mode, void* parameters, int ncid)
 	    }
 	}
     }
+    
+    {
+	NCglobalstate* gs = NC_getglobalstate();
+        if(gs->meta_block_size.defined) {
+            if (H5Pset_meta_block_size(fapl_id, (hsize_t)gs->meta_block_size.size) < 0) {
+                BAIL(NC_EHDFERR);
+            }
+    	}
+    }
 
     /* Set HDF5 format compatibility in the FILE ACCESS property list.
      * Compatibility is transient and must be reselected every time

--- a/nc_test4/CMakeLists.txt
+++ b/nc_test4/CMakeLists.txt
@@ -23,10 +23,10 @@ SET(NC4_TESTS tst_dims tst_dims2 tst_dims3 tst_files tst_files4
   tst_rename2 tst_rename3 tst_h5_endians tst_atts_string_rewrite tst_put_vars_two_unlim_dim
   tst_hdf5_file_compat tst_fill_attr_vanish tst_rehash tst_types tst_bug324
   tst_atts3 tst_put_vars tst_elatefill tst_udf tst_bug1442 tst_broken_files
-  tst_quantize tst_h_transient_types tst_strided_write tst_varsperf)
+  tst_quantize tst_h_transient_types tst_strided_write tst_varsperf tst_meta_block_size)
 
 IF(HAS_PAR_FILTERS)
-SET(NC4_tests $NC4_TESTS tst_alignment)
+SET(NC4_tests ${NC4_TESTS} tst_alignment)
 ENDIF()
 
 # Note, renamegroup needs to be compiled before run_grp_rename

--- a/nc_test4/Makefile.am
+++ b/nc_test4/Makefile.am
@@ -36,7 +36,7 @@ tst_atts_string_rewrite tst_hdf5_file_compat tst_fill_attr_vanish	\
 tst_rehash tst_filterparser tst_bug324 tst_types tst_atts3		\
 tst_put_vars tst_elatefill tst_udf tst_put_vars_two_unlim_dim		\
 tst_bug1442 tst_quantize tst_h_transient_types tst_strided_write	\
-tst_varsperf
+tst_varsperf tst_meta_block_size
 
 if HAS_PAR_FILTERS
 NC4_TESTS += tst_alignment

--- a/nc_test4/tst_meta_block_size.c
+++ b/nc_test4/tst_meta_block_size.c
@@ -30,7 +30,7 @@ main(int argc, char **argv)
     printf("\n*** Testing nc_set_meta_block_size and nc_get_meta_block_size.\n");
 
     /*
-     * Test 1: nc_set_meta_block_size / nc_get_meta_block_size round-trip. 
+     * Test 1: nc_set_meta_block_size / nc_get_meta_block_size  
      */
     printf("*** Test 1: round-trip nc_set_meta_block_size / nc_get_meta_block_size...");
     {

--- a/nc_test4/tst_meta_block_size.c
+++ b/nc_test4/tst_meta_block_size.c
@@ -1,0 +1,107 @@
+/* Copyright 2026 University Corporation for Atmospheric Research/Unidata.
+   See COPYRIGHT file for conditions of use.
+
+   Test nc_set_meta_block_size and nc_get_meta_block_size.
+   Pattern follows nc_test4/tst_alignment.c.
+
+   @author Ward Fisher
+*/
+
+#include <nc_tests.h>
+#include "err_macros.h"
+#include <hdf5.h>
+#include <string.h>
+
+#define FILE_NAME  "tst_meta_block_size.nc"
+#define FILE_NAME2 "tst_meta_block_size2.nc"
+#define META_BLOCK_SIZE ((size_t)1048576)  /* 1 MiB */
+#define DIM_LEN 64
+
+int
+main(int argc, char **argv)
+{
+    int ncid, varid, dimid;
+    size_t retrieved;
+    float data_out[DIM_LEN], data_in[DIM_LEN];
+    hid_t fapl_id;
+    hsize_t hdf5_retrieved;
+    int i;
+
+    printf("\n*** Testing nc_set_meta_block_size and nc_get_meta_block_size.\n");
+
+    /*
+     * Test 1: nc_set_meta_block_size / nc_get_meta_block_size round-trip. 
+     */
+    printf("*** Test 1: round-trip nc_set_meta_block_size / nc_get_meta_block_size...");
+    {
+        if (nc_set_meta_block_size(META_BLOCK_SIZE)) ERR;
+        if (nc_get_meta_block_size(&retrieved)) ERR;
+        if (retrieved != META_BLOCK_SIZE) ERR;
+    }
+    SUMMARIZE_ERR;
+
+    /*
+     * Test 2: create and write a netCDF-4 file while the override is set. 
+     */
+    printf("*** Test 2: create and write a netCDF-4 file with meta_block_size set...");
+    {
+        size_t chunks[1];
+
+        if (nc_set_meta_block_size(META_BLOCK_SIZE)) ERR;
+        if (nc_create(FILE_NAME, NC_NETCDF4, &ncid)) ERR;
+        if (nc_def_dim(ncid, "d0", DIM_LEN, &dimid)) ERR;
+        if (nc_def_var(ncid, "v0", NC_FLOAT, 1, &dimid, &varid)) ERR;
+        chunks[0] = DIM_LEN;
+        if (nc_def_var_chunking(ncid, varid, NC_CHUNKED, chunks)) ERR;
+        if (nc_enddef(ncid)) ERR;
+        for (i = 0; i < DIM_LEN; i++) data_out[i] = (float)i;
+        if (nc_put_var_float(ncid, varid, data_out)) ERR;
+        if (nc_close(ncid)) ERR;
+    }
+    SUMMARIZE_ERR;
+
+    /*
+     * Test 3: data written with the override active is readable. 
+     */
+    printf("*** Test 3: read back data from file written with meta_block_size set...");
+    {
+        if (nc_open(FILE_NAME, NC_NOWRITE, &ncid)) ERR;
+        if (nc_inq_varid(ncid, "v0", &varid)) ERR;
+        if (nc_get_var_float(ncid, varid, data_in)) ERR;
+        for (i = 0; i < DIM_LEN; i++)
+            if (data_in[i] != data_out[i]) ERR;
+        if (nc_close(ncid)) ERR;
+    }
+    SUMMARIZE_ERR;
+
+    /*
+     * Test 4: HDF5 FAPL API round-trip.                                   
+     * Verifies H5Pset_meta_block_size / H5Pget_meta_block_size behave as  
+     * expected.                  
+     */
+    printf("*** Test 4: HDF5 FAPL meta_block_size round-trip...");
+    {
+        if ((fapl_id = H5Pcreate(H5P_FILE_ACCESS)) < 0) ERR;
+        if (H5Pset_meta_block_size(fapl_id, (hsize_t)META_BLOCK_SIZE) < 0) ERR;
+        if (H5Pget_meta_block_size(fapl_id, &hdf5_retrieved) < 0) ERR;
+        if (hdf5_retrieved != (hsize_t)META_BLOCK_SIZE) ERR;
+        if (H5Pclose(fapl_id) < 0) ERR;
+    }
+    SUMMARIZE_ERR;
+
+    /* 
+     * Test 5: setting size to 0 disables the override.             
+     * A file created after the reset should succeed normally.
+     */
+    printf("*** Test 5: nc_set_meta_block_size(0) disables the override...");
+    {
+        if (nc_set_meta_block_size(0)) ERR;
+        if (nc_get_meta_block_size(&retrieved)) ERR;
+        if (retrieved != 0) ERR;
+        if (nc_create(FILE_NAME2, NC_NETCDF4, &ncid)) ERR;
+        if (nc_close(ncid)) ERR;
+    }
+    SUMMARIZE_ERR;
+
+    FINAL_RESULTS;
+}


### PR DESCRIPTION
* Fixes #3386 

Patterned after `nc_set_alignment()` and `nc_get_alignment()`, allows for runtime modification of the HDF5 library meta_block_size.  This change is prompted by the discussion in #3386.