### PR TITLE
reorganize UDF slots, now using 7 bits of mode flag instead of 10, returning 3 for future use...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ build_llvm
 Vagrantfile
 netcdf-fortran
 .windsurf
+.devin

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,10 @@ Release Notes       {#RELEASE_NOTES}
 
 This file contains a high-level description of this package's evolution. Releases are in reverse chronological order (most recent first). Note that, as of netcdf 4.2, the `netcdf-c++` and `netcdf-fortran` libraries have been separated into their own libraries.
 
+## Unreleased
+
+* Expanded user-defined format (UDF) slots from 10 to 64 by changing the mode encoding: NC_UDF_FLAG (bit 6) marks a UDF mode and a 6-bit field at bits 19-24 holds the slot number. Use the new NC_UDF(n) macro for any slot 0-63. The macros NC_UDF0 through NC_UDF9 continue to work, but the numeric values of NC_UDF1 through NC_UDF9 changed; code that uses the macros needs only recompilation, but code that hard-codes the old numeric values, or bit-tests modes against them, must be updated. NC_UDF0 keeps its old value (0x0040). Mode bits 7, 16, and 25 are recovered for future use. NC_MAX_UDF_FORMATS is now 64.
+
 ## 4,10.1 - July 6, 2026
 
 * Fixed outstanding CVE issues. See [Github 3236](https://github.com/Unidata/netcdf-c/issues/3236) and [Github 3402](https://github.com/Unidata/netcdf-c/pull/3402) for more information.

--- a/docs/dispatch.md
+++ b/docs/dispatch.md
@@ -25,20 +25,11 @@ and the specific code should be consulted to see the actual parameters.
 <tr><td>PNetCDF<td>libsrcp<td>NC_FORMATX_PNETCDF
 <tr><td>DAP2<td>libdap2<td>NC_FORMATX_DAP2
 <tr><td>DAP4<td>libdap4<td>NC_FORMATX_DAP4
-<tr><td>UDF0<td>N.A.<td>NC_FORMATX_UDF0
-<tr><td>UDF1<td>N.A.<td>NC_FORMATX_UDF1
-<tr><td>UDF2<td>N.A.<td>NC_FORMATX_UDF2
-<tr><td>UDF3<td>N.A.<td>NC_FORMATX_UDF3
-<tr><td>UDF4<td>N.A.<td>NC_FORMATX_UDF4
-<tr><td>UDF5<td>N.A.<td>NC_FORMATX_UDF5
-<tr><td>UDF6<td>N.A.<td>NC_FORMATX_UDF6
-<tr><td>UDF7<td>N.A.<td>NC_FORMATX_UDF7
-<tr><td>UDF8<td>N.A.<td>NC_FORMATX_UDF8
-<tr><td>UDF9<td>N.A.<td>NC_FORMATX_UDF9
+<tr><td>UDF slot n (0-63)<td>N.A.<td>NC_FORMATX_UDF(n)
 <tr><td>NCZarr<td>libnczarr<td>NC_FORMATX_NCZARR
 </table>
 
-Note that UDF0 through UDF9 (10 slots total) allow for user-defined dispatch tables to
+Note that the 64 UDF slots (0 through 63) allow for user-defined dispatch tables to
 be implemented. These can be registered programmatically via nc_def_user_format() or
 automatically loaded from RC file configuration. See [User-Defined Formats](#user_defined_formats)
 for details.

--- a/docs/udf_plugin_development.md
+++ b/docs/udf_plugin_development.md
@@ -18,8 +18,8 @@ A UDF plugin consists of:
 2. RC file parsing (if configured)
 3. Plugin library loading (`dlopen`/`LoadLibrary`)
 4. Init function location (`dlsym`/`GetProcAddress`)
-5. Init function execution
-6. Dispatch table registration via `nc_def_user_format()`
+5. Init function execution; the init function returns a pointer to the plugin's dispatch table
+6. The loader verifies the dispatch table ABI version and registers the table via `nc_def_user_format()`
 7. Plugin remains loaded for process lifetime
 
 # Dispatch Table Structure {#udf_dev_dispatch}
@@ -30,7 +30,7 @@ The `NC_Dispatch` structure is defined in `include/netcdf_dispatch.h`. It contai
 
 ```c
 typedef struct NC_Dispatch {
-    int model;              /* NC_FORMATX_UDF0 through NC_FORMATX_UDF9 */
+    int model;              /* NC_FORMATX_UDF(n) for slot n (0-63) */
     int dispatch_version;   /* Must be NC_DISPATCH_VERSION */
     
     /* Function pointers for all netCDF operations */
@@ -85,42 +85,39 @@ The initialization function is called when your plugin is loaded.
 ## Function Signature
 
 ```c
-int plugin_init(void);
+NC_Dispatch* plugin_init(void);
 ```
+
+The init function returns a pointer to the plugin's dispatch table. The plugin loader verifies the table's ABI version and registers it with `nc_def_user_format()`. The plugin does not register itself.
 
 ## Requirements
 
 1. Must be exported (not static)
-2. Must call `nc_def_user_format()` to register dispatch table
-3. Should return NC_NOERR on success, error code on failure
+2. Must return a pointer to a fully populated NC_Dispatch structure, or NULL on failure
+3. The dispatch table's `dispatch_version` field must be set to NC_DISPATCH_VERSION
 4. Name must match RC file INIT key
 
 ## Example Implementation
 
 ```c
 #include <netcdf.h>
+#include "netcdf_dispatch.h"
 
 /* Your dispatch table */
 extern NC_Dispatch my_dispatcher;
 
 /* Initialization function - must be exported */
-int my_plugin_init(void)
+NC_Dispatch* my_plugin_init(void)
 {
-    int ret;
-    
-    /* Register dispatch table with magic number */
-    ret = nc_def_user_format(NC_UDF0 | NC_NETCDF4, 
-                             &my_dispatcher,
-                             "MYFMT");
-    if (ret != NC_NOERR)
-        return ret;
-    
     /* Additional initialization if needed */
     /* ... */
-    
-    return NC_NOERR;
+
+    /* Return the dispatch table; the loader registers it. */
+    return &my_dispatcher;
 }
 ```
+
+When registering programmatically instead of through the RC-based loader, call `nc_def_user_format()` directly from your application code.
 
 # Implementing Dispatch Functions {#udf_dev_functions}
 
@@ -216,14 +213,20 @@ install(TARGETS myplugin LIBRARY DESTINATION lib)
 #include <assert.h>
 
 extern NC_Dispatch my_dispatcher;
-extern int my_plugin_init(void);
+extern NC_Dispatch* my_plugin_init(void);
 
 int main() {
     int ret;
+    NC_Dispatch *table;
     NC_Dispatch *disp;
     
     /* Test initialization */
-    ret = my_plugin_init();
+    table = my_plugin_init();
+    assert(table);
+    assert(table->dispatch_version == NC_DISPATCH_VERSION);
+    
+    /* Register, as the plugin loader would */
+    ret = nc_def_user_format(NC_UDF0, table, NULL);
     assert(ret == NC_NOERR);
     
     /* Verify registration */
@@ -341,11 +344,12 @@ gdb ./test_program
 
 # Example Plugin {#udf_dev_example}
 
-See `examples/C/udf_plugin_example/` for a complete working plugin implementation.
+See `nc_test4/tst_udf_self_load_plugin.c` for a complete working plugin that is built as a shared library and loaded through the RC-based loader by `nc_test4/tst_udf_self_load.c`.
 
 # Reference {#udf_dev_ref}
 
 - Dispatch table definition: `include/netcdf_dispatch.h`
 - Pre-defined functions: `libdispatch/dreadonly.c`, `libdispatch/dnotnc*.c`
 - Example implementations: `libhdf5/hdf5dispatch.c`, `libsrc/nc3dispatch.c`
-- Test plugins: `nc_test4/test_plugin_lib.c`
+- Plugin loader: `libdispatch/dudfplugins.c`
+- Test plugins: `nc_test4/tst_udf.c`, `nc_test4/tst_udf_multi.c`, `nc_test4/tst_udf_self_load_plugin.c`

--- a/docs/user_defined_formats.md
+++ b/docs/user_defined_formats.md
@@ -3,7 +3,7 @@ User-Defined Formats {#user_defined_formats}
 
 # Introduction {#udf_intro}
 
-NetCDF-C supports user-defined formats (UDFs) that allow developers to extend the library to work with custom file formats. The library provides 10 UDF slots (UDF0 through UDF9) that can be registered either programmatically or via RC file configuration.
+NetCDF-C supports user-defined formats (UDFs) that allow developers to extend the library to work with custom file formats. The library provides 64 UDF slots (0 through 63) that can be registered either programmatically or via RC file configuration.
 
 User-defined formats enable:
 - Support for proprietary or specialized file formats
@@ -11,14 +11,13 @@ User-defined formats enable:
 - Format translation and adaptation layers
 - Integration with domain-specific data formats
 
+The [NetCDF Expansion Pack (NEP)](https://github.com/Intelligent-Data-Design-Inc/NEP) is a working example of this feature. It uses UDF plugins to read GRIB2, FITS, GeoTIFF, PDS4, CDF, DICOM, and PDB files through the standard netCDF API. Consult its source for complete, production UDF dispatch tables and plugin initialization code.
+
 # Available UDF Slots {#udf_slots}
 
-The netCDF-C library provides 10 user-defined format slots:
+There are NC_MAX_UDF_FORMATS (64) slots, numbered 0 through 63. A UDF mode flag is built with the NC_UDF(n) macro: NC_UDF_FLAG (bit 6, 0x0040) marks the mode as user-defined, and the slot number is stored in a 6-bit field at bits 19-24 (NC_UDF_NUM_SHIFT/NC_UDF_NUM_MASK). The convenience macros NC_UDF0 through NC_UDF9 are equivalent to NC_UDF(0) through NC_UDF(9); NC_UDF0 keeps its historic value of 0x0040.
 
-- **UDF0** and **UDF1**: Original slots, mode flags in lower 16 bits
-- **UDF2** through **UDF9**: Extended slots, mode flags in upper 16 bits
-
-Each slot can be independently configured with its own dispatch table, initialization function, and optional magic number for automatic format detection.
+Each slot can be independently configured with its own dispatch table, initialization function, and optional magic number for automatic format detection. Because the slot number is a field rather than individual bits, only one UDF slot can be selected per mode; do not combine two NC_UDF(n) values with bitwise OR, as that produces the flag for a different slot.
 
 # Registering UDFs Programmatically {#udf_programmatic}
 
@@ -32,9 +31,11 @@ int nc_def_user_format(int mode_flag, NC_Dispatch *dispatch_table,
 ```
 
 **Parameters:**
-- `mode_flag`: One of NC_UDF0 through NC_UDF9, optionally combined with other mode flags (e.g., NC_NETCDF4)
+- `mode_flag`: NC_UDF(n) for slot n (0-63), optionally combined with other mode flags (e.g., NC_NETCDF4)
 - `dispatch_table`: Pointer to your dispatch table structure
 - `magic_number`: Optional magic number string (max NC_MAX_MAGIC_NUMBER_LEN bytes) for automatic format detection, or NULL
+
+A magic number cannot be registered with a netCDF-3 mode. Combining a magic number with NC_64BIT_OFFSET, NC_64BIT_DATA, or NC_CLASSIC_MODEL (without NC_NETCDF4) returns NC_EINVAL.
 
 **Example:**
 
@@ -89,7 +90,7 @@ Later files override earlier ones. Use `NCRCENV_HOME` to override the home direc
 
 ## RC File Format for UDFs
 
-For each UDF slot (0-9), configure these keys:
+For each UDF slot (0-63), configure these keys:
 
 ```
 NETCDF.UDF<N>.LIBRARY=<full-path-to-library>
@@ -130,10 +131,12 @@ Plugins are loaded during library initialization (`nc_initialize()`):
 2. For each configured UDF slot:
    - Library is loaded using dlopen (Unix) or LoadLibrary (Windows)
    - Init function is located using dlsym or GetProcAddress
-   - Init function is called
-   - Init function must call `nc_def_user_format()` to register the dispatch table
-3. Dispatch table ABI version is verified
-4. Magic number (if provided) is optionally verified
+   - Init function is called; it returns a pointer to the plugin's dispatch table
+   - The loader registers the returned dispatch table by calling `nc_def_user_format()`
+3. Dispatch table ABI version is verified against NC_DISPATCH_VERSION
+4. Magic number (if provided) is registered for automatic format detection
+
+A plugin that fails to load produces a log warning but does not prevent library initialization. The other slots load normally.
 
 **Note:** Library handles are intentionally not closed; they remain loaded for the lifetime of the process.
 
@@ -153,7 +156,7 @@ When `nc_open()` is called without a specific format flag:
 - Use unique, distinctive strings (4-8 bytes recommended)
 - Place at the beginning of your file format
 - Avoid conflicts with existing formats:
-  - NetCDF-3: "CDF\001" or "CDF\002"
+  - NetCDF-3: "CDF\001", "CDF\002", or "CDF\005"
   - HDF5: "\211HDF\r\n\032\n"
   - NetCDF-4: Same as HDF5
 - Maximum length: NC_MAX_MAGIC_NUMBER_LEN bytes
@@ -179,14 +182,14 @@ nc_open("mydata.dat", 0, &ncid);  /* No mode flag needed! */
 
 In addition to automatic detection by magic number, a file can be opened
 explicitly with a UDF mode flag. When `nc_open()` or `nc_create()` is called
-with one of `NC_UDF0` through `NC_UDF9`, the corresponding registered UDF
+with a `NC_UDF(n)` mode flag, the corresponding registered UDF
 dispatch table is used regardless of the file's actual contents. This makes it
 possible to read or write any other file through
 a custom dispatcher.
 
 The UDF mode flag can be combined with behavioral flags such as `NC_WRITE` or
 `NC_DISKLESS`, but it cannot be combined with other format-selection flags such
-as `NC_NETCDF4`, `NC_64BIT_OFFSET`, or another `NC_UDFx` flag. The selected UDF
+as `NC_NETCDF4` or `NC_64BIT_OFFSET`. The selected UDF
 slot must already have been registered, either programmatically with
 `nc_def_user_format()` or from an RC file; otherwise the open call will fail.
 
@@ -288,13 +291,13 @@ Common errors and solutions:
 
 ## Init function fails
 
-**Cause:** Plugin initialization error
+**Cause:** Plugin initialization error; init function returned NULL or a dispatch table with the wrong ABI version
 
-**Solution:** Check plugin logs; verify nc_def_user_format() is called correctly
+**Solution:** Check plugin logs; verify the init function returns a valid NC_Dispatch pointer with dispatch_version set to NC_DISPATCH_VERSION
 
 # Complete Example {#udf_example}
 
-See `examples/C/udf_example.c` for a complete working example of implementing a user-defined format.
+The test suite contains complete working examples. See `nc_test4/tst_udf.c` for programmatic registration, `nc_test4/tst_udf_multi.c` for use of all 10 slots at once, and `nc_test4/tst_udf_self_load_plugin.c` for a plugin loaded from an RC file.
 
 # Troubleshooting {#udf_troubleshooting}
 
@@ -351,10 +354,11 @@ int main() {
 - [Dispatch Table Architecture](dispatch.md) - Internal architecture
 - [UDF Plugin Development Guide](#udf_plugin_development) - Creating plugins
 - [RC File Reference](#auth_support) - RC file format details
+- [NetCDF Expansion Pack (NEP)](https://github.com/Intelligent-Data-Design-Inc/NEP) - Production UDF plugins for GRIB2, FITS, GeoTIFF, PDS4, CDF, DICOM, and PDB
 - API Reference: nc_def_user_format(), nc_inq_user_format()
 
 # References {#udf_references}
 
 - NetCDF-C Dispatch Layer: docs/dispatch.md
-- Example Implementation: examples/C/udf_example.c
+- Plugin Loader Implementation: libdispatch/dudfplugins.c
 - Test Suite: nc_test4/tst_udf*.c

--- a/include/nc.h
+++ b/include/nc.h
@@ -129,13 +129,22 @@ EXTERNL int NC_copy_data_all(NC* nc, nc_type xtypeid, const void* memory, size_t
 
 /* Macros to map NC_FORMAT_XX to metadata structure (e.g. NC_FILE_INFO_T) */
 /* Fast test for what file structure is used */
-#define NC3INFOFLAGS ((1<<NC_FORMATX_NC3)|(1<<NC_FORMATX_PNETCDF)|(1<<NC_FORMATX_DAP2))
-#define FILEINFOFLAGS ((1<<NC_FORMATX_NC_HDF5)|(1<<NC_FORMATX_NC_HDF4)|(1<<NC_FORMATX_DAP4)|(1<<NC_FORMATX_UDF1)|(1<<NC_FORMATX_UDF0)|(1<<NC_FORMATX_NCZARR))
 
-#define USENC3INFO(nc) ((1<<(nc->dispatch->model)) & NC3INFOFLAGS)
-#define USEFILEINFO(nc) ((1<<(nc->dispatch->model)) & FILEINFOFLAGS)
-#define USED2INFO(nc) ((1<<(nc->dispatch->model)) & (1<<NC_FORMATX_DAP2))
-#define USED4INFO(nc) ((1<<(nc->dispatch->model)) & (1<<NC_FORMATX_DAP4))
+/* Test whether a model constant is a UDF format constant. The UDF
+   constants form two ranges (NC_FORMATX_UDF0 to NC_FORMATX_UDF1, and
+   NC_FORMATX_UDF2 to NC_FORMATX_UDF_MAX) and can exceed 31, so they
+   must be tested by range: (1<<model) is undefined behavior for
+   model >= 31. All UDF formats use NC_FILE_INFO_T metadata. */
+#define UDFMODEL(model) (((model) >= NC_FORMATX_UDF0 && (model) <= NC_FORMATX_UDF1) \
+                         || ((model) >= NC_FORMATX_UDF2 && (model) <= NC_FORMATX_UDF_MAX))
+
+#define NC3INFOFLAGS ((1<<NC_FORMATX_NC3)|(1<<NC_FORMATX_PNETCDF)|(1<<NC_FORMATX_DAP2))
+#define FILEINFOFLAGS ((1<<NC_FORMATX_NC_HDF5)|(1<<NC_FORMATX_NC_HDF4)|(1<<NC_FORMATX_DAP4)|(1<<NC_FORMATX_NCZARR))
+
+#define USENC3INFO(nc) (!UDFMODEL((nc)->dispatch->model) && ((1<<((nc)->dispatch->model)) & NC3INFOFLAGS))
+#define USEFILEINFO(nc) (UDFMODEL((nc)->dispatch->model) || ((1<<((nc)->dispatch->model)) & FILEINFOFLAGS))
+#define USED2INFO(nc) (!UDFMODEL((nc)->dispatch->model) && ((1<<((nc)->dispatch->model)) & (1<<NC_FORMATX_DAP2)))
+#define USED4INFO(nc) (!UDFMODEL((nc)->dispatch->model) && ((1<<((nc)->dispatch->model)) & (1<<NC_FORMATX_DAP4)))
 
 /* In DAP4 and Zarr (and maybe other places in the future)
    we may have dimensions with a size, but no name.

--- a/include/netcdf.h
+++ b/include/netcdf.h
@@ -125,9 +125,13 @@ extern "C" {
 /* Define the ioflags bits for nc_create and nc_open.
    Currently unused in lower 16 bits:
         0x0002
-   All upper 16 bits are unused except
-        0x20000
-        0x40000
+        0x0080
+   Upper 16 bits used:
+        0x20000 (NC_NOATTCREORD)
+        0x40000 (NC_NODIMSCALE_ATTACH)
+        0x80000-0x1000000 (bits 19-24, UDF slot number field)
+   Free upper bits: 16, 25, 26-30. Bit 31 is the sign bit and must
+   not be used.
 */
 
 /* Lower 16 bits */
@@ -144,23 +148,31 @@ extern "C" {
 #define NC_CDF5          NC_64BIT_DATA  /**< Alias NC_CDF5 to NC_64BIT_DATA */
 
 /** @name User-Defined Format Mode Flags
- * Mode flags for user-defined formats (UDF0-UDF9).
+ * Mode flags for user-defined formats (UDF slots 0-63).
+ * A UDF mode is marked by NC_UDF_FLAG (bit 6); the slot number is
+ * held in a 6-bit field at bits 19-24. Use NC_UDF(n) to build the
+ * mode flag for slot n. The convenience macros NC_UDF0 through
+ * NC_UDF9 are retained; their values (except NC_UDF0) changed when
+ * the encoding changed from one bit per slot.
  * Use with nc_def_user_format() to register custom format handlers.
- * Can not be combined with other mode flags (e.g., NC_NETCDF4).
+ * Can not be combined with other format-selection flags (e.g.,
+ * NC_64BIT_OFFSET), except NC_NETCDF4.
  * See @ref user_defined_formats for details.
  * @{ */
-#define NC_UDF0          0x0040  /**< User-defined format 0 (bit 6). */
-#define NC_UDF1          0x0080  /**< User-defined format 1 (bit 7). */
-/* UDF2-UDF9 use bits 16, 19-25 (skipping bits 17-18 which are used by
- * NC_NOATTCREORD=0x20000 and NC_NODIMSCALE_ATTACH=0x40000) */
-#define NC_UDF2          0x10000  /**< User-defined format 2 (bit 16). */
-#define NC_UDF3          0x80000  /**< User-defined format 3 (bit 19). */
-#define NC_UDF4          0x100000  /**< User-defined format 4 (bit 20). */
-#define NC_UDF5          0x200000  /**< User-defined format 5 (bit 21). */
-#define NC_UDF6          0x400000  /**< User-defined format 6 (bit 22). */
-#define NC_UDF7          0x800000  /**< User-defined format 7 (bit 23). */
-#define NC_UDF8          0x1000000  /**< User-defined format 8 (bit 24). */
-#define NC_UDF9          0x2000000  /**< User-defined format 9 (bit 25). */
+#define NC_UDF_FLAG      0x0040 /**< Mode selects a user-defined format (bit 6). */
+#define NC_UDF_NUM_SHIFT 19     /**< Bit position of the UDF slot number field. */
+#define NC_UDF_NUM_MASK  0x3F   /**< 6-bit UDF slot number field: slots 0-63. */
+#define NC_UDF(n)        (NC_UDF_FLAG | ((n) << NC_UDF_NUM_SHIFT)) /**< Mode flag for UDF slot n (0-63). */
+#define NC_UDF0          NC_UDF(0) /**< User-defined format 0 (0x0040, value unchanged). */
+#define NC_UDF1          NC_UDF(1) /**< User-defined format 1. */
+#define NC_UDF2          NC_UDF(2) /**< User-defined format 2. */
+#define NC_UDF3          NC_UDF(3) /**< User-defined format 3. */
+#define NC_UDF4          NC_UDF(4) /**< User-defined format 4. */
+#define NC_UDF5          NC_UDF(5) /**< User-defined format 5. */
+#define NC_UDF6          NC_UDF(6) /**< User-defined format 6. */
+#define NC_UDF7          NC_UDF(7) /**< User-defined format 7. */
+#define NC_UDF8          NC_UDF(8) /**< User-defined format 8. */
+#define NC_UDF9          NC_UDF(9) /**< User-defined format 9. */
 /**@}*/
 
 #define NC_CLASSIC_MODEL 0x0100 /**< Enforce classic model on netCDF-4. Mode flag for nc_create(). */
@@ -193,10 +205,10 @@ Use this in mode flags for both nc_create() and nc_open(). */
 #define NC_NODIMSCALE_ATTACH 0x40000 /**< Disable the netcdf-4 (hdf5) attaching of dimscales to variables (#2128) */
 
 #define NC_MAX_MAGIC_NUMBER_LEN 8 /**< Max len of user-defined format magic number. */
-/** Maximum number of user-defined format slots (UDF0-UDF9).
+/** Maximum number of user-defined format slots (0-63).
  * @see nc_def_user_format(), nc_inq_user_format()
  * @see @ref user_defined_formats */
-#define NC_MAX_UDF_FORMATS 10
+#define NC_MAX_UDF_FORMATS 64
 
 /** Format specifier for nc_set_default_format() and returned
  *  by nc_inq_format. This returns the format as provided by
@@ -221,7 +233,7 @@ Use this in mode flags for both nc_create() and nc_open(). */
 #define NC_FORMAT_CDF5    NC_FORMAT_64BIT_DATA
 
 /* Define a mask covering format flags only */
-#define NC_FORMAT_ALL (NC_64BIT_OFFSET|NC_64BIT_DATA|NC_CLASSIC_MODEL|NC_NETCDF4|NC_UDF0|NC_UDF1|NC_UDF2|NC_UDF3|NC_UDF4|NC_UDF5|NC_UDF6|NC_UDF7|NC_UDF8|NC_UDF9)
+#define NC_FORMAT_ALL (NC_64BIT_OFFSET|NC_64BIT_DATA|NC_CLASSIC_MODEL|NC_NETCDF4|NC_UDF_FLAG|(NC_UDF_NUM_MASK << NC_UDF_NUM_SHIFT))
 
 /**@}*/
 
@@ -270,6 +282,10 @@ Use this in mode flags for both nc_create() and nc_open(). */
 #define NC_FORMATX_UDF7      (16) /**< User-defined format 7 */
 #define NC_FORMATX_UDF8      (17) /**< User-defined format 8 */
 #define NC_FORMATX_UDF9      (18) /**< User-defined format 9 */
+/** Format constant for UDF slot n (0-63). Slots 0-1 map to 8-9;
+ * slots 2-63 map to 11-72, skipping 10 (NC_FORMATX_NCZARR). */
+#define NC_FORMATX_UDF(n)    ((n) < 2 ? NC_FORMATX_UDF0 + (n) : NC_FORMATX_UDF2 + (n) - 2)
+#define NC_FORMATX_UDF_MAX   (NC_FORMATX_UDF2 + NC_MAX_UDF_FORMATS - 3) /**< Largest UDF format constant (72). */
 /**@}*/
 #define NC_FORMATX_UNDEFINED (0)
 

--- a/include/netcdf.h
+++ b/include/netcdf.h
@@ -165,14 +165,6 @@ extern "C" {
 #define NC_UDF(n)        (NC_UDF_FLAG | ((n) << NC_UDF_NUM_SHIFT)) /**< Mode flag for UDF slot n (0-63). */
 #define NC_UDF0          NC_UDF(0) /**< User-defined format 0 (0x0040, value unchanged). */
 #define NC_UDF1          NC_UDF(1) /**< User-defined format 1. */
-#define NC_UDF2          NC_UDF(2) /**< User-defined format 2. */
-#define NC_UDF3          NC_UDF(3) /**< User-defined format 3. */
-#define NC_UDF4          NC_UDF(4) /**< User-defined format 4. */
-#define NC_UDF5          NC_UDF(5) /**< User-defined format 5. */
-#define NC_UDF6          NC_UDF(6) /**< User-defined format 6. */
-#define NC_UDF7          NC_UDF(7) /**< User-defined format 7. */
-#define NC_UDF8          NC_UDF(8) /**< User-defined format 8. */
-#define NC_UDF9          NC_UDF(9) /**< User-defined format 9. */
 /**@}*/
 
 #define NC_CLASSIC_MODEL 0x0100 /**< Enforce classic model on netCDF-4. Mode flag for nc_create(). */

--- a/libdispatch/dfile.c
+++ b/libdispatch/dfile.c
@@ -45,51 +45,34 @@
 #endif
 
 
-/* User-defined formats - expanded from 2 to 10 slots.
- * These arrays store dispatch tables and magic numbers for up to 10 custom formats.
+/* User-defined formats - 64 slots.
+ * These arrays store dispatch tables and magic numbers for up to 64 custom formats.
  * Array-based design replaces the previous individual UDF0/UDF1 global variables. */
 NC_Dispatch *UDF_dispatch_tables[NC_MAX_UDF_FORMATS] = {NULL};
 char UDF_magic_numbers[NC_MAX_UDF_FORMATS][NC_MAX_MAGIC_NUMBER_LEN + 1] = {{0}};
 
-/** Helper function to convert NC_UDFn mode flag to array index (0-9).
- * @param mode_flag The mode flag (NC_UDF0 through NC_UDF9)
- * @return Array index 0-9, or -1 if not a valid UDF flag or multiple UDF flags set
- * @note UDF flags are not sequential in bit positions due to conflicts with
- *       NC_NOATTCREORD (0x20000) and NC_NODIMSCALE_ATTACH (0x40000) */
+/** Helper function to convert a UDF mode flag to array index (0-63).
+ * A UDF mode is marked by NC_UDF_FLAG; the slot number is held in a
+ * 6-bit field at NC_UDF_NUM_SHIFT. Build UDF modes with NC_UDF(n).
+ * @param mode_flag The mode flag, e.g. NC_UDF(3)
+ * @return Array index 0-63, or -1 if NC_UDF_FLAG is not set */
 static int udf_mode_to_index(int mode_flag) {
-    int count = 0;
-    int index = -1;
-    
-    /* Count how many UDF flags are set and remember the index */
-    if (fIsSet(mode_flag, NC_UDF0)) { count++; index = 0; }
-    if (fIsSet(mode_flag, NC_UDF1)) { count++; index = 1; }
-    if (fIsSet(mode_flag, NC_UDF2)) { count++; index = 2; }
-    if (fIsSet(mode_flag, NC_UDF3)) { count++; index = 3; }
-    if (fIsSet(mode_flag, NC_UDF4)) { count++; index = 4; }
-    if (fIsSet(mode_flag, NC_UDF5)) { count++; index = 5; }
-    if (fIsSet(mode_flag, NC_UDF6)) { count++; index = 6; }
-    if (fIsSet(mode_flag, NC_UDF7)) { count++; index = 7; }
-    if (fIsSet(mode_flag, NC_UDF8)) { count++; index = 8; }
-    if (fIsSet(mode_flag, NC_UDF9)) { count++; index = 9; }
-    
-    /* Only one UDF flag should be set at a time */
-    if (count != 1)
+    if (!fIsSet(mode_flag, NC_UDF_FLAG))
         return -1;
-    
-    return index;
+    return (mode_flag >> NC_UDF_NUM_SHIFT) & NC_UDF_NUM_MASK;
 }
 
-/** Helper function to convert NC_FORMATX_UDFn to array index (0-9).
- * @param formatx The format constant (NC_FORMATX_UDF0 through NC_FORMATX_UDF9)
- * @return Array index 0-9, or -1 if not a valid UDF format constant
+/** Helper function to convert NC_FORMATX_UDF(n) to array index (0-63).
+ * @param formatx The format constant (NC_FORMATX_UDF(0) through NC_FORMATX_UDF(63))
+ * @return Array index 0-63, or -1 if not a valid UDF format constant
  * @note Handles the gap in format numbering: UDF0=8, UDF1=9, UDF2=11, UDF3=12, etc.
  *       (NC_FORMATX_NCZARR=10 occupies the slot between UDF1 and UDF2) */
 static int udf_formatx_to_index(int formatx) {
     /* UDF0 and UDF1 are sequential (8, 9) */
     if (formatx >= NC_FORMATX_UDF0 && formatx <= NC_FORMATX_UDF1)
         return formatx - NC_FORMATX_UDF0;
-    /* UDF2-UDF9 start at 11 (skipping NCZARR at 10) */
-    if (formatx >= NC_FORMATX_UDF2 && formatx <= NC_FORMATX_UDF9)
+    /* UDF2-UDF63 start at 11 (skipping NCZARR at 10) */
+    if (formatx >= NC_FORMATX_UDF2 && formatx <= NC_FORMATX_UDF_MAX)
         return formatx - NC_FORMATX_UDF2 + 2;
     return -1;
 }
@@ -152,7 +135,7 @@ static int udf_formatx_to_index(int formatx) {
  * not match the current dispatch table version), then ::NC_EINVAL
  * will be returned.
  *
- * @param mode_flag NC_UDF0 or NC_UDF1
+ * @param mode_flag NC_UDF(n) for slot n (0-63).
  * @param dispatch_table Pointer to dispatch table to use for this user format.
  * @param magic_number Magic number used to identify file. Ignored if
  * NULL.
@@ -203,7 +186,7 @@ nc_def_user_format(int mode_flag, NC_Dispatch *dispatch_table, char *magic_numbe
 /**
  * Inquire about user-defined format.
  *
- * @param mode_flag NC_UDF0 or NC_UDF1
+ * @param mode_flag NC_UDF(n) for slot n (0-63).
  * 
  * @param dispatch_table Pointer that gets pointer to dispatch table to use for this user format, or NULL if this user-defined format is not defined. Ignored if NULL.
  * @param magic_number Pointer that gets magic number used to identify file, if one has been set. Magic number will be of max size NC_MAX_MAGIC_NUMBER_LEN. Ignored if NULL.
@@ -1936,34 +1919,6 @@ NC_create(const char *path0, int cmode, size_t initialsz,
         dispatcher = NCP_dispatch_table;
         break;
 #endif
-#ifdef USE_NETCDF4
-    case NC_FORMATX_UDF0:
-    case NC_FORMATX_UDF1:
-    case NC_FORMATX_UDF2:
-    case NC_FORMATX_UDF3:
-    case NC_FORMATX_UDF4:
-    case NC_FORMATX_UDF5:
-    case NC_FORMATX_UDF6:
-    case NC_FORMATX_UDF7:
-    case NC_FORMATX_UDF8:
-    case NC_FORMATX_UDF9:
-        {
-            /* Convert format constant to array index and validate */
-            int udf_index = udf_formatx_to_index(model.impl);
-            if (udf_index < 0 || udf_index >= NC_MAX_UDF_FORMATS) {
-                stat = NC_EINVAL;
-                goto done;
-            }
-            /* Get the dispatch table for this UDF slot */
-            dispatcher = UDF_dispatch_tables[udf_index];
-            /* Ensure the UDF format has been registered via nc_def_user_format() */
-            if (!dispatcher) {
-                stat = NC_ENOTBUILT;
-                goto done;
-            }
-        }
-        break;
-#endif /* USE_NETCDF4 */
 #ifdef NETCDF_ENABLE_NCZARR
     case NC_FORMATX_NCZARR:
         dispatcher = NCZ_dispatch_table;
@@ -1973,7 +1928,25 @@ NC_create(const char *path0, int cmode, size_t initialsz,
         dispatcher = NC3_dispatch_table;
         break;
     default:
-        {stat = NC_ENOTNC; goto done;}
+        {
+#ifdef USE_NETCDF4
+            /* UDF format constants are a range, so handle them here.
+             * Convert format constant to array index and validate. */
+            int udf_index = udf_formatx_to_index(model.impl);
+            if (udf_index >= 0) {
+                /* Get the dispatch table for this UDF slot */
+                dispatcher = UDF_dispatch_tables[udf_index];
+                /* Ensure the UDF format has been registered via nc_def_user_format() */
+                if (!dispatcher) {
+                    stat = NC_ENOTBUILT;
+                    goto done;
+                }
+                break;
+            }
+#endif /* USE_NETCDF4 */
+            stat = NC_ENOTNC;
+            goto done;
+        }
     }
 
     /* Create the NC* instance and insert its dispatcher and model */
@@ -2108,14 +2081,6 @@ NC_open(const char *path0, int omode, int basepe, size_t *chunksizehintp,
 #ifdef NETCDF_ENABLE_NCZARR
 	nczarrbuilt = 1;
 #endif
-        /* Check which UDF formats are built (i.e., have been registered).
-         * A UDF format is considered "built" if its dispatch table is non-NULL. */
-        int udfbuilt[NC_MAX_UDF_FORMATS] = {0};
-        for(int i = 0; i < NC_MAX_UDF_FORMATS; i++) {
-            if(UDF_dispatch_tables[i] != NULL)
-                udfbuilt[i] = 1;
-        }
-
         if(!hdf5built && model.impl == NC_FORMATX_NC4)
         {stat = NC_ENOTBUILT; goto done;}
         if(!hdf4built && model.impl == NC_FORMATX_NC_HDF4)
@@ -2124,11 +2089,11 @@ NC_open(const char *path0, int omode, int basepe, size_t *chunksizehintp,
         {stat = NC_ENOTBUILT; goto done;}
 	if(!nczarrbuilt && model.impl == NC_FORMATX_NCZARR)
         {stat = NC_ENOTBUILT; goto done;}
-        /* Check all UDF formats - ensure the requested format has been registered */
-        for(int i = 0; i < NC_MAX_UDF_FORMATS; i++) {
-            /* Convert array index to format constant (handles gap: UDF0=8, UDF1=9, UDF2=11...) */
-            int formatx = (i <= 1) ? (NC_FORMATX_UDF0 + i) : (NC_FORMATX_UDF2 + i - 2);
-            if(!udfbuilt[i] && model.impl == formatx)
+        /* If the model is a UDF format, ensure it has been registered.
+         * A UDF format is considered "built" if its dispatch table is non-NULL. */
+        {
+            int udf_index = udf_formatx_to_index(model.impl);
+            if(udf_index >= 0 && UDF_dispatch_tables[udf_index] == NULL)
                 {stat = NC_ENOTBUILT; goto done;}
         }
     }
@@ -2155,18 +2120,17 @@ NC_open(const char *path0, int omode, int basepe, size_t *chunksizehintp,
 		| (1<<NC_FORMATX_PNETCDF)
 #endif
 		; /* end of the built flags */
-        /* Add UDF formats to built flags - set bit for each registered UDF format.
-         * Use unsigned literal (1U) to avoid integer overflow for higher bit positions. */
-        for(int i = 0; i < NC_MAX_UDF_FORMATS; i++) {
-            if(UDF_dispatch_tables[i] != NULL) {
-                /* Convert array index to format constant */
-                int formatx = (i <= 1) ? (NC_FORMATX_UDF0 + i) : (NC_FORMATX_UDF2 + i - 2);
-                built |= (1U << formatx);
-            }
+        /* Verify the requested format is available. UDF format constants
+         * can exceed 31, so they cannot be checked with a bitmask; a UDF
+         * format is available iff its dispatch table is registered. */
+        {
+            int udf_index = udf_formatx_to_index(model.impl);
+            if(udf_index >= 0) {
+                if(UDF_dispatch_tables[udf_index] == NULL)
+                    {stat = NC_ENOTBUILT; goto done;}
+            } else if((built & (1U << model.impl)) == 0)
+                {stat = NC_ENOTBUILT; goto done;}
         }
-	/* Verify the requested format is available */
-	if((built & (1U << model.impl)) == 0)
-            {stat = NC_ENOTBUILT; goto done;}
 #ifndef NETCDF_ENABLE_CDF5
 	/* Special case because there is no separate CDF5 dispatcher */
         if(model.impl == NC_FORMATX_NC3 && (omode & NC_64BIT_DATA))
@@ -2207,40 +2171,29 @@ NC_open(const char *path0, int omode, int basepe, size_t *chunksizehintp,
             dispatcher = HDF4_dispatch_table;
             break;
 #endif
-#ifdef USE_NETCDF4
-        case NC_FORMATX_UDF0:
-        case NC_FORMATX_UDF1:
-        case NC_FORMATX_UDF2:
-        case NC_FORMATX_UDF3:
-        case NC_FORMATX_UDF4:
-        case NC_FORMATX_UDF5:
-        case NC_FORMATX_UDF6:
-        case NC_FORMATX_UDF7:
-        case NC_FORMATX_UDF8:
-        case NC_FORMATX_UDF9:
-            {
-                /* Convert format constant to array index and validate */
-                int udf_index = udf_formatx_to_index(model.impl);
-                if (udf_index < 0 || udf_index >= NC_MAX_UDF_FORMATS) {
-                    stat = NC_EINVAL;
-                    goto done;
-                }
-                /* Get the dispatch table for this UDF slot */
-                dispatcher = UDF_dispatch_tables[udf_index];
-                /* Ensure the UDF format has been registered via nc_def_user_format() */
-                if (!dispatcher) {
-                    stat = NC_ENOTBUILT;
-                    goto done;
-                }
-            }
-            break;
-#endif /* USE_NETCDF4 */
         case NC_FORMATX_NC3:
             dispatcher = NC3_dispatch_table;
             break;
         default:
-            stat = NC_ENOTNC;
-	    goto done;
+            {
+#ifdef USE_NETCDF4
+                /* UDF format constants are a range, so handle them here.
+                 * Convert format constant to array index and validate. */
+                int udf_index = udf_formatx_to_index(model.impl);
+                if (udf_index >= 0) {
+                    /* Get the dispatch table for this UDF slot */
+                    dispatcher = UDF_dispatch_tables[udf_index];
+                    /* Ensure the UDF format has been registered via nc_def_user_format() */
+                    if (!dispatcher) {
+                        stat = NC_ENOTBUILT;
+                        goto done;
+                    }
+                    break;
+                }
+#endif /* USE_NETCDF4 */
+                stat = NC_ENOTNC;
+                goto done;
+            }
         }
     }
 

--- a/libdispatch/dfile.c
+++ b/libdispatch/dfile.c
@@ -55,9 +55,16 @@ char UDF_magic_numbers[NC_MAX_UDF_FORMATS][NC_MAX_MAGIC_NUMBER_LEN + 1] = {{0}};
  * A UDF mode is marked by NC_UDF_FLAG; the slot number is held in a
  * 6-bit field at NC_UDF_NUM_SHIFT. Build UDF modes with NC_UDF(n).
  * @param mode_flag The mode flag, e.g. NC_UDF(3)
- * @return Array index 0-63, or -1 if NC_UDF_FLAG is not set */
+ * @return Array index 0-63, or -1 if NC_UDF_FLAG is not set or the
+ * mode has bits set above the slot number field (as produced by
+ * NC_UDF(n) with n outside 0-63) */
 static int udf_mode_to_index(int mode_flag) {
     if (!fIsSet(mode_flag, NC_UDF_FLAG))
+        return -1;
+    /* Reject modes with bits set above the slot number field. These
+     * result from NC_UDF(n) with n outside 0-63 and must not be
+     * silently aliased to a valid slot. */
+    if (mode_flag & ~((1 << (NC_UDF_NUM_SHIFT + 6)) - 1))
         return -1;
     return (mode_flag >> NC_UDF_NUM_SHIFT) & NC_UDF_NUM_MASK;
 }

--- a/libdispatch/dinfermodel.c
+++ b/libdispatch/dinfermodel.c
@@ -123,16 +123,7 @@ static struct FORMATMODES {
 {"classic",NC_FORMATX_NC3,0}, /* ditto */
 {"netcdf-4",NC_FORMATX_NC4,NC_FORMAT_NETCDF4},
 {"enhanced",NC_FORMATX_NC4,NC_FORMAT_NETCDF4},
-{"udf0",NC_FORMATX_UDF0,0},
-{"udf1",NC_FORMATX_UDF1,0},
-{"udf2",NC_FORMATX_UDF2,0},
-{"udf3",NC_FORMATX_UDF3,0},
-{"udf4",NC_FORMATX_UDF4,0},
-{"udf5",NC_FORMATX_UDF5,0},
-{"udf6",NC_FORMATX_UDF6,0},
-{"udf7",NC_FORMATX_UDF7,0},
-{"udf8",NC_FORMATX_UDF8,0},
-{"udf9",NC_FORMATX_UDF9,0},
+/* "udf<N>" mode names are handled generically in processmodearg() */
 {"nczarr",NC_FORMATX_NCZARR,NC_FORMAT_NETCDF4},
 {"zarr",NC_FORMATX_NCZARR,NC_FORMAT_NETCDF4},
 {"bytes",NC_FORMATX_NC4,NC_FORMAT_NETCDF4}, /* temporary until 3 vs 4 is determined */
@@ -185,7 +176,8 @@ static const struct MODEINFER modenegations[] = {
 {NULL,NULL}
 };
 
-/* Map FORMATX to readability to get magic number */
+/* Map FORMATX to readability to get magic number.
+ * UDF formats (all readable) are handled generically in isreadable(). */
 static struct Readable {
     int impl;
     int readable;
@@ -196,19 +188,19 @@ static struct Readable {
 {NC_FORMATX_PNETCDF,1},
 {NC_FORMATX_DAP2,0},
 {NC_FORMATX_DAP4,0},
-{NC_FORMATX_UDF0,1},
-{NC_FORMATX_UDF1,1},
-{NC_FORMATX_UDF2,1},
-{NC_FORMATX_UDF3,1},
-{NC_FORMATX_UDF4,1},
-{NC_FORMATX_UDF5,1},
-{NC_FORMATX_UDF6,1},
-{NC_FORMATX_UDF7,1},
-{NC_FORMATX_UDF8,1},
-{NC_FORMATX_UDF9,1},
 {NC_FORMATX_NCZARR,0}, /* eventually make readable */
 {0,0},
 };
+
+/* Return 1 if impl is a UDF format constant (NC_FORMATX_UDF(n) for
+ * n in 0..NC_MAX_UDF_FORMATS-1), else 0. Note the gap in numbering:
+ * NC_FORMATX_NCZARR=10 sits between UDF1=9 and UDF2=11. */
+static int
+udfimpl(int impl)
+{
+    return (impl >= NC_FORMATX_UDF0 && impl <= NC_FORMATX_UDF1)
+        || (impl >= NC_FORMATX_UDF2 && impl <= NC_FORMATX_UDF_MAX);
+}
 
 /* Define the known URL protocols and their interpretation */
 static struct NCPROTOCOLLIST {
@@ -454,6 +446,15 @@ processmodearg(const char* arg, NCmodel* model)
 {
     int stat = NC_NOERR;
     struct FORMATMODES* format = formatmodes;
+    /* Handle "udf<N>" mode names generically for all UDF slots */
+    if(strncmp(arg,"udf",3)==0) {
+        char* endp = NULL;
+        long n = strtol(arg+3,&endp,10);
+        if(endp != arg+3 && *endp == '\0' && n >= 0 && n < NC_MAX_UDF_FORMATS) {
+            model->impl = NC_FORMATX_UDF((int)n);
+            return check(stat);
+        }
+    }
     for(;format->tag;format++) {
 	if(strcmp(format->tag,arg)==0) {
             model->impl = format->impl;
@@ -758,24 +759,13 @@ NC_omodeinfer(int useparallel, int cmode, NCmodel* model)
     /* Process the cmode; may override some already set flags. The
      * user-defined formats must be checked first. They may choose to
      * use some of the other flags, like NC_NETCDF4, so we must first
-     * check NC_UDF0-NC_UDF9 before checking for any other flag. */
+     * check NC_UDF_FLAG before checking for any other flag. */
     int udf_found = 0;
-    /* Lookup table for all UDF mode flags. This replaces the previous bit-shift
-     * calculation which was fragile due to non-sequential bit positions
-     * (bits 16, 19-25 to avoid conflicts with NC_NOATTCREORD and NC_NODIMSCALE_ATTACH). */
-    static const int udf_flags[NC_MAX_UDF_FORMATS] = {
-        NC_UDF0, NC_UDF1, NC_UDF2, NC_UDF3, NC_UDF4,
-        NC_UDF5, NC_UDF6, NC_UDF7, NC_UDF8, NC_UDF9
-    };
-    /* Check if any UDF format flag is set in the mode */
-    for(int i = 0; i < NC_MAX_UDF_FORMATS; i++) {
-        if(fIsSet(cmode, udf_flags[i])) {
-            /* Convert array index to format constant (handles gap in numbering) */
-            int formatx = (i <= 1) ? (NC_FORMATX_UDF0 + i) : (NC_FORMATX_UDF2 + i - 2);
-            model->impl = formatx;
-            udf_found = 1;
-            break;
-        }
+    if(fIsSet(cmode, NC_UDF_FLAG)) {
+        /* Extract the UDF slot number and convert to format constant */
+        int udf_index = (cmode >> NC_UDF_NUM_SHIFT) & NC_UDF_NUM_MASK;
+        model->impl = NC_FORMATX_UDF(udf_index);
+        udf_found = 1;
     }
     
     if(udf_found)
@@ -1049,26 +1039,19 @@ NC_infermodel(const char* path, int* omodep, int iscreate, int useparallel, void
     case NC_FORMATX_DAP2:
 	omode &= ~(NC_NETCDF4|NC_64BIT_OFFSET|NC_64BIT_DATA|NC_CLASSIC_MODEL);
 	break;
-    case NC_FORMATX_UDF0:
-    case NC_FORMATX_UDF1:
-    case NC_FORMATX_UDF2:
-    case NC_FORMATX_UDF3:
-    case NC_FORMATX_UDF4:
-    case NC_FORMATX_UDF5:
-    case NC_FORMATX_UDF6:
-    case NC_FORMATX_UDF7:
-    case NC_FORMATX_UDF8:
-    case NC_FORMATX_UDF9:
-        if(model->format == NC_FORMAT_64BIT_OFFSET) 
-            omode |= NC_64BIT_OFFSET;
-        else if(model->format == NC_FORMAT_64BIT_DATA)
-            omode |= NC_64BIT_DATA;
-        else if(model->format == NC_FORMAT_NETCDF4)  
-            omode |= NC_NETCDF4;
-        else if(model->format == NC_FORMAT_NETCDF4_CLASSIC)  
-            omode |= NC_NETCDF4|NC_CLASSIC_MODEL;
-        break;
     default:
+        /* UDF format constants are a range, so handle them here */
+        if(udfimpl(model->impl)) {
+            if(model->format == NC_FORMAT_64BIT_OFFSET) 
+                omode |= NC_64BIT_OFFSET;
+            else if(model->format == NC_FORMAT_64BIT_DATA)
+                omode |= NC_64BIT_DATA;
+            else if(model->format == NC_FORMAT_NETCDF4)  
+                omode |= NC_NETCDF4;
+            else if(model->format == NC_FORMAT_NETCDF4_CLASSIC)  
+                omode |= NC_NETCDF4|NC_CLASSIC_MODEL;
+            break;
+        }
 	{stat = NC_ENOTNC; goto done;}
     }
 
@@ -1088,6 +1071,9 @@ isreadable(NCURI* uri, NCmodel* model)
 {
     int canread = 0;
     struct Readable* r;
+    /* All UDF formats are readable */
+    if(udfimpl(model->impl))
+        return 1;
     /* Step 1: Look up the implementation */
     for(r=readable;r->impl;r++) {
 	if(model->impl == r->impl) {canread = r->readable; break;}
@@ -1522,9 +1508,7 @@ NC_interpret_magic_number(char* magic, NCmodel* model)
     int status = NC_NOERR;
     int tmpimpl = 0;
     /* Look at the magic number - save any UDF format on entry */
-    if(model->impl >= NC_FORMATX_UDF0 && model->impl <= NC_FORMATX_UDF1)
-        tmpimpl = model->impl;
-    else if(model->impl >= NC_FORMATX_UDF2 && model->impl <= NC_FORMATX_UDF9)
+    if(udfimpl(model->impl))
         tmpimpl = model->impl;
 
     /* Use the complete magic number string for HDF5 */
@@ -1563,7 +1547,7 @@ NC_interpret_magic_number(char* magic, NCmodel* model)
      goto done;
 
 done:
-     /* if model->impl was any UDF format (0-9) on entry, make it so on exit */
+     /* if model->impl was any UDF format on entry, make it so on exit */
      if(tmpimpl)
          model->impl = tmpimpl;
      /* if this is a UDF magic_number update the model->impl */
@@ -1571,8 +1555,7 @@ done:
          if (strlen(UDF_magic_numbers[i]) && !strncmp(UDF_magic_numbers[i], magic,
                                                        strlen(UDF_magic_numbers[i])))
          {
-             int formatx = (i <= 1) ? (NC_FORMATX_UDF0 + i) : (NC_FORMATX_UDF2 + i - 2);
-             model->impl = formatx;
+             model->impl = NC_FORMATX_UDF(i);
              model->format = NC_FORMAT_NETCDF4;
              status = NC_NOERR;
              break;

--- a/libdispatch/dudfplugins.c
+++ b/libdispatch/dudfplugins.c
@@ -90,7 +90,7 @@ get_symbol(void* handle, const char* symbol)
 /**
  * Load a single UDF plugin library and call its initialization function.
  *
- * @param udf_number UDF slot number (0-9).
+ * @param udf_number UDF slot number (0 to NC_MAX_UDF_FORMATS - 1).
  * @param library_path Full path to the plugin library.
  * @param init_func Name of the initialization function.
  * @param magic Optional magic number string (can be NULL).
@@ -111,15 +111,8 @@ load_udf_plugin(int udf_number, const char* library_path,
     char magic_check[NC_MAX_MAGIC_NUMBER_LEN + 1];
 #endif
     
-    /* Determine mode flag from UDF number.
-     * Use explicit array to avoid bit-collision bugs from shifting. */
-    {
-        int udf_flags[NC_MAX_UDF_FORMATS] = {
-            NC_UDF0, NC_UDF1, NC_UDF2, NC_UDF3, NC_UDF4,
-            NC_UDF5, NC_UDF6, NC_UDF7, NC_UDF8, NC_UDF9
-        };
-        mode_flag = udf_flags[udf_number];
-    }
+    /* Determine mode flag from UDF number. */
+    mode_flag = NC_UDF(udf_number);
     
     /* Load the library */
     handle = load_library(library_path);
@@ -225,9 +218,9 @@ done:
 /**
  * Load and initialize all UDF plugins from RC file configuration.
  *
- * This function loops through all 10 UDF slots (0-9) and checks for
- * corresponding RC file entries. If both LIBRARY and INIT keys are
- * present for a slot, it attempts to load that plugin.
+ * This function loops through all NC_MAX_UDF_FORMATS UDF slots and
+ * checks for corresponding RC file entries. If both LIBRARY and INIT
+ * keys are present for a slot, it attempts to load that plugin.
  *
  * @return NC_NOERR (always succeeds, even if plugins fail to load).
  *
@@ -239,7 +232,7 @@ NC_udf_load_plugins(void)
 {
     int stat = NC_NOERR;
     
-    /* Loop through all 10 UDF slots */
+    /* Loop through all UDF slots */
     for (int i = 0; i < NC_MAX_UDF_FORMATS; i++) {
         char key_lib[64], key_init[64], key_magic[64];
         const char* lib = NULL;

--- a/libsrc4/nc4dispatch.c
+++ b/libsrc4/nc4dispatch.c
@@ -51,7 +51,7 @@ NC4_initialize(void)
 #ifdef USE_UDF1
     /* If user-defined format 0 was specified during configure, set up
      * it's dispatch table. */
-    if ((ret = nc_def_user_format(NC_UDF1F, &UDF1_DISPATCH_FUNC, NULL)))
+    if ((ret = nc_def_user_format(NC_UDF1, &UDF1_DISPATCH_FUNC, NULL)))
         return ret;
 #endif /* USE_UDF0 */
 

--- a/nc_test4/tst_udf.c
+++ b/nc_test4/tst_udf.c
@@ -316,6 +316,14 @@ main(int argc, char **argv)
                                magic_number) != NC_EINVAL) ERR;
         if (nc_def_user_format(NC_UDF(0) | NC_64BIT_DATA, &tst_dispatcher,
                                magic_number) != NC_EINVAL) ERR;
+
+        /* An out-of-range slot number must be rejected, not silently
+         * aliased to a valid slot. NC_UDF(64) would alias slot 0 and
+         * NC_UDF(70) would alias slot 6 if the overflow bits above the
+         * slot number field were ignored. */
+        if (nc_def_user_format(NC_UDF(64), &tst_dispatcher, NULL) != NC_EINVAL) ERR;
+        if (nc_def_user_format(NC_UDF(70), &tst_dispatcher, NULL) != NC_EINVAL) ERR;
+        if (nc_inq_user_format(NC_UDF(64), NULL, NULL) != NC_EINVAL) ERR;
     }
     SUMMARIZE_ERR;
     printf("*** testing self-registration init pattern (returns NC_Dispatch*)...");

--- a/nc_test4/tst_udf.c
+++ b/nc_test4/tst_udf.c
@@ -309,6 +309,13 @@ main(int argc, char **argv)
             if (nc_def_user_format(NC_CLASSIC_MODEL, &tst_dispatcher, 
                                    magic_number) != NC_EINVAL) ERR;
         }
+
+        /* A UDF mode combined with a netcdf3 flag and a magic number is
+         * rejected, for any slot including the highest one. */
+        if (nc_def_user_format(NC_UDF(63) | NC_64BIT_OFFSET, &tst_dispatcher,
+                               magic_number) != NC_EINVAL) ERR;
+        if (nc_def_user_format(NC_UDF(0) | NC_64BIT_DATA, &tst_dispatcher,
+                               magic_number) != NC_EINVAL) ERR;
     }
     SUMMARIZE_ERR;
     printf("*** testing self-registration init pattern (returns NC_Dispatch*)...");

--- a/nc_test4/tst_udf_multi.c
+++ b/nc_test4/tst_udf_multi.c
@@ -2,9 +2,11 @@
    Corporation for Atmospheric Research/Unidata. See COPYRIGHT file
    for conditions of use.
 
-   Test that all 10 UDF (User-Defined Format) slots can be used
-   simultaneously. This test verifies the fix for GitHub issue #3372,
-   where UDF code only allowed 2 UDF layers instead of 10.
+   Test that all NC_MAX_UDF_FORMATS UDF (User-Defined Format) slots
+   can be used simultaneously. This test originally verified the fix
+   for GitHub issue #3372, where UDF code only allowed 2 UDF layers;
+   it now also verifies the flag-plus-number mode encoding that
+   provides 64 slots.
 
    Ed Hartnett
 */
@@ -20,31 +22,18 @@
 
 #define FILE_NAME "tst_udf_multi.nc"
 
-/* Each UDF slot gets a unique return code for identification */
-#define UDF0_RETURN 100
-#define UDF1_RETURN 101
-#define UDF2_RETURN 102
-#define UDF3_RETURN 103
-#define UDF4_RETURN 104
-#define UDF5_RETURN 105
-#define UDF6_RETURN 106
-#define UDF7_RETURN 107
-#define UDF8_RETURN 108
-#define UDF9_RETURN 109
+/* Each UDF slot gets a unique return code for identification:
+ * UDF_RETURN_BASE + slot number. */
+#define UDF_RETURN_BASE 100
 
-/* Mode flags for each UDF */
-int udf_modes[NC_MAX_UDF_FORMATS] = {
-    NC_UDF0, NC_UDF1, NC_UDF2, NC_UDF3, NC_UDF4,
-    NC_UDF5, NC_UDF6, NC_UDF7, NC_UDF8, NC_UDF9
-};
+/* Mode flags for each UDF; filled in by init_dispatchers() */
+int udf_modes[NC_MAX_UDF_FORMATS];
 
-/* Expected return codes from each UDF's inq_format function */
-int udf_returns[NC_MAX_UDF_FORMATS] = {
-    UDF0_RETURN, UDF1_RETURN, UDF2_RETURN, UDF3_RETURN, UDF4_RETURN,
-    UDF5_RETURN, UDF6_RETURN, UDF7_RETURN, UDF8_RETURN, UDF9_RETURN
-};
+/* Expected return codes from each UDF's inq_format function;
+ * filled in by init_dispatchers() */
+int udf_returns[NC_MAX_UDF_FORMATS];
 
-/* 10 dispatch tables, one for each UDF slot */
+/* One dispatch table for each UDF slot */
 static NC_Dispatch udf_dispatchers[NC_MAX_UDF_FORMATS];
 
 /* Simple open function that always succeeds */
@@ -70,65 +59,32 @@ tst_get_vara(int ncid, int varid, const size_t *start, const size_t *count,
     return NC_NOERR;
 }
 
-/* inq_format returns unique code per UDF for identification */
-static int
-tst_inq_format_udf0(int ncid, int *formatp)
-{
-    return UDF0_RETURN;
-}
-static int
-tst_inq_format_udf1(int ncid, int *formatp)
-{
-    return UDF1_RETURN;
-}
-static int
-tst_inq_format_udf2(int ncid, int *formatp)
-{
-    return UDF2_RETURN;
-}
-static int
-tst_inq_format_udf3(int ncid, int *formatp)
-{
-    return UDF3_RETURN;
-}
-static int
-tst_inq_format_udf4(int ncid, int *formatp)
-{
-    return UDF4_RETURN;
-}
-static int
-tst_inq_format_udf5(int ncid, int *formatp)
-{
-    return UDF5_RETURN;
-}
-static int
-tst_inq_format_udf6(int ncid, int *formatp)
-{
-    return UDF6_RETURN;
-}
-static int
-tst_inq_format_udf7(int ncid, int *formatp)
-{
-    return UDF7_RETURN;
-}
-static int
-tst_inq_format_udf8(int ncid, int *formatp)
-{
-    return UDF8_RETURN;
-}
-static int
-tst_inq_format_udf9(int ncid, int *formatp)
-{
-    return UDF9_RETURN;
-}
+/* inq_format returns unique code per UDF for identification.
+ * One function is generated per slot with a macro. */
+#define DEFINE_INQ_FORMAT(N)                        \
+    static int                                      \
+    tst_inq_format_udf##N(int ncid, int *formatp)   \
+    {                                               \
+        return UDF_RETURN_BASE + N;                 \
+    }
+
+#define UDF_SLOT_LIST(X)                                        \
+    X(0)  X(1)  X(2)  X(3)  X(4)  X(5)  X(6)  X(7)              \
+    X(8)  X(9)  X(10) X(11) X(12) X(13) X(14) X(15)             \
+    X(16) X(17) X(18) X(19) X(20) X(21) X(22) X(23)             \
+    X(24) X(25) X(26) X(27) X(28) X(29) X(30) X(31)             \
+    X(32) X(33) X(34) X(35) X(36) X(37) X(38) X(39)             \
+    X(40) X(41) X(42) X(43) X(44) X(45) X(46) X(47)             \
+    X(48) X(49) X(50) X(51) X(52) X(53) X(54) X(55)             \
+    X(56) X(57) X(58) X(59) X(60) X(61) X(62) X(63)
+
+UDF_SLOT_LIST(DEFINE_INQ_FORMAT)
 
 /* Array of function pointers for each UDF's inq_format */
 typedef int (*inq_format_func)(int, int*);
+#define INQ_FORMAT_ENTRY(N) tst_inq_format_udf##N,
 static inq_format_func udf_inq_formats[NC_MAX_UDF_FORMATS] = {
-    tst_inq_format_udf0, tst_inq_format_udf1, tst_inq_format_udf2,
-    tst_inq_format_udf3, tst_inq_format_udf4, tst_inq_format_udf5,
-    tst_inq_format_udf6, tst_inq_format_udf7, tst_inq_format_udf8,
-    tst_inq_format_udf9
+    UDF_SLOT_LIST(INQ_FORMAT_ENTRY)
 };
 
 #ifdef _MSC_VER
@@ -141,7 +97,7 @@ NC4_no_show_metadata(int ncid)
 #endif
 
 
-/* Initialize all 10 dispatch tables */
+/* Initialize all dispatch tables */
 static void
 init_dispatchers(void)
 {
@@ -152,12 +108,9 @@ init_dispatchers(void)
 
         memset(dsp, 0, sizeof(NC_Dispatch));
 
-        /* UDF0 and UDF1 use NC_FORMATX_UDF0 and NC_FORMATX_UDF1
-         * UDF2-UDF9 start at NC_FORMATX_UDF2 */
-        if (i <= 1)
-            dsp->model = NC_FORMATX_UDF0 + i;
-        else
-            dsp->model = NC_FORMATX_UDF2 + i - 2;
+        udf_modes[i] = NC_UDF(i);
+        udf_returns[i] = UDF_RETURN_BASE + i;
+        dsp->model = NC_FORMATX_UDF(i);
 
         dsp->dispatch_version = NC_DISPATCH_VERSION;
         dsp->create = NC_RO_create;
@@ -254,20 +207,21 @@ main(int argc, char **argv)
 
     init_dispatchers();
 
-    printf("\n*** Testing all 10 UDF slots can be used simultaneously.\n");
+    printf("\n*** Testing all %d UDF slots can be used simultaneously.\n",
+           NC_MAX_UDF_FORMATS);
 
-    printf("*** testing all 10 UDF slots can be registered...");
+    printf("*** testing all %d UDF slots can be registered...", NC_MAX_UDF_FORMATS);
     {
         /* Create an empty file to play with */
         if (nc_create(FILE_NAME, 0, &ncid)) ERR;
         if (nc_close(ncid)) ERR;
 
-        /* Register all 10 UDF formats */
+        /* Register all UDF formats */
         for (i = 0; i < NC_MAX_UDF_FORMATS; i++) {
             if (nc_def_user_format(udf_modes[i], &udf_dispatchers[i], NULL)) ERR;
         }
 
-        /* Verify all 10 were registered correctly */
+        /* Verify all were registered correctly */
         for (i = 0; i < NC_MAX_UDF_FORMATS; i++) {
             NC_Dispatch *disp_in;
             if (nc_inq_user_format(udf_modes[i], &disp_in, NULL)) ERR;
@@ -312,34 +266,34 @@ main(int argc, char **argv)
     }
     SUMMARIZE_ERR;
 
-    printf("*** testing UDF mode flags don't collide with other flags...");
+    printf("*** testing UDF mode encoding...");
     {
-        /* Verify that NC_UDF2 through NC_UDF9 don't share bits with
-         * important mode flags like NC_NOATTCREORD (0x20000) and
-         * NC_NODIMSCALE_ATTACH (0x40000). This was the root cause of
-         * GitHub issue #3372. */
+        /* Verify the flag-plus-number encoding. The slot number field
+         * must not collide with mode flags that may legally combine
+         * with a UDF open, such as NC_NOATTCREORD (0x20000) and
+         * NC_NODIMSCALE_ATTACH (0x40000). Bit collisions with these
+         * flags were the root cause of GitHub issue #3372. */
+        int critical_flags = NC_NOATTCREORD | NC_NODIMSCALE_ATTACH | NC_NETCDF4;
 
-        /* These flags should not overlap with UDF flags */
-        int critical_flags = NC_NOATTCREORD | NC_NODIMSCALE_ATTACH;
+        /* NC_UDF0 must keep its historic value. */
+        if (NC_UDF0 != 0x0040) ERR;
 
-        for (i = 2; i < NC_MAX_UDF_FORMATS; i++) {
-            /* UDF2+ should not share bits with critical flags */
+        for (i = 0; i < NC_MAX_UDF_FORMATS; i++) {
+            /* Every UDF mode must have the UDF flag set. */
+            if (!(udf_modes[i] & NC_UDF_FLAG)) ERR;
+
+            /* The slot number must round-trip through the field. */
+            if (((udf_modes[i] >> NC_UDF_NUM_SHIFT) & NC_UDF_NUM_MASK) != i) {
+                fprintf(stderr, "UDF%d (0x%x): slot number does not round-trip\n",
+                        i, udf_modes[i]);
+                ERR;
+            }
+
+            /* The encoding must not collide with combinable flags. */
             if (udf_modes[i] & critical_flags) {
                 fprintf(stderr, "UDF%d (0x%x) collides with critical flags\n",
                         i, udf_modes[i]);
                 ERR;
-            }
-        }
-
-        /* Also verify no two UDF flags share bits */
-        for (i = 0; i < NC_MAX_UDF_FORMATS; i++) {
-            int j;
-            for (j = i + 1; j < NC_MAX_UDF_FORMATS; j++) {
-                if (udf_modes[i] & udf_modes[j]) {
-                    fprintf(stderr, "UDF%d (0x%x) and UDF%d (0x%x) share bits\n",
-                            i, udf_modes[i], j, udf_modes[j]);
-                    ERR;
-                }
             }
         }
     }

--- a/nc_test4/tst_udf_open_mode.c
+++ b/nc_test4/tst_udf_open_mode.c
@@ -6,10 +6,10 @@
    registered UDF dispatch table, even when the file on disk is a valid
    NetCDF-4/HDF5 file that would normally be auto-detected as HDF5.
 
-   This test exercises all 10 UDF slots (UDF0 through UDF9) by
-   registering a minimal dispatch table in each slot and verifying that
-   nc_open() with the matching mode flag dispatches to the UDF handler
-   instead of to the HDF5 handler.
+   This test exercises all NC_MAX_UDF_FORMATS UDF slots by registering
+   a minimal dispatch table in each slot and verifying that nc_open()
+   with the matching mode flag dispatches to the UDF handler instead
+   of to the HDF5 handler.
 
    See https://github.com/Unidata/netcdf-c/issues/3417
 
@@ -26,16 +26,10 @@
 
 #define FILE_NAME "tst_udf_open_mode.nc"
 
-static const int udf_modes[NC_MAX_UDF_FORMATS] = {
-    NC_UDF0, NC_UDF1, NC_UDF2, NC_UDF3, NC_UDF4,
-    NC_UDF5, NC_UDF6, NC_UDF7, NC_UDF8, NC_UDF9
-};
-
-static const int udf_models[NC_MAX_UDF_FORMATS] = {
-    NC_FORMATX_UDF0, NC_FORMATX_UDF1, NC_FORMATX_UDF2, NC_FORMATX_UDF3,
-    NC_FORMATX_UDF4, NC_FORMATX_UDF5, NC_FORMATX_UDF6, NC_FORMATX_UDF7,
-    NC_FORMATX_UDF8, NC_FORMATX_UDF9
-};
+/* Mode flags and format constants for each UDF slot; filled in by
+ * init_dispatchers(). */
+static int udf_modes[NC_MAX_UDF_FORMATS];
+static int udf_models[NC_MAX_UDF_FORMATS];
 
 /* Minimal UDF dispatch stubs. */
 
@@ -89,6 +83,8 @@ init_dispatchers(void)
         NC_Dispatch *dsp = &udf_dispatchers[i];
         memset(dsp, 0, sizeof(NC_Dispatch));
 
+        udf_modes[i] = NC_UDF(i);
+        udf_models[i] = NC_FORMATX_UDF(i);
         dsp->model = udf_models[i];
         dsp->dispatch_version = NC_DISPATCH_VERSION;
 

--- a/ncdump/ncdump.c
+++ b/ncdump/ncdump.c
@@ -277,7 +277,7 @@ kind_string(int kind)
 	return "netCDF-4 classic model";
     default:
         if(kind == NC_FORMATX_UDF0 || kind == NC_FORMATX_UDF1
-           || (kind >= NC_FORMATX_UDF2 && kind <= NC_FORMATX_UDF9))
+           || (kind >= NC_FORMATX_UDF2 && kind <= NC_FORMATX_UDF_MAX))
             return "user-defined format";
         error("unrecognized file format: %d", kind);
 	return "unrecognized";
@@ -319,7 +319,7 @@ kind_string_extended(int kind, int mode)
 	break;
     default:
         if(kind == NC_FORMATX_UDF0 || kind == NC_FORMATX_UDF1
-           || (kind >= NC_FORMATX_UDF2 && kind <= NC_FORMATX_UDF9))
+           || (kind >= NC_FORMATX_UDF2 && kind <= NC_FORMATX_UDF_MAX))
             snprintf(text,sizeof(text),"%s mode=%08x", "user-defined format",mode);
         else {
             error("unrecognized extended format: %d",kind);


### PR DESCRIPTION
Fixes #3440 

When I set up user-defined formats, I allowed for two. Well that was ridiculously low. What a dumb solution. What was I thinking?

Then I re-factored it, and took up 10 bits to allow for 10 UDF slots. This solution was far too primitive. What am I, some kind of caveman? Am I siting in a ditch sticking berries up my nose?

Finally, in this PR, a sensible organization is presented. One bit to flag whether a UDF is used. 6 bits to hold the UDF number. Some supporting macros to preserve backward compatibility and make things easy to use.

Now we can have 64 UDFs at one time. Will this be enough? I rather think so, but at one point I thought 2 would be enough, so my track record is not good.

With the NetCDF Expansion Pack, I have already used 9 slots. Using the NEP, netCDF can read medical imagery, protein folding data, and all sorts of NASA interplanetary data. Fun with formats!!
