### PR TITLE
fix: nc_def_var_chunking_ints should dispatch to format-aware handler

### DIFF
--- a/libhdf5/hdf5var.c
+++ b/libhdf5/hdf5var.c
@@ -1040,7 +1040,12 @@ NC4_def_var_chunking(int ncid, int varid, int storage, const size_t *chunksizesp
 /**
  * @internal Define chunking stuff for a var. This is called by
  * the fortran API.
- * Note: see libsrc4/nc4cache.c for definition when HDF5 is disabled
+ *
+ * NOTE: This function is now defined in libsrc4/nc4cache.c as a
+ * format-agnostic wrapper that delegates to nc_def_var_chunking()
+ * (which dispatches to the correct backend). The HDF5-specific
+ * version that called nc_def_var_extra() has been removed because
+ * it did not update NCZarr cache state (see GitHub issue #487).
  *
  * @param ncid File ID.
  * @param varid Variable ID.
@@ -1058,6 +1063,10 @@ NC4_def_var_chunking(int ncid, int varid, int storage, const size_t *chunksizesp
  * @returns ::NC_EBADCHUNK Bad chunksize.
  * @author Ed Hartnett
  */
+#if 0
+/* Moved to libsrc4/nc4cache.c as a format-agnostic wrapper that
+ * delegates to nc_def_var_chunking() for correct dispatch to HDF5,
+ * NCZarr, etc. See fix-nczarr-chunking-cache-stale. */
 int
 nc_def_var_chunking_ints(int ncid, int varid, int storage, int *chunksizesp)
 {
@@ -1086,6 +1095,7 @@ nc_def_var_chunking_ints(int ncid, int varid, int storage, int *chunksizesp)
         free(cs);
     return retval;
 }
+#endif /* 0 */
 
 /**
  * @internal This functions sets fill value and no_fill mode for a

--- a/libsrc4/nc4cache.c
+++ b/libsrc4/nc4cache.c
@@ -163,23 +163,55 @@ nc_get_chunk_cache_ints(int *sizep, int *nelemsp, int *preemptionp)
 }
 
 #ifndef USE_HDF5
-/* See definitions in libhd5/hdf5var.c */
-/* Make sure they are always defined */
-/* Note: if netcdf-4 is completely disabled, then the definitions in
- * libdispatch/dfile.c take effect.
- */
-
 int
 nc_set_var_chunk_cache_ints(int ncid, int varid, int size, int nelems,
                             int preemption)
 {
     return NC_NOERR;
 }
+#endif /*USE_HDF5*/
 
+/**
+ * Fortran-compatible wrapper for nc_def_var_chunking().
+ * Converts int* chunksizes to size_t* and delegates to the
+ * format-aware nc_def_var_chunking() dispatch.
+ *
+ * This replaces the previous stub (which returned NC_NOERR
+ * without doing anything) and the HDF5-specific version in
+ * libhdf5/hdf5var.c (which set metadata but did not update
+ * NCZarr cache state).
+ *
+ * @param ncid File ID.
+ * @param varid Variable ID.
+ * @param storage Contiguous or chunked.
+ * @param chunksizesp Array of chunk sizes (int).
+ *
+ * @return NC_NOERR No error.
+ * @author Ed Hartnett, Dennis Heimbigner
+ */
 int
 nc_def_var_chunking_ints(int ncid, int varid, int storage, int *chunksizesp)
 {
-    return NC_NOERR;
-}
+    int i, retval;
+    NC_VAR_INFO_T *var = NULL;
+    size_t *cs = NULL;
 
-#endif /*USE_HDF5*/
+    /* Find the variable to get its rank. */
+    if ((retval = nc4_find_grp_h5_var(ncid, varid, NULL, NULL, &var)))
+        return retval;
+    assert(var);
+
+    /* Allocate size_t array and convert. */
+    if (var->ndims > 0) {
+        if (!(cs = malloc(var->ndims * sizeof(size_t))))
+            return NC_ENOMEM;
+        for (i = 0; i < var->ndims; i++)
+            cs[i] = (size_t)chunksizesp[i];
+    }
+
+    /* Delegate to format-aware dispatch (works for HDF5, NCZarr, etc.) */
+    retval = nc_def_var_chunking(ncid, varid, storage, cs);
+
+    if (cs) free(cs);
+    return retval;
+}

--- a/nczarr_test/CMakeLists.txt
+++ b/nczarr_test/CMakeLists.txt
@@ -108,6 +108,9 @@ IF(NETCDF_ENABLE_TESTS)
 
 #  ADD_BIN_TEST(nczarr_test test_endians ${TSTCOMMONSRC})
 
+  # Test nc_def_var_chunking_ints (Fortran compatibility wrapper)
+  add_bin_test(nczarr_test tst_chunking_ints)
+
   # Unlimited Tests
   IF(USE_HDF5)
   add_bin_test_with_util_lib(nczarr_test test_unlim_vars test_utils)

--- a/nczarr_test/Makefile.am
+++ b/nczarr_test/Makefile.am
@@ -43,7 +43,9 @@ ut_json_SOURCES = ut_json.c ${commonsrc}
 
 test_fillonlyz_SOURCES = test_fillonlyz.c ${testcommonsrc}
 
-check_PROGRAMS += test_fillonlyz test_quantize test_notzarr
+tst_chunking_ints_SOURCES = tst_chunking_ints.c
+
+check_PROGRAMS += test_fillonlyz test_quantize test_notzarr tst_chunking_ints
 
 # Unlimited Dimension tests
 if USE_HDF5
@@ -59,6 +61,7 @@ if NETCDF_BUILD_UTILITIES
 TESTS += run_ut_misc.sh
 TESTS += run_ut_map.sh
 TESTS += run_ut_mapapi.sh
+TESTS += tst_chunking_ints
 
 if AX_DISABLE # Obsolete tests
 TESTS += run_ut_chunk.sh

--- a/nczarr_test/tst_chunking_ints.c
+++ b/nczarr_test/tst_chunking_ints.c
@@ -1,0 +1,125 @@
+/* Copyright 2018, University Corporation for Atmospheric Research.
+ * See COPYRIGHT file for copying and redistribution conditions.
+ */
+/**
+ * @file
+ * Test nc_def_var_chunking_ints with NCZarr.
+ *
+ * Regression test for GitHub issue
+ * https://github.com/Unidata/netcdf-fortran/issues/487
+ *
+ * nc_def_var_chunking_ints is the Fortran-compatible wrapper that
+ * accepts int* chunksizes. Prior to the fix, it either was a no-op
+ * stub (NCZarr-only builds) or called HDF5-specific code that did
+ * not update NCZarr cache state. This test verifies that chunk
+ * data files are written at the correct size.
+ *
+ * @author Generated from explore_487 investigation
+ */
+
+#include <config.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <netcdf.h>
+
+#define DIM 256
+#define CHUNK 128
+#define FILE_NAME "file://tst_chunking_ints.zarr#mode=zarr,file"
+
+#define CHECK(expr) do { \
+    int _r = (expr); \
+    if (_r != NC_NOERR) { \
+        fprintf(stderr, "Error at %s:%d: %s\n", __FILE__, __LINE__, nc_strerror(_r)); \
+        return 2; \
+    } \
+} while(0)
+
+static long
+get_file_size(const char *path)
+{
+    struct stat st;
+    if (stat(path, &st) != 0) return -1;
+    return (long)st.st_size;
+}
+
+int
+main(void)
+{
+    int ncid, dimid_x, dimid_y, varid;
+    int chunks[2] = {CHUNK, CHUNK};
+    float data[DIM][DIM];
+    long expected_chunk_size = (long)CHUNK * CHUNK * sizeof(float);
+    int nerrs = 0;
+
+    printf("\n*** Testing nc_def_var_chunking_ints with NCZarr.\n");
+    printf("*** Expected chunk file size: %ld bytes\n", expected_chunk_size);
+
+    /* Create file with chunked variable */
+    CHECK(nc_create(FILE_NAME, NC_CLOBBER | NC_NETCDF4, &ncid));
+    CHECK(nc_def_dim(ncid, "y", DIM, &dimid_y));
+    CHECK(nc_def_dim(ncid, "x", DIM, &dimid_x));
+    CHECK(nc_def_var(ncid, "v", NC_FLOAT, 2,
+                   (int[]){dimid_y, dimid_x}, &varid));
+
+    /* Use the Fortran-compatible int* wrapper */
+    CHECK(nc_def_var_chunking_ints(ncid, varid, NC_CHUNKED, chunks));
+
+    /* Verify chunking was set correctly */
+    {
+        int contiguous;
+        size_t chunks_out[2];
+        CHECK(nc_inq_var_chunking(ncid, varid, &contiguous, chunks_out));
+        if (contiguous != 0) {
+            printf("FAIL: contiguous != 0\n");
+            nerrs++;
+        }
+        if (chunks_out[0] != CHUNK || chunks_out[1] != CHUNK) {
+            printf("FAIL: chunks=[%zu,%zu] expected [%d,%d]\n",
+                   chunks_out[0], chunks_out[1], CHUNK, CHUNK);
+            nerrs++;
+        }
+    }
+
+    /* Write data */
+    {
+        int i, j;
+        for (i = 0; i < DIM; i++)
+            for (j = 0; j < DIM; j++)
+                data[i][j] = 42.0f;
+    }
+    CHECK(nc_enddef(ncid));
+    CHECK(nc_put_var_float(ncid, varid, &data[0][0]));
+    CHECK(nc_close(ncid));
+
+    /* Verify each chunk file has the correct size */
+    {
+        int i, j;
+        char path[256];
+        for (i = 0; i < DIM / CHUNK; i++) {
+            for (j = 0; j < DIM / CHUNK; j++) {
+                long sz;
+                snprintf(path, sizeof(path),
+                         "tst_chunking_ints.zarr/v/%d.%d", i, j);
+                sz = get_file_size(path);
+                if (sz != expected_chunk_size) {
+                    printf("FAIL: %s size=%ld, expected=%ld\n",
+                           path, sz, expected_chunk_size);
+                    nerrs++;
+                }
+            }
+        }
+    }
+
+    /* Cleanup */
+    {
+        (void)system("rm -rf tst_chunking_ints.zarr");
+    }
+
+    if (nerrs) {
+        printf("FAILED: %d errors\n", nerrs);
+        return 2;
+    }
+    printf("PASSED\n");
+    return 0;
+}

--- a/nczarr_test/tst_chunking_ints.c
+++ b/nczarr_test/tst_chunking_ints.c
@@ -22,6 +22,8 @@
 #include <stdlib.h>
 #include <sys/stat.h>
 #include <netcdf.h>
+#include <netcdf_f.h>
+#include <ncpathmgr.h>
 
 #define DIM 256
 #define CHUNK 128
@@ -38,8 +40,16 @@
 static long
 get_file_size(const char *path)
 {
+    /* Use the portable stat wrapper from ncpathmgr.h; raw stat() is
+     * unreliable on Windows (_stat64 layout) and does not perform the
+     * path conversion (NCpathcvt) that the rest of the codebase relies
+     * on. See libnczarr/zmap_file.c for the same pattern. */
+#ifdef _WIN32
+    struct _stat64 st;
+#else
     struct stat st;
-    if (stat(path, &st) != 0) return -1;
+#endif
+    if (NCstat(path, &st) != 0) return -1;
     return (long)st.st_size;
 }
 


### PR DESCRIPTION
## Problem

`nc_def_var_chunking_ints()` is the Fortran-compatible wrapper (accepts `int*` chunksizes) called by `nf90_def_var_chunking()` in netcdf-fortran. It had two broken paths for NCZarr files:

1. **NCZarr-only builds (no HDF5):** the stub in `libsrc4/nc4cache.c` returned `NC_NOERR` without doing anything, so chunk sizes were never applied. The variable kept default chunk sizes (full dimension), producing a single chunk file with full-variable data.

2. **HDF5-enabled builds:** the implementation in `libhdf5/hdf5var.c` called `nc_def_var_extra()` which set `var->chunksizes` (metadata correct) but did NOT update NCZarr-specific cache state (`zvar->chunkproduct`, `zvar->chunksize`, `zvar->cache->valid`). The write path used stale cache values, writing full-variable-sized chunk data files.

Both cases produced correct `.zarray` metadata but wrong chunk data files — unreadable by `zarr-python` and `xarray`.

See: Unidata/netcdf-fortran#487

## Fix

Make `nc_def_var_chunking_ints()` convert `int*` to `size_t*` and delegate to `nc_def_var_chunking()`, which dispatches to the correct format backend (`NCZ_def_var_chunking` for NCZarr, `NC4_def_var_chunking` for HDF5). Both correctly update all internal state.

## Changes

- Replace stub in `libsrc4/nc4cache.c` with dispatch-aware implementation
- ifdef-out the HDF5-only version in `libhdf5/hdf5var.c`
- Add regression test `nczarr_test/tst_chunking_ints.c`

## Verification

- C tests: all 4 chunk files correctly sized at 65536 bytes (was 262144)
- Fortran reproducer: chunks correctly applied, output readable by both `zarr-python` and `xarray`
- No HDF5 regressions: dispatch path unchanged for HDF5 files