### PR TITLE
Fix ncdump debug log level problem

### DIFF
--- a/libdispatch/nclog.c
+++ b/libdispatch/nclog.c
@@ -175,7 +175,7 @@ nclogtextn(int level, const char* text, size_t count)
 static const char*
 nctagname(int tag)
 {
-    if(tag < NCLOGOFF || tag >= NCLOGDEBUG)
+    if(tag < NCLOGOFF || tag > NCLOGDEBUG)
 	return "unknown";
     return nctagset[tag];
 }

--- a/ncdump/ncdump.c
+++ b/ncdump/ncdump.c
@@ -2389,15 +2389,13 @@ main(int argc, char *argv[])
 	      goto fail;
 	  }
 	  break;
-        case 'L':
-#ifdef LOGGING
-	  {
-	  int level = atoi(optarg);
-	  if(level >= 0)
-	    nc_set_log_level(level);
-	  }
+	    case 'L':
+	      int level = atoi(optarg); // atoi return 0 (NCLOGOFF) on error
+	      level = !level ? NCLOGNOTE : level; // If -L NCLOGNOTE is default
+#ifdef LOGGING // This is for parallel builds
+	      nc_set_log_level(level);
 #endif
-	  ncsetloglevel(NCLOGNOTE);
+	      ncsetloglevel(level);
 	  break;
 	case 'F':
 	  formatting_specs.filter_atts = true;

--- a/ncdump/ncdump.c
+++ b/ncdump/ncdump.c
@@ -2390,12 +2390,14 @@ main(int argc, char *argv[])
 	  }
 	  break;
 	    case 'L':
+		{
 	      int level = atoi(optarg); // atoi return 0 (NCLOGOFF) on error
 	      level = !level ? NCLOGNOTE : level; // If -L NCLOGNOTE is default
 #ifdef LOGGING // This is for parallel builds
 	      nc_set_log_level(level);
 #endif
 	      ncsetloglevel(level);
+		}
 	  break;
 	case 'F':
 	  formatting_specs.filter_atts = true;


### PR DESCRIPTION
This PR addresses 2 issues around `NCLOGDEBUG` logging.
 - The tag rendered is  `"unknown"`  instead of `"DEBUG"` with such level is set.
 - `ncdump -L` will always set log level to `NCLOGNOTE` if even if `-L4` is provided (`NCLOGDEBUG`)

---- 

It is unclear to me why both `nc_set_log_level` and `ncsetloglevel` exist:
```
df3636b959 (Dennis Heimbigner 2023-09-26 16:56:48 -0600 35) EXTERNL int ncsetloglevel(int level);
```
```
18f4bca367 (Ed Hartnett       2010-06-03 13:24:43 +0000 1947) nc_set_log_level(int new_level);
```

Can you shed some light on this @edhartnett? Maintaining 2 similar APIs seems a bit counter-productive, but maybe there's a good reason.