### PR TITLE
Fix integer overflow in the classic-format length arithmetic (ticket RPX-9159448)

### DIFF
--- a/libsrc/ncx.h
+++ b/libsrc/ncx.h
@@ -132,38 +132,68 @@
  */
 #define X_ALIGN			4	/* a.k.a. BYTES_PER_XDR_UNIT */
 
+/*
+ * These turn a file-supplied element count into an external byte length.  The
+ * product can exceed SIZE_MAX and wrap, so each one saturates instead;
+ * SIZE_MAX is not an allocatable size, so callers reject it rather than being
+ * handed an undersized buffer.  _RNDUP() in include/rnd.h is left alone,
+ * because nc3internal.c also applies it to off_t offsets and it has to stay
+ * type generic.
+ */
 #define ncx_len_char(nelems) \
-	_RNDUP((nelems), X_ALIGN)
+	((size_t)(nelems) > SIZE_MAX - (X_ALIGN - 1) \
+		? SIZE_MAX \
+		: _RNDUP((size_t)(nelems), X_ALIGN))
 
 #define ncx_len_short(nelems) \
-	(((nelems) + (nelems)%2)  * X_SIZEOF_SHORT)
+	((size_t)(nelems) > (SIZE_MAX / X_SIZEOF_SHORT) - 1 \
+		? SIZE_MAX \
+		: ((size_t)(nelems) + (size_t)(nelems) % 2) * X_SIZEOF_SHORT)
 
 #define ncx_len_int(nelems) \
-	((nelems) * X_SIZEOF_INT)
+	((size_t)(nelems) > SIZE_MAX / X_SIZEOF_INT \
+		? SIZE_MAX \
+		: (size_t)(nelems) * X_SIZEOF_INT)
 
 #define ncx_len_long(nelems) \
-	((nelems) * X_SIZEOF_LONG)
+	((size_t)(nelems) > SIZE_MAX / X_SIZEOF_LONG \
+		? SIZE_MAX \
+		: (size_t)(nelems) * X_SIZEOF_LONG)
 
 #define ncx_len_float(nelems) \
-	((nelems) * X_SIZEOF_FLOAT)
+	((size_t)(nelems) > SIZE_MAX / X_SIZEOF_FLOAT \
+		? SIZE_MAX \
+		: (size_t)(nelems) * X_SIZEOF_FLOAT)
 
 #define ncx_len_double(nelems) \
-	((nelems) * X_SIZEOF_DOUBLE)
+	((size_t)(nelems) > SIZE_MAX / X_SIZEOF_DOUBLE \
+		? SIZE_MAX \
+		: (size_t)(nelems) * X_SIZEOF_DOUBLE)
 
 #define ncx_len_ubyte(nelems) \
-	_RNDUP((nelems), X_ALIGN)
+	((size_t)(nelems) > SIZE_MAX - (X_ALIGN - 1) \
+		? SIZE_MAX \
+		: _RNDUP((size_t)(nelems), X_ALIGN))
 
 #define ncx_len_ushort(nelems) \
-	(((nelems) + (nelems)%2)  * X_SIZEOF_USHORT)
+	((size_t)(nelems) > (SIZE_MAX / X_SIZEOF_USHORT) - 1 \
+		? SIZE_MAX \
+		: ((size_t)(nelems) + (size_t)(nelems) % 2) * X_SIZEOF_USHORT)
 
 #define ncx_len_uint(nelems) \
-	((nelems) * X_SIZEOF_UINT)
+	((size_t)(nelems) > SIZE_MAX / X_SIZEOF_UINT \
+		? SIZE_MAX \
+		: (size_t)(nelems) * X_SIZEOF_UINT)
 
 #define ncx_len_int64(nelems) \
-	((nelems) * X_SIZEOF_INT64)
+	((size_t)(nelems) > SIZE_MAX / X_SIZEOF_INT64 \
+		? SIZE_MAX \
+		: (size_t)(nelems) * X_SIZEOF_INT64)
 
 #define ncx_len_uint64(nelems) \
-	((nelems) * X_SIZEOF_UINT64)
+	((size_t)(nelems) > SIZE_MAX / X_SIZEOF_UINT64 \
+		? SIZE_MAX \
+		: (size_t)(nelems) * X_SIZEOF_UINT64)
 
 /* End ncx_len */
 

--- a/libsrc/v1hpg.c
+++ b/libsrc/v1hpg.c
@@ -124,13 +124,8 @@ fprintf(stderr, "nextread %lu, remaining %lu\n",
 	(unsigned long)((char *)gsp->end - (char *)gsp->pos));
 #endif
     /*
-     * Bound the request against the space that remains, rather than by adding
-     * nextread to gsp->pos.  That addition overflows for a large nextread and
-     * the comparison then succeeds, admitting a read past gsp->end.  The
-     * element counts that reach here through ncx_len_int() and ncx_len_int64()
-     * in this file come from the file header, so nextread is attacker
-     * influenced.  Subtraction cannot overflow.  The first test keeps a window
-     * whose pos has passed end from yielding a large unsigned difference.
+     * Bound against the space that remains.  Adding nextread to gsp->pos
+     * overflows for a large nextread, and the test then wrongly succeeds.
      */
     if((char *)gsp->pos <= (char *)gsp->end
 	&& nextread <= (size_t)((char *)gsp->end - (char *)gsp->pos))

--- a/libsrc/v1hpg.c
+++ b/libsrc/v1hpg.c
@@ -123,7 +123,17 @@ fprintf(stderr, "nextread %lu, remaining %lu\n",
 	(unsigned long)nextread,
 	(unsigned long)((char *)gsp->end - (char *)gsp->pos));
 #endif
-    if((char *)gsp->pos + nextread <= (char *)gsp->end)
+    /*
+     * Bound the request against the space that remains, rather than by adding
+     * nextread to gsp->pos.  That addition overflows for a large nextread and
+     * the comparison then succeeds, admitting a read past gsp->end.  The
+     * element counts that reach here through ncx_len_int() and ncx_len_int64()
+     * in this file come from the file header, so nextread is attacker
+     * influenced.  Subtraction cannot overflow.  The first test keeps a window
+     * whose pos has passed end from yielding a large unsigned difference.
+     */
+    if((char *)gsp->pos <= (char *)gsp->end
+	&& nextread <= (size_t)((char *)gsp->end - (char *)gsp->pos))
 	return NC_NOERR;
 
     return fault_v1hs(gsp, nextread);


### PR DESCRIPTION
Two arithmetic fixes in the classic library, from support ticket RPX-9159448. @WardF asked for both and said they could go in one PR, so there is no matching issue.

The ncx_len_*() macros in libsrc/ncx.h multiply a file-supplied element count by a fixed element size. That product can exceed SIZE_MAX and wrap, so a buffer sized from it comes out smaller than the count that later fills it. The macros now saturate to SIZE_MAX, which new_x_NC_attr() already rejects through its existing sz > SIZE_MAX - xsz guard.

check_v1hs() in libsrc/v1hpg.c bounded a header read by adding the length to gsp->pos and comparing against gsp->end. That addition overflows for a large length and the comparison then succeeds. It now compares against the space that remains.

Both commits are needed. v1hpg.c passes check_v1hs() a length from ncx_len_int() and ncx_len_int64(), so saturating without the second fix would hand the old test a SIZE_MAX that it accepts. The file from the ticket is now refused through the normal error path, and every test gives the same result before and after.

AI usage: I used an LLM while drafting and testing this. The reasoning and the testing are mine and I can walk through any of it.
