### PR TITLE
nc_perf: order the shell tests after tst_create_files under CMake

### DIFF
--- a/nc_perf/CMakeLists.txt
+++ b/nc_perf/CMakeLists.txt
@@ -43,6 +43,28 @@ add_sh_test(nc_perf run_par_bm_test)
 ENDIF(TEST_PARALLEL4)
 ENDIF(NETCDF_BUILD_UTILITIES)
 
+# tst_create_files writes the files several of the shell tests read:
+# run_bm_elena reads tst_elena_int_3D.nc, run_bm_test1 reads tst_floats_1D.nc
+# and tst_<type>2_<n>D.nc, run_bm_test2 reads tst_simple.nc, and
+# run_par_bm_test reads what run_bm_test1 leaves behind. Makefile.am states
+# these orderings explicitly (`run_bm_test1.log: tst_create_files.log` and
+# friends); without the same statement here, `ctest -j` is free to start a
+# reader while tst_create_files is still writing.
+#
+# add_sh_test expands to nothing when bash is absent, and run_par_bm_test only
+# exists for parallel builds, so guard on the test rather than on the
+# conditions that created it.
+FOREACH(READER run_bm_elena run_bm_test1 run_bm_test2)
+  IF(TEST nc_perf_${READER})
+    SET_TESTS_PROPERTIES(nc_perf_${READER} PROPERTIES
+                         DEPENDS nc_perf_tst_create_files)
+  ENDIF()
+ENDFOREACH()
+IF(TEST nc_perf_run_par_bm_test)
+  SET_TESTS_PROPERTIES(nc_perf_run_par_bm_test PROPERTIES
+                       DEPENDS "nc_perf_tst_create_files;nc_perf_run_bm_test1")
+ENDIF()
+
 FILE(GLOB COPY_FILES ${CMAKE_CURRENT_SOURCE_DIR}/*.sh)
 FILE(COPY ${COPY_FILES} DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/ FILE_PERMISSIONS OWNER_WRITE OWNER_READ OWNER_EXECUTE)
 


### PR DESCRIPTION
Fixes #3443.

`nc_perf/tst_create_files` writes the files several of the `nc_perf` shell tests
read. `Makefile.am` declares that ordering explicitly:

```make
# tst_create_files creates files for other tests.
run_bm_elena.log:    tst_create_files.log
run_bm_test1.log:    tst_create_files.log
run_bm_test2.log:    tst_create_files.log
run_par_bm_test.log: tst_create_files.log run_bm_test1.log
```

`nc_perf/CMakeLists.txt` declares none of it, so `ctest -j` starts the readers
alongside the writer. This adds the same four orderings with `DEPENDS`.

## Before / after

Same build tree, files removed first so it is in the state a fresh tree is in:

```sh
cd <build>/nc_perf && rm -f tst_elena_int_3D.nc tst_simple.nc tst_floats_1D.nc \
    tst_floats2_*D.nc tst_ints2_*D.nc tst_shorts2_*D.nc
cd <build> && ctest -j4 -R 'nc_perf_tst_create_files|nc_perf_run_bm_test[12]|nc_perf_run_bm_elena'
```

Before — all four start at once, two lose the race:

```
    Start 204: nc_perf_run_bm_elena
    Start 205: nc_perf_run_bm_test1
    Start 195: nc_perf_tst_create_files
    Start 206: nc_perf_run_bm_test2
1/4 Test #204: nc_perf_run_bm_elena .....***Failed  0.05 sec
2/4 Test #206: nc_perf_run_bm_test2 .....***Failed  0.06 sec
3/4 Test #195: nc_perf_tst_create_files .   Passed  3.84 sec
4/4 Test #205: nc_perf_run_bm_test1 .....   Passed  4.19 sec
```

After — the writer runs first, then the readers go in parallel:

```
    Start 195: nc_perf_tst_create_files
1/4 Test #195: nc_perf_tst_create_files .   Passed  3.58 sec
    Start 204: nc_perf_run_bm_elena
    Start 206: nc_perf_run_bm_test2
    Start 205: nc_perf_run_bm_test1
2/4 Test #206: nc_perf_run_bm_test2 .....   Passed  0.31 sec
3/4 Test #205: nc_perf_run_bm_test1 .....   Passed  5.11 sec
4/4 Test #204: nc_perf_run_bm_elena .....   Passed 24.95 sec

100% tests passed, 0 tests failed out of 4
```

Wall clock is unchanged in practice — the readers still run concurrently with
each other, only not with the writer.

## Notes

* Guarded on `if(TEST ...)` rather than on the conditions that created the
  tests: `add_sh_test` expands to nothing when bash is absent, and
  `run_par_bm_test` only exists under `TEST_PARALLEL4`. Verified on a serial
  build, where the `run_par_bm_test` property is correctly skipped.
* `DEPENDS` in ctest only orders; it does not fail a test whose dependency
  failed, and it is ignored when the dependency is not part of the selected
  set. That matches what the make rules do.
* Autotools builds are unaffected — this only adds to `nc_perf/CMakeLists.txt`.
