### PR TITLE
Attribute group path fix

### DIFF
--- a/ncdump/cdl/Makefile.am
+++ b/ncdump/cdl/Makefile.am
@@ -10,6 +10,7 @@
 EXTRA_DIST = \
 c0.cdl example_good.cdl fills.cdl nc_enddef.cdl nc_sync.cdl pres_temp_4D.cdl \
 ref_const_test.cdl ref_ctest1_nc4.cdl ref_ctest1_nc4c.cdl ref_dimscope.cdl \
+ref_attscope.cdl \
 ref_nctst.cdl ref_nctst_64bit_offset.cdl ref_nctst_netcdf4.cdl \
 ref_nctst_netcdf4_classic.cdl \
 ref_tst_comp.cdl ref_tst_comp2.cdl ref_tst_comp3.cdl \

--- a/ncdump/cdl/ref_attscope.cdl
+++ b/ncdump/cdl/ref_attscope.cdl
@@ -1,0 +1,33 @@
+netcdf ref_attscope {
+dimensions:
+  d = 2 ;
+variables:
+  int main_var(d) ;
+
+group: g {
+  variables:
+    int g_var0(d) ;
+    int g_var1 ;
+} // group g
+
+group: f {
+  variables:
+    int f_var0(d) ;
+    byte f_var0:att_local = 1b ;
+    // same-group path reference
+    byte /f/f_var0:att_abs = 2b ;
+    // cross-group path references
+    byte /g/g_var0:att0 = 3b ;
+    byte /g/g_var1:att1 = 4b ;
+    // path reference to a variable in the root group
+    byte /main_var:att_root = 5b ;
+  // group-global attribute (no variable)
+  :att_global = "group f" ;
+} // group f
+
+group: h {
+  variables:
+    // attribute declared in a group containing no variables
+    byte /g/g_var1:att2 = 6b ;
+} // group h
+}

--- a/ncdump/expected/Makefile.am
+++ b/ncdump/expected/Makefile.am
@@ -6,6 +6,7 @@
 EXTRA_DIST = \
 c0.dmp example_good.dmp fills.dmp nc_enddef.dmp nc_sync.dmp pres_temp_4D.dmp \
 ref_const_test.dmp ref_ctest1_nc4.dmp ref_ctest1_nc4c.dmp ref_dimscope.dmp \
+ref_attscope.dmp \
 ref_nctst.dmp ref_nctst_64bit_offset.dmp ref_nctst_netcdf4.dmp \
 ref_nctst_netcdf4_classic.dmp \
 ref_tst_comp.dmp ref_tst_comp2.dmp ref_tst_comp3.dmp \

--- a/ncdump/expected/ref_attscope.dmp
+++ b/ncdump/expected/ref_attscope.dmp
@@ -1,0 +1,40 @@
+netcdf ref_attscope {
+dimensions:
+	d = 2 ;
+variables:
+	int main_var(d) ;
+		main_var:att_root = 5b ;
+data:
+
+ main_var = _, _ ;
+
+group: g {
+  variables:
+  	int g_var0(d) ;
+  		g_var0:att0 = 3b ;
+  	int g_var1 ;
+  		g_var1:att1 = 4b ;
+  		g_var1:att2 = 6b ;
+  data:
+
+   g_var0 = _, _ ;
+
+   g_var1 = _ ;
+  } // group g
+
+group: f {
+  variables:
+  	int f_var0(d) ;
+  		f_var0:att_local = 1b ;
+  		f_var0:att_abs = 2b ;
+
+  // group attributes:
+  		:att_global = "group f" ;
+  data:
+
+   f_var0 = _, _ ;
+  } // group f
+
+group: h {
+  } // group h
+}

--- a/ncdump/tst_ncgen_shared.sh
+++ b/ncdump/tst_ncgen_shared.sh
@@ -99,6 +99,7 @@ ref_tst_h_scalar \
 ref_tst_nul4 \
 ref_tst_econst \
 ref_tst_econst2 \
+ref_attscope \
 "
 
 TESTS4="$TESTS4 ref_tst_vlen_data2"

--- a/ncgen/genbin.c
+++ b/ncgen/genbin.c
@@ -457,7 +457,7 @@ genbin_writeattr(Generator* generator, Symbol* asym, Bytebuffer* databuf,
     int varid, grpid, typid;
     Symbol* basetype = asym->typ.basetype;
 
-    grpid = asym->container->nc_id;
+    grpid = (asym->att.var == NULL?asym->container->nc_id : asym->att.var->container->nc_id);
     varid = (asym->att.var == NULL?NC_GLOBAL : asym->att.var->nc_id);
     typid = basetype->nc_id;
 

--- a/ncgen/genc.c
+++ b/ncgen/genc.c
@@ -1137,6 +1137,7 @@ genc_writeattr(Generator* generator, Symbol* asym, Bytebuffer* code,
     Symbol* basetype = asym->typ.basetype;
     int typecode = basetype->typ.typecode;
     size_t len = asym->data->length; /* default assumption */
+    Symbol* attgroup = (asym->att.var == NULL?asym->container : asym->att.var->container);
 
     /* define a block to avoid name clashes*/
     codeline("");
@@ -1187,7 +1188,7 @@ genc_writeattr(Generator* generator, Symbol* asym, Bytebuffer* code,
         bbprintf0(stmt,"%sstat = nc_put_att_%s(%s, %s, \"%s\", %s, %lu, %s_att);\n",
 		indented(1),
 		ncstype(basetype->typ.typecode),
-		groupncid(asym->container),
+		groupncid(attgroup),
 		(asym->att.var == NULL?"NC_GLOBAL"
 			              :varncid(asym->att.var)),
 		escapifyname(asym->name),
@@ -1202,7 +1203,7 @@ genc_writeattr(Generator* generator, Symbol* asym, Bytebuffer* code,
         bbprintf0(stmt,"%sstat = nc_put_att_%s(%s, %s, \"%s\", %lu, %s);\n",
 		indented(1),
 		ncstype(basetype->typ.typecode),
-		groupncid(asym->container),
+		groupncid(attgroup),
 		(asym->att.var == NULL?"NC_GLOBAL"
 			              :varncid(asym->att.var)),
 		escapifyname(asym->name),
@@ -1224,7 +1225,7 @@ genc_writeattr(Generator* generator, Symbol* asym, Bytebuffer* code,
         bbprintf0(stmt,"%sstat = nc_put_att_%s(%s, %s, \"%s\", %s, %lu, %s_att);",
 		indented(1),
 		ncstype(basetype->typ.typecode),
-		groupncid(asym->container),
+		groupncid(attgroup),
 		(asym->att.var == NULL?"NC_GLOBAL"
 			              :varncid(asym->att.var)),
 		escapifyname(asym->name),
@@ -1243,7 +1244,7 @@ genc_writeattr(Generator* generator, Symbol* asym, Bytebuffer* code,
         bbprintf0(stmt,"%sstat = nc_put_att_%s(%s, %s, \"%s\", %lu, %s_att);",
 		indented(1),
 		ncstype(basetype->typ.typecode),
-		groupncid(asym->container),
+		groupncid(attgroup),
 		(asym->att.var == NULL?"NC_GLOBAL"
 			              :varncid(asym->att.var)),
 		escapifyname(asym->name),
@@ -1262,7 +1263,7 @@ genc_writeattr(Generator* generator, Symbol* asym, Bytebuffer* code,
 	}
         bbprintf0(stmt,"%sstat = nc_put_att(%s, %s, \"%s\", %s, %lu, %s_att);\n",
 		indented(1),
-		groupncid(asym->container),
+		groupncid(attgroup),
 		(asym->att.var == NULL?"NC_GLOBAL"
 			              :varncid(asym->att.var)),
 		escapifyname(asym->name),


### PR DESCRIPTION
Fixes #3447 

I believe this fixes an issue whereby attributes assigned to something in a different group were instead being assigned to variables in the enclosing group instead.
See #3447 for MWE and longer description.

This should address that by setting the appropriate group NCID (if supplied) before using it for assignment, rather than using the container ID for all cases.

I also add an ncgen->ncdump test case to cover instances that led me to find this.

Disclosure, C is not my main language, though I have worked with it before and am familiar with other compiled languages.
I'm also not deeply familiar with the codebase so please do review to check everything looks OK, and let me know if I missed anything either in the ncgen code, or any other language generators.