### PR TITLE
Make nc_perf's tst_chunks3 build with MSVC

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -66,6 +66,7 @@ This file contains a high-level description of this package's evolution. Release
 
 ## 4.10.0 - February 25, 2026
 
+* Fix the `nc_perf` build with MSVC so that `tst_chunks3` can be built and run on Windows. See [Github 3425](https://github.com/Unidata/netcdf-c/issues/3425) for more information. 
 * Regularize, cleanup, and refactor various AWS features, especially WRT regularizing AWS-related constants. See [Github 3229](https://github.com/Unidata/netcdf-c/issues/3229) for more information. 
 * Add extra failure handling to the daos inferencing. See [Github 3238](https://github.com/Unidata/netcdf-c/issues/3238) for more information. 
 * Regularize, cleanup, and refactor various AWS features, especially WRT regularizing AWS-related constants. See [Github 3229](https://github.com/Unidata/netcdf-c/issues/3229) for more information. 

--- a/nc_perf/tst_chunks3.c
+++ b/nc_perf/tst_chunks3.c
@@ -27,6 +27,61 @@
 #ifdef HAVE_SYS_RESOURCE_H
 #include <sys/resource.h>
 #endif
+
+/* MSVC has no getrusage(2), but the timing macros below are built on it.
+ * Supply the subset of the interface those macros use.
+ *
+ * GetProcessTimes reports kernel and user CPU time for the process in 100 ns
+ * ticks, which is what ru_utime/ru_stime hold here. The macros sum the two and
+ * divide by the repetition count, so the measurement remains CPU time and stays
+ * comparable with the POSIX platforms.
+ *
+ * ru_inblock/ru_oublock have no Win32 equivalent and are reported as zero; the
+ * timing macros read them but never print them. */
+#if defined(_WIN32) && !defined(HAVE_SYS_RESOURCE_H)
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <winsock2.h>   /* struct timeval; must precede windows.h */
+#include <windows.h>
+
+#define RUSAGE_SELF 0
+
+struct rusage {
+    struct timeval ru_utime;
+    struct timeval ru_stime;
+    long ru_inblock;
+    long ru_oublock;
+};
+
+static __inline void
+nc_filetime_to_timeval(const FILETIME *ft, struct timeval *tv)
+{
+    /* 100 ns ticks since an epoch that cancels out: only differences are used */
+    ULARGE_INTEGER t;
+    t.LowPart = ft->dwLowDateTime;
+    t.HighPart = ft->dwHighDateTime;
+    tv->tv_sec = (long)(t.QuadPart / 10000000ULL);
+    tv->tv_usec = (long)((t.QuadPart % 10000000ULL) / 10ULL);
+}
+
+static __inline int
+getrusage(int who, struct rusage *ru)
+{
+    FILETIME creation, exit, kernel, user;
+    (void)who;
+    if (!GetProcessTimes(GetCurrentProcess(), &creation, &exit, &kernel, &user))
+        return -1;
+    nc_filetime_to_timeval(&user, &ru->ru_utime);
+    nc_filetime_to_timeval(&kernel, &ru->ru_stime);
+    ru->ru_inblock = 0;
+    ru->ru_oublock = 0;
+    return 0;
+}
+#endif /* _WIN32 && !HAVE_SYS_RESOURCE_H */
 #include "nc_tests.h"		/* The ERR macro is here... */
 #include "netcdf.h"
 

--- a/nc_perf/tst_utils.c
+++ b/nc_perf/tst_utils.c
@@ -15,7 +15,12 @@ See \ref copyright file for more info.
 
 #include <nc_tests.h>
 #include <time.h>
+/* struct timeval comes from <winsock2.h> on Windows. */
+#if defined(_WIN32) && !defined(HAVE_SYS_TIME_H)
+#include <winsock2.h>
+#else
 #include <sys/time.h>
+#endif
 
 /** Subtract the `struct timeval' values X and Y, storing the result in
    RESULT.  Return 1 if the difference is negative, otherwise 0.  This


### PR DESCRIPTION
Fixes the two things that stop `nc_perf/tst_chunks3` compiling with MSVC, so
that `-DNETCDF_ENABLE_BENCHMARKS=ON` can be used on Windows for that benchmark.
Addresses part of #3425.

### What is here

**`nc_perf/tst_chunks3.c`** — the `TIMING_DECLS` / `TIMING_START` / `TIMING_END`
macros are built on `struct rusage` and `getrusage(RUSAGE_SELF, ...)`, which
MSVC does not provide. This supplies the subset of the interface those macros
use, on top of `GetProcessTimes`: it reports kernel and user CPU time for the
process in 100 ns ticks, which is exactly what `ru_utime` / `ru_stime` hold
here, so the measurement remains CPU time rather than becoming wall clock and
stays comparable with the POSIX platforms. `ru_inblock` / `ru_oublock` have no
Win32 equivalent and are reported as zero — the macros read them but never
print them.

**`nc_perf/tst_utils.c`** — includes `<sys/time.h>` unconditionally for
`struct timeval` (used by `nc4_timeval_subtract`). On Windows that type comes
from `<winsock2.h>`. `tst_chunks3` links this file, so it fails to compile even
once the timing macros are satisfied.

Both additions are behind `#if defined(_WIN32)`, so the POSIX builds see no
change at all.

### What is deliberately not here

The other `nc_perf` programs are untouched and still do not build on Windows —
`bm_file`, `tst_ar4*`, `tst_wrf_reads`, `tst_mem` and the rest use
`gettimeofday` / `<unistd.h>` the same way. I scoped this to `tst_chunks3`
because that is the one I can verify end to end; #3425 has a note on the wider
question, including the option of skipping `add_subdirectory(nc_perf)` on
`WIN32` instead, if you would rather `nc_perf` stay POSIX-only.

### Testing

**Windows** — `tst_chunks3` builds with MSVC 14.51 on a `windows-2025` runner
and runs to completion. Sample of its output there (deflate 6, 64³ elements,
16³ chunks):

```
  contiguous write   1  64  64                0.00061 sec
  chunked    write   1  64  64   16  16  16    0.0017 sec   2.8 x slower
  compressed write   1  64  64   16  16  16    0.0015 sec   2.4 x slower

  contiguous write  64   1  64                 0.0098 sec
  chunked    write  64   1  64   16  16  16    0.0013 sec   7.3 x faster
  compressed write  64   1  64   16  16  16    0.0012 sec     8 x faster
```

The shim's arithmetic was also checked directly against mocked `GetProcessTimes`
values: 0.33 s of added user time yields a 330000 µs delta, as the macros expect.

**Linux** — configured with `-DENABLE_BENCHMARKS=ON` against HDF5 1.10.10 and
built the `tst_chunks3` target from this branch: compiles without new warnings
and produces the same output as before the change, which is expected since the
new code is entirely inside `#if defined(_WIN32)`.

I came to this while adding a Windows leg to a netCDF-4 benchmark that uses
`tst_chunks3`; happy to adjust naming or placement if you would prefer the shim
somewhere more central, such as a shared test header.