### PR TITLE
Check code style/format on CI 

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,8 @@
+---
+AllowShortFunctionsOnASingleLine: None
+BreakBeforeBraces: Attach
+IndentWidth: 8
+ContinuationIndentWidth: 8
+TabWidth: 8
+UseTab: Always
+...

--- a/.clang-format
+++ b/.clang-format
@@ -1,6 +1,7 @@
 ---
 AllowShortFunctionsOnASingleLine: None
 BreakBeforeBraces: Attach
+ColumnLimit: 0                          # Unchecked
 IndentWidth: 8
 ContinuationIndentWidth: 8
 TabWidth: 8

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -82,9 +82,9 @@ These tests will be run against any pull request submitted; you are encouraged t
 
 ## Code-style  <A NAME="codestyle"></A>
 
-If you want format your contributed code `clang-format` is the right tool to use as it is [interaged with `git`](https://clang.llvm.org/docs/ClangFormat.html#git-integration). Calling it as a pre-commit hook ensures you add code-style respecting commits.
+If to contribute please format your code. `clang-format` is the right tool to use, as it is [interaged with `git`](https://clang.llvm.org/docs/ClangFormat.html#git-integration). Calling it in the pre-commit hook ensures you add code-style respecting commits.
 
-For that modify the `.git/hooks/pre-commit` script adding something like:
+For that modify `.git/hooks/pre-commit` to include something like:
 ```
 set -euo pipefail
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -14,6 +14,7 @@ Thanks for your interest in contributing to the netCDF project.  There are many 
 	* [Spot-checks](#spotcheck)
 	* [Continuous Integration testing](#contint)
 	* [Regression testing with Docker](#regression)
+	* [Code-style](#codestyle)
 * [Final Remarks](#conclusion)
 
 # AI and LLM Policy <A NAME="aiguidelines"></A>
@@ -51,7 +52,7 @@ Many of the pull requests we receive do little other than to fix a typo or corre
 
 # Testing your changes <A NAME="testing"></A>
 
-There are several ways to test your changes to ensure that your pull request passes QA.  There are manual *spot-checks* which test the code "on-the-spot", and there are automated *continuous integration* tests which will run and evaluate any contributes to ensure nothing breaks.  **Advanced** users may also use Unidata-maintained *Docker* images for running *regression* tests.
+There are several ways to test your changes to ensure that your pull request passes QA.  There are manual *spot-checks* which test the code "on-the-spot", and there are automated *continuous integration* tests which will run and evaluate any contributes to ensure nothing breaks.  **Advanced** users may also use Unidata-maintained *Docker* images for running *regression* tests. Code style is also checked but not enforced, however it is ideal that contributions/changes respect them.
 
 ## Spot-check tests <A NAME="spotcheck"></A>
 
@@ -78,6 +79,35 @@ We provide several Docker images for performing regression tests against netCDF-
 By performing these comprehensive tests, we're able to see if any change in the core library results in unexpected behavior with the common interfaces.  For full documentation, please see [this page](https://github.com/Unidata/docker-nctests/tree/master/tests-regression).  
 
 These tests will be run against any pull request submitted; you are encouraged to make use of them if you so like.
+
+## Code-style  <A NAME="codestyle"></A>
+
+If you want format your contributed code `clang-format` is the right tool to use as it is [interaged with `git`](https://clang.llvm.org/docs/ClangFormat.html#git-integration). Calling it as a pre-commit hook ensures you add code-style respecting commits.
+
+For that modify the `.git/hooks/pre-commit` script adding something like:
+```
+set -euo pipefail
+
+tmpfile="$(mktemp)"
+trap 'rm -f "$tmpfile"' EXIT
+
+# Compare staged changes against clang-format output without modifying files.
+if ! git clang-format --staged --diff --style=file >"$tmpfile" 2>&1; then
+    # If there is meaningful output, formatting is required.
+    if [[ -s "$tmpfile" ]]; then
+        echo "ERROR: Staged changes are not clang-formatted."
+        echo
+        cat "$tmpfile"
+        echo
+        echo "Run:"
+        echo "  git clang-format"
+        echo "Then stage the updated files and commit again."
+        exit 1
+    fi
+fi
+
+exit 0
+```
 
 # We are here to help <A NAME="conclusion"></A>
 

--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -1,32 +1,11 @@
 name: Code Style checks
-on: [pull_request, push]
+on: [pull_request]
 jobs:
   clang-format:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0   # needed for diff-based checks
-      #- name: Install clang-format
-      #  shell: bash -l {0}
-      #  run: |
-      #    apt update -y
-      #    apt install clang-format -y
-      #    curl -O https://raw.githubusercontent.com/llvm/llvm-project/main/clang/tools/clang-format/git-clang-format
-      #    chmod +x git-clang-format
-      #    mv git-clang-format /usr/local/bin/
+          fetch-depth: 0
       - name: Run code-style check on changes
-        shell: bash -l {0}
-        run: |
-          git fetch origin ${{ github.base_ref }}
-          echo $(which git-clang-format)
-          # Only check staged changes, don't modify anything, exit non-zero if unformatted
-          if ! git clang-format-18 --staged --diff --style=file > /tmp/cf-diff 2>&1; then
-              if [ -s /tmp/cf-diff ] && ! grep -q "clang-format did not modify any files" /tmp/cf-diff; then
-                  echo "clang-format found issues in staged changes:"
-                  cat /tmp/cf-diff
-                  echo
-                  echo "Run 'git clang-format' to fix, then re-stage and commit."
-                  exit 1
-              fi
-          fi
+        run: git clang-format-18 --diff ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.base.sha }}

--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -1,0 +1,32 @@
+name: Code Style checks
+on: [pull_request, push]
+jobs:
+  clang-format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # needed for diff-based checks
+      #- name: Install clang-format
+      #  shell: bash -l {0}
+      #  run: |
+      #    apt update -y
+      #    apt install clang-format -y
+      #    curl -O https://raw.githubusercontent.com/llvm/llvm-project/main/clang/tools/clang-format/git-clang-format
+      #    chmod +x git-clang-format
+      #    mv git-clang-format /usr/local/bin/
+      - name: Run code-style check on changes
+        shell: bash -l {0}
+        run: |
+          git fetch origin ${{ github.base_ref }}
+          echo $(which git-clang-format)
+          # Only check staged changes, don't modify anything, exit non-zero if unformatted
+          if ! git clang-format-18 --staged --diff --style=file > /tmp/cf-diff 2>&1; then
+              if [ -s /tmp/cf-diff ] && ! grep -q "clang-format did not modify any files" /tmp/cf-diff; then
+                  echo "clang-format found issues in staged changes:"
+                  cat /tmp/cf-diff
+                  echo
+                  echo "Run 'git clang-format' to fix, then re-stage and commit."
+                  exit 1
+              fi
+          fi

--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -4,8 +4,16 @@ jobs:
   clang-format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Run code-style check on changes
-        run: git clang-format-18 --diff ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.base.sha }}
+        run: |
+          git clang-format-18 \
+            --diff \
+            ${{ github.event.pull_request.head.sha }} \
+            ${{ github.event.pull_request.base.sha }} ||
+          (
+            echo "::error::❌ Code style check failed. See the [contributing guide](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}?tab=contributing-ov-file#codestyle) for formatting requirements."
+            exit 1
+          )


### PR DESCRIPTION
Consistent code style/formatting has been a somewhat problematic topic in this repository.

There has been some attempts at addressing this "unimportant" but frustrating issue. 

What I propose with this PR is a CI job that checks code-formatting **only** on **modified/new code.**

It uses `clang-format` which is integrated with `git` via `git-clang-format`[^1]. Which rely on `the .clang-format` configuration file.

It also documents the importance of setting up  a pre-commit to validate commits with respect to code-formatting. Ideally `precommit` tool[^2] or a tracked hooks[^3] folder could help streamlining the process.

This is a bit Ad Hoc but I'm happy to get input. @seanm I've seen your efforts in this regard and likely you have valuable feedback!

[^1]: https://clang.llvm.org/docs/ClangFormat.html#git-integration
[^2]: https://pre-commit.com/
[^3]: https://git-scm.com/book/ms/v2/Customizing-Git-Git-Hooks