### PR TITLE
Report unknown dtypes

### DIFF
--- a/libnczarr/zsync.c
+++ b/libnczarr/zsync.c
@@ -1457,8 +1457,10 @@ define_var1(NC_FILE_INFO_T* file, NC_GRP_INFO_T* grp, const char* varname)
 	int endianness;
 	if((stat = NCJdictget(jvar,"dtype",&jvalue))<0) {stat = NC_EINVAL; goto done;}
 	/* Convert dtype to nc_type + endianness */
-	if((stat = ncz_dtype2nctype(NCJstring(jvalue),NC_NAT,purezarr,&vtype,&endianness,&vtypelen)))
+	if((stat = ncz_dtype2nctype(NCJstring(jvalue),NC_NAT,purezarr,&vtype,&endianness,&vtypelen))){
+	    ZLOG(NCLOGERR, "Unsupported data type detected in variable \"%s\" (dtype=\"%s\").", varname, NCJstring(jvalue));
 	    goto done;
+	}
 	if(vtype > NC_NAT && vtype <= NC_MAX_ATOMIC_TYPE) {
 	    /* Locate the NC_TYPE_INFO_T object */
 	    if((stat = ncz_gettype(file,grp,vtype,&var->type_info)))

--- a/nczarr_test/run_corrupt.sh
+++ b/nczarr_test/run_corrupt.sh
@@ -17,6 +17,7 @@ cd $ISOPATH
 export NCLOGGING=WARN
 
 testnoshape1() {
+  echo "*** testing no shape (zip)"
   zext=file
   rm -fr ./ref_noshape.file
   unzip ${srcdir}/ref_noshape.file.zip
@@ -26,12 +27,43 @@ testnoshape1() {
 }
 
 testnoshape2() {
+  echo "*** testing no shape (s3)"
   # Test against the original issue URL
   rm -f tmp_noshape2_gs.cdl
   fileurl="https://storage.googleapis.com/cmip6/CMIP6/CMIP/NASA-GISS/GISS-E2-1-G/historical/r1i1p1f1/day/tasmin/gn/v20181015/#mode=zarr,s3&aws.profile=no"
   ${NCDUMP} -h $flags $fileurl > tmp_noshape2_gs.cdl
 }
- 
+
+test_bad_dtype() {
+  echo "*** testing bad dtype"
+  name='bad_dtype'
+  mkdir -p "${name}.zarr/id"
+  cat > "${name}.zarr/.zgroup" <<-EOF
+{"zarr_format":2}
+EOF
+cat > "${name}.zarr/id/.zarray" <<-EOF
+{
+  "chunks": [225,265],
+  "compressor": null,
+  "dtype": "|O",
+  "fill_value": null,
+  "filters": null,
+  "order": "C",
+  "shape": [1799,1059],
+  "zarr_format": 2
+}
+EOF
+  set +e
+  "${NCDUMP}" -h "file://${name}.zarr#mode=zarr" > ncdump_dtype_output.txt 2>&1
+  ret=$?
+  set -e
+  if test $ret -ne 0 && grep -q 'ERR: Unsupported data type detected in variable "id" (dtype="|O").' ncdump_dtype_output.txt; then
+    return 0;
+  fi
+  return 1;
+}
+
+test_bad_dtype
 testnoshape1
 if test "x$FEATURE_S3TESTS" = xyes && test "x$FEATURE_S3_INTERNAL" = xyes ; then
     # The aws-sdk-cpp driver does not support google storage


### PR DESCRIPTION
Small PR to log errors when a zarr datasets contains unsupported dtypes for a given variable.