### PR TITLE
Zarr version refactor

### DIFF
--- a/libnczarr/zarr.c
+++ b/libnczarr/zarr.c
@@ -57,11 +57,8 @@ ncz_create_dataset(NC_FILE_INFO_T* file, NC_GRP_INFO_T* root, NClist* controls)
 	{stat = NC_ENOMEM; goto done;}
 
     /* fill in some of the zinfo and zroot fields */
-    zinfo->zarr.zarr_version = atoi(ZARRVERSION);
-    sscanf(NCZARRVERSION,"%lu.%lu.%lu",
-	   &zinfo->zarr.nczarr_version.major,
-	   &zinfo->zarr.nczarr_version.minor,
-	   &zinfo->zarr.nczarr_version.release);
+    zinfo->format.zarr = ZARRFORMAT2;
+    zinfo->format.nczarr = NCZARRFORMAT2;
 
     zinfo->default_maxstrlen = NCZ_MAXSTR_DEFAULT;
 
@@ -213,7 +210,7 @@ int
 NCZ_get_libversion(unsigned long* majorp, unsigned long* minorp,unsigned long* releasep)
 {
     unsigned long m0,m1,m2;
-    sscanf(NCZARRVERSION,"%lu.%lu.%lu",&m0,&m1,&m2);
+    sscanf(NCZARR_PACKAGE_VERSION,"%lu.%lu.%lu",&m0,&m1,&m2);
     if(majorp) *majorp = m0;
     if(minorp) *minorp = m1;
     if(releasep) *releasep = m2;
@@ -235,7 +232,7 @@ int
 NCZ_get_superblock(NC_FILE_INFO_T* file, int* superblockp)
 {
     NCZ_FILE_INFO_T* zinfo = file->format_file_info;
-    if(superblockp) *superblockp = zinfo->zarr.nczarr_version.major;
+    if(superblockp) *superblockp = zinfo->format.nczarr;
     return NC_NOERR;
 }
 

--- a/libnczarr/zinfer.c
+++ b/libnczarr/zinfer.c
@@ -65,11 +65,15 @@ int NCZ_infer_nczarr_format(NC_FILE_INFO_T *file) {
           stat = NC_ENCZARR;
         }
       }
-    } else {
-      zfile->controls.flags |= FLAG_PUREZARR;
-      stat = NC_NOERR;
     }
   }
+
+  if(nczarrformat == NCZARRFORMAT0) {
+      zfile->controls.flags |= FLAG_PUREZARR;
+  }
+  zfile->format.nczarr = nczarrformat;
+
+
 done:
   return THROW(stat);
 }

--- a/libnczarr/zinfer.c
+++ b/libnczarr/zinfer.c
@@ -16,7 +16,7 @@ int NCZ_infer_zarr_format(NC_FILE_INFO_T *file) {
   /* check for the existence of **any** of the keys, infer format based on it*/
   for (zo = zarrobjects; zo->name; zo++) {
     if (NC_NOERR == nczmap_exists(zfile->map, zo->name)) {
-      zfile->zarr.zarr_version = zo->format;
+      zfile->format.zarr = zo->format;
       stat = NC_NOERR;
       break;
     }
@@ -32,13 +32,10 @@ int NCZ_infer_nczarr_format(NC_FILE_INFO_T *file) {
   struct ZARROBJ *zobjs =
       &(((NCZ_GRP_INFO_T *)file->root_grp->format_grp_info)->zgroup);
 
-  int zarrformat = zfile->zarr.zarr_version;
+  int zarrformat = zfile->format.zarr;
+  int nczarrformat = NCZARRFORMAT0;
 
-  zfile->zarr.nczarr_version.major = 0;
-  zfile->zarr.nczarr_version.minor = 0;
-  zfile->zarr.nczarr_version.release = 0;
-
-  if (zarrformat == 2) {
+  if (zarrformat == ZARRFORMAT2) {
     /* Fetch /.zattrs and /.zgroup contents */
     if ((stat = NCZMD_fetch_json_group(zfile, "/", &zobjs->obj)) ||
         (stat = NCZMD_fetch_json_attrs(zfile, "/", &zobjs->atts))) {
@@ -61,10 +58,8 @@ int NCZ_infer_nczarr_format(NC_FILE_INFO_T *file) {
           NCJ_OK == NCJdictget(jsuperblock, "version", &jnczarrversion) &&
           jnczarrversion != NULL && NCJsort(jnczarrversion) == NCJ_STRING) {
 
-        if (sscanf(NCJstring(jnczarrversion), "%lu.%lu.%lu",
-                   &zfile->zarr.nczarr_version.major,
-                   &zfile->zarr.nczarr_version.minor,
-                   &zfile->zarr.nczarr_version.release) != 3) {
+        if (sscanf(NCJstring(jnczarrversion), NCZARR_FORMAT_VERSION_TEMPLATE,
+                   &nczarrformat) != 1) {
           nclog(NCLOGERR, "Issue detecting NCZARR version from %s",
                 NCJstring(jnczarrversion));
           stat = NC_ENCZARR;

--- a/libnczarr/zinternal.h
+++ b/libnczarr/zinternal.h
@@ -124,12 +124,12 @@ typedef struct NCZ_FILE_INFO {
     struct NCauth* auth;
     struct NCZ_Metadata metadata;
     struct nczarr {
-	int zarr_version;
-	struct {
-	    unsigned long major;
-	    unsigned long minor;
-	    unsigned long release;
-	} nczarr_version;
+      int zarr_version;
+      struct {
+        unsigned long major;
+        unsigned long minor;
+        unsigned long release;
+      } nczarr_version;
     } zarr;
     int creating; /* 1=> created 0=>open */
     int native_endianness; /* NC_ENDIAN_LITTLE | NC_ENDIAN_BIG */

--- a/libnczarr/zinternal.h
+++ b/libnczarr/zinternal.h
@@ -12,11 +12,23 @@
 #ifndef ZINTERNAL_H
 #define ZINTERNAL_H
 
-#define ZARRVERSION "2"
+#define ZARRFORMAT2 2
 
-/* NCZARRVERSION is independent of Zarr version,
-   but NCZARRVERSION => ZARRVERSION */
-#define NCZARRVERSION "2.0.0"
+/* Define the possible NCZarr format versions */
+/* These are independent of the Zarr specification version */
+#define NCZARRFORMAT0 0 /* if this is a pure zarr dataset */
+#define NCZARRFORMAT2 2
+
+/* Map the Zarr Format version to a string */
+#define ZARR_FORMAT_VERSION_TEMPLATE "%d"
+
+/* Map the NCZarr Format version to a string */
+#define NCZARR_FORMAT_VERSION_TEMPLATE "%d.0.0"
+
+
+/* NCZARR_PACKAGE_VERSION is independent of Zarr format,
+   but NCZARR_PACKAGE_VERSION => ZARRFORMAT[2] */
+#define NCZARR_PACKAGE_VERSION "2.0.0"
 
 /* These have to do with creating chunked datasets in ZARR. */
 #define NCZ_CHUNKSIZE_FACTOR (10)
@@ -123,14 +135,10 @@ typedef struct NCZ_FILE_INFO {
     struct NCZMAP* map; /* implementation */
     struct NCauth* auth;
     struct NCZ_Metadata metadata;
-    struct nczarr {
-      int zarr_version;
-      struct {
-        unsigned long major;
-        unsigned long minor;
-        unsigned long release;
-      } nczarr_version;
-    } zarr;
+    struct ZarrFormat {
+      int zarr;
+      int nczarr;
+    } format;
     int creating; /* 1=> created 0=>open */
     int native_endianness; /* NC_ENDIAN_LITTLE | NC_ENDIAN_BIG */
     NClist* controllist; /* Envv format */

--- a/libnczarr/zsync.c
+++ b/libnczarr/zsync.c
@@ -180,7 +180,7 @@ ncz_sync_grp(NC_FILE_INFO_T* file, NC_GRP_INFO_T* grp, int isclose)
 
     /* build Z2GROUP contents */
     NCJnew(NCJ_DICT,&jgroup);
-    snprintf(version,sizeof(version),"%d",zinfo->zarr.zarr_version);
+    snprintf(version,sizeof(version),"%d",zinfo->format.zarr);
     if((stat = NCJaddstring(jgroup,NCJ_STRING,"zarr_format"))<0) {stat = NC_EINVAL; goto done;}
     if((stat = NCJaddstring(jgroup,NCJ_INT,version))<0) {stat = NC_EINVAL; goto done;}
 
@@ -192,10 +192,7 @@ ncz_sync_grp(NC_FILE_INFO_T* file, NC_GRP_INFO_T* grp, int isclose)
     if(!purezarr) {
         if(grp->parent == NULL) { /* Root group */
 	    /* create superblock */
-            snprintf(version,sizeof(version),"%lu.%lu.%lu",
-		 zinfo->zarr.nczarr_version.major,
-		 zinfo->zarr.nczarr_version.minor,
-		 zinfo->zarr.nczarr_version.release);
+            snprintf(version,sizeof(version),NCZARR_FORMAT_VERSION_TEMPLATE, zinfo->format.nczarr);
 	    NCJnew(NCJ_DICT,&jsuper);
 	    if((stat = NCJinsertstring(jsuper,"version",version))<0) {stat = NC_EINVAL; goto done;}
 	}
@@ -347,7 +344,7 @@ ncz_sync_var_meta(NC_FILE_INFO_T* file, NC_VAR_INFO_T* var, int isclose)
     NCJnew(NCJ_DICT,&jvar);
 
     /* zarr_format key */
-    snprintf(number,sizeof(number),"%d",zinfo->zarr.zarr_version);
+    snprintf(number,sizeof(number),"%d",zinfo->format.zarr);
     if((stat = NCJaddstring(jvar,NCJ_STRING,"zarr_format"))<0) {stat = NC_EINVAL; goto done;}
     if((stat = NCJaddstring(jvar,NCJ_INT,number))<0) {stat = NC_EINVAL; goto done;}
 
@@ -1451,7 +1448,7 @@ define_var1(NC_FILE_INFO_T* file, NC_GRP_INFO_T* grp, const char* varname)
 	int version;
 	if((stat = NCJdictget(jvar,"zarr_format",&jvalue))<0) {stat = NC_EINVAL; goto done;}
 	sscanf(NCJstring(jvalue),"%d",&version);
-	if(version != zinfo->zarr.zarr_version)
+	if(version != zinfo->format.zarr)
 	    {stat = (THROW(NC_ENCZARR)); goto done;}
     }
 

--- a/nczarr_test/ut_zinfer.c
+++ b/nczarr_test/ut_zinfer.c
@@ -197,6 +197,14 @@ int test_NCZ_infer_nczarr_format() {
     return 3;
   }
 
+  if (!(zinfo.controls.flags & FLAG_PUREZARR)) {
+    fprintf(stderr, "Failed! Expected PUREZARR flag with nczarr version: %d",
+            zinfo.format.nczarr);
+    return 4;
+  }
+  // Reset flag for next test;
+  zinfo.controls.flags &= ~(zinfo.controls.flags & FLAG_PUREZARR);
+
   KV_ptr = KV2nczarr;
   ret = NCZ_infer_nczarr_format(&file);
   if (NCZARRFORMAT2 != zinfo.format.nczarr) {
@@ -205,6 +213,11 @@ int test_NCZ_infer_nczarr_format() {
             "(" NCZARR_FORMAT_VERSION_TEMPLATE ") expected %d\n",
             zinfo.format.nczarr, NCZARRFORMAT2);
     return 5;
+  }
+  if (zinfo.controls.flags & FLAG_PUREZARR) {
+    fprintf(stderr, "Failed! PUREZARR flag NOT expected with nczarr version: %d\n",
+            zinfo.format.nczarr);
+    return 6;
   }
 
   // TODO:

--- a/nczarr_test/ut_zinfer.c
+++ b/nczarr_test/ut_zinfer.c
@@ -119,11 +119,11 @@ int test_NCZ_infer_zarr_format() {
               NC_ENOTZARR, ret);
       return 1;
     }
-    if (zinfo.zarr.zarr_version != 0) {
+    if (zinfo.format.zarr != 0) {
       fprintf(stderr,
               "Failed! Expected zarr version to be left unset (0) but it set "
               "to %d\n",
-              zinfo.zarr.zarr_version);
+              zinfo.format.zarr);
       return 2;
     }
   }
@@ -139,9 +139,9 @@ int test_NCZ_infer_zarr_format() {
               ret, v);
       return 3;
     }
-    if (zinfo.zarr.zarr_version != v) {
+    if (zinfo.format.zarr != v) {
       fprintf(stderr, "Failed! Expected version 2 detection (%d)\n",
-              zinfo.zarr.zarr_version);
+              zinfo.format.zarr);
       return 4;
     }
     KV_ptr = KV3;
@@ -168,7 +168,7 @@ int test_NCZ_infer_nczarr_format() {
   fprintf(stderr, "Testing NCZ_infer_nczarr_format\n");
   int ret = NC_NOERR;
 
-  assert(zinfo.zarr.zarr_version == 0);
+  assert(zinfo.format.zarr == 0);
   ret = NCZ_infer_nczarr_format(&file);
   if (ret != NC_ENOTZARR) {
     fprintf(stderr, "Failed! Expected return code NC_ENOTZARR (%d), got (%d)\n",
@@ -176,7 +176,7 @@ int test_NCZ_infer_nczarr_format() {
     return 1;
   }
 
-  zinfo.zarr.zarr_version = 2;
+  zinfo.format.zarr = 2;
 
   KV_ptr = KV2pure;
   // Alternative to NCZMD_set_metadata_handler();
@@ -189,28 +189,26 @@ int test_NCZ_infer_nczarr_format() {
     return 2;
   }
 
-  if (0 != zinfo.zarr.nczarr_version.major ||
-      0 != zinfo.zarr.nczarr_version.minor ||
-      0 != zinfo.zarr.nczarr_version.release) {
-    fprintf(stderr, "Failed! Wrong nczarr version detectedr (%lu.%lu.%lu)\n",
-            zinfo.zarr.nczarr_version.major, zinfo.zarr.nczarr_version.minor,
-            zinfo.zarr.nczarr_version.release);
+  if (NCZARRFORMAT0 != zinfo.format.nczarr) {
+    fprintf(stderr,
+            "Failed! Wrong nczarr version detected "
+            "(" NCZARR_FORMAT_VERSION_TEMPLATE ") expected %d\n",
+            zinfo.format.nczarr, NCZARRFORMAT0);
     return 3;
   }
 
   KV_ptr = KV2nczarr;
   ret = NCZ_infer_nczarr_format(&file);
-  if (2 != zinfo.zarr.nczarr_version.major ||
-      0 != zinfo.zarr.nczarr_version.minor ||
-      0 != zinfo.zarr.nczarr_version.release) {
-    fprintf(stderr, "Failed! Wrong nczarr version detectedr (%lu.%lu.%lu)\n",
-            zinfo.zarr.nczarr_version.major, zinfo.zarr.nczarr_version.minor,
-            zinfo.zarr.nczarr_version.release);
-    return 4;
+  if (NCZARRFORMAT2 != zinfo.format.nczarr) {
+    fprintf(stderr,
+            "Failed! Wrong nczarr version detected "
+            "(" NCZARR_FORMAT_VERSION_TEMPLATE ") expected %d\n",
+            zinfo.format.nczarr, NCZARRFORMAT2);
+    return 5;
   }
 
   // TODO:
-  // zinfo.zarr.zarr_version = 3;
+  // zinfo.format.zarr = 3;
   // KV_ptr = KV3;
   // zinfo.map = mockmap();
   // zinfo.metadata = *NCZ_metadata_handler3;


### PR DESCRIPTION
This PR modifies how nczarr version is represented internally.
From 3 x `unsigned int` to a  single `int` this is taken from #3068
As far as I can tell `nczarr` only ever used `"2.0.0"` as value