### PR TITLE
Use `grep -F` instead of `fgrep`

### DIFF
--- a/hdf4_test/run_formatx_hdf4.sh
+++ b/hdf4_test/run_formatx_hdf4.sh
@@ -22,7 +22,7 @@ ${execdir}/tst_interops2
 echo "Test extended format output for a HDF4 file"
 rm -f tmp_tst_formatx_hdf4
 ${NCDUMP} -K $FILE >tmp_tst_formatx_hdf4
-if ! fgrep 'HDF4 mode=00001000' <tmp_tst_formatx_hdf4 ; then
+if ! grep -F 'HDF4 mode=00001000' <tmp_tst_formatx_hdf4 ; then
 TMP=`cat tmp_tst_formatx_hdf4`
 echo "*** Fail: extended format for an HDF4 file: result=" $TMP
 ECODE=1

--- a/ncdap_test/testurl.sh
+++ b/ncdap_test/testurl.sh
@@ -79,9 +79,9 @@ echo "command: ${NCDUMP} -h $url"
 ${NCDUMP} "$url" >./tmp_testurl 2> ./errtmp_testurl
 if test "x${SHOW}" = x1 ; then cat ./tmp_testurl ; fi
 # Look for the value of maxStrlen in output cdl
-if ! fgrep -i "maxstrlen = 16" ./tmp_testurl ; then
+if ! grep -F -i "maxstrlen = 16" ./tmp_testurl ; then
 echo "***Fail: maxStrlen not recognized"
-fgrep -i "maxstrlen16 = 16" ./tmp_testurl > ./errtmp_testurl
+grep -F -i "maxstrlen16 = 16" ./tmp_testurl > ./errtmp_testurl
 fi
 
 fi

--- a/ncdap_test/tst_ncdap3.sh
+++ b/ncdap_test/tst_ncdap3.sh
@@ -18,7 +18,7 @@ for x in ${FILETESTS} ; do
   # determine if this is an xfailtest
   isxfail=0
   if test "x${XFAILTESTS}" != x ; then
-    if IGNORE=`echon " ${XFAILTESTS} " | fgrep " ${x} "`; then isxfail=1; fi
+    if IGNORE=`echon " ${XFAILTESTS} " | grep -F " ${x} "`; then isxfail=1; fi
   fi
   ok=1
   if ${NCDUMP} ${DUMPFLAGS} "${url}" | sed 's/\\r//g' > ${x}.dmp ; then ok=$ok; else ok=0; fi

--- a/ncdap_test/tst_urls.sh
+++ b/ncdap_test/tst_urls.sh
@@ -125,7 +125,7 @@ constrain() {
 setcache() {
   CACHE="[cache]"
   if test "x${NOCACHETESTS}" != x ; then
-    if IGNORE=`echon " ${NOCACHETESTS} " | fgrep " $1 "`; then CACHE=; fi
+    if IGNORE=`echon " ${NOCACHETESTS} " | grep -F " $1 "`; then CACHE=; fi
   fi
   PARAMS="${PARAMS}${CACHE}"
 }
@@ -133,7 +133,7 @@ setcache() {
 setprefetch() {
   PREFETCH="[prefetch]"
   if test "x${NOPREFETCHTESTS}" != x ; then
-    if IGNORE=`echon " ${NOPREFETCHTESTS} " | fgrep " $1 "`; then PREFETCH=; fi
+    if IGNORE=`echon " ${NOPREFETCHTESTS} " | grep -F " $1 "`; then PREFETCH=; fi
   fi
   PARAMS="${PARAMS}${PREFETCH}"
 }

--- a/ncdump/run_ncgen_tests.sh
+++ b/ncdump/run_ncgen_tests.sh
@@ -11,7 +11,7 @@ set -e
 # This shell script runs the ncdump tests.
 # get some config.h parameters
 if test -f ${top_builddir}/config.h ; then
-  if fgrep -e '#define NETCDF_ENABLE_CDF5 1' ${top_builddir}/config.h >/dev/null ; then
+  if grep -F -e '#define NETCDF_ENABLE_CDF5 1' ${top_builddir}/config.h >/dev/null ; then
     CDF5=1
   else
     CDF5=0

--- a/ncdump/tst_64bit.sh
+++ b/ncdump/tst_64bit.sh
@@ -8,7 +8,7 @@ if test "x$srcdir" = x ; then srcdir=`pwd`; fi
 # This shell script runs the ncdump tests.
 # get some config.h parameters
 if test -f ${top_builddir}/config.h ; then
-  if fgrep -e '#define NETCDF_ENABLE_CDF5 1' ${top_builddir}/config.h >/dev/null ; then
+  if grep -F -e '#define NETCDF_ENABLE_CDF5 1' ${top_builddir}/config.h >/dev/null ; then
     CDF5=1
   else
     CDF5=0

--- a/ncdump/tst_fileinfo.sh
+++ b/ncdump/tst_fileinfo.sh
@@ -21,7 +21,7 @@ ${execdir}/tst_fileinfo
 
 # Do a false negative test
 rm -f ./tst_fileinfo.tmp
-if $NCDUMP -s $NF | fgrep '_IsNetcdf4 = 0' > ./tst_fileinfo.tmp ; then
+if $NCDUMP -s $NF | grep -F '_IsNetcdf4 = 0' > ./tst_fileinfo.tmp ; then
    echo "Pass: False negative for file: $NF"
 else
    echo "FAIL: False negative for file: $NF"
@@ -31,7 +31,7 @@ rm -f ./tst_fileinfo.tmp
 
 # Verify handling of a file with no _NCProperties attribute
 rm -f ./tst_fileinfo.tmp
-if $NCDUMP -s $NPNCP | fgrep '_NCProperties=' > ./tst_fileinfo.tmp ; then
+if $NCDUMP -s $NPNCP | grep -F '_NCProperties=' > ./tst_fileinfo.tmp ; then
    echo "Fail: $NPNCP has _NCProperties attribute"
    EXIT=1
 else
@@ -41,9 +41,9 @@ rm -f ./tst_fileinfo.tmp
 
 if test -e $NCF ; then
    # look at the _IsNetcdf4 flag
-   N_IS=`${NCDUMP} -s $NCF | fgrep '_IsNetcdf4' | tr -d ' ;\r'`
+   N_IS=`${NCDUMP} -s $NCF | grep -F '_IsNetcdf4' | tr -d ' ;\r'`
    N_IS=`echo $N_IS | cut -d= -f2`
-   H_IS=`${NCDUMP} -s $HDF | fgrep '_IsNetcdf4' | tr -d ' ;\r'`
+   H_IS=`${NCDUMP} -s $HDF | grep -F '_IsNetcdf4' | tr -d ' ;\r'`
    H_IS=`echo $H_IS | cut -d= -f2`
    if test "x$N_IS" = 'x0' ;then
      echo "FAIL: $NCF is marked as not netcdf-4"
@@ -62,8 +62,8 @@ echo "PASS: $NCF is marked as netcdf-4"
 # Test what happens when we read a file that used provenance version 1
 rm -f ./tst_fileinfo.tmp ./tst_fileinfo2.tmp
 $NCDUMP -hs $NPV1 >tst_fileinfo2.tmp
-fgrep '_NCProperties' <tst_fileinfo2.tmp > ./tst_fileinfo.tmp
-if ! XXX=`fgrep 'version=1' tst_fileinfo.tmp` ; then
+grep -F '_NCProperties' <tst_fileinfo2.tmp > ./tst_fileinfo.tmp
+if ! XXX=`grep -F 'version=1' tst_fileinfo.tmp` ; then
   echo "FAIL: $NPV1 is not marked as version=1"
   EXIT=1
 fi

--- a/ncdump/tst_formatx3.sh
+++ b/ncdump/tst_formatx3.sh
@@ -6,7 +6,7 @@ if test "x$srcdir" = x ; then srcdir=`pwd`; fi
 # This shell script runs the ncdump tests.
 # get some config.h parameters
 if test -f ${top_builddir}/config.h ; then
-  if fgrep -e '#define NETCDF_ENABLE_CDF5 1' ${top_builddir}/config.h >/dev/null ; then
+  if grep -F -e '#define NETCDF_ENABLE_CDF5 1' ${top_builddir}/config.h >/dev/null ; then
     NETCDF_ENABLE_CDF5=1
   else
     NETCDF_ENABLE_CDF5=0

--- a/ncdump/tst_inmemory_nc4.sh
+++ b/ncdump/tst_inmemory_nc4.sh
@@ -36,7 +36,7 @@ dotest "3" "$CLASSIC"
 dotest "5" "$EXTENDED5"
 
 if test -f ${top_builddir}/config.h ; then
-  if fgrep -e '#define USE_NETCDF4 1' ${top_builddir}/config.h >/dev/null ; then
+  if grep -F -e '#define USE_NETCDF4 1' ${top_builddir}/config.h >/dev/null ; then
     dotest "4" "$EXTENDED4"
   fi
 fi

--- a/ncdump/tst_lengths.sh
+++ b/ncdump/tst_lengths.sh
@@ -5,7 +5,7 @@ if test "x$srcdir" = x ; then srcdir=`pwd`; fi
 
 # get some config.h parameters
 if test -f ${top_builddir}/config.h ; then
-  if fgrep -e '#define NETCDF_ENABLE_CDF5 1' ${top_builddir}/config.h >/dev/null ; then
+  if grep -F -e '#define NETCDF_ENABLE_CDF5 1' ${top_builddir}/config.h >/dev/null ; then
     HAVE_CDF5=1
   else
     HAVE_CDF5=0

--- a/ncdump/tst_nccopy3.sh
+++ b/ncdump/tst_nccopy3.sh
@@ -14,7 +14,7 @@ echo ""
 
 # get some config.h parameters
 if test -f ${top_builddir}/config.h ; then
-  if fgrep -e '#define NETCDF_ENABLE_CDF5 1' ${top_builddir}/config.h >/dev/null ; then
+  if grep -F -e '#define NETCDF_ENABLE_CDF5 1' ${top_builddir}/config.h >/dev/null ; then
     HAVE_CDF5=1
   else
     HAVE_CDF5=0

--- a/ncdump/tst_nccopy4.sh
+++ b/ncdump/tst_nccopy4.sh
@@ -67,10 +67,10 @@ fi
 echo "*** Test nccopy -d0 turns off compression, shuffling of compressed, shuffled file ..."
 ${NCCOPY} -d0 tst_inflated4.nc tmp_ncc4.nc
 ${NCDUMP} -sh tmp_ncc4.nc > tmp_ncc4.cdl
-if fgrep '_DeflateLevel' < tmp_ncc4.cdl ; then
+if grep -F '_DeflateLevel' < tmp_ncc4.cdl ; then
     exit 1
 fi
-if fgrep '_Shuffle' < tmp_ncc4.cdl ; then
+if grep -F '_Shuffle' < tmp_ncc4.cdl ; then
     exit 1
 fi
 rm tst_deflated.nc tst_inflated.nc tst_inflated4.nc tmp_ncc4.nc tmp_ncc4.cdl


### PR DESCRIPTION
On Fedora I get lots of these:
```
198: fgrep: warning: fgrep is obsolescent; using grep -F
```