### PR TITLE
Windows registers 204 of the 215 tests Linux and macOS run

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1418,6 +1418,13 @@ if(MSVC)
   endif()
   set(WINVERMAJOR ${WVM} CACHE STRING "" FORCE)
   set(WINVERBUILD ${WVB} CACHE STRING "" FORCE)
+
+  # Every netCDF-C executable takes UTF-8 for its command line and its file
+  # names. /MANIFESTINPUT is merged into the manifest the linker already
+  # embeds, so this needs no per-target wiring and no mt.exe step.
+  set(NC_UTF8_MANIFEST "${CMAKE_CURRENT_SOURCE_DIR}/cmake/netcdf_utf8.manifest")
+  set(CMAKE_EXE_LINKER_FLAGS
+      "${CMAKE_EXE_LINKER_FLAGS} /MANIFEST:EMBED /MANIFESTINPUT:${NC_UTF8_MANIFEST}")
 endif()
 
 #####

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,12 @@ endif()
 if(MSVC)
   set(ISMSVC yes)
 endif()
-if(osname MATCHES "MINGW.*" OR osname MATCHES "MSYS.*")
+# `uname -s` reports MINGW64_NT-* / MSYS_NT-* whenever cmake is started from a
+# Git-Bash or MSYS2 shell, which says nothing about the compiler in use. An MSVC
+# build launched from Git Bash therefore set ISMINGW (and CMake's own MINGW), and
+# everything gated on "not MinGW" silently vanished -- the ncdump unicode tests
+# among them. Trust the toolchain, not the shell that started it.
+if(NOT MSVC AND (osname MATCHES "MINGW.*" OR osname MATCHES "MSYS.*"))
   set(ISMINGW yes)
   set(MINGW yes)
 endif()
@@ -136,8 +141,14 @@ endif()
 include(GNUInstallDirs)
 
 if(MSVC)
-  set(GLOBAL PROPERTY USE_FOLDERS ON)
-  target_compile_options(netcdf PRIVATE "/utf-8")
+  set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+  # UTF-8 source and execution character sets for the whole tree, not just the
+  # library: nc_test/tst_utf8_validate.c and several ncdump references carry
+  # UTF-8 literals that MSVC would otherwise read in the ANSI code page. The
+  # previous form named the `netcdf` target, which liblib/ does not create until
+  # much later in this file, and set a variable called GLOBAL rather than the
+  # USE_FOLDERS property.
+  add_compile_options("/utf-8")
 endif()
 
 # auto-configure style checks, other CMake modules.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -417,7 +417,9 @@ option(NETCDF_GENERATE_NCGEN "Automatically regenerate ncgen C files if required
 include(CMakeDependentOption)
 
 # Option to use MMAP
-cmake_dependent_option(NETCDF_ENABLE_MMAP "Use MMAP." ON "NOT WIN32" OFF)
+# libsrc/mmapio.c now builds on Windows too: libsrc/ncwinmmap.h supplies the
+# mmap()/munmap() slice it uses, over CreateFileMapping/MapViewOfFile.
+option(NETCDF_ENABLE_MMAP "Use MMAP." ON)
 
 # Option to use examples.
 option(NETCDF_ENABLE_EXAMPLES "Build Examples" ON)
@@ -1382,8 +1384,10 @@ if(NETCDF_ENABLE_ATEXIT_FINALIZE AND NOT HAVE_ATEXIT)
 endif()
 endif()
 
-# Check to see if MAP_ANONYMOUS is defined.
-if(NETCDF_ENABLE_MMAP)
+# Check to see if MAP_ANONYMOUS is defined. Windows has neither <sys/mman.h> nor
+# mmap(); libsrc/ncwinmmap.h provides both for the one file that needs them, so
+# the probe is not the question to ask there.
+if(NETCDF_ENABLE_MMAP AND NOT WIN32)
   CHECK_C_SOURCE_COMPILES("
   #include <sys/mman.h>
   int main() {int x = MAP_ANONYMOUS;}" HAVE_MAPANON)

--- a/cmake/netcdf_utf8.manifest
+++ b/cmake/netcdf_utf8.manifest
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+  Declare UTF-8 as the process active code page.
+
+  Without this, the UCRT hands main() an argv transcoded from the UTF-16
+  command line into the legacy ANSI code page, so any path the ANSI code page
+  cannot represent arrives as a literal question mark, which is an illegal
+  character in a Windows file name. That is why nc_create() on a non-Latin
+  path used to fail with EINVAL. With the setting, argv, the ANSI CRT file
+  calls and GetACP() are all UTF-8, which is what the rest of netCDF-C already
+  assumes (see WINUTF8 in libdispatch/dpathmgr.c).
+
+  Requires Windows 10 1903 or later. On anything older the setting is ignored
+  and behaviour is exactly what it was before.
+-->
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <assemblyIdentity type="win32" name="Unidata.netCDF" version="1.0.0.0"/>
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings xmlns:ws2019="http://schemas.microsoft.com/SMI/2019/WindowsSettings">
+      <ws2019:activeCodePage>UTF-8</ws2019:activeCodePage>
+    </windowsSettings>
+  </application>
+</assembly>

--- a/include/nc.h
+++ b/include/nc.h
@@ -64,18 +64,22 @@ extern int nc__pseudofd(void);
 /* This function gets a current default create flag */
 extern int nc_get_default_format(void);
 
-extern int add_to_NCList(NC*);
-extern void del_from_NCList(NC*);/* does not free object */
-extern NC* find_in_NCList(int ext_ncid);
-extern NC* find_in_NCList_by_name(const char*);
-extern int move_in_NCList(NC *ncp, int new_id);
-extern void free_NCList(void);/* reclaim whole list */
-extern int count_NCList(void); /* return # of entries in NClist */
-extern int iterate_NCList(int i,NC**); /* Walk from 0 ...; ERANGE return => stop */
+/* The NC list. These are internal, but unit_test/tst_nclist.c links against
+   them, so they have to leave the DLL on Windows the way they leave the shared
+   object everywhere else. EXTERNL is a no-op off Windows. */
+EXTERNL int add_to_NCList(NC*);
+EXTERNL void del_from_NCList(NC*);/* does not free object */
+EXTERNL NC* find_in_NCList(int ext_ncid);
+EXTERNL NC* find_in_NCList_by_name(const char*);
+EXTERNL int move_in_NCList(NC *ncp, int new_id);
+EXTERNL void free_NCList(void);/* reclaim whole list */
+EXTERNL int count_NCList(void); /* return # of entries in NClist */
+EXTERNL int iterate_NCList(int i,NC**); /* Walk from 0 ...; ERANGE return => stop */
 
-/* Defined in nc.c */
-extern void free_NC(NC*);
-extern int new_NC(const struct NC_Dispatch*, const char*, int, NC**);
+/* Defined in nc.c. EXTERNL for the same reason as the NC list above:
+   unit_test/tst_nclist.c and unit_test/tst_nc4internal.c call them. */
+EXTERNL void free_NC(NC*);
+EXTERNL int new_NC(const struct NC_Dispatch*, const char*, int, NC**);
 
 /* Defined in dinstance_intern.c */
 

--- a/include/nc4internal.h
+++ b/include/nc4internal.h
@@ -331,22 +331,27 @@ extern int nc4_convert_type(const void *src, void *dest, const nc_type src_type,
 extern int nc4_reopen_dataset(NC_GRP_INFO_T *grp, NC_VAR_INFO_T *var);
 extern int nc4_read_atts(NC_GRP_INFO_T *grp, NC_VAR_INFO_T *var);
 
+/* The declarations below that are spelled EXTERNL rather than extern are the
+   ones unit_test/tst_nc4internal.c calls. They are still internal to the
+   library; EXTERNL only makes them leave the DLL on Windows the way they
+   already leave the shared object on every other platform, which is what the
+   test needs in order to run there at all. EXTERNL is a no-op off Windows. */
 /* Find items in the in-memory lists of metadata. */
-extern int nc4_find_nc_grp_h5(int ncid, NC **nc, NC_GRP_INFO_T **grp,
+EXTERNL int nc4_find_nc_grp_h5(int ncid, NC **nc, NC_GRP_INFO_T **grp,
                        NC_FILE_INFO_T **h5);
-extern int nc4_find_grp_h5(int ncid, NC_GRP_INFO_T **grp, NC_FILE_INFO_T **h5);
-extern int nc4_find_nc4_grp(int ncid, NC_GRP_INFO_T **grp);
-extern int nc4_find_dim(NC_GRP_INFO_T *grp, int dimid, NC_DIM_INFO_T **dim,
+EXTERNL int nc4_find_grp_h5(int ncid, NC_GRP_INFO_T **grp, NC_FILE_INFO_T **h5);
+EXTERNL int nc4_find_nc4_grp(int ncid, NC_GRP_INFO_T **grp);
+EXTERNL int nc4_find_dim(NC_GRP_INFO_T *grp, int dimid, NC_DIM_INFO_T **dim,
                  NC_GRP_INFO_T **dim_grp);
-extern int nc4_find_var(NC_GRP_INFO_T *grp, const char *name, NC_VAR_INFO_T **var);
+EXTERNL int nc4_find_var(NC_GRP_INFO_T *grp, const char *name, NC_VAR_INFO_T **var);
 extern int nc4_find_dim_len(NC_GRP_INFO_T *grp, int dimid, size_t **len);
-extern int nc4_find_type(const NC_FILE_INFO_T *h5, int typeid1, NC_TYPE_INFO_T **type);
+EXTERNL int nc4_find_type(const NC_FILE_INFO_T *h5, int typeid1, NC_TYPE_INFO_T **type);
 extern NC_TYPE_INFO_T *nc4_rec_find_named_type(NC_GRP_INFO_T *start_grp, char *name);
 extern NC_TYPE_INFO_T *nc4_rec_find_equal_type(NC_GRP_INFO_T *start_grp, int ncid1,
                                         NC_TYPE_INFO_T *type);
 extern int nc4_find_nc_att(int ncid, int varid, const char *name, int attnum,
                     NC_ATT_INFO_T **att);
-extern int nc4_find_grp_h5_var(int ncid, int varid, NC_FILE_INFO_T **h5,
+EXTERNL int nc4_find_grp_h5_var(int ncid, int varid, NC_FILE_INFO_T **h5,
                         NC_GRP_INFO_T **grp, NC_VAR_INFO_T **var);
 extern int nc4_find_grp_att(NC_GRP_INFO_T *grp, int varid, const char *name,
                      int attnum, NC_ATT_INFO_T **att);
@@ -357,30 +362,30 @@ extern int nc4_get_typeclass(const NC_FILE_INFO_T *h5, nc_type xtype,
 extern int nc4_type_free(NC_TYPE_INFO_T *type);
 
 /* These list functions add and delete vars, atts. */
-extern int nc4_nc4f_list_add(NC *nc, const char *path, int mode);
+EXTERNL int nc4_nc4f_list_add(NC *nc, const char *path, int mode);
 extern int nc4_nc4f_list_del(NC_FILE_INFO_T *h5);
-extern int nc4_file_list_add(int ncid, const char *path, int mode,
+EXTERNL int nc4_file_list_add(int ncid, const char *path, int mode,
                       void **dispatchdata);
-extern int nc4_file_list_get(int ncid, char **path, int *mode,
+EXTERNL int nc4_file_list_get(int ncid, char **path, int *mode,
                       void **dispatchdata);
-extern int nc4_file_list_del(int ncid);
-extern int nc4_file_change_ncid(int ncid, unsigned short new_ncid_index);
-extern int nc4_var_list_add(NC_GRP_INFO_T* grp, const char* name, int ndims,
+EXTERNL int nc4_file_list_del(int ncid);
+EXTERNL int nc4_file_change_ncid(int ncid, unsigned short new_ncid_index);
+EXTERNL int nc4_var_list_add(NC_GRP_INFO_T* grp, const char* name, int ndims,
                      NC_VAR_INFO_T **var);
 extern int nc4_var_list_add2(NC_GRP_INFO_T* grp, const char* name,
                       NC_VAR_INFO_T **var);
 extern int nc4_var_set_ndims(NC_VAR_INFO_T *var, int ndims);
 extern int nc4_var_list_del(NC_GRP_INFO_T *grp, NC_VAR_INFO_T *var);
-extern int nc4_dim_list_add(NC_GRP_INFO_T *grp, const char *name, size_t len,
+EXTERNL int nc4_dim_list_add(NC_GRP_INFO_T *grp, const char *name, size_t len,
                      int assignedid, NC_DIM_INFO_T **dim);
 extern int nc4_dim_list_del(NC_GRP_INFO_T *grp, NC_DIM_INFO_T *dim);
 extern int nc4_type_new(size_t size, const char *name, int assignedid,
                  NC_TYPE_INFO_T **type);
-extern int nc4_type_list_add(NC_GRP_INFO_T *grp, size_t size, const char *name,
+EXTERNL int nc4_type_list_add(NC_GRP_INFO_T *grp, size_t size, const char *name,
                       NC_TYPE_INFO_T **type);
 extern int nc4_type_list_del(NC_GRP_INFO_T *grp, NC_TYPE_INFO_T *type);
 extern int nc4_type_free(NC_TYPE_INFO_T *type);
-extern int nc4_field_list_add(NC_TYPE_INFO_T* parent, const char *name,
+EXTERNL int nc4_field_list_add(NC_TYPE_INFO_T* parent, const char *name,
                        size_t offset, nc_type xtype, int ndims,
                        const int *dim_sizesp);
 extern int nc4_att_list_add(NCindex *list, const char *name, NC_ATT_INFO_T **att);

--- a/include/ncdispatch.h
+++ b/include/ncdispatch.h
@@ -100,7 +100,10 @@ typedef struct NC_MPI_INFO {
 extern int NCDISPATCH_initialize(void);
 extern int NCDISPATCH_finalize(void);
 
-extern const NC_Dispatch* NC3_dispatch_table;
+/* EXTERNL, not extern: unit_test/tst_nc4internal.c reads this table, and a data
+   symbol has to be declared dllimport to be reachable across a Windows DLL
+   boundary. No effect off Windows. */
+EXTERNL const NC_Dispatch* NC3_dispatch_table;
 extern int NC3_initialize(void);
 extern int NC3_finalize(void);
 

--- a/libsrc/mmapio.c
+++ b/libsrc/mmapio.c
@@ -29,7 +29,13 @@
 #include <stdio.h>
 #endif
 
+#ifdef _WIN32
+/* Windows has no <sys/mman.h>; ncwinmmap.h supplies the mmap()/munmap() slice
+   this file uses, on top of CreateFileMapping/MapViewOfFile. */
+#include "ncwinmmap.h"
+#else
 #include <sys/mman.h>
+#endif
 
 #ifndef MAP_ANONYMOUS
 #  ifdef MAP_ANON
@@ -55,6 +61,10 @@
 #define SEEK_CUR 1
 #define SEEK_END 2
 #endif
+
+/* mmap() reports failure as MAP_FAILED; parts of this file used to test for
+   NULL, which no implementation returns. Accept either. */
+#define NC_MMAP_FAILED(m) ((m) == NULL || (m) == (void*)MAP_FAILED)
 
 /* Define the mode flags for create: let umask decide */
 #define OPENMODE 0666
@@ -123,7 +133,11 @@ mmapio_new(const char* path, int ioflags, size_t initialsize, ncio** nciopp, NCM
     int openfd = -1;
 
     if(pagesize == 0) {
-#if defined HAVE_SYSCONF
+#if defined _WIN32
+        SYSTEM_INFO info;
+        GetSystemInfo(&info);
+        pagesize = (size_t)info.dwPageSize;
+#elif defined HAVE_SYSCONF
         pagesize = (size_t)sysconf(_SC_PAGE_SIZE);
 #elif defined HAVE_GETPAGESIZE
         pagesize = (size_t)getpagesize();
@@ -233,7 +247,14 @@ mmapio_create(const char* path, int ioflags,
                                     PROT_READ|PROT_WRITE,
 				    MAP_PRIVATE|MAP_ANONYMOUS,
                                     mmapio->mapfd,0);
-	{mmapio->memory[0] = 0;} /* test writing of the mmap'd memory */
+	/* The test for a usable mapping used to be a bare store into
+	   memory[0]; on a failed mmap that is a dereference of NULL or -1. */
+	if(NC_MMAP_FAILED(mmapio->memory)) {
+	    mmapio->memory = NULL;
+	    status = NC_EDISKLESS;
+	    goto unwind_open;
+	}
+	mmapio->memory[0] = 0; /* test writing of the mmap'd memory */
     } else { /*persist */
         /* Open the file to get fd,  but make sure we can write it if needed */
         oflags = O_RDWR;
@@ -256,8 +277,10 @@ mmapio_create(const char* path, int ioflags,
                                     PROT_READ|PROT_WRITE,
 				    MAP_SHARED,
                                     mmapio->mapfd,0);
-	if(mmapio->memory == NULL) {
-	    return NC_EDISKLESS;
+	if(NC_MMAP_FAILED(mmapio->memory)) {
+	    mmapio->memory = NULL;
+	    status = NC_EDISKLESS;
+	    goto unwind_open;
 	}
     } /*!persist*/
 
@@ -355,6 +378,11 @@ mmapio_open(const char* path,
                                     readwrite?(PROT_READ|PROT_WRITE):(PROT_READ),
 				    MAP_SHARED,
                                     mmapio->mapfd,0);
+    if(NC_MMAP_FAILED(mmapio->memory)) {
+	mmapio->memory = NULL;
+	mmapio_close(nciop,0);
+	return NC_EDISKLESS;
+    }
 #ifdef DEBUG
 fprintf(stderr,"mmapio_open: initial memory: %lu/%lu\n",(unsigned long)mmapio->memory,(unsigned long)mmapio->alloc);
 #endif
@@ -436,20 +464,29 @@ mmapio_pad_length(ncio* nciop, off_t length)
 	off_t pos = lseek(mmapio->mapfd,0,SEEK_CUR); /* save current position*/
 	/* cause file to be extended in size */
 	lseek(mmapio->mapfd,(off_t)newsize-1,SEEK_SET);
-        write(mmapio->mapfd,"",mmapio->alloc);
+	/* One byte at newsize-1 is what extends the file; the length used to
+	   be mmapio->alloc, which read that many bytes from a one-byte
+	   literal. */
+        write(mmapio->mapfd,"",1);
 	lseek(mmapio->mapfd,pos,SEEK_SET); /* reset position */
 	}
 
 #ifdef HAVE_MREMAP
 	newmem = (char*)mremap(mmapio->memory,mmapio->alloc,newsize,MREMAP_MAYMOVE);
-	if(newmem == NULL) return NC_ENOMEM;
+	if(NC_MMAP_FAILED(newmem)) return NC_ENOMEM;
 #else
-        /* note: mmapio->mapfd >= 0 => persist */
-        newmem = (char*)mmap(NULL,newsize,
-                                    mmapio->mapfd >= 0?(PROT_READ|PROT_WRITE):(PROT_READ),
-				    MAP_SHARED,
-                                    mmapio->mapfd,0);
-	if(newmem == NULL) return NC_ENOMEM;
+        /* No mremap outside glibc, so map a fresh region and copy. The old
+           form asked for MAP_SHARED on mapfd, which is -1 for a non-persist
+           (anonymous) file, and for PROT_READ only; neither can work, because
+           growing a diskless file has to produce writable anonymous memory,
+           exactly as the initial mapping did. */
+        if(mmapio->mapfd >= 0)
+            newmem = (char*)mmap(NULL,newsize,PROT_READ|PROT_WRITE,
+                                 MAP_SHARED,mmapio->mapfd,0);
+        else
+            newmem = (char*)mmap(NULL,newsize,PROT_READ|PROT_WRITE,
+                                 MAP_PRIVATE|MAP_ANONYMOUS,-1,0);
+	if(NC_MMAP_FAILED(newmem)) return NC_ENOMEM;
 	memcpy(newmem,mmapio->memory,mmapio->alloc);
         munmap(mmapio->memory,mmapio->alloc);
 #endif
@@ -484,8 +521,11 @@ mmapio_close(ncio* nciop, int doUnlink)
     mmapio = (NCMMAPIO*)nciop->pvt;
     assert(mmapio != NULL);
 
-    /* Since we are using mmap, persisting to a file should be automatic */
-    status = munmap(mmapio->memory,mmapio->alloc);
+    /* Since we are using mmap, persisting to a file should be automatic.
+       mmapio_create() reaches unwind_open with no mapping when mmap() fails,
+       so guard the unmap. */
+    if(mmapio->memory != NULL)
+	status = munmap(mmapio->memory,mmapio->alloc);
     mmapio->memory = NULL; /* so we do not try to free it */
 
     /* Close file if it was open */

--- a/libsrc/ncwinmmap.h
+++ b/libsrc/ncwinmmap.h
@@ -1,0 +1,115 @@
+/*
+ *	Copyright 2018, University Corporation for Atmospheric Research
+ *	See netcdf/COPYRIGHT file for copying and redistribution conditions.
+ */
+
+/*
+ * The slice of <sys/mman.h> that libsrc/mmapio.c actually uses, implemented on
+ * the Win32 section API. mmapio.c needs exactly two anonymous-vs-file cases and
+ * no mprotect, no msync (MAP_SHARED writes are coherent with the file on
+ * Windows as they are on POSIX) and no partial unmapping, so the shim is small.
+ *
+ * Both cases go through CreateFileMapping + MapViewOfFile rather than
+ * VirtualAlloc for the anonymous one, so that a single munmap() --
+ * UnmapViewOfFile -- releases either kind without having to remember which it
+ * was. The section handle is closed as soon as the view exists: Windows keeps
+ * the section alive for as long as a view of it is mapped.
+ *
+ * Offsets are always zero here. If that ever changes, note that MapViewOfFile
+ * requires the offset to be a multiple of the allocation granularity (64 KB),
+ * not of the page size.
+ */
+
+#ifndef NCWINMMAP_H
+#define NCWINMMAP_H
+
+#ifdef _WIN32
+
+#include <windows.h>
+#include <io.h>
+#include <errno.h>
+#include <stdlib.h>
+
+#define PROT_NONE  0x0
+#define PROT_READ  0x1
+#define PROT_WRITE 0x2
+
+#define MAP_FILE      0x00
+#define MAP_SHARED    0x01
+#define MAP_PRIVATE   0x02
+#define MAP_ANONYMOUS 0x20
+#define MAP_ANON      MAP_ANONYMOUS
+
+#define MAP_FAILED ((void*)-1)
+
+static void*
+nc_win_mmap(void* addr, size_t len, int prot, int flags, int fd, long long offset)
+{
+    HANDLE section = NULL;
+    HANDLE file = INVALID_HANDLE_VALUE;
+    DWORD protect;
+    DWORD access;
+    ULARGE_INTEGER maxsize;
+    ULARGE_INTEGER off;
+    void* view = NULL;
+
+    (void)addr; /* a fixed mapping address is never asked for here */
+
+    if(len == 0) {errno = EINVAL; return MAP_FAILED;}
+
+    if(prot & PROT_WRITE) {
+	protect = PAGE_READWRITE;
+	access = (flags & MAP_PRIVATE) ? FILE_MAP_COPY : FILE_MAP_WRITE;
+    } else if(prot & PROT_READ) {
+	protect = PAGE_READONLY;
+	access = FILE_MAP_READ;
+    } else {
+	errno = EINVAL;
+	return MAP_FAILED;
+    }
+
+    if(!(flags & MAP_ANONYMOUS)) {
+	file = (HANDLE)_get_osfhandle(fd);
+	if(file == INVALID_HANDLE_VALUE) {errno = EBADF; return MAP_FAILED;}
+	/* A file-backed section is sized by the file when maxsize is zero, and
+	   mmapio.c has already grown the file to at least len. */
+	maxsize.QuadPart = 0;
+    } else {
+	/* Pagefile-backed: the size has to be stated. FILE_MAP_COPY on such a
+	   section would make the pages private but leave nothing to be private
+	   from, so an anonymous mapping is always mapped for write. */
+	file = INVALID_HANDLE_VALUE;
+	maxsize.QuadPart = (ULONGLONG)offset + (ULONGLONG)len;
+	access = FILE_MAP_WRITE;
+	protect = PAGE_READWRITE;
+    }
+
+    section = CreateFileMappingA(file, NULL, protect,
+				 maxsize.HighPart, maxsize.LowPart, NULL);
+    if(section == NULL) {errno = ENOMEM; return MAP_FAILED;}
+
+    off.QuadPart = (ULONGLONG)offset;
+    view = MapViewOfFile(section, access, off.HighPart, off.LowPart, len);
+
+    /* The view holds its own reference to the section. */
+    CloseHandle(section);
+
+    if(view == NULL) {errno = ENOMEM; return MAP_FAILED;}
+    return view;
+}
+
+static int
+nc_win_munmap(void* addr, size_t len)
+{
+    (void)len; /* Windows unmaps whole views only, which is all mmapio.c does */
+    if(addr == NULL || addr == MAP_FAILED) return 0;
+    if(!UnmapViewOfFile(addr)) {errno = EINVAL; return -1;}
+    return 0;
+}
+
+#define mmap(a,l,p,f,fd,o)  nc_win_mmap((a),(l),(p),(f),(fd),(long long)(o))
+#define munmap(a,l)         nc_win_munmap((a),(l))
+
+#endif /*_WIN32*/
+
+#endif /*NCWINMMAP_H*/

--- a/nc_test/CMakeLists.txt
+++ b/nc_test/CMakeLists.txt
@@ -127,10 +127,6 @@ IF(NETCDF_BUILD_UTILITIES)
       ENDIF()
     ENDIF()
 
-  IF(BUILD_MMAP)
-    add_sh_test(nc_test run_mmap)
-  ENDIF()
-
 ENDIF(NETCDF_BUILD_UTILITIES)
 
 # Copy some test files from current source dir to out-of-tree build dir.

--- a/nc_test/CMakeLists.txt
+++ b/nc_test/CMakeLists.txt
@@ -50,9 +50,11 @@ set_property(TARGET nc_test PROPERTY UNITY_BUILD OFF)
 # Some extra stand-alone tests
 SET(TESTS t_nc tst_small tst_misc tst_norm tst_names tst_nofill tst_nofill2 tst_nofill3 tst_meta tst_inq_type tst_utf8_phrases tst_global_fillval tst_max_var_dims tst_formats tst_def_var_fill tst_err_enddef tst_default_format)
 
-IF(NOT WIN32)
+# tst_utf8_validate's cases are deliberately malformed byte sequences, which
+# used to be raw bytes in the source. MSVC transcodes string literals from the
+# source charset, so those bytes did not survive the compile and the test was
+# excluded here. They are octal escapes now, identical on every compiler.
 SET(TESTS ${TESTS} tst_utf8_validate)
-ENDIF()
 
 IF(NOT HAVE_BASH)
   SET(TESTS ${TESTS} tst_atts3)

--- a/nc_test/tst_utf8_validate.c
+++ b/nc_test/tst_utf8_validate.c
@@ -3,6 +3,18 @@
  *  See the LICENSE file for more information.
  */
 
+/*
+ * NOTE ON ENCODING: every byte above 0x7f in the test data below is written as
+ * a three-digit octal escape, and this file is pure ASCII. That is deliberate
+ * and must stay that way. Most of the cases here are byte sequences that are
+ * *not* valid UTF-8, which is the whole point of the test, and a compiler that
+ * transcodes string literals from a source character set cannot carry them
+ * through unchanged: MSVC rejects the file outright under /utf-8 and silently
+ * rewrites the bytes without it. Escapes are the one spelling every compiler
+ * reproduces exactly, and they are why this test can run on Windows at all.
+ * Do not "restore" the raw characters.
+ */
+
 #include <config.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -87,7 +99,7 @@ struct Test {
 */
 static const struct Test utf8ok[] = {
 {0, "1.1.1", "Greek word 'kosme'",
-"Îºá½¹ÏƒÎ¼Îµ"},
+"\316\272\341\275\271\317\203\316\274\316\265"},
 NULLTEST
 };
 
@@ -96,27 +108,27 @@ static const struct Test utf8boundary[] = {
 /*2  Boundary condition test */
 /*2.1  First possible sequence of a certain length */
 {0,"2.1.1", "1 byte  (U-00000000)",        "\000"},
-{0,"2.1.2", "2 bytes (U-00000080)",        "Â€"},
-{0,"2.1.3", "3 bytes (U-00000800)",        "à €"},
-{0,"2.1.4", "4 bytes (U-00010000)",        "ğ€€"},
-{1,"2.1.5", "5 bytes (U-00200000)",        "øˆ€€€"},
-{1,"2.1.6", "6 bytes (U-04000000)",        "ü„€€€€"},
+{0,"2.1.2", "2 bytes (U-00000080)",        "\302\200"},
+{0,"2.1.3", "3 bytes (U-00000800)",        "\340\240\200"},
+{0,"2.1.4", "4 bytes (U-00010000)",        "\360\220\200\200"},
+{1,"2.1.5", "5 bytes (U-00200000)",        "\370\210\200\200\200"},
+{1,"2.1.6", "6 bytes (U-04000000)",        "\374\204\200\200\200\200"},
 
 /*2.2  Last possible sequence of a certain length*/
 {0,"2.2.1", "1 byte  (U-0000007F)",        ""},
-{0,"2.2.2", "2 bytes (U-000007FF)",        "ß¿"},
-{0,"2.2.3", "3 bytes (U-0000FFFF)",        "ï¿¿"}, /*See 5.3.2 */
-{1,"2.2.4", "4 bytes (U-001FFFFF)",        "÷¿¿¿"},
-{1,"2.2.5", "5 bytes (U-03FFFFFF)",        "û¿¿¿¿"},
-{1,"2.2.6", "6 bytes (U-7FFFFFFF)",        "ı¿¿¿¿¿"},
+{0,"2.2.2", "2 bytes (U-000007FF)",        "\337\277"},
+{0,"2.2.3", "3 bytes (U-0000FFFF)",        "\357\277\277"}, /*See 5.3.2 */
+{1,"2.2.4", "4 bytes (U-001FFFFF)",        "\367\277\277\277"},
+{1,"2.2.5", "5 bytes (U-03FFFFFF)",        "\373\277\277\277\277"},
+{1,"2.2.6", "6 bytes (U-7FFFFFFF)",        "\375\277\277\277\277\277"},
 
 /*2.3  Other boundary conditions*/
 
-{0,"2.3.1", "U-0000D7FF = ed 9f bf", "íŸ¿"},
-{0,"2.3.2", "U-0000E000 = ee 80 80", "î€€"},
-{0,"2.3.3", "U-0000FFFD = ef bf bd", "ï¿½"},
-{0,"2.3.4", "U-0010FFFF = f4 8f bf bf", "ô¿¿"},
-{1,"2.3.5", "U-00110000 = f4 90 80 80", "ô€€"},
+{0,"2.3.1", "U-0000D7FF = ed 9f bf", "\355\237\277"},
+{0,"2.3.2", "U-0000E000 = ee 80 80", "\356\200\200"},
+{0,"2.3.3", "U-0000FFFD = ef bf bd", "\357\277\275"},
+{0,"2.3.4", "U-0010FFFF = f4 8f bf bf", "\364\217\277\277"},
+{1,"2.3.5", "U-00110000 = f4 90 80 80", "\364\220\200\200"},
 NULLTEST
 };
 
@@ -128,17 +140,17 @@ static const struct Test utf8bad[] = {
        Each unexpected continuation byte should be separately signalled
        as a malformed sequence of its own.
 */
-{1,"3.1.1", "First continuation byte 0x80", "€"},
-{1,"3.1.2", "Last  continuation byte 0xbf", "¿"},
+{1,"3.1.1", "First continuation byte 0x80", "\200"},
+{1,"3.1.2", "Last  continuation byte 0xbf", "\277"},
 
-{1,"3.1.3", "2 continuation bytes", "€¿"},
-{1,"3.1.4", "3 continuation bytes", "€¿€"},
-{1,"3.1.5", "4 continuation bytes", "€¿€¿"},
-{1,"3.1.6", "5 continuation bytes", "€¿€¿€"},
-{1,"3.1.7", "6 continuation bytes", "€¿€¿€¿"},
-{1,"3.1.8", "7 continuation bytes", "€¿€¿€¿€"},
+{1,"3.1.3", "2 continuation bytes", "\200\277"},
+{1,"3.1.4", "3 continuation bytes", "\200\277\200"},
+{1,"3.1.5", "4 continuation bytes", "\200\277\200\277"},
+{1,"3.1.6", "5 continuation bytes", "\200\277\200\277\200"},
+{1,"3.1.7", "6 continuation bytes", "\200\277\200\277\200\277"},
+{1,"3.1.8", "7 continuation bytes", "\200\277\200\277\200\277\200"},
 {1,"3.1.9", "Sequence of all 64 possible continuation bytes (0x80-0xbf)",
-   "€‚ƒ„…†‡ˆ‰Š‹Œ‘’“”•–—˜™š›œŸ ¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿"
+   "\200\201\202\203\204\205\206\207\210\211\212\213\214\215\216\217\220\221\222\223\224\225\226\227\230\231\232\233\234\235\236\237\240\241\242\243\244\245\246\247\250\251\252\253\254\255\256\257\260\261\262\263\264\265\266\267\270\271\272\273\274\275\276\277"
 },
 
 /*3.2  Lonely start characters*/
@@ -147,31 +159,31 @@ static const struct Test utf8bad[] = {
        each followed by a space character*/
 
 {1,"3.2.1", "All 32 first bytes of 2-byte sequences",
-"À Á Â Ã Ä Å Æ Ç È É Ê Ë Ì Í Î Ï Ğ Ñ Ò Ó Ô Õ Ö × Ø Ù Ú Û Ü İ Ş ß "
+"\300 \301 \302 \303 \304 \305 \306 \307 \310 \311 \312 \313 \314 \315 \316 \317 \320 \321 \322 \323 \324 \325 \326 \327 \330 \331 \332 \333 \334 \335 \336 \337 "
 },
 
 /*3.2.2  All 16 first bytes of 3-byte sequences (0xe0-0xef),
        each followed by a space character:*/
 {1,"3.2.2", "All 16 first bytes of 3-byte sequences",
-"à á â ã ä å æ ç è é ê ë ì í î ï "
+"\340 \341 \342 \343 \344 \345 \346 \347 \350 \351 \352 \353 \354 \355 \356 \357 "
 },
 
 /*3.2.3  All 8 first bytes of 4-byte sequences (0xf0-0xf7),
        each followed by a space character:*/
 {1,"3.2.3", "All 8 first bytes of 4-byte sequences",
-   "ğ ñ ò ó ô õ ö ÷ "
+   "\360 \361 \362 \363 \364 \365 \366 \367 "
 },
 
 /*3.2.4  All 4 first bytes of 5-byte sequences (0xf8-0xfb),
        each followed by a space character:*/
 {1,"3.2.4", "All 4 first bytes of 5-byte sequences",
-   "ø ù ú û "
+   "\370 \371 \372 \373 "
 },
 
 /*3.2.5  All 2 first bytes of 6-byte sequences (0xfc-0xfd),
        each followed by a space character:*/
 {1,"3.2.5", "All 2 first bytes of 6-byte sequences",
-   "ü ı "
+   "\374 \375 "
 },
 
 /*3.3  Sequences with last continuation byte missing
@@ -179,32 +191,32 @@ All bytes of an incomplete sequence should be signalled as a single
 malformed sequence, i.e., you should see only a single replacement
 character in each of the next 10 tests. (Characters as in section 2)
 */
-{1,"3.3.1", "2-byte sequence with last byte missing (U+0000)",     "À"},
-{1,"3.3.2", "3-byte sequence with last byte missing (U+0000)",     "à€"},
-{1,"3.3.3", "4-byte sequence with last byte missing (U+0000)",     "ğ€€"},
-{1,"3.3.4", "5-byte sequence with last byte missing (U+0000)",     "ø€€€"},
-{1,"3.3.5", "6-byte sequence with last byte missing (U+0000)",     "ü€€€€"},
-{1,"3.3.6", "2-byte sequence with last byte missing (U-000007FF)", "ß"},
-{1,"3.3.7", "3-byte sequence with last byte missing (U-0000FFFF)", "ï¿"},
-{1,"3.3.8", "4-byte sequence with last byte missing (U-001FFFFF)", "÷¿¿"},
-{1,"3.3.9", "5-byte sequence with last byte missing (U-03FFFFFF)", "û¿¿¿"},
-{1,"3.3.10", "6-byte sequence with last byte missing (U-7FFFFFFF)", "ı¿¿¿¿"},
+{1,"3.3.1", "2-byte sequence with last byte missing (U+0000)",     "\300"},
+{1,"3.3.2", "3-byte sequence with last byte missing (U+0000)",     "\340\200"},
+{1,"3.3.3", "4-byte sequence with last byte missing (U+0000)",     "\360\200\200"},
+{1,"3.3.4", "5-byte sequence with last byte missing (U+0000)",     "\370\200\200\200"},
+{1,"3.3.5", "6-byte sequence with last byte missing (U+0000)",     "\374\200\200\200\200"},
+{1,"3.3.6", "2-byte sequence with last byte missing (U-000007FF)", "\337"},
+{1,"3.3.7", "3-byte sequence with last byte missing (U-0000FFFF)", "\357\277"},
+{1,"3.3.8", "4-byte sequence with last byte missing (U-001FFFFF)", "\367\277\277"},
+{1,"3.3.9", "5-byte sequence with last byte missing (U-03FFFFFF)", "\373\277\277\277"},
+{1,"3.3.10", "6-byte sequence with last byte missing (U-7FFFFFFF)", "\375\277\277\277\277"},
 
 /*3.4 Concatenation of incomplete sequences
 All the 10 sequences of 3.3 concatenated; you should see 10 malformed
 sequences being signalled:
 */
 {1, "3.4.1", "All the 10 sequences of 3.3 concatenated",
-   "Àà€ğ€€ø€€€ü€€€€ßï¿÷¿¿û¿¿¿ı¿¿¿¿"
+   "\300\340\200\360\200\200\370\200\200\200\374\200\200\200\200\337\357\277\367\277\277\373\277\277\277\375\277\277\277\277"
 },
 
 /*3.5  Impossible bytes
 The following two bytes cannot appear in a correct UTF-8 string
 */
 
-{1,"3.5.1", "fe", "ş"},
-{1,"3.5.2", "ff", "ÿ"},
-{1,"3.5.3", "fe fe ff ff", "şşÿÿ"},
+{1,"3.5.1", "fe", "\376"},
+{1,"3.5.2", "ff", "\377"},
+{1,"3.5.3", "fe fe ff ff", "\376\376\377\377"},
 
 /*
 4  Overlong sequences
@@ -237,11 +249,11 @@ a replacement character. If you see a slash below, you do not have a
 safe UTF-8 decoder!
 */
 
-{1,"4.1.1", "U+002F = c0 af             ", "À¯"},
-{1,"4.1.2", "U+002F = e0 80 af          ", "à€¯"},
-{1,"4.1.3", "U+002F = f0 80 80 af       ", "ğ€€¯"},
-{1,"4.1.4", "U+002F = f8 80 80 80 af    ", "ø€€€¯"},
-{1,"4.1.5", "U+002F = fc 80 80 80 80 af ", "ü€€€€¯"},
+{1,"4.1.1", "U+002F = c0 af             ", "\300\257"},
+{1,"4.1.2", "U+002F = e0 80 af          ", "\340\200\257"},
+{1,"4.1.3", "U+002F = f0 80 80 af       ", "\360\200\200\257"},
+{1,"4.1.4", "U+002F = f8 80 80 80 af    ", "\370\200\200\200\257"},
+{1,"4.1.5", "U+002F = fc 80 80 80 80 af ", "\374\200\200\200\200\257"},
 
 /*4.2  Maximum overlong sequences
 
@@ -251,11 +263,11 @@ is a boundary test for safe UTF-8 decoders. All five characters should
 be rejected like malformed UTF-8 sequences.
 */
 
-{1,"4.2.1", "U-0000007F = c1 bf             ", "Á¿"},
-{1,"4.2.2", "U-000007FF = e0 9f bf          ", "àŸ¿"},
-{1,"4.2.3", "U-0000FFFF = f0 8f bf bf       ", "ğ¿¿"},
-{1,"4.2.4", "U-001FFFFF = f8 87 bf bf bf    ", "ø‡¿¿¿"},
-{1,"4.2.5", "U-03FFFFFF = fc 83 bf bf bf bf ", "üƒ¿¿¿¿"},
+{1,"4.2.1", "U-0000007F = c1 bf             ", "\301\277"},
+{1,"4.2.2", "U-000007FF = e0 9f bf          ", "\340\237\277"},
+{1,"4.2.3", "U-0000FFFF = f0 8f bf bf       ", "\360\217\277\277"},
+{1,"4.2.4", "U-001FFFFF = f8 87 bf bf bf    ", "\370\207\277\277\277"},
+{1,"4.2.5", "U-03FFFFFF = fc 83 bf bf bf bf ", "\374\203\277\277\277\277"},
 
 /*
 4.3  Overlong representation of the NUL character
@@ -265,11 +277,11 @@ UTF-8 sequences and should not be treated like the ASCII NUL
 character.
 */
 
-{1,"4.3.1", "U+0000 = c0 80             ", "À€"},
-{1,"4.3.2", "U+0000 = e0 80 80          ", "à€€"},
-{1,"4.3.3", "U+0000 = f0 80 80 80       ", "ğ€€€"},
-{1,"4.3.4", "U+0000 = f8 80 80 80 80    ", "ø€€€€"},
-{1,"4.3.5", "U+0000 = fc 80 80 80 80 80 ", "ü€€€€€"},
+{1,"4.3.1", "U+0000 = c0 80             ", "\300\200"},
+{1,"4.3.2", "U+0000 = e0 80 80          ", "\340\200\200"},
+{1,"4.3.3", "U+0000 = f0 80 80 80       ", "\360\200\200\200"},
+{1,"4.3.4", "U+0000 = f8 80 80 80 80    ", "\370\200\200\200\200"},
+{1,"4.3.5", "U+0000 = fc 80 80 80 80 80 ", "\374\200\200\200\200\200"},
 
 /*
 5  Illegal code positions
@@ -281,24 +293,24 @@ comparable to overlong UTF-8 sequences.
 */
 /*5.1 Single UTF-16 surrogates*/
 
-{1,"5.1.1", "U+D800 = ed a0 80 ", "í €"},
-{1,"5.1.2", "U+DB7F = ed ad bf ", "í­¿"},
-{1,"5.1.3", "U+DB80 = ed ae 80 ", "í®€"},
-{1,"5.1.4", "U+DBFF = ed af bf ", "í¯¿"},
-{1,"5.1.5", "U+DC00 = ed b0 80 ", "í°€"},
-{1,"5.1.6", "U+DF80 = ed be 80 ", "í¾€"},
-{1,"5.1.7", "U+DFFF = ed bf bf ", "í¿¿"},
+{1,"5.1.1", "U+D800 = ed a0 80 ", "\355\240\200"},
+{1,"5.1.2", "U+DB7F = ed ad bf ", "\355\255\277"},
+{1,"5.1.3", "U+DB80 = ed ae 80 ", "\355\256\200"},
+{1,"5.1.4", "U+DBFF = ed af bf ", "\355\257\277"},
+{1,"5.1.5", "U+DC00 = ed b0 80 ", "\355\260\200"},
+{1,"5.1.6", "U+DF80 = ed be 80 ", "\355\276\200"},
+{1,"5.1.7", "U+DFFF = ed bf bf ", "\355\277\277"},
 
 /*5.2 Paired UTF-16 surrogates */
 
-{1,"5.2.1", "U+D800 U+DC00 = ed a0 80 ed b0 80 ", "í €í°€"},
-{1,"5.2.2", "U+D800 U+DFFF = ed a0 80 ed bf bf ", "í €í¿¿"},
-{1,"5.2.3", "U+DB7F U+DC00 = ed ad bf ed b0 80 ", "í­¿í°€"},
-{1,"5.2.4", "U+DB7F U+DFFF = ed ad bf ed bf bf ", "í­¿í¿¿"},
-{1,"5.2.5", "U+DB80 U+DC00 = ed ae 80 ed b0 80 ", "í®€í°€"},
-{1,"5.2.6", "U+DB80 U+DFFF = ed ae 80 ed bf bf ", "í®€í¿¿"},
-{1,"5.2.7", "U+DBFF U+DC00 = ed af bf ed b0 80 ", "í¯¿í°€"},
-{1,"5.2.8", "U+DBFF U+DFFF = ed af bf ed bf bf ", "í¯¿í¿¿"},
+{1,"5.2.1", "U+D800 U+DC00 = ed a0 80 ed b0 80 ", "\355\240\200\355\260\200"},
+{1,"5.2.2", "U+D800 U+DFFF = ed a0 80 ed bf bf ", "\355\240\200\355\277\277"},
+{1,"5.2.3", "U+DB7F U+DC00 = ed ad bf ed b0 80 ", "\355\255\277\355\260\200"},
+{1,"5.2.4", "U+DB7F U+DFFF = ed ad bf ed bf bf ", "\355\255\277\355\277\277"},
+{1,"5.2.5", "U+DB80 U+DC00 = ed ae 80 ed b0 80 ", "\355\256\200\355\260\200"},
+{1,"5.2.6", "U+DB80 U+DFFF = ed ae 80 ed bf bf ", "\355\256\200\355\277\277"},
+{1,"5.2.7", "U+DBFF U+DC00 = ed af bf ed b0 80 ", "\355\257\277\355\260\200"},
+{1,"5.2.8", "U+DBFF U+DFFF = ed af bf ed bf bf ", "\355\257\277\355\277\277"},
 NULLTEST
 };
 
@@ -326,20 +338,20 @@ Particularly problematic noncharacters in 16-bit applications:
 */
 
 static const struct Test utf8problematic[] = {
-{0,"5.3.1", "U+FFFE = ef bf be ", "ï¿¾"},
-{0,"5.3.2", "U+FFFF = ef bf bf ", "ï¿¿"},
+{0,"5.3.1", "U+FFFE = ef bf be ", "\357\277\276"},
+{0,"5.3.2", "U+FFFF = ef bf bf ", "\357\277\277"},
 NULLTEST
 };
 
 /* Other (utf16) noncharacters: */
 static const struct Test utf8nonchars[] = {
 {0,"5.3.3", "U+FDD0 .. U+FDEF ",
-"ï·ï·‘ï·’ï·“ï·”ï·•ï·–ï·—ï·˜ï·™ï·šï·›ï·œï·ï·ï·Ÿï· ï·¡ï·¢ï·£ï·¤ï·¥ï·¦ï·§ï·¨ï·©ï·ªï·«ï·¬ï·­ï·®ï·¯"
+"\357\267\220\357\267\221\357\267\222\357\267\223\357\267\224\357\267\225\357\267\226\357\267\227\357\267\230\357\267\231\357\267\232\357\267\233\357\267\234\357\267\235\357\267\236\357\267\237\357\267\240\357\267\241\357\267\242\357\267\243\357\267\244\357\267\245\357\267\246\357\267\247\357\267\250\357\267\251\357\267\252\357\267\253\357\267\254\357\267\255\357\267\256\357\267\257"
 },
 
 /* Do not understand this test; it passes, but should it? */
 {0,"5.3.4", "U+nFFFE U+nFFFF (for n = 1..10)",
-       "ğŸ¿¾ğŸ¿¿ğ¯¿¾ğ¯¿¿ğ¿¿¾ğ¿¿¿ñ¿¾ñ¿¿ñŸ¿¾ñŸ¿¿ñ¯¿¾ñ¯¿¿ñ¿¿¾ñ¿¿¿ò¿¾ò¿¿òŸ¿¾òŸ¿¿ò¯¿¾ò¯¿¿ò¿¿¾ò¿¿¿ó¿¾ó¿¿óŸ¿¾óŸ¿¿ó¯¿¾ó¯¿¿ó¿¿¾ó¿¿¿ô¿¾ô¿¿"
+       "\360\237\277\276\360\237\277\277\360\257\277\276\360\257\277\277\360\277\277\276\360\277\277\277\361\217\277\276\361\217\277\277\361\237\277\276\361\237\277\277\361\257\277\276\361\257\277\277\361\277\277\276\361\277\277\277\362\217\277\276\362\217\277\277\362\237\277\276\362\237\277\277\362\257\277\276\362\257\277\277\362\277\277\276\362\277\277\277\363\217\277\276\363\217\277\277\363\237\277\276\363\237\277\277\363\257\277\276\363\257\277\277\363\277\277\276\363\277\277\277\364\217\277\276\364\217\277\277"
 },
 NULLTEST
 };

--- a/nc_test4/CMakeLists.txt
+++ b/nc_test4/CMakeLists.txt
@@ -88,9 +88,10 @@ ENDIF(${HDF5_VERSION} VERSION_GREATER "1.10.0")
 BUILD_BIN_TEST(tst_empty_vlen_unlim)
 ADD_SH_TEST(nc_test4 run_empty_vlen_test)
 
-IF(NOT WIN32)
-  SET(NC4_TESTS ${NC4_TESTS} tst_interops5 tst_camrun)
-ENDIF()
+# tst_camrun and tst_interops5 build on Windows now: tst_camrun needed its
+# <unistd.h> guarded and an fclose(NULL) removed, and tst_interops5 needed its
+# two variable-length arrays given constant bounds, which MSVC requires.
+SET(NC4_TESTS ${NC4_TESTS} tst_interops5 tst_camrun)
 
 # UDF self-registration plugin loading test.
 # Build a test plugin as a shared library, then build a test that

--- a/nc_test4/tst_camrun.c
+++ b/nc_test4/tst_camrun.c
@@ -15,7 +15,13 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <netcdf.h>
+#ifdef _WIN32
+/* getpid() below; on POSIX it comes from <unistd.h> */
+#include <process.h>
+#endif
+#ifdef HAVE_UNISTD_H
 #include <unistd.h>
+#endif
 
 #define FILE_NAME "tst_camrun.nc"
    /* rank (number of dimensions) for each variable */
@@ -685,10 +691,16 @@ get_mem_used2(int *mem_used)
       (void)fscanf(pf, "%u %u %u %u %u %u", &size, &resident, &share,
 	     &text, &lib, &data);
       *mem_used = (int)(data * page_size) / MEGABYTE;
+      fclose(pf);
    }
    else
+   {
+      /* No /proc: any platform but Linux, which now includes Windows, where
+	 this file compiles for the first time. The fclose() used to sit here,
+	 outside the if, so this branch called fclose(NULL) -- undefined
+	 behaviour, and a fail-fast (0xC0000409) with the Microsoft runtime. */
       *mem_used = -1;
-  fclose(pf);
+   }
 }
 
 int

--- a/nc_test4/tst_interops5.c
+++ b/nc_test4/tst_interops5.c
@@ -23,8 +23,14 @@ main(int argc, char **argv)
 #define GRPA_NAME "grpa"
 #define VAR_NAME "vara"
 #define NDIMS 2
-      hsize_t nrowCur = 7;               /* current size */
-      hsize_t ncolCur = 3;
+/* amat and xydimMat below were sized from the hsize_t variables, which makes
+   them variable-length arrays. MSVC does not implement those, so the sizes are
+   named as macros and the variables initialised from them: same sizes, no VLA,
+   no change on any other platform. */
+#define NROWCUR 7
+#define NCOLCUR 3
+      hsize_t nrowCur = NROWCUR;          /* current size */
+      hsize_t ncolCur = NCOLCUR;
       hsize_t nrowMax = nrowCur + 0;     /* maximum size */
       hsize_t ncolMax = ncolCur + 0;
 
@@ -43,7 +49,7 @@ main(int argc, char **argv)
 	 = "This is a netCDF dimension but not a netCDF variable.";
       char dimNameBuf[1000];
       char *varaName = "/grpa/vara";
-      short amat[nrowCur][ncolCur];
+      short amat[NROWCUR][NCOLCUR];
       int ii, jj;
 
       xscaleDims[0] = nrowCur;
@@ -135,7 +141,7 @@ main(int argc, char **argv)
 
       /* Write dimension values for both xdim, ydim */
       {
-      short xydimMat[ nrowCur >= ncolCur ? nrowCur : ncolCur];
+      short xydimMat[NROWCUR >= NCOLCUR ? NROWCUR : NCOLCUR];
       for (ii = 0; ii < nrowCur; ii++)
 	 xydimMat[ii] = 0;    /*#### 100 * ii; */
 

--- a/ncdump/CMakeLists.txt
+++ b/ncdump/CMakeLists.txt
@@ -258,21 +258,21 @@ endif()
     SET_TESTS_PROPERTIES(ncdump_tst_null_byte_padding PROPERTIES WILL_FAIL TRUE)
   endif(USE_STRICT_NULL_BYTE_HEADER_PADDING)
 
-  if(NOT MSVC AND NOT MINGW)
-    add_sh_test(ncdump tst_output)
-    set_tests_properties(ncdump_tst_output PROPERTIES DEPENDS "ref_ctest;ref_ctest64")
-    add_sh_test(ncdump tst_nccopy3)
-    # Known failure on MSVC; the number of 0's padding
-    # is different, but the result is actually correct.
-    if(USE_HDF5)
-      add_sh_test(ncdump tst_netcdf4)
-    endif()
-
-    set_tests_properties(ncdump_tst_nccopy3 PROPERTIES DEPENDS
-      "ncdump_tst_calendars;ncdump_run_utf8_tests;ncdump_tst_output;ncdump_tst_64bit;ncdump_run_tests;ncdump_tst_lengths")
-    set_tests_properties(ncdump_tst_nccopy3 PROPERTIES RUN_SERIAL TRUE)
-
+  # These three were excluded from MSVC builds because ncdump's scientific
+  # notation used to differ there: the pre-VS2015 CRT padded exponents to three
+  # digits (1e+009), so the .cdl comparisons failed on formatting alone. The
+  # UCRT has printed C99-conformant two-digit exponents since VS2015 and all
+  # three now compare clean, so run them everywhere.
+  add_sh_test(ncdump tst_output)
+  set_tests_properties(ncdump_tst_output PROPERTIES DEPENDS "ref_ctest;ref_ctest64")
+  add_sh_test(ncdump tst_nccopy3)
+  if(USE_HDF5)
+    add_sh_test(ncdump tst_netcdf4)
   endif()
+
+  set_tests_properties(ncdump_tst_nccopy3 PROPERTIES DEPENDS
+    "ncdump_tst_calendars;ncdump_run_utf8_tests;ncdump_tst_output;ncdump_tst_64bit;ncdump_run_tests;ncdump_tst_lengths")
+  set_tests_properties(ncdump_tst_nccopy3 PROPERTIES RUN_SERIAL TRUE)
 
   if(USE_HDF5)
     add_sh_test(ncdump tst_formatx4)

--- a/unit_test/CMakeLists.txt
+++ b/unit_test/CMakeLists.txt
@@ -12,10 +12,8 @@ IF(USE_X_GETOPT)
   SET(XGETOPTSRC "${CMAKE_CURRENT_SOURCE_DIR}/../libdispatch/XGetopt.c")
 ENDIF()
 
-# Currently (August 21, 2019): Some tests will not work with
-# Visual Studio. The unit tests are for internal netCDF functions,
-# so we don't want to make them external, which would be required to
-# run on Windows.
+# The two tests that once needed Visual Studio to be excluded here are
+# tst_nclist and tst_nc4internal; see the comment on them below.
 
 SET(UNIT_TESTS test_ncuri)
 add_bin_test(unit_test test_ncuri)
@@ -24,10 +22,11 @@ SET(UNIT_TESTS test_dauth)
 add_bin_test(unit_test test_dauth)
 
 IF(NETCDF_ENABLE_HDF5)
-  IF(NOT WIN32)
-    add_bin_test(unit_test tst_nclist)
-    add_bin_test(unit_test tst_nc4internal)
-  ENDIF(NOT WIN32)
+  # These two call library-internal functions directly. They run on Windows now
+  # that those entry points are declared EXTERNL (see include/nc.h and
+  # include/nc4internal.h); nothing else about them was platform specific.
+  add_bin_test(unit_test tst_nclist)
+  add_bin_test(unit_test tst_nc4internal)
   build_bin_test(tst_reclaim ${XGETOPTSRC})
   if(NETCDF_BUILD_UTILITIES)
     add_sh_test(unit_test run_reclaim_tests)


### PR DESCRIPTION
The test suite registers **204** tests on Windows and **215** on Linux and
macOS, from the same sources with the same cmake options. The eleven-test gap
is not eleven skips — those tests are never added to the build, so nothing in
the ctest output says they are missing, and a Windows run reports "100% tests
passed" over a suite five percent smaller than the one the other two platforms
run.

This registers all eleven and makes them pass.

## The eleven, and what was actually in the way

| test | gate | obstacle |
| --- | --- | --- |
| `ncdump_test_unicode_directory` | `if(NOT ISMINGW)` | `ISMINGW` is a false positive under MSVC |
| `ncdump_test_unicode_path` | `if(NOT ISMINGW)` | same |
| `ncdump_tst_output` | `if(NOT MSVC AND NOT MINGW)` | pre-VS2015 exponent padding |
| `ncdump_tst_nccopy3` | `if(NOT MSVC AND NOT MINGW)` | same |
| `ncdump_tst_netcdf4` | `if(NOT MSVC AND NOT MINGW)` | same |
| `nc_test4_tst_camrun` | `IF(NOT WIN32)` | unguarded `<unistd.h>`, then `fclose(NULL)` |
| `nc_test4_tst_interops5` | `IF(NOT WIN32)` | two variable-length arrays |
| `nc_test_tst_utf8_validate` | `IF(NOT WIN32)` | invalid-UTF-8 test data as raw source bytes |
| `unit_test_tst_nclist` | `IF(NOT WIN32)` | internal symbols not exported from the DLL |
| `unit_test_tst_nc4internal` | `IF(NOT WIN32)` | same |
| `nc_test_run_mmap` | `IF(BUILD_MMAP)` | `NETCDF_ENABLE_MMAP` forced off on WIN32 |

Two of these gates are simply wrong today, three name an obstacle that took one
line to remove, and two name a real design question. Details below, one section
per commit.

### `cmake: do not mistake a Git-Bash shell for a MinGW toolchain`

`CMakeLists.txt` sets `ISMINGW` — and CMake's own `MINGW` — from `uname -s`:

```cmake
if(osname MATCHES "MINGW.*" OR osname MATCHES "MSYS.*")
  set(ISMINGW yes)
  set(MINGW yes)
endif()
```

`uname -s` in Git for Windows answers `MINGW64_NT-10.0-22621`. That is a fact
about the shell, not about the compiler. Configure an ordinary MSVC build from
Git Bash — which is what `shell: bash` on a `windows-latest` runner gives you —
and the build declares itself MinGW. `CMakeCache.txt` records it plainly:

```
BUILDNAME:STRING=MINGW64_NT-10.0-22621-3.3.6-bec3d608-341.x86_64-x86_64
```

Everything behind "not MinGW" then vanishes without a word, in every
subdirectory, because `MINGW` is set too. The visible casualty is
`ncdump/CMakeLists.txt`'s `if(NOT ISMINGW)`.

The same commit fixes two lines in the `if(MSVC)` block below that have never
done what they read as:

```cmake
set(GLOBAL PROPERTY USE_FOLDERS ON)              # sets a variable named GLOBAL
target_compile_options(netcdf PRIVATE "/utf-8")  # `netcdf` is created ~1300 lines later
```

`liblib/` creates the `netcdf` target long after this point in the file, so
`/utf-8` had never been applied to anything.

### `utilities: declare UTF-8 as the active code page for MSVC executables`

`ncgen` cannot create a file whose name the ANSI code page cannot represent:

```
$ ncgen -3 -b -o "tst_utf8_海.nc" ref_tst_utf8.cdl
ncgen: Invalid argument
	(ncgen/genbin.c:genbin_netcdf:61)
```

The name never reaches `nc_create()` intact. With `NCPATHDEBUG=1`:

```
>>> NCpathcvt: inparsed=Path{kind=6 drive='0' path=|tst_utf8_?.nc|}
```

Git Bash starts the process with a UTF-16 command line; the UCRT transcodes
that into `argv` through the ANSI code page **before `main()` runs**, and a
character the code page cannot represent becomes a literal `?` — an illegal
character in a Windows file name, hence `EINVAL`. `NCpathcvt()` cannot recover
a byte that was replaced before it was called.

`libdispatch/dpathmgr.c` already anticipates the fix: every entry point carries
an `#ifdef WINUTF8 … if(acp == CP_UTF8)` fast path, waiting for a `GetACP()`
that returns UTF-8. An application manifest declaring `activeCodePage UTF-8`
supplies it — `argv`, the ANSI CRT file calls and `GetACP()` all become UTF-8.
It is merged into the manifest the linker already embeds via
`/MANIFEST:EMBED /MANIFESTINPUT`, so no target needs individual wiring and no
`mt.exe` step is added. Windows 10 1903 or later; older systems ignore the
setting and behave exactly as before.

### `ncdump: run tst_output, tst_nccopy3 and tst_netcdf4 with MSVC`

The comment beside the exclusion is accurate about the cause — "the number of
0's padding is different, but the result is actually correct" — and the cause
is that the pre-VS2015 CRT padded `printf` exponents to three digits (`1e+009`
where C99 wants `1e+09`), so the `.cdl` comparisons failed on formatting alone.
The UCRT has been C99-conformant since VS2015. All three scripts exit 0 with no
diff against MSVC 19.x. Deleting the gate is the whole change.

### `nc_test4: build and run tst_camrun and tst_interops5 with MSVC`

* `tst_camrun.c` includes `<unistd.h>` unguarded, for nothing but `getpid()`.
* `tst_camrun.c`'s `get_mem_used2()` calls `fclose(pf)` **outside** the
  `if (pf)` branch — `fclose(NULL)` on any platform without `/proc`, which has
  always included macOS. The Microsoft runtime fail-fasts on it, so the test
  died with `0xC0000409` before printing a line.
* `tst_interops5.c` sizes `short amat[nrowCur][ncolCur]` from `hsize_t`
  variables, which makes them variable-length arrays; MSVC does not implement
  those. Both bounds are compile-time constants in fact, so they are named as
  macros and the variables initialised from them — same sizes, no VLA, no
  change on any other platform.

### `nc_test: build and run tst_utf8_validate with MSVC`

The point of this test is byte sequences that are **not** valid UTF-8, and they
were raw bytes in the source. A compiler that transcodes string literals from a
source character set cannot carry those through: MSVC rejects the file under
`/utf-8` (`C2001: newline in constant`, because an invalid lead byte swallows
the closing quote) and silently rewrites the bytes through the ANSI code page
without it — which would have been the worse outcome, because the test would
then have passed while asserting things about data it was no longer testing.

Every byte above 0x7f is now a three-digit octal escape and the file is pure
ASCII. Octal escapes are fixed length, so a following digit cannot extend them;
`\x` escapes are greedy and would not have been safe here. The data is
byte-for-byte what it was — only the spelling changed — and a note at the top
of the file says so, because "restoring" the characters would break Windows
again.

### `unit_test: run tst_nclist and tst_nc4internal on Windows`

`unit_test/CMakeLists.txt` states the trade exactly:

> Currently (August 21, 2019): Some tests will not work with Visual Studio. The
> unit tests are for internal netCDF functions, so we don't want to make them
> external, which would be required to run on Windows.

**This is the one judgment call in the PR, and it is worth a maintainer's
decision rather than mine.** The two tests reach 23 symbols: the `NC` list and
`free_NC`/`new_NC` in `nc.h`, sixteen `nc4_*` entry points in `nc4internal.h`,
and `NC3_dispatch_table` in `ncdispatch.h`. On Linux and macOS all 23 already
leave the shared object under default visibility; only Windows needs the
declaration to say so. `EXTERNL` expands to plain `extern` off Windows, and all
three headers are internal, so no installed header's public surface changes.

`NC3_dispatch_table` is the interesting one: it is a data symbol, and a plain
`extern` data reference cannot be fixed up through an import library at all, so
that declaration in particular has to carry `dllimport`.

If widening the Windows export surface by 23 symbols is unwanted, the
alternatives are `WINDOWS_EXPORT_ALL_SYMBOLS` on the `netcdf` target — the
exact Windows analogue of what Linux does by default, needing no header edits,
but exporting everything and drawing `LNK4197` wherever an explicit
`dllexport` already exists — or dropping this commit and living with 213. The
other six commits are independent of it.

### `libsrc: mmap support on Windows, and three bugs in mmapio.c`

`NETCDF_ENABLE_MMAP` was `cmake_dependent_option(… ON "NOT WIN32" OFF)`, so
`libsrc/mmapio.c` was never compiled on Windows and `nc_test/run_mmap.sh` is
the one test in the suite Windows was missing outright rather than excluding by
name.

The port is small because `mmapio.c` uses very little of `<sys/mman.h>`: an
anonymous private mapping, a file-backed `MAP_SHARED` mapping, and `munmap`. No
`mprotect`, no `msync` — `MAP_SHARED` writes are coherent with the file on
Windows as they are on POSIX — and no partial unmapping. A 115-line
`libsrc/ncwinmmap.h` supplies that slice over `CreateFileMapping` /
`MapViewOfFile`. The anonymous case goes through a section object too, rather
than `VirtualAlloc`, so a single `UnmapViewOfFile` releases either kind and
`munmap()` does not have to remember which it was; the section handle is closed
as soon as the view exists, since the view holds its own reference.

Making the file compile turned up three bugs in it, **none Windows-specific**.
All three bite on any platform without glibc's `mremap()`, which includes
macOS:

* `mmapio_pad_length()` grows the region with
  `mmap(NULL, newsize, mmapio->mapfd >= 0 ? (PROT_READ|PROT_WRITE) : (PROT_READ), MAP_SHARED, mmapio->mapfd, 0)`.
  `mapfd` is `-1` for a non-persist (diskless) file, so that asks for a shared
  mapping of file descriptor −1, read-only, to hold a file about to be written.
* The same function extends the backing file with
  `write(mmapio->mapfd, "", mmapio->alloc)` — `alloc` bytes read out of a
  one-byte string literal.
* Failure is tested as `== NULL`, and no `mmap()` returns NULL; `MAP_FAILED` is
  `(void*)-1`. The non-persist create path does not test at all — it stores
  into `memory[0]` "to test writing of the mmap'd memory", which on a failed
  mapping is a dereference of −1.

It also drops a duplicate `add_sh_test(nc_test run_mmap)` that registers the
same test name twice in the same directory.

## Verification

Windows 11, MSVC 19.x (Visual Studio 18), HDF5 `develop`, zlib from vcpkg,
`ctest -j4 --timeout 1200`, configured with `-DENABLE_HDF5=ON
-DBUILD_UTILITIES=ON -DENABLE_TESTS=ON -DENABLE_BENCHMARKS=ON` and
DAP/NCZarr/byterange/plugins off.

**On this branch, i.e. `main` plus these seven commits:**

```
94% tests passed, 13 tests failed out of 215
```

215 registered, up from 204. All eleven newly registered tests pass. **All 13
failures are in `nc_perf/`**, which does not compile with MSVC on `main` today
and is entirely independent of this PR — 19 of its 23 sources fail from
unguarded `<sys/time.h>` / `<unistd.h>`, `getopt_long_only()`, unresolved
`getopt`/`optarg`/`optind`, and `strtok_r`/`sbrk`. Nothing outside `nc_perf`
fails.

**With `nc_perf` also building** (measured on a tree that carries a fix for it
as well, so `nc_perf` is not the variable):

```
100% tests passed, 0 tests failed out of 215
```

And the point of the exercise: diffing that run's JUnit output against the
Linux run's in both directions, the two sets of 215 test **names** are
identical, not merely equal in count.

Linux and macOS are unaffected — `EXTERNL` is a no-op there, the octal escapes
are the same bytes, the VLA bounds are the same values, and the three
`mmapio.c` corrections are fixes on paths those platforms already take (the
`mremap` `#else` branch on macOS in particular).
