### PR TITLE
Improve NCauth creation from RC file

### DIFF
--- a/libdispatch/dauth.c
+++ b/libdispatch/dauth.c
@@ -33,10 +33,17 @@ See COPYRIGHT for license information.
 #undef MEMCHECK
 #define MEMCHECK(x) if((x)==NULL) {goto nomem;} else {}
 
+
+#define NCAUTH_SSL_VERIFY_DEFAULT -1
+
+#define TO_STR(X) #X
+#define NCAUTH_SSL_VERIFY_DEFAULT_STR TO_STR(NCAUTH_SSL_VERIFY_DEFAULT)
+
+
 /* Define the curl flag defaults in envv style */
 static const char* AUTHDEFAULTS[] = {
-"HTTP.SSL.VERIFYPEER","-1", /* Use default */
-"HTTP.SSL.VERIFYHOST","-1", /* Use default */
+"HTTP.SSL.VERIFYPEER", NCAUTH_SSL_VERIFY_DEFAULT_STR, /* Use default */
+"HTTP.SSL.VERIFYHOST", NCAUTH_SSL_VERIFY_DEFAULT_STR, /* Use default */
 "HTTP.TIMEOUT","1800", /*seconds */ /* Long but not infinite */
 "HTTP.CONNECTTIMEOUT","50", /*seconds */ /* Long but not infinite */
 "HTTP.ENCODE","1", /* Use default */
@@ -262,7 +269,7 @@ setauthfield(NCauth* auth, const char* flag, const char* value)
     int ret = NC_NOERR;
     if(value == NULL) goto done;
 
-    int int_value = -1;
+    int int_value = NCAUTH_SSL_VERIFY_DEFAULT;
     value_to_int(value, &int_value);
 
     if(strcmp(flag,"HTTP.ENCODE")==0) {
@@ -330,7 +337,7 @@ setauthfield(NCauth* auth, const char* flag, const char* value)
     }
     if(strcmp(flag,"HTTP.SSL.VALIDATE")==0) {
         switch (int_value) {
-            case -1: //default
+            case NCAUTH_SSL_VERIFY_DEFAULT: //default
                 auth->ssl.verifypeer = -1;
                 auth->ssl.verifyhost = -1;
                 break;
@@ -458,3 +465,5 @@ setdefaults(NCauth* auth)
 	}
     }
 }
+
+#undef TO_STR

--- a/libdispatch/dauth.c
+++ b/libdispatch/dauth.c
@@ -28,7 +28,12 @@ See COPYRIGHT for license information.
 
 #include "ncrc.h"
 
-#undef DEBUG
+#define DEBUG 1
+#if DEBUG
+#define DEBUGLOG(...) nclog(__VA_ARGS__)
+#else
+#define DEBUGLOG(...) ((void)0)
+#endif
 
 #undef MEMCHECK
 #define MEMCHECK(x) if((x)==NULL) {goto nomem;} else {}
@@ -270,34 +275,24 @@ setauthfield(NCauth* auth, const char* flag, const char* value)
 
     if(strcmp(flag,"HTTP.ENCODE")==0) {
         if(atoi(value)) {auth->curlflags.encode = 1;} else {auth->curlflags.encode = 0;}
-#ifdef DEBUG
-        nclog(NCLOGNOTE,"HTTP.encode: %ld", (long)auth->curlflags.encode);
-#endif
+        DEBUGLOG(NCLOGNOTE,"HTTP.encode: %ld", (long)auth->curlflags.encode);
     }
     if(strcmp(flag,"HTTP.VERBOSE")==0) {
         if(atoi(value)) auth->curlflags.verbose = 1;
-#ifdef DEBUG
-            nclog(NCLOGNOTE,"HTTP.VERBOSE: %ld", (long)auth->curlflags.verbose);
-#endif
+        DEBUGLOG(NCLOGNOTE,"HTTP.VERBOSE: %ld", (long)auth->curlflags.verbose);
     }
     if(strcmp(flag,"HTTP.TIMEOUT")==0) {
         if(atoi(value)) auth->curlflags.timeout = atoi(value);
-#ifdef DEBUG
-            nclog(NCLOGNOTE,"HTTP.TIMEOUT: %ld", (long)auth->curlflags.timeout);
-#endif
+        DEBUGLOG(NCLOGNOTE,"HTTP.TIMEOUT: %ld", (long)auth->curlflags.timeout);
     }
     if(strcmp(flag,"HTTP.CONNECTTIMEOUT")==0) {
         if(atoi(value)) auth->curlflags.connecttimeout = atoi(value);
-#ifdef DEBUG
-            nclog(NCLOGNOTE,"HTTP.CONNECTTIMEOUT: %ld", (long)auth->curlflags.connecttimeout);
-#endif
+        DEBUGLOG(NCLOGNOTE,"HTTP.CONNECTTIMEOUT: %ld", (long)auth->curlflags.connecttimeout);
     }
     if(strcmp(flag,"HTTP.USERAGENT")==0) {
         if(atoi(value)) auth->curlflags.useragent = strdup(value);
         MEMCHECK(auth->curlflags.useragent);
-#ifdef DEBUG
-            nclog(NCLOGNOTE,"HTTP.USERAGENT: %s", auth->curlflags.useragent);
-#endif
+        DEBUGLOG(NCLOGNOTE,"HTTP.USERAGENT: %s", auth->curlflags.useragent);
     }
     if(
 	strcmp(flag,"HTTP.COOKIEFILE")==0
@@ -308,28 +303,20 @@ setauthfield(NCauth* auth, const char* flag, const char* value)
 	nullfree(auth->curlflags.cookiejar);
         auth->curlflags.cookiejar = strdup(value);
         MEMCHECK(auth->curlflags.cookiejar);
-#ifdef DEBUG
-            nclog(NCLOGNOTE,"HTTP.COOKIEJAR: %s", auth->curlflags.cookiejar);
-#endif
+        DEBUGLOG(NCLOGNOTE,"HTTP.COOKIEJAR: %s", auth->curlflags.cookiejar);
     }
     if(strcmp(flag,"HTTP.PROXY.SERVER")==0 || strcmp(flag,"HTTP.PROXY_SERVER")==0) {
         ret = NC_parseproxy(auth,value);
         if(ret != NC_NOERR) goto done;
-#ifdef DEBUG
-            nclog(NCLOGNOTE,"HTTP.PROXY.SERVER: %s", value);
-#endif
+        DEBUGLOG(NCLOGNOTE,"HTTP.PROXY.SERVER: %s", value);
     }
     if(strcmp(flag,"HTTP.SSL.VERIFYPEER")==0) {
 	    auth->ssl.verifypeer = int_value;
-#ifdef DEBUG
-                nclog(NCLOGNOTE,"HTTP.SSL.VERIFYPEER: %d", v);
-#endif
+        DEBUGLOG(NCLOGNOTE,"HTTP.SSL.VERIFYPEER: %d", int_value);
     }
     if(strcmp(flag,"HTTP.SSL.VERIFYHOST")==0) {
 	    auth->ssl.verifyhost = int_value;
-#ifdef DEBUG
-                nclog(NCLOGNOTE,"HTTP.SSL.VERIFYHOST: %d", v);
-#endif
+        DEBUGLOG(NCLOGNOTE,"HTTP.SSL.VERIFYHOST: %d", int_value);
     }
     if(strcmp(flag,"HTTP.SSL.VALIDATE")==0) {
         switch (int_value) {
@@ -352,53 +339,41 @@ setauthfield(NCauth* auth, const char* flag, const char* value)
 	nullfree(auth->ssl.certificate);
         auth->ssl.certificate = strdup(value);
         MEMCHECK(auth->ssl.certificate);
-#ifdef DEBUG
-            nclog(NCLOGNOTE,"HTTP.SSL.CERTIFICATE: %s", auth->ssl.certificate);
-#endif
+        DEBUGLOG(NCLOGNOTE,"HTTP.SSL.CERTIFICATE: %s", auth->ssl.certificate);
     }
 
     if(strcmp(flag,"HTTP.SSL.KEY")==0) {
 	nullfree(auth->ssl.key);
         auth->ssl.key = strdup(value);
         MEMCHECK(auth->ssl.key);
-#ifdef DEBUG
-            nclog(NCLOGNOTE,"HTTP.SSL.KEY: %s", auth->ssl.key);
-#endif
+        DEBUGLOG(NCLOGNOTE,"HTTP.SSL.KEY: %s", auth->ssl.key);
     }
 
     if(strcmp(flag,"HTTP.SSL.KEYPASSWORD")==0) {
 	nullfree(auth->ssl.keypasswd) ;
         auth->ssl.keypasswd = strdup(value);
         MEMCHECK(auth->ssl.keypasswd);
-#ifdef DEBUG
-            nclog(NCLOGNOTE,"HTTP.SSL.KEYPASSWORD: %s", auth->ssl.keypasswd);
-#endif
+        DEBUGLOG(NCLOGNOTE,"HTTP.SSL.KEYPASSWORD: %s", auth->ssl.keypasswd);
     }
 
     if(strcmp(flag,"HTTP.SSL.CAINFO")==0) {
 	nullfree(auth->ssl.cainfo) ;
         auth->ssl.cainfo = strdup(value);
         MEMCHECK(auth->ssl.cainfo);
-#ifdef DEBUG
-            nclog(NCLOGNOTE,"HTTP.SSL.CAINFO: %s", auth->ssl.cainfo);
-#endif
+        DEBUGLOG(NCLOGNOTE,"HTTP.SSL.CAINFO: %s", auth->ssl.cainfo);
     }
 
     if(strcmp(flag,"HTTP.SSL.CAPATH")==0) {
 	nullfree(auth->ssl.capath) ;
         auth->ssl.capath = strdup(value);
         MEMCHECK(auth->ssl.capath);
-#ifdef DEBUG
-            nclog(NCLOGNOTE,"HTTP.SSL.CAPATH: %s", auth->ssl.capath);
-#endif
+        DEBUGLOG(NCLOGNOTE,"HTTP.SSL.CAPATH: %s", auth->ssl.capath);
     }
     if(strcmp(flag,"HTTP.NETRC")==0) {
         nullfree(auth->curlflags.netrc);
         auth->curlflags.netrc = strdup(value);
         MEMCHECK(auth->curlflags.netrc);
-#ifdef DEBUG
-            nclog(NCLOGNOTE,"HTTP.NETRC: %s", auth->curlflags.netrc);
-#endif
+        DEBUGLOG(NCLOGNOTE,"HTTP.NETRC: %s", auth->curlflags.netrc);
     }
 
     if(strcmp(flag,"HTTP.CREDENTIALS.USERNAME")==0) {

--- a/libdispatch/dauth.c
+++ b/libdispatch/dauth.c
@@ -28,7 +28,7 @@ See COPYRIGHT for license information.
 
 #include "ncrc.h"
 
-#define DEBUG 1
+#define DEBUG 0
 #if DEBUG
 #define DEBUGLOG(...) nclog(__VA_ARGS__)
 #else

--- a/libdispatch/dauth.c
+++ b/libdispatch/dauth.c
@@ -34,23 +34,19 @@ See COPYRIGHT for license information.
 #define MEMCHECK(x) if((x)==NULL) {goto nomem;} else {}
 
 
-#define NCAUTH_SSL_VERIFY_DEFAULT -1
+#define NCAUTH_DEFAULT_SSL_VERIFY -1
 
-#define TO_STR(X) #X
-#define NCAUTH_SSL_VERIFY_DEFAULT_STR TO_STR(NCAUTH_SSL_VERIFY_DEFAULT)
-
-
-/* Define the curl flag defaults in envv style */
-static const char* AUTHDEFAULTS[] = {
-"HTTP.SSL.VERIFYPEER", NCAUTH_SSL_VERIFY_DEFAULT_STR, /* Use default */
-"HTTP.SSL.VERIFYHOST", NCAUTH_SSL_VERIFY_DEFAULT_STR, /* Use default */
-"HTTP.TIMEOUT","1800", /*seconds */ /* Long but not infinite */
-"HTTP.CONNECTTIMEOUT","50", /*seconds */ /* Long but not infinite */
-"HTTP.ENCODE","1", /* Use default */
-NULL,
+static const NCauth default_auth = {
+    .ssl = {
+        .verifyhost = NCAUTH_DEFAULT_SSL_VERIFY,
+        .verifypeer = NCAUTH_DEFAULT_SSL_VERIFY,
+    },
+    .curlflags.timeout = 1800,
+    .curlflags.connecttimeout=50,
+    .curlflags.encode = 1,
 };
 
-/* Forward */
+/* Forward for helper functions */
 static int setauthfield(NCauth* auth, const char* flag, const char* value);
 static void setdefaults(NCauth*);
 
@@ -111,7 +107,7 @@ NC_authsetup(NCauth** authp, NCURI* uri)
     if((auth=calloc(1,sizeof(NCauth)))==NULL)
         {ret = NC_ENOMEM; goto done;}
 
-    setdefaults(auth);
+    memcpy(auth, &default_auth, sizeof(default_auth));
 
     /* Note, we still must do this function even if
        ncrc_getglobalstate()->rc.ignore is set in order
@@ -269,7 +265,7 @@ setauthfield(NCauth* auth, const char* flag, const char* value)
     int ret = NC_NOERR;
     if(value == NULL) goto done;
 
-    int int_value = NCAUTH_SSL_VERIFY_DEFAULT;
+    int int_value = NCAUTH_DEFAULT_SSL_VERIFY;
     value_to_int(value, &int_value);
 
     if(strcmp(flag,"HTTP.ENCODE")==0) {
@@ -337,7 +333,7 @@ setauthfield(NCauth* auth, const char* flag, const char* value)
     }
     if(strcmp(flag,"HTTP.SSL.VALIDATE")==0) {
         switch (int_value) {
-            case NCAUTH_SSL_VERIFY_DEFAULT: //default
+            case NCAUTH_DEFAULT_SSL_VERIFY: //default
                 auth->ssl.verifypeer = -1;
                 auth->ssl.verifyhost = -1;
                 break;
@@ -452,18 +448,3 @@ NC_parsecredentials(const char* userpwd, char** userp, char** pwdp)
   free(user);
   return NC_NOERR;
 }
-
-static void
-setdefaults(NCauth* auth)
-{
-    int ret = NC_NOERR;
-    const char** p;
-    for(p=AUTHDEFAULTS;*p;p+=2) {
-	ret = setauthfield(auth,p[0],p[1]);
-	if(ret) {
-            nclog(NCLOGERR, "RC file defaulting failed for: %s=%s",p[0],p[1]);
-	}
-    }
-}
-
-#undef TO_STR

--- a/libdispatch/dauth.c
+++ b/libdispatch/dauth.c
@@ -246,15 +246,15 @@ static int is_numeric(const char * str){
     return 1;
 }
 
-static void value_to_int(const char* value, int*value_int) {
+static void truthy_to_int(const char* value, int*value_int) {
     if (value == NULL || value_int == NULL) {
         return;
     }
-    if (strcasecmp(value, "False") == 0 || strcasecmp(value, "No") == 0)
+    if (strcasecmp(value, "False") == 0 || strcasecmp(value, "No") == 0 || strcasecmp(value,"Off")==0)
     {
         *value_int = 0;
     }
-    else if (strcasecmp(value, "True") == 0 || strcasecmp(value, "Yes") == 0)
+    else if (strcasecmp(value, "True") == 0 || strcasecmp(value, "Yes") == 0 || strcasecmp(value, "On") == 0 )
     {
         *value_int = 1;
     }
@@ -271,7 +271,7 @@ setauthfield(NCauth* auth, const char* flag, const char* value)
     if(value == NULL) goto done;
 
     int int_value = NCAUTH_DEFAULT_SSL_VERIFY;
-    value_to_int(value, &int_value);
+    truthy_to_int(value, &int_value);
 
     if(strcmp(flag,"HTTP.ENCODE")==0) {
         if(atoi(value)) {auth->curlflags.encode = 1;} else {auth->curlflags.encode = 0;}
@@ -311,18 +311,28 @@ setauthfield(NCauth* auth, const char* flag, const char* value)
         DEBUGLOG(NCLOGNOTE,"HTTP.PROXY.SERVER: %s", value);
     }
     if(strcmp(flag,"HTTP.SSL.VERIFYPEER")==0) {
+        if (NCAUTH_DEFAULT_SSL_VERIFY == int_value) {
+            nclog(NCLOGWARN, "RC-File key \"HTTP.SSL.VERIFYPEER\" contains invalid value! Ignoring it.");
+            ret = NC_ERCFILE;
+        }
 	    auth->ssl.verifypeer = int_value;
         DEBUGLOG(NCLOGNOTE,"HTTP.SSL.VERIFYPEER: %d", int_value);
     }
     if(strcmp(flag,"HTTP.SSL.VERIFYHOST")==0) {
+        if (NCAUTH_DEFAULT_SSL_VERIFY == int_value) {
+            nclog(NCLOGWARN, "RC-File key \"HTTP.SSL.VERIFYHOST\" contains invalid value! Ignoring it.");
+            ret = NC_ERCFILE;
+        }
 	    auth->ssl.verifyhost = int_value;
         DEBUGLOG(NCLOGNOTE,"HTTP.SSL.VERIFYHOST: %d", int_value);
     }
     if(strcmp(flag,"HTTP.SSL.VALIDATE")==0) {
         switch (int_value) {
             case NCAUTH_DEFAULT_SSL_VERIFY: //default
-                auth->ssl.verifypeer = -1;
-                auth->ssl.verifyhost = -1;
+                nclog(NCLOGWARN, "RC-File Key \"HTTP.SSL.VALIDATE\" contains invalid value! Ignoring it.");
+                auth->ssl.verifypeer = NCAUTH_DEFAULT_SSL_VERIFY;
+                auth->ssl.verifyhost = NCAUTH_DEFAULT_SSL_VERIFY;
+                ret = NC_ERCFILE;
                 break;
             case 0:
                 auth->ssl.verifypeer = 0;

--- a/libdispatch/dauth.c
+++ b/libdispatch/dauth.c
@@ -223,11 +223,48 @@ NC_authfree(NCauth* auth)
 
 /**************************************************/
 
+static int is_numeric(const char * str){
+    if (str == NULL || strlen(str) == 0) {
+        return 0;
+    }
+
+    for (const char *c = str; c < str + strlen(str); c++)
+    {
+        if ( !('0' <= *c  && *c <= '9')) {
+            return 0;
+        }
+    }
+
+    return 1;
+}
+
+static void value_to_int(const char* value, int*value_int) {
+    if (value == NULL || value_int == NULL) {
+        return;
+    }
+    if (strcasecmp(value, "False") == 0 || strcasecmp(value, "No") == 0)
+    {
+        *value_int = 0;
+    }
+    else if (strcasecmp(value, "True") == 0 || strcasecmp(value, "Yes") == 0)
+    {
+        *value_int = 1;
+    }
+    else if (is_numeric(value))
+    {
+        *value_int = atoi(value);
+    }
+}
+
 static int
 setauthfield(NCauth* auth, const char* flag, const char* value)
 {
     int ret = NC_NOERR;
     if(value == NULL) goto done;
+
+    int int_value = -1;
+    value_to_int(value, &int_value);
+
     if(strcmp(flag,"HTTP.ENCODE")==0) {
         if(atoi(value)) {auth->curlflags.encode = 1;} else {auth->curlflags.encode = 0;}
 #ifdef DEBUG
@@ -280,28 +317,32 @@ setauthfield(NCauth* auth, const char* flag, const char* value)
 #endif
     }
     if(strcmp(flag,"HTTP.SSL.VERIFYPEER")==0) {
-	int v;
-        if((v = atoi(value))) {
-	    auth->ssl.verifypeer = v;
+	    auth->ssl.verifypeer = int_value;
 #ifdef DEBUG
                 nclog(NCLOGNOTE,"HTTP.SSL.VERIFYPEER: %d", v);
 #endif
-	}
     }
     if(strcmp(flag,"HTTP.SSL.VERIFYHOST")==0) {
-	int v;
-        if((v = atoi(value))) {
-	    auth->ssl.verifyhost = v;
+	    auth->ssl.verifyhost = int_value;
 #ifdef DEBUG
                 nclog(NCLOGNOTE,"HTTP.SSL.VERIFYHOST: %d", v);
 #endif
-	}
     }
     if(strcmp(flag,"HTTP.SSL.VALIDATE")==0) {
-        if(atoi(value)) {
-	    auth->ssl.verifypeer = 1;
-	    auth->ssl.verifyhost = 2;
-	}
+        switch (int_value) {
+            case -1: //default
+                auth->ssl.verifypeer = -1;
+                auth->ssl.verifyhost = -1;
+                break;
+            case 0:
+                auth->ssl.verifypeer = 0;
+                auth->ssl.verifyhost = 0;
+                break;
+            default:
+                auth->ssl.verifypeer = 1;
+                auth->ssl.verifyhost = 2;
+                break;
+        }
     }
 
     if(strcmp(flag,"HTTP.SSL.CERTIFICATE")==0) {

--- a/unit_test/CMakeLists.txt
+++ b/unit_test/CMakeLists.txt
@@ -19,6 +19,8 @@ ENDIF()
 
 SET(UNIT_TESTS test_ncuri)
 add_bin_test(unit_test test_ncuri)
+SET(UNIT_TESTS test_dauth)
+add_bin_test(unit_test test_dauth)
 
 IF(NETCDF_ENABLE_HDF5)
   IF(NOT WIN32)

--- a/unit_test/Makefile.am
+++ b/unit_test/Makefile.am
@@ -27,8 +27,8 @@ noinst_PROGRAMS =
 noinst_PROGRAMS += ncpluginpath
 ncpluginpath_SOURCES = ncpluginpath.c
 
-check_PROGRAMS += tst_nclist test_ncuri test_pathcvt
-TESTS += tst_nclist test_ncuri run_pathcvt.sh
+check_PROGRAMS += tst_nclist test_ncuri test_pathcvt test_dauth
+TESTS += tst_nclist test_ncuri run_pathcvt.sh test_dauth
 
 # Performance tests
 if BUILD_BENCHMARKS

--- a/unit_test/test_dauth.c
+++ b/unit_test/test_dauth.c
@@ -1,0 +1,114 @@
+/*********************************************************************
+ *   Copyright 2018, UCAR/Unidata
+ *   See netcdf/COPYRIGHT file for copying and redistribution conditions.
+ *********************************************************************/
+
+/**
+unit tests for libdispatch/dauth.c
+*/
+
+#include "../libdispatch/dauth.c" //To test static function setauthfield
+
+typedef struct Test {
+  char *field;
+  char *value;
+  NCauth initial;
+  NCauth expected;
+} Test;
+
+#define TEST_OK 0
+#define TEST_ERROR 1
+
+#define extract_auth_field(a, f) a.f
+
+NCauth testauth = {0};
+const NCauth auth_off = {0};
+const NCauth auth_on = {.ssl = {.verifypeer = 1, .verifyhost = 2}};
+const NCauth auth_default_ssl = {.ssl = {.verifypeer = -1, .verifyhost = -1}};
+
+const NCauth auth_host_on = {.ssl = {.verifyhost = 1}};
+const NCauth auth_host_default = {.ssl = {.verifyhost = -1}};
+
+const NCauth auth_peer_on = {.ssl = {.verifypeer = 1}};
+const NCauth auth_peer_default = {.ssl = {.verifypeer = -1}};
+
+const NCauth untouched = {{0xF}};
+
+static Test TESTS[] = {
+  // SSL VALIDATE -> changes both verifypeer and verifyhost
+  /* 1 */ {"HTTP.SSL.VALIDATE", "1",     auth_off, auth_on},
+  /* 2 */ {"HTTP.SSL.VALIDATE", "yes",   auth_off, auth_on},
+  /* 3 */ {"HTTP.SSL.VALIDATE", "YES",   auth_off, auth_on},
+  /* 4 */ {"HTTP.SSL.VALIDATE", "true",  auth_off, auth_on},
+  /* 5 */ {"HTTP.SSL.VALIDATE", "True",  auth_off, auth_on},
+  /* 6 */ {"HTTP.SSL.VALIDATE", "0",     auth_on, auth_off},
+  /* 7 */ {"HTTP.SSL.VALIDATE", "No",    auth_on, auth_off},
+  /* 8 */ {"HTTP.SSL.VALIDATE", "no",    auth_on, auth_off},
+  /* 9 */ {"HTTP.SSL.VALIDATE", "false", auth_on, auth_off},
+  /*10 */ {"HTTP.SSL.VALIDATE", "False", auth_on, auth_off},
+  /*11 */ {"HTTP.SSL.VALIDATE", "",      auth_on, auth_default_ssl},
+  /*12 */ {"HTTP.SSL.VALIDATE", NULL, untouched, untouched},
+
+  // SSL VERIFY HOST
+  /*13 */ {"HTTP.SSL.VERIFYHOST", "1",     auth_off, auth_host_on},
+  /*14 */ {"HTTP.SSL.VERIFYHOST", "true",  auth_off, auth_host_on},
+  /*15 */ {"HTTP.SSL.VERIFYHOST", "True",  auth_off, auth_host_on},
+  /*16 */ {"HTTP.SSL.VERIFYHOST", "0",     auth_host_on, auth_off},
+  /*17 */ {"HTTP.SSL.VERIFYHOST", "false", auth_host_on, auth_off},
+  /*18 */ {"HTTP.SSL.VERIFYHOST", "False", auth_host_on, auth_off},
+  /*19 */ {"HTTP.SSL.VERIFYHOST", "",      auth_off, auth_host_default},
+  /*20 */ {"HTTP.SSL.VERIFYHOST", NULL,    auth_on, auth_on},
+
+  // SSL VERIFY PEER
+  /*21 */ {"HTTP.SSL.VERIFYPEER", "1",     auth_off, auth_peer_on},
+  /*22 */ {"HTTP.SSL.VERIFYPEER", "True",  auth_off, auth_peer_on},
+  /*23 */ {"HTTP.SSL.VERIFYPEER", "0",     auth_peer_on, auth_off},
+  /*24 */ {"HTTP.SSL.VERIFYPEER", "false", auth_peer_on, auth_off},
+  /*25 */ {"HTTP.SSL.VERIFYPEER", "",      auth_off, auth_peer_default},
+  /*26 */ {"HTTP.SSL.VERIFYPEER", NULL, untouched, untouched},
+  // END
+  { NULL, NULL, {{0}}, {{0} } }
+};
+
+void auth_print(const NCauth *auth, FILE *f) {
+  if (f == NULL) {
+    f = stdout;
+  }
+  fprintf(f, "NCAuth:\n");
+  fprintf(f,
+          "\tHTTP.SSL.VERIFYPEER:%d\n"
+          "\tHTTP.SSL.VERIFYHOST:%d\n",
+          auth->ssl.verifypeer, auth->ssl.verifyhost);
+}
+
+int main(int argc, char **argv) {
+  Test *test;
+  int failcount = 0;
+  int index;
+
+  for (index = 0, test = TESTS; test->field; test++, index++) {
+    int ret = 0;
+    memcpy(&testauth, &test->initial, sizeof(test->initial));
+    // setdefaults(&testauth);
+    ret = setauthfield(&testauth, test->field, test->value);
+    // auth_print(testauth, NULL);
+    if (ret != NC_NOERR) {
+      fprintf(stderr, "Set auth fail: %s\n", test->field);
+      failcount++;
+    } else {
+      if (memcmp(&testauth, &test->expected, sizeof(test->expected))) {
+        fprintf(stderr, "Failed test #%d, %s = \"%s\" not set properly\n",
+                index + 1, test->field,
+                (test->value == NULL) ? "NULL" : test->value);
+        fprintf(stderr, "Expected:\n");
+        auth_print(&test->expected, stderr);
+        fprintf(stderr, "Got:\n");
+        auth_print(&testauth, stderr);
+        failcount++;
+      }
+    }
+  }
+
+  fprintf(stderr, "%s test_dauth\n", failcount > 0 ? "***FAIL" : "***PASS");
+  return (failcount > 0 ? 1 : 0);
+}

--- a/unit_test/test_dauth.c
+++ b/unit_test/test_dauth.c
@@ -9,6 +9,17 @@ unit tests for libdispatch/dauth.c
 
 #include "../libdispatch/dauth.c" //To test static function setauthfield
 
+#define AUTH_OFF {{0}}
+#define AUTH_ON {.ssl = {.verifypeer = 1, .verifyhost = 2}}
+#define AUTH_DEFAULT_SSL {.ssl = {.verifypeer = -1, .verifyhost = -1}}
+
+#define AUTH_HOST_ON {.ssl = {.verifyhost = 1}}
+#define AUTH_HOST_DEFAULT {.ssl = {.verifyhost = -1}}
+
+#define AUTH_PEER_ON {.ssl = {.verifypeer = 1}}
+#define AUTH_PEER_DEFAULT {.ssl = {.verifypeer = -1}}
+#define AUTH_UNTOUCHED {{0xF}}
+
 typedef struct Test {
   char *field;
   char *value;
@@ -16,56 +27,36 @@ typedef struct Test {
   NCauth expected;
 } Test;
 
-#define TEST_OK 0
-#define TEST_ERROR 1
-
-#define extract_auth_field(a, f) a.f
-
-NCauth testauth = {0};
-const NCauth auth_off = {0};
-const NCauth auth_on = {.ssl = {.verifypeer = 1, .verifyhost = 2}};
-const NCauth auth_default_ssl = {.ssl = {.verifypeer = -1, .verifyhost = -1}};
-
-const NCauth auth_host_on = {.ssl = {.verifyhost = 1}};
-const NCauth auth_host_default = {.ssl = {.verifyhost = -1}};
-
-const NCauth auth_peer_on = {.ssl = {.verifypeer = 1}};
-const NCauth auth_peer_default = {.ssl = {.verifypeer = -1}};
-
-const NCauth untouched = {{0xF}};
-
 static Test TESTS[] = {
   // SSL VALIDATE -> changes both verifypeer and verifyhost
-  /* 1 */ {"HTTP.SSL.VALIDATE", "1",     auth_off, auth_on},
-  /* 2 */ {"HTTP.SSL.VALIDATE", "yes",   auth_off, auth_on},
-  /* 3 */ {"HTTP.SSL.VALIDATE", "YES",   auth_off, auth_on},
-  /* 4 */ {"HTTP.SSL.VALIDATE", "true",  auth_off, auth_on},
-  /* 5 */ {"HTTP.SSL.VALIDATE", "True",  auth_off, auth_on},
-  /* 6 */ {"HTTP.SSL.VALIDATE", "0",     auth_on, auth_off},
-  /* 7 */ {"HTTP.SSL.VALIDATE", "No",    auth_on, auth_off},
-  /* 8 */ {"HTTP.SSL.VALIDATE", "no",    auth_on, auth_off},
-  /* 9 */ {"HTTP.SSL.VALIDATE", "false", auth_on, auth_off},
-  /*10 */ {"HTTP.SSL.VALIDATE", "False", auth_on, auth_off},
-  /*11 */ {"HTTP.SSL.VALIDATE", "",      auth_on, auth_default_ssl},
-  /*12 */ {"HTTP.SSL.VALIDATE", NULL, untouched, untouched},
-
+  /* 1 */ {"HTTP.SSL.VALIDATE", "1",       AUTH_OFF, AUTH_ON},
+  /* 2 */ {"HTTP.SSL.VALIDATE", "yes",     AUTH_OFF, AUTH_ON},
+  /* 3 */ {"HTTP.SSL.VALIDATE", "YES",     AUTH_OFF, AUTH_ON},
+  /* 4 */ {"HTTP.SSL.VALIDATE", "true",    AUTH_OFF, AUTH_ON},
+  /* 5 */ {"HTTP.SSL.VALIDATE", "True",    AUTH_OFF, AUTH_ON},
+  /* 6 */ {"HTTP.SSL.VALIDATE", "0",       AUTH_ON, AUTH_OFF},
+  /* 7 */ {"HTTP.SSL.VALIDATE", "No",      AUTH_ON, AUTH_OFF},
+  /* 8 */ {"HTTP.SSL.VALIDATE", "no",      AUTH_ON, AUTH_OFF},
+  /* 9 */ {"HTTP.SSL.VALIDATE", "false",   AUTH_ON, AUTH_OFF},
+  /*10 */ {"HTTP.SSL.VALIDATE", "False",   AUTH_ON, AUTH_OFF},
+  /*11 */ {"HTTP.SSL.VALIDATE", "",        AUTH_ON, AUTH_DEFAULT_SSL},
+  /*12 */ {"HTTP.SSL.VALIDATE", NULL,      AUTH_ON, AUTH_ON},
   // SSL VERIFY HOST
-  /*13 */ {"HTTP.SSL.VERIFYHOST", "1",     auth_off, auth_host_on},
-  /*14 */ {"HTTP.SSL.VERIFYHOST", "true",  auth_off, auth_host_on},
-  /*15 */ {"HTTP.SSL.VERIFYHOST", "True",  auth_off, auth_host_on},
-  /*16 */ {"HTTP.SSL.VERIFYHOST", "0",     auth_host_on, auth_off},
-  /*17 */ {"HTTP.SSL.VERIFYHOST", "false", auth_host_on, auth_off},
-  /*18 */ {"HTTP.SSL.VERIFYHOST", "False", auth_host_on, auth_off},
-  /*19 */ {"HTTP.SSL.VERIFYHOST", "",      auth_off, auth_host_default},
-  /*20 */ {"HTTP.SSL.VERIFYHOST", NULL,    auth_on, auth_on},
-
+  /*13 */ {"HTTP.SSL.VERIFYHOST", "1",     AUTH_OFF, AUTH_HOST_ON},
+  /*14 */ {"HTTP.SSL.VERIFYHOST", "true",  AUTH_OFF, AUTH_HOST_ON},
+  /*15 */ {"HTTP.SSL.VERIFYHOST", "True",  AUTH_OFF, AUTH_HOST_ON},
+  /*16 */ {"HTTP.SSL.VERIFYHOST", "0",     AUTH_HOST_ON, AUTH_OFF},
+  /*17 */ {"HTTP.SSL.VERIFYHOST", "false", AUTH_HOST_ON, AUTH_OFF},
+  /*18 */ {"HTTP.SSL.VERIFYHOST", "False", AUTH_HOST_ON, AUTH_OFF},
+  /*19 */ {"HTTP.SSL.VERIFYHOST", "",      AUTH_OFF, AUTH_HOST_DEFAULT},
+  /*20 */ {"HTTP.SSL.VERIFYHOST", NULL,    AUTH_HOST_ON, AUTH_HOST_ON},
   // SSL VERIFY PEER
-  /*21 */ {"HTTP.SSL.VERIFYPEER", "1",     auth_off, auth_peer_on},
-  /*22 */ {"HTTP.SSL.VERIFYPEER", "True",  auth_off, auth_peer_on},
-  /*23 */ {"HTTP.SSL.VERIFYPEER", "0",     auth_peer_on, auth_off},
-  /*24 */ {"HTTP.SSL.VERIFYPEER", "false", auth_peer_on, auth_off},
-  /*25 */ {"HTTP.SSL.VERIFYPEER", "",      auth_off, auth_peer_default},
-  /*26 */ {"HTTP.SSL.VERIFYPEER", NULL, untouched, untouched},
+  /*21 */ {"HTTP.SSL.VERIFYPEER", "1",     AUTH_OFF, AUTH_PEER_ON},
+  /*22 */ {"HTTP.SSL.VERIFYPEER", "True",  AUTH_OFF, AUTH_PEER_ON},
+  /*23 */ {"HTTP.SSL.VERIFYPEER", "0",     AUTH_PEER_ON, AUTH_OFF},
+  /*24 */ {"HTTP.SSL.VERIFYPEER", "false", AUTH_PEER_ON, AUTH_OFF},
+  /*25 */ {"HTTP.SSL.VERIFYPEER", "",      AUTH_OFF, AUTH_PEER_DEFAULT},
+  /*26 */ {"HTTP.SSL.VERIFYPEER", NULL,    AUTH_PEER_ON, AUTH_PEER_ON},
   // END
   { NULL, NULL, {{0}}, {{0} } }
 };
@@ -74,8 +65,8 @@ void auth_print(const NCauth *auth, FILE *f) {
   if (f == NULL) {
     f = stdout;
   }
-  fprintf(f, "NCAuth:\n");
   fprintf(f,
+          "NCAuth:\n"
           "\tHTTP.SSL.VERIFYPEER:%d\n"
           "\tHTTP.SSL.VERIFYHOST:%d\n",
           auth->ssl.verifypeer, auth->ssl.verifyhost);
@@ -85,6 +76,7 @@ int main(int argc, char **argv) {
   Test *test;
   int failcount = 0;
   int index;
+  NCauth testauth = {0};
 
   for (index = 0, test = TESTS; test->field; test++, index++) {
     int ret = 0;

--- a/unit_test/test_dauth.c
+++ b/unit_test/test_dauth.c
@@ -9,6 +9,7 @@ unit tests for libdispatch/dauth.c
 
 #include "../libdispatch/dauth.c" //To test static function setauthfield
 
+#define STR_NULL(x) ((x == NULL) ? "NULL" : x)
 #define AUTH_OFF {{0}}
 #define AUTH_ON {.ssl = {.verifypeer = 1, .verifyhost = 2}}
 #define AUTH_DEFAULT_SSL {.ssl = {.verifypeer = -1, .verifyhost = -1}}
@@ -23,42 +24,47 @@ unit tests for libdispatch/dauth.c
 typedef struct Test {
   char *field;
   char *value;
+  int code;
   NCauth initial;
   NCauth expected;
 } Test;
 
 static Test TESTS[] = {
   // SSL VALIDATE -> changes both verifypeer and verifyhost
-  /* 1 */ {"HTTP.SSL.VALIDATE", "1",       AUTH_OFF, AUTH_ON},
-  /* 2 */ {"HTTP.SSL.VALIDATE", "yes",     AUTH_OFF, AUTH_ON},
-  /* 3 */ {"HTTP.SSL.VALIDATE", "YES",     AUTH_OFF, AUTH_ON},
-  /* 4 */ {"HTTP.SSL.VALIDATE", "true",    AUTH_OFF, AUTH_ON},
-  /* 5 */ {"HTTP.SSL.VALIDATE", "True",    AUTH_OFF, AUTH_ON},
-  /* 6 */ {"HTTP.SSL.VALIDATE", "0",       AUTH_ON, AUTH_OFF},
-  /* 7 */ {"HTTP.SSL.VALIDATE", "No",      AUTH_ON, AUTH_OFF},
-  /* 8 */ {"HTTP.SSL.VALIDATE", "no",      AUTH_ON, AUTH_OFF},
-  /* 9 */ {"HTTP.SSL.VALIDATE", "false",   AUTH_ON, AUTH_OFF},
-  /*10 */ {"HTTP.SSL.VALIDATE", "False",   AUTH_ON, AUTH_OFF},
-  /*11 */ {"HTTP.SSL.VALIDATE", "",        AUTH_ON, AUTH_DEFAULT_SSL},
-  /*12 */ {"HTTP.SSL.VALIDATE", NULL,      AUTH_ON, AUTH_ON},
+  /* 1 */ {"HTTP.SSL.VALIDATE", "1",        NC_NOERR, AUTH_OFF, AUTH_ON},
+  /* 2 */ {"HTTP.SSL.VALIDATE", "yes",      NC_NOERR, AUTH_OFF, AUTH_ON},
+  /* 3 */ {"HTTP.SSL.VALIDATE", "YES",      NC_NOERR, AUTH_OFF, AUTH_ON},
+  /* 4 */ {"HTTP.SSL.VALIDATE", "true",     NC_NOERR, AUTH_OFF, AUTH_ON},
+  /* 5 */ {"HTTP.SSL.VALIDATE", "True",     NC_NOERR, AUTH_OFF, AUTH_ON},
+  /* 7 */ {"HTTP.SSL.VALIDATE", "0",        NC_NOERR, AUTH_ON, AUTH_OFF},
+  /* 8 */ {"HTTP.SSL.VALIDATE", "No",       NC_NOERR, AUTH_ON, AUTH_OFF},
+  /* 9 */ {"HTTP.SSL.VALIDATE", "no",       NC_NOERR, AUTH_ON, AUTH_OFF},
+  /*10 */ {"HTTP.SSL.VALIDATE", "false",    NC_NOERR, AUTH_ON, AUTH_OFF},
+  /*11 */ {"HTTP.SSL.VALIDATE", "False",    NC_NOERR, AUTH_ON, AUTH_OFF},
+  /*13 */ {"HTTP.SSL.VALIDATE", "",       NC_ERCFILE, AUTH_ON, AUTH_DEFAULT_SSL},
+  /*14 */ {"HTTP.SSL.VALIDATE", NULL,       NC_NOERR, AUTH_ON, AUTH_ON},
   // SSL VERIFY HOST
-  /*13 */ {"HTTP.SSL.VERIFYHOST", "1",     AUTH_OFF, AUTH_HOST_ON},
-  /*14 */ {"HTTP.SSL.VERIFYHOST", "true",  AUTH_OFF, AUTH_HOST_ON},
-  /*15 */ {"HTTP.SSL.VERIFYHOST", "True",  AUTH_OFF, AUTH_HOST_ON},
-  /*16 */ {"HTTP.SSL.VERIFYHOST", "0",     AUTH_HOST_ON, AUTH_OFF},
-  /*17 */ {"HTTP.SSL.VERIFYHOST", "false", AUTH_HOST_ON, AUTH_OFF},
-  /*18 */ {"HTTP.SSL.VERIFYHOST", "False", AUTH_HOST_ON, AUTH_OFF},
-  /*19 */ {"HTTP.SSL.VERIFYHOST", "",      AUTH_OFF, AUTH_HOST_DEFAULT},
-  /*20 */ {"HTTP.SSL.VERIFYHOST", NULL,    AUTH_HOST_ON, AUTH_HOST_ON},
+  /*15 */ {"HTTP.SSL.VERIFYHOST", "1",      NC_NOERR, AUTH_OFF, AUTH_HOST_ON},
+  /*16 */ {"HTTP.SSL.VERIFYHOST", "true",   NC_NOERR, AUTH_OFF, AUTH_HOST_ON},
+  /*17 */ {"HTTP.SSL.VERIFYHOST", "True",   NC_NOERR, AUTH_OFF, AUTH_HOST_ON},
+  /*18 */ {"HTTP.SSL.VERIFYHOST", "0",      NC_NOERR, AUTH_HOST_ON, AUTH_OFF},
+  /*19 */ {"HTTP.SSL.VERIFYHOST", "false",  NC_NOERR, AUTH_HOST_ON, AUTH_OFF},
+  /*20 */ {"HTTP.SSL.VERIFYHOST", "False",  NC_NOERR, AUTH_HOST_ON, AUTH_OFF},
+  /*21 */ {"HTTP.SSL.VERIFYHOST", "",     NC_ERCFILE, AUTH_OFF, AUTH_HOST_DEFAULT},
+  /*22 */ {"HTTP.SSL.VERIFYHOST", NULL,     NC_NOERR, AUTH_HOST_ON, AUTH_HOST_ON},
   // SSL VERIFY PEER
-  /*21 */ {"HTTP.SSL.VERIFYPEER", "1",     AUTH_OFF, AUTH_PEER_ON},
-  /*22 */ {"HTTP.SSL.VERIFYPEER", "True",  AUTH_OFF, AUTH_PEER_ON},
-  /*23 */ {"HTTP.SSL.VERIFYPEER", "0",     AUTH_PEER_ON, AUTH_OFF},
-  /*24 */ {"HTTP.SSL.VERIFYPEER", "false", AUTH_PEER_ON, AUTH_OFF},
-  /*25 */ {"HTTP.SSL.VERIFYPEER", "",      AUTH_OFF, AUTH_PEER_DEFAULT},
-  /*26 */ {"HTTP.SSL.VERIFYPEER", NULL,    AUTH_PEER_ON, AUTH_PEER_ON},
+  /*23 */ {"HTTP.SSL.VERIFYPEER", "1",     NC_NOERR, AUTH_OFF, AUTH_PEER_ON},
+  /*24 */ {"HTTP.SSL.VERIFYPEER", "True",  NC_NOERR, AUTH_OFF, AUTH_PEER_ON},
+  /*25 */ {"HTTP.SSL.VERIFYPEER", "0",     NC_NOERR, AUTH_PEER_ON, AUTH_OFF},
+  /*26 */ {"HTTP.SSL.VERIFYPEER", "false", NC_NOERR, AUTH_PEER_ON, AUTH_OFF},
+  /*27 */ {"HTTP.SSL.VERIFYPEER", "",    NC_ERCFILE, AUTH_OFF, AUTH_PEER_DEFAULT},
+  /*28 */ {"HTTP.SSL.VERIFYPEER", NULL,    NC_NOERR, AUTH_PEER_ON, AUTH_PEER_ON},
+  // Test invalid fields!
+  /*29 */ {"HTTP.SSL.VALIDATE",   "BAD", NC_ERCFILE, AUTH_ON, AUTH_DEFAULT_SSL},
+  /*30 */ {"HTTP.SSL.VERIFYPEER", "BAD", NC_ERCFILE, AUTH_PEER_ON, AUTH_PEER_DEFAULT},
+  /*31 */ {"HTTP.SSL.VERIFYHOST", "BAD", NC_ERCFILE, AUTH_HOST_ON, AUTH_HOST_DEFAULT},
   // END
-  { NULL, NULL, {{0}}, {{0} } }
+  { NULL, NULL, 0, {{0}}, {{0} } }
 };
 
 void auth_print(const NCauth *auth, FILE *f) {
@@ -82,20 +88,21 @@ int main(int argc, char **argv) {
     int ret = 0;
     memcpy(&testauth, &test->initial, sizeof(test->initial));
     ret = setauthfield(&testauth, test->field, test->value);
-    if (ret != NC_NOERR) {
-      fprintf(stderr, "Set auth fail: %s\n", test->field);
+    if (ret != test->code) {
+      fprintf(
+          stderr,
+          "Failed test #%d, setauthfield returned %d instead of %d (%s = %s)\n",
+          index + 1, ret, test->code, test->field, STR_NULL(test->value));
       failcount++;
-    } else {
-      if (memcmp(&testauth, &test->expected, sizeof(test->expected))) {
-        fprintf(stderr, "Failed test #%d, %s = \"%s\" not set properly\n",
-                index + 1, test->field,
-                (test->value == NULL) ? "NULL" : test->value);
-        fprintf(stderr, "Expected:\n");
-        auth_print(&test->expected, stderr);
-        fprintf(stderr, "Got:\n");
-        auth_print(&testauth, stderr);
-        failcount++;
-      }
+    }
+    if (memcmp(&testauth, &test->expected, sizeof(test->expected))) {
+      fprintf(stderr, "Failed test #%d, %s = \"%s\" not set properly\n",
+              index + 1, test->field, STR_NULL(test->value));
+      fprintf(stderr, "Expected:\n");
+      auth_print(&test->expected, stderr);
+      fprintf(stderr, "Got:\n");
+      auth_print(&testauth, stderr);
+      failcount++;
     }
   }
 

--- a/unit_test/test_dauth.c
+++ b/unit_test/test_dauth.c
@@ -36,11 +36,13 @@ static Test TESTS[] = {
   /* 3 */ {"HTTP.SSL.VALIDATE", "YES",      NC_NOERR, AUTH_OFF, AUTH_ON},
   /* 4 */ {"HTTP.SSL.VALIDATE", "true",     NC_NOERR, AUTH_OFF, AUTH_ON},
   /* 5 */ {"HTTP.SSL.VALIDATE", "True",     NC_NOERR, AUTH_OFF, AUTH_ON},
+  /* 6 */ {"HTTP.SSL.VALIDATE", "on",       NC_NOERR, AUTH_OFF, AUTH_ON},
   /* 7 */ {"HTTP.SSL.VALIDATE", "0",        NC_NOERR, AUTH_ON, AUTH_OFF},
   /* 8 */ {"HTTP.SSL.VALIDATE", "No",       NC_NOERR, AUTH_ON, AUTH_OFF},
   /* 9 */ {"HTTP.SSL.VALIDATE", "no",       NC_NOERR, AUTH_ON, AUTH_OFF},
   /*10 */ {"HTTP.SSL.VALIDATE", "false",    NC_NOERR, AUTH_ON, AUTH_OFF},
   /*11 */ {"HTTP.SSL.VALIDATE", "False",    NC_NOERR, AUTH_ON, AUTH_OFF},
+  /*12 */ {"HTTP.SSL.VALIDATE", "off",      NC_NOERR, AUTH_ON, AUTH_OFF},
   /*13 */ {"HTTP.SSL.VALIDATE", "",       NC_ERCFILE, AUTH_ON, AUTH_DEFAULT_SSL},
   /*14 */ {"HTTP.SSL.VALIDATE", NULL,       NC_NOERR, AUTH_ON, AUTH_ON},
   // SSL VERIFY HOST

--- a/unit_test/test_dauth.c
+++ b/unit_test/test_dauth.c
@@ -81,9 +81,7 @@ int main(int argc, char **argv) {
   for (index = 0, test = TESTS; test->field; test++, index++) {
     int ret = 0;
     memcpy(&testauth, &test->initial, sizeof(test->initial));
-    // setdefaults(&testauth);
     ret = setauthfield(&testauth, test->field, test->value);
-    // auth_print(testauth, NULL);
     if (ret != NC_NOERR) {
       fprintf(stderr, "Set auth fail: %s\n", test->field);
       failcount++;


### PR DESCRIPTION
This PR fixes https://github.com/Unidata/netcdf-c/issues/3408. I was aware of this issue from when I was fetching data from a local S3/HTTP server (no cert or self-signed). 

It also:
 - Adds unit testing for the faulty helper function `setauthfield`. Mainly to catch regressions.
 - Removing `setdefaults()` since once can replace it with a simple `memcpy` from a `static const NCauth` with the default values.
 - Minor refactoring
 - It also allows one to set `HTTP.SSL.{VALIDATE|VERIFYPEER|VERIFYHOST}`  to `on/off/true/false/` (case insensitive).
  - The caveat/question: if the value is invalid, what should be the behaviour? Fail or setting to the defaults? 
 
