### PR TITLE
Preserve Blosc input buffer for incompressible chunks

### DIFF
--- a/nc_test4/tst_bloscfail.sh
+++ b/nc_test4/tst_bloscfail.sh
@@ -49,7 +49,8 @@ export HDF5_PLUGIN_DIR
 export HDF5_PLUGIN_PATH="$HDF5_PLUGIN_DIR"
 
 localclean() {
-rm -f ./tmp_bloscx3.nc ./tmp_bloscx4.nc ./tmp_bloscx4_fail.nc
+rm -f ./tmp_bloscx3.nc ./tmp_bloscx4.nc ./tmp_bloscx4_fail.nc \
+      ./tmp_bloscx4_fail.cdl
 }
 
 # Execute the specified tests
@@ -59,12 +60,11 @@ localclean
 ${NCGEN} -3 -o tmp_bloscx3.nc ${srcdir}/ref_bloscx.cdl
 # This should pass
 ${NCCOPY} -4 -V three_dmn_rec_var -F *,32001,0,0,0,0,1,1,0 ./tmp_bloscx3.nc ./tmp_bloscx4.nc
-# This should fail because shuffle is off
-if ${NCCOPY} -4 -V three_dmn_rec_var -F *,32001,0,0,0,0,1,0,0 ./tmp_bloscx3.nc ./tmp_bloscx4_fail.nc ; then
-    echo "*** not xfail: nccopy "
-else
-    echo "*** xfail: nccopy "
-fi
+# Without shuffle this data is not compressible.  Since the Blosc filter is
+# optional, HDF5 should store the original chunk instead of failing the write.
+${NCCOPY} -4 -V three_dmn_rec_var -F *,32001,0,0,0,0,1,0,0 ./tmp_bloscx3.nc ./tmp_bloscx4_fail.nc
+${NCDUMP} -n x3 ./tmp_bloscx4_fail.nc > ./tmp_bloscx4_fail.cdl
+diff -b -w -B ${srcdir}/ref_bloscx.cdl ./tmp_bloscx4_fail.cdl
 
 localclean
 

--- a/plugins/H5Zblosc.c
+++ b/plugins/H5Zblosc.c
@@ -296,8 +296,9 @@ size_t blosc_filter(unsigned flags, size_t cd_nelmts,
     bloscsize = blosc_compress(clevel, doshuffle, typesize, nbytes, *buf, outbuf, nbytes);
 #endif
     if(bloscsize == 0) {
-        fprintf(stderr,"Blosc_Filter Error: blosc_filter: Buffer is uncompressible.\n");
-	goto failed;
+      /* The filter is optional.  Leave the input buffer unchanged so HDF5
+       * can store this chunk without compression. */
+      goto failed;
     } else if(bloscsize < 0) {
       fprintf(stderr,"Blosc Filter Error: blosc_filter: blosc compression error\n");
       goto failed;
@@ -354,8 +355,6 @@ size_t blosc_filter(unsigned flags, size_t cd_nelmts,
 
 failed:
    free(outbuf);
-   *buf = NULL;
-   *buf_size = 0;
    return 0;
 
 } /* End filter function */


### PR DESCRIPTION
## Summary

- preserve the original chunk buffer when Blosc reports that compressed output would not fit
- let HDF5 skip the optional filter and store that chunk uncompressed
- turn the existing expected-failure case into a required round-trip regression test

## Root cause

Blosc receives an output buffer no larger than the input chunk and returns zero when the compressed representation would not fit. That is a normal outcome for an optional compression filter.

The failure path currently sets the input buffer pointer to NULL and its size to zero before returning. HDF5 then has no original buffer available for its optional-filter fallback, so a normal incompressible chunk becomes a NetCDF: HDF error.

This regresses the behavior discussed in #2458 and fixed by #2461. The buffer reset was later added in df3636b95974ebccdd149c280ce09b3d897a5dd8. The same error message is reported for the NCZarr path in #3075.

## Tests

- confirmed the updated nc_test4_tst_bloscfail fails with NetCDF: HDF error on the current buffer-reset behavior
- confirmed nc_test4_tst_bloscfail passes with this change and validates the round-trip data
- confirmed nc_test4_tst_specific_filters passes

Tested with HDF5 1.14.6 and Blosc 1.21.x.

## References

- Regression of #2458
- Restores the fallback implemented by #2461
- Related to #3075

## Tool-use disclosure

This contribution was prepared with assistance from OpenAI Codex and manually scoped to the Blosc filter fallback and its existing regression test. The commit includes an Assisted-by trailer.