### PR TITLE
libdispatch/dstring.c: SIZE_MAX is defined in stdint.h

### DIFF
--- a/libdispatch/dstring.c
+++ b/libdispatch/dstring.c
@@ -7,6 +7,7 @@
 #include "config.h"
 #include <stdlib.h>
 #include <stdio.h>
+#include <stdint.h>
 #include <string.h>
 #include <ctype.h>
 #include <assert.h>


### PR DESCRIPTION
* When commit 0e0cb290673fa5a8056df603a95d6bdc7865e9c4 is backported to older versions of netcdf-c, e.g., 4.7.4, SIZE_MAX is undefined. This commit can be backported with the aforementioned commit to avoid compilation failures.